### PR TITLE
Fix Windows path comparison crash in server startup

### DIFF
--- a/packages/react-grab-claude-code/src/server.ts
+++ b/packages/react-grab-claude-code/src/server.ts
@@ -1,4 +1,5 @@
 import net from "node:net";
+import { pathToFileURL } from "node:url";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { streamSSE } from "hono/streaming";
@@ -106,6 +107,6 @@ export const startServer = async (port: number = DEFAULT_PORT) => {
   console.log(`[React Grab] Server started on port ${port}`);
 };
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   startServer(DEFAULT_PORT).catch(console.error);
 }

--- a/packages/react-grab-cursor/src/server.ts
+++ b/packages/react-grab-cursor/src/server.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import net from "node:net";
+import { pathToFileURL } from "node:url";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { streamSSE } from "hono/streaming";
@@ -217,6 +218,6 @@ export const startServer = async (port: number = DEFAULT_PORT) => {
   console.log(`[React Grab] Server started on port ${port}`);
 };
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   startServer(DEFAULT_PORT).catch(console.error);
 }


### PR DESCRIPTION
Fix Windows path comparison crash in server startup

  On Windows, the entry point detection failed because:
  - `import.meta.url` returns `file:///C:/Users/...` (forward slashes)
  - `process.argv[1]` returns `C:\Users\...` (backslashes)

  Use `pathToFileURL()` from `node:url` to normalize paths before comparison,
  ensuring cross-platform compatibility.

  Affected packages:
  - @react-grab/claude-code
  - @react-grab/cursor