### PR TITLE
docs: mention requirement to install Cursor CLI for Cursor agent integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ export default function RootLayout({ children }) {
 
 ### Cursor CLI
 
+You must have the [`cursor-agent` CLI](https://cursor.com/docs/cli/overview) installed.
+
 #### Server Setup
 
 The server runs on port `5567` and interfaces with the `cursor-agent` CLI. Add to your `package.json`:


### PR DESCRIPTION
I was debugging `spawn cursor-agent ENOENT` error, which is obvious in hindsight but seeing this in the readme would've made this easier for me.