### PR TITLE
feat: open file in local editor when clicking component tag

### DIFF
--- a/packages/react-grab/src/core.tsx
+++ b/packages/react-grab/src/core.tsx
@@ -790,6 +790,19 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
             return;
           }
 
+          // Prefer DOM attributes (added by tools like lovable-tagger)
+          const componentPath = element.getAttribute("data-component-path");
+          const componentLine = element.getAttribute("data-component-line");
+
+          if (componentPath) {
+            setSelectionFilePath(componentPath);
+            setSelectionLineNumber(
+              componentLine ? parseInt(componentLine, 10) : undefined,
+            );
+            return;
+          }
+
+          // Fallback to React Fiber stack
           getStack(element)
             .then((stack) => {
               if (!stack) return;


### PR DESCRIPTION
- Add direct editor URL scheme support (vscode, cursor, windsurf, trae, webstorm, phpstorm, idea, zed, sublime, atom)
- Use __PROJECT_ROOT__ from Vite config to build absolute file paths
- Use __PREFERRED_EDITOR__ from Vite config to select editor (default: vscode)
- Clean up localhost URL prefixes from file paths
- Fallback to react-grab.com/open-file when __PROJECT_ROOT__ is not configured