### PR TITLE
fix: prevent underlying element click handlers during overlay mode

### DIFF
--- a/packages/react-grab/src/index.ts
+++ b/packages/react-grab/src/index.ts
@@ -259,6 +259,18 @@ export const init = (options: Options = {}) => {
     }));
   };
 
+  const handleClick = (event: MouseEvent) => {
+    const { overlayMode } = libStore.getState();
+
+    if (overlayMode === "hidden") {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation();
+  };
+
   const handleVisibilityChange = () => {
     if (document.hidden) {
       cleanupGrabbedIndicators();
@@ -287,7 +299,8 @@ export const init = (options: Options = {}) => {
   };
 
   window.addEventListener("mousemove", handleMouseMove);
-  window.addEventListener("mousedown", handleMouseDown);
+  window.addEventListener("mousedown", handleMouseDown, true);
+  window.addEventListener("click", handleClick, true);
   window.addEventListener("scroll", handleScroll, true);
   window.addEventListener("resize", handleResize);
   document.addEventListener("visibilitychange", handleVisibilityChange);
@@ -472,7 +485,8 @@ export const init = (options: Options = {}) => {
 
   return () => {
     window.removeEventListener("mousemove", handleMouseMove);
-    window.removeEventListener("mousedown", handleMouseDown);
+    window.removeEventListener("mousedown", handleMouseDown, true);
+    window.removeEventListener("click", handleClick, true);
     window.removeEventListener("scroll", handleScroll, true);
     window.removeEventListener("resize", handleResize);
     document.removeEventListener("visibilitychange", handleVisibilityChange);


### PR DESCRIPTION
### Problem
When overlay mode is active, clicking on elements to grab them also triggers the underlying element's click handlers (e.g., navigation, form submission, button actions). This creates a confusing UX where users unintentionally interact with the page while trying to grab elements.


### Solution
Prevent underlying element clicks during overlay mode by using capture phase event listeners.

### ASIS
https://github.com/user-attachments/assets/40947046-a69b-4ca8-b483-fae904484d58


### TOBE
https://github.com/user-attachments/assets/5e9188f2-202e-4e3f-b46f-07bbe4c4f9a5

