### PR TITLE
fix(claude-code): replace cross-spawn with native child_process for Node.js v24 compatibility

### DIFF
--- a/.changeset/fix-node24-dynamic-require.md
+++ b/.changeset/fix-node24-dynamic-require.md
@@ -1,0 +1,7 @@
+---
+"@react-grab/claude-code": patch
+---
+
+fix: replace cross-spawn with native node:child_process to fix Node.js v24 compatibility
+
+The CLI was failing on Node.js v24 with "Dynamic require of child_process is not supported" because cross-spawn uses dynamic require() for native modules. Replacing it with the native node:child_process module resolves this issue.

--- a/packages/provider-claude-code/package.json
+++ b/packages/provider-claude-code/package.json
@@ -28,13 +28,11 @@
     "build": "rm -rf dist && NODE_ENV=production tsup"
   },
   "devDependencies": {
-    "@types/cross-spawn": "^6.0.6",
     "tsup": "^8.4.0"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.1.0",
     "@hono/node-server": "^1.19.6",
-    "cross-spawn": "^7.0.6",
     "fkill": "^9.0.0",
     "hono": "^4.0.0",
     "picocolors": "^1.1.1",

--- a/packages/provider-claude-code/src/cli.ts
+++ b/packages/provider-claude-code/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { join } from "node:path";
-import spawn from "cross-spawn";
+import { spawn } from "node:child_process";
 import pc from "picocolors";
 import { DEFAULT_PORT } from "./constants.js";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,9 +208,6 @@ importers:
       '@hono/node-server':
         specifier: ^1.19.6
         version: 1.19.6(hono@4.10.7)
-      cross-spawn:
-        specifier: ^7.0.6
-        version: 7.0.6
       fkill:
         specifier: ^9.0.0
         version: 9.0.0
@@ -224,9 +221,6 @@ importers:
         specifier: workspace:*
         version: link:../react-grab
     devDependencies:
-      '@types/cross-spawn':
-        specifier: ^6.0.6
-        version: 6.0.6
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -8704,7 +8698,7 @@ snapshots:
       eslint: 9.37.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.37.0(jiti@2.6.1))
@@ -8737,7 +8731,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -8806,7 +8800,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
## Summary
Fixes CLI startup failure on Node.js v24+

## Problem
The CLI fails on Node.js v24 with:
```
Error: Dynamic require of "child_process" is not supported
    at file:///.../node_modules/@react-grab/claude-code/dist/cli.js:15:9
```

This occurs because `cross-spawn` uses dynamic `require()` for native Node modules, which ESM bundles don't support in Node.js v24.

## Solution
- Replace `cross-spawn` with native `node:child_process` spawn
- Remove `cross-spawn` and `@types/cross-spawn` dependencies

The native `spawn` works identically for this use case (spawning the server process).

## Testing
- Tested on Node.js v24.7.0 (macOS Darwin 25.0.0)
- CLI starts successfully and spawns the server process
- Build completes without errors

## Workaround for users
Use version 0.0.70: `npx @react-grab/claude-code@0.0.70`