### PR TITLE
feat: add voiceMode option for auto-starting speech recognition

### DIFF
--- a/packages/react-grab/README.md
+++ b/packages/react-grab/README.md
@@ -286,6 +286,8 @@ React Grab provides an public customization API. Check out the [type definitions
 import { init } from "react-grab/core";
 
 const api = init({
+  voiceMode: true, // auto-start speech recognition when input expands
+
   theme: {
     enabled: true, // disable all UI by setting to false
     hue: 180, // shift colors by 180 degrees (pink → cyan/turquoise)

--- a/packages/react-grab/src/components/renderer.tsx
+++ b/packages/react-grab/src/components/renderer.tsx
@@ -113,6 +113,7 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
               window.open(openFileUrl, "_blank");
             }
           }}
+          voiceMode={props.voiceMode}
         />
       </Show>
 

--- a/packages/react-grab/src/components/selection-label.tsx
+++ b/packages/react-grab/src/components/selection-label.tsx
@@ -38,6 +38,7 @@ interface SelectionLabelProps {
   isPendingDismiss?: boolean;
   onConfirmDismiss?: () => void;
   onCancelDismiss?: () => void;
+  voiceMode?: boolean;
 }
 
 interface TagBadgeProps {
@@ -368,6 +369,10 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
     if (props.isInputExpanded && inputRef) {
       setTimeout(() => {
         inputRef?.focus();
+        // Auto-start voice recognition when in voiceMode
+        if (props.voiceMode && speechRecognition.isSupported()) {
+          speechRecognition.start();
+        }
       }, 0);
     } else {
       speechRecognition.stop();

--- a/packages/react-grab/src/core.tsx
+++ b/packages/react-grab/src/core.tsx
@@ -2173,6 +2173,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
             onNativeSelectionCopy={() => void handleNativeSelectionCopy()}
             onNativeSelectionEnter={handleNativeSelectionEnter}
             theme={theme()}
+            voiceMode={options.voiceMode}
           />
         ),
         rendererRoot,

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -188,6 +188,7 @@ export interface Options {
   onCrosshair?: (visible: boolean, context: CrosshairContext) => void;
   onOpenFile?: (filePath: string, lineNumber?: number) => void;
   agent?: AgentOptions;
+  voiceMode?: boolean;
 }
 
 export interface ReactGrabAPI {
@@ -268,6 +269,7 @@ export interface ReactGrabRendererProps {
   onNativeSelectionCopy?: () => void;
   onNativeSelectionEnter?: () => void;
   theme?: Required<Theme>;
+  voiceMode?: boolean;
 }
 
 export interface GrabbedBox {


### PR DESCRIPTION
## Summary
- Adds `voiceMode` option to auto-start speech recognition when the input field expands
- When enabled, users can immediately dictate prompts without clicking the mic button
- Useful for hands-free workflows with coding agents

## Changes
- Added `voiceMode?: boolean` to `Options` and `ReactGrabRendererProps` types
- Threaded the option through core.tsx → renderer.tsx → selection-label.tsx
- Auto-starts speech recognition on input expansion when `voiceMode: true`
- Added documentation to README.md

## Usage
```typescript
import { init } from "react-grab/core";

init({ voiceMode: true });
```

## Test plan
- [x] Tested in Chrome - speech recognition auto-starts when input expands
- [x] Tested in Safari - speech recognition auto-starts when input expands
- [x] Verified voiceMode defaults to off (opt-in behavior)

