### PR TITLE
fix: keyboard shortcut for Dvorak/Colemak users

### DIFF
--- a/packages/react-grab/src/core.tsx
+++ b/packages/react-grab/src/core.tsx
@@ -154,8 +154,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     );
 
     const isTargetKeyCombination = (event: KeyboardEvent) =>
-      // NOTE: we use event.code instead of event.key for keyboard layout compatibility (e.g., AZERTY, QWERTZ)
-      (event.metaKey || event.ctrlKey) && event.code === "KeyC";
+      (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "c";
 
     const getAutoScrollDirection = (clientX: number, clientY: number) => {
       return {
@@ -804,8 +803,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         if (!isHoldingKeys() && !isActivated()) return;
 
         const isReleasingModifier = !event.metaKey && !event.ctrlKey;
-        // NOTE: we use event.code instead of event.key for keyboard layout compatibility (e.g., AZERTY, QWERTZ)
-        const isReleasingC = event.code === "KeyC";
+        const isReleasingC = event.key.toLowerCase() === "c";
 
         if (isReleasingC || isReleasingModifier) {
           if (isToggleMode()) return;


### PR DESCRIPTION
## Summary

This reverts to using `event.key` instead of `event.code` for detecting the Cmd+C shortcut.

I ran into an issue on my Dvorak layout where Cmd+C wasn't activating react-grab. Instead, Cmd+J (the physical QWERTY C position) was triggering it.

## Context

I noticed the recent commit b2fe8fa switched from `event.key` to `event.code` with a comment about keyboard layout compatibility for AZERTY/QWERTZ. I think there might be some confusion here, so I wanted to open this as a draft to discuss:

- `event.code` = physical key position (QWERTY-based)
- `event.key` = actual character produced (respects layout)

For AZERTY/QWERTZ, the C key is in roughly the same physical position as QWERTY, so `event.code` works fine there. But for layouts like Dvorak or Colemak where keys are completely rearranged, `event.code` breaks the expected behavior.

Standard OS behavior (macOS, Windows, Linux) is that Cmd+C means "Command + the key that produces C on your layout", not "Command + the physical QWERTY C position". Users who prefer physical-position shortcuts typically use special OS layouts like "Dvorak-QWERTY ⌘".

Totally possible I'm missing something here. Happy to discuss or close this if there was a specific reason for the change that I'm not aware of.

## Changes

- `isTargetKeyCombination`: use `event.key.toLowerCase() === "c"`
- keyup handler: use `event.key.toLowerCase() === "c"`