### PR TITLE
feat: open file in local editor when clicking component tag

### DIFF
--- a/packages/react-grab/src/components/renderer.tsx
+++ b/packages/react-grab/src/components/renderer.tsx
@@ -11,13 +11,14 @@ import { SelectionLabel } from "./selection-label.js";
 declare const __PROJECT_ROOT__: string | undefined;
 declare const __PREFERRED_EDITOR__: string | undefined;
 
-// Editor URL schemes for common frontend editors
+// Editor URL schemes for common editors
 const EDITOR_URL_SCHEMES: Record<string, string> = {
   vscode: "vscode://file{file}:{line}:{column}",
   cursor: "cursor://file{file}:{line}:{column}",
   windsurf: "windsurf://file{file}:{line}:{column}",
   trae: "trae://file{file}:{line}:{column}",
   webstorm: "webstorm://open?file={file}&line={line}&column={column}",
+  rider: "rider://open?file={file}&line={line}&column={column}",
   zed: "zed://file{file}:{line}:{column}",
 };
 

--- a/packages/react-grab/src/core.tsx
+++ b/packages/react-grab/src/core.tsx
@@ -790,6 +790,19 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
             return;
           }
 
+          // Prefer DOM attributes (added by tools like lovable-tagger)
+          const componentPath = element.getAttribute("data-component-path");
+          const componentLine = element.getAttribute("data-component-line");
+
+          if (componentPath) {
+            setSelectionFilePath(componentPath);
+            setSelectionLineNumber(
+              componentLine ? parseInt(componentLine, 10) : undefined,
+            );
+            return;
+          }
+
+          // Fallback to React Fiber stack
           getStack(element)
             .then((stack) => {
               if (!stack) return;


### PR DESCRIPTION
## Summary

Adds the ability to click on the floating label to open the selected element's source file directly in your local editor.

### Changes

1. **Click to open in editor**: When clicking the component tag in the floating label, opens the file at the component's location in your preferred editor

2. **Improved file path detection**: Prioritizes `data-component-path` and `data-component-line` DOM attributes (added by tools like lovable-tagger) over React Fiber stack traces, providing more accurate source file locations

### Supported Editors

- VS Code (default)
- Cursor
- Windsurf  
- Trae
- WebStorm
- Zed

### Configuration

Users need to configure their Vite project:

```typescript
// vite.config.ts
export default defineConfig({
  define: {
    __PROJECT_ROOT__: JSON.stringify(process.cwd()),
    __PREFERRED_EDITOR__: JSON.stringify(process.env.REACT_GRAB_EDITOR || 'vscode'),
  },
})
```

### Fallback Behavior

- If `__PROJECT_ROOT__` is not defined, falls back to opening react-grab.com/open-file
- If no DOM attributes are found, falls back to React Fiber stack trace for file path detection

Closes #50