### PR TITLE
feat: add auto open in editor after copying element

### DIFF
--- a/packages/react-grab/README.md
+++ b/packages/react-grab/README.md
@@ -278,6 +278,48 @@ export default function RootLayout({ children }) {
 }
 ```
 
+## Open in Editor
+
+React Grab can automatically open the source file in your editor after copying an element. This streamlines the workflow - select an element, copy it, and the file opens at the exact line.
+
+```typescript
+import { init } from "react-grab/core";
+
+init({
+  openInEditor: {
+    enabled: true,
+    editor: "auto", // or "vscode", "cursor", "webstorm", "zed", etc.
+  },
+});
+```
+
+### Supported Editors
+
+- `auto` - Automatically detect the running editor (default)
+- `vscode` - Visual Studio Code
+- `cursor` - Cursor
+- `webstorm` - WebStorm
+- `phpstorm` - PhpStorm
+- `idea` - IntelliJ IDEA
+- `zed` - Zed
+- `sublime` - Sublime Text
+- `atom` - Atom
+- `vim` - MacVim
+- `emacs` - Emacs
+
+### Custom URL Scheme
+
+For editors not in the preset list, you can provide a custom URL scheme:
+
+```typescript
+init({
+  openInEditor: {
+    enabled: true,
+    customUrlScheme: "myeditor://open?file={file}&line={line}&column={column}",
+  },
+});
+```
+
 ## Extending React Grab
 
 React Grab provides an public customization API. Check out the [type definitions](https://github.com/aidenybai/react-grab/blob/main/packages/react-grab/src/types.ts) to see all available options for extending React Grab.
@@ -295,6 +337,12 @@ const api = init({
     elementLabel: {
       enabled: false, // disable element label
     },
+  },
+
+  // Auto open in editor after copying
+  openInEditor: {
+    enabled: true,
+    editor: "cursor", // or "vscode", "auto", etc.
   },
 
   onElementSelect: (element) => {

--- a/packages/react-grab/src/context.ts
+++ b/packages/react-grab/src/context.ts
@@ -137,6 +137,31 @@ export const getElementContext = async (
   return `${html}${stackContext.join("")}`;
 };
 
+export interface FileLocation {
+  filePath: string;
+  lineNumber?: number;
+  columnNumber?: number;
+}
+
+export const getFileLocation = async (
+  element: Element,
+): Promise<FileLocation | null> => {
+  const stack = await getStack(element);
+  if (!stack) return null;
+
+  for (const frame of stack) {
+    if (frame.fileName && isSourceFile(frame.fileName)) {
+      return {
+        filePath: normalizeFileName(frame.fileName),
+        lineNumber: frame.lineNumber,
+        columnNumber: frame.columnNumber,
+      };
+    }
+  }
+
+  return null;
+};
+
 export const getHTMLPreview = (element: Element): string => {
   const tagName = element.tagName.toLowerCase();
   if (!(element instanceof HTMLElement)) {

--- a/packages/react-grab/src/core.tsx
+++ b/packages/react-grab/src/core.tsx
@@ -18,7 +18,9 @@ import {
   getStack,
   getElementContext,
   getNearestComponentName,
+  getFileLocation,
 } from "./context.js";
+import { openInEditor } from "./utils/open-in-editor.js";
 import { isSourceFile, normalizeFileName } from "bippy/source";
 import { copyContent } from "./utils/copy-content.js";
 import { getElementAtPosition } from "./utils/get-element-at-position.js";
@@ -541,6 +543,18 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
         if (didCopy) {
           options.onCopySuccess?.(elements, copiedContent);
+
+          // Auto open in editor if enabled
+          if (options.openInEditor?.enabled && elements.length > 0) {
+            const fileLocation = await getFileLocation(elements[0]);
+            if (fileLocation) {
+              openInEditor(fileLocation.filePath, {
+                ...options.openInEditor,
+                lineNumber: fileLocation.lineNumber,
+                column: fileLocation.columnNumber,
+              });
+            }
+          }
         }
       } catch (error) {
         options.onCopyError?.(error as Error);

--- a/packages/react-grab/src/index.ts
+++ b/packages/react-grab/src/index.ts
@@ -25,6 +25,8 @@ export type {
   AgentProvider,
   AgentSessionStorage,
   AgentOptions,
+  EditorType,
+  OpenInEditorOptions,
 } from "./types.js";
 
 import { init } from "./core.js";

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -2,6 +2,41 @@ export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
 };
 
+/**
+ * Supported editor types for "Open in Editor" feature
+ */
+export type EditorType =
+  | "auto"
+  | "vscode"
+  | "cursor"
+  | "webstorm"
+  | "phpstorm"
+  | "idea"
+  | "zed"
+  | "sublime"
+  | "atom"
+  | "emacs"
+  | "vim";
+
+export interface OpenInEditorOptions {
+  /**
+   * Whether to automatically open the file in editor after copying
+   * @default false
+   */
+  enabled?: boolean;
+  /**
+   * Which editor to use. 'auto' will try to detect the running editor.
+   * @default 'auto'
+   */
+  editor?: EditorType;
+  /**
+   * Custom URL scheme for editors not in the preset list
+   * Use {file}, {line}, {column} as placeholders
+   * Example: "myeditor://open?file={file}&line={line}"
+   */
+  customUrlScheme?: string;
+}
+
 export interface Theme {
   /**
    * Globally toggle the entire overlay
@@ -186,6 +221,10 @@ export interface Options {
   ) => void;
   onCrosshair?: (visible: boolean, context: CrosshairContext) => void;
   onOpenFile?: (filePath: string, lineNumber?: number) => void;
+  /**
+   * Options for automatically opening the file in editor after copying
+   */
+  openInEditor?: OpenInEditorOptions;
   agent?: AgentOptions;
 }
 

--- a/packages/react-grab/src/utils/open-in-editor.ts
+++ b/packages/react-grab/src/utils/open-in-editor.ts
@@ -1,0 +1,148 @@
+import type { EditorType, OpenInEditorOptions } from "../types.js";
+
+/**
+ * URL schemes for different editors
+ * {file} - absolute file path
+ * {line} - line number (optional)
+ * {column} - column number (optional)
+ */
+const EDITOR_URL_SCHEMES: Record<string, string> = {
+  vscode: "vscode://file{file}:{line}:{column}",
+  cursor: "cursor://file{file}:{line}:{column}",
+  webstorm: "webstorm://open?file={file}&line={line}&column={column}",
+  phpstorm: "phpstorm://open?file={file}&line={line}&column={column}",
+  idea: "idea://open?file={file}&line={line}&column={column}",
+  zed: "zed://file{file}:{line}:{column}",
+  sublime: "subl://open?url=file://{file}&line={line}&column={column}",
+  atom: "atom://core/open/file?filename={file}&line={line}&column={column}",
+  emacs: "emacs://open?url=file://{file}&line={line}&column={column}",
+  vim: "mvim://open?url=file://{file}&line={line}&column={column}",
+};
+
+/**
+ * Default editor detection order
+ */
+const EDITOR_DETECTION_ORDER: EditorType[] = [
+  "cursor",
+  "vscode",
+  "zed",
+  "webstorm",
+  "idea",
+  "phpstorm",
+  "sublime",
+  "atom",
+];
+
+/**
+ * Try to detect which editor the user is likely using
+ * This is a simple heuristic based on common patterns
+ */
+function detectEditor(): EditorType {
+  if (typeof window === "undefined") {
+    return "vscode"; // Default fallback
+  }
+
+  // Check for Cursor-specific indicators
+  // Cursor uses a different user agent or has specific window properties
+  const userAgent = navigator.userAgent.toLowerCase();
+
+  // Check URL referrer or opener for hints
+  const referrer = document.referrer.toLowerCase();
+
+  if (referrer.includes("cursor") || userAgent.includes("cursor")) {
+    return "cursor";
+  }
+
+  if (referrer.includes("vscode") || userAgent.includes("vscode")) {
+    return "vscode";
+  }
+
+  // Check localStorage for previous editor preference
+  try {
+    const savedEditor = localStorage.getItem("react-grab-editor");
+    if (savedEditor && savedEditor in EDITOR_URL_SCHEMES) {
+      return savedEditor as EditorType;
+    }
+  } catch {
+    // localStorage not available
+  }
+
+  // Default to vscode as it's most common
+  return "vscode";
+}
+
+/**
+ * Build the URL to open a file in the editor
+ */
+function buildEditorUrl(
+  editor: EditorType,
+  filePath: string,
+  lineNumber?: number,
+  column?: number,
+  customUrlScheme?: string,
+): string {
+  const scheme = customUrlScheme || EDITOR_URL_SCHEMES[editor];
+
+  if (!scheme) {
+    // Fallback to vscode if editor not found
+    return buildEditorUrl("vscode", filePath, lineNumber, column);
+  }
+
+  return scheme
+    .replace("{file}", filePath)
+    .replace("{line}", String(lineNumber || 1))
+    .replace("{column}", String(column || 1));
+}
+
+/**
+ * Open a file in the configured editor
+ */
+export function openInEditor(
+  filePath: string,
+  options?: OpenInEditorOptions & { lineNumber?: number; column?: number },
+): boolean {
+  if (!options?.enabled) {
+    return false;
+  }
+
+  const editor = options.editor === "auto" ? detectEditor() : (options.editor || "vscode");
+  const url = buildEditorUrl(
+    editor,
+    filePath,
+    options.lineNumber,
+    options.column,
+    options.customUrlScheme,
+  );
+
+  try {
+    // Use window.open for URL scheme
+    // Some browsers block window.open, so we also try location.href
+    const opened = window.open(url, "_self");
+    if (!opened) {
+      // Fallback: create a hidden link and click it
+      const link = document.createElement("a");
+      link.href = url;
+      link.style.display = "none";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    }
+    return true;
+  } catch (error) {
+    console.warn("[react-grab] Failed to open editor:", error);
+    return false;
+  }
+}
+
+/**
+ * Save user's editor preference
+ */
+export function saveEditorPreference(editor: EditorType): void {
+  try {
+    localStorage.setItem("react-grab-editor", editor);
+  } catch {
+    // localStorage not available
+  }
+}
+
+export { EDITOR_URL_SCHEMES, EDITOR_DETECTION_ORDER, detectEditor, buildEditorUrl };


### PR DESCRIPTION
## Summary

Implements the feature requested in #46 - automatically open the source file in the user's editor after copying an element.

### Changes

- Add `EditorType` and `OpenInEditorOptions` types
- Create `openInEditor` utility function with multi-editor support
- Integrate auto-open into the copy success flow
- Update README with documentation

### Supported Editors

- VS Code, Cursor, WebStorm, PhpStorm, IntelliJ IDEA, Zed, Sublime Text, Atom, Vim, Emacs
- Custom URL scheme support for unlisted editors
- Auto-detection of running editor

### Usage

```typescript
import { init } from "react-grab/core";

init({
  openInEditor: {
    enabled: true,
    editor: "auto", // or "vscode", "cursor", etc.
  },
});
```

### Implementation Details

1. After copying element context to clipboard, check if `openInEditor.enabled` is true
2. Get the file location from the first selected element
3. Build the editor-specific URL scheme and open it

This keeps the existing workflow (select → copy) and just adds the editor opening as an enhancement.

Closes #46