### PR TITLE
fix: guard tagName.toLowerCase() against undefined element

### DIFF
--- a/packages/react-grab/src/agent.ts
+++ b/packages/react-grab/src/agent.ts
@@ -177,7 +177,7 @@ export const createAgentManager = (
     const element = document.elementFromPoint(centerX, centerY);
     if (!element) return undefined;
 
-    if (tagName && element.tagName.toLowerCase() !== tagName) {
+    if (tagName && (element.tagName || "").toLowerCase() !== tagName) {
       return undefined;
     }
 

--- a/packages/react-grab/src/context.ts
+++ b/packages/react-grab/src/context.ts
@@ -138,7 +138,7 @@ export const getElementContext = async (
 };
 
 export const getHTMLPreview = (element: Element): string => {
-  const tagName = element.tagName.toLowerCase();
+  const tagName = (element.tagName || "").toLowerCase();
   if (!(element instanceof HTMLElement)) {
     return `<${tagName} />`;
   }
@@ -180,7 +180,7 @@ export const getHTMLPreview = (element: Element): string => {
     if (elements.length === 0) return "";
     if (elements.length <= 2) {
       return elements
-        .map((el) => `<${el.tagName.toLowerCase()} ...>`)
+        .map((el) => `<${(el.tagName || "").toLowerCase()} ...>`)
         .join("\n  ");
     }
     return `(${elements.length} elements)`;

--- a/packages/react-grab/src/utils/is-selection-inside-editable-element.ts
+++ b/packages/react-grab/src/utils/is-selection-inside-editable-element.ts
@@ -1,5 +1,5 @@
 const isEditableElement = (element: Element): boolean => {
-  const tagName = element.tagName.toLowerCase();
+  const tagName = (element.tagName || "").toLowerCase();
   if (tagName === "input" || tagName === "textarea") {
     return true;
   }


### PR DESCRIPTION
## Summary

During Next.js page transitions, elements may be destroyed and `element.tagName` can become `undefined`, causing `TypeError: Cannot read properties of undefined (reading 'toLowerCase')`.

This PR adds defensive checks to **4 places** where `tagName.toLowerCase()` was called without protection:

- `context.ts:141` - `getHTMLPreview` function
- `context.ts:183` - `formatElements` helper
- `agent.ts:180` - element validation check
- `is-selection-inside-editable-element.ts:2` - `isEditableElement` function (called from `selectionchange` event)

## Changes

```diff
- const tagName = element.tagName.toLowerCase();
+ const tagName = (element.tagName || "").toLowerCase();
```

## Related

Fixes #44