### PR TITLE
fix(provider-cursor): use cross-spawn for Windows compatibility

### DIFF
--- a/packages/provider-cursor/package.json
+++ b/packages/provider-cursor/package.json
@@ -28,10 +28,12 @@
     "build": "rm -rf dist && NODE_ENV=production tsup"
   },
   "devDependencies": {
+    "@types/cross-spawn": "^6.0.6",
     "tsup": "^8.4.0"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.6",
+    "cross-spawn": "^7.0.6",
     "hono": "^4.0.0",
     "picocolors": "^1.1.1",
     "react-grab": "workspace:*"

--- a/packages/provider-cursor/src/server.ts
+++ b/packages/provider-cursor/src/server.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import spawn from "cross-spawn";
 import net from "node:net";
 import { pathToFileURL } from "node:url";
 import { Hono } from "hono";


### PR DESCRIPTION
## Summary
- Use `cross-spawn` package instead of native `spawn` for Windows compatibility
- This properly handles `.cmd` wrapper scripts on Windows without the security risks of `shell: true`

## Why cross-spawn over shell: true?
- **Safer**: Properly escapes arguments, preventing command injection
- **Standard**: Industry-standard solution for cross-platform spawn
- **Cleaner**: No conditional platform checks needed

## Changes
- Add `cross-spawn` dependency
- Add `@types/cross-spawn` dev dependency
- Replace `import { spawn } from "node:child_process"` with `import spawn from "cross-spawn"`


Fixes #61
Related to #45