### PR TITLE
Revert readme 55 percent stat

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Grab any element on in your app and give it to Cursor, Claude Code, etc. to chan
 
 By default coding agents cannot access elements on your page. React Grab fixes this - just point and click to provide context!
 
-**[Makes coding agents 55% faster at frontend →](https://react-grab.com/blog/intro)**
-
 - Hold <kbd>⌘C</kbd> and click on any element on your page
 - Works with Cursor, Claude Code, OpenCode
 - Just a single script tag (it’s just JavaScript!)


### PR DESCRIPTION
Revert the "Makes coding agents 55% faster at frontend" stat in the README.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca103251-582b-4871-af3e-9d9dd75621de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ca103251-582b-4871-af3e-9d9dd75621de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

