### PR TITLE
fix(provider-cursor): use cwd option instead of --workspace flag

### DIFF
--- a/packages/provider-cursor/src/server.ts
+++ b/packages/provider-cursor/src/server.ts
@@ -93,7 +93,6 @@ export const createServer = () => {
 
       const workspacePath =
         options?.workspace ?? process.env.REACT_GRAB_CWD ?? process.cwd();
-      cursorAgentArgs.push("--workspace", workspacePath);
 
       if (isFollowUp && cursorChatId) {
         cursorAgentArgs.push("--resume", cursorChatId);
@@ -110,6 +109,7 @@ export const createServer = () => {
           stdout: "pipe",
           stderr: "pipe",
           env: { ...process.env },
+          cwd: workspacePath,
         });
 
         if (sessionId) {
@@ -260,13 +260,13 @@ export const createServer = () => {
       ];
 
       const workspacePath = process.env.REACT_GRAB_CWD ?? process.cwd();
-      cursorAgentArgs.push("--workspace", workspacePath);
 
       const cursorProcess = execa("cursor-agent", cursorAgentArgs, {
         stdin: "pipe",
         stdout: "pipe",
         stderr: "pipe",
         env: { ...process.env },
+        cwd: workspacePath,
       });
 
       if (cursorProcess.stdin) {


### PR DESCRIPTION
## Summary
Fixes #67

The `cursor-agent` CLI does not support the `--workspace` option, causing the error:
```
Error: cursor-agent exited with code 1 stderr: error: unknown option '--workspace'
```

According to [Cursor's CLI documentation](https://cursor.com/docs/cli/using), the available options are `--resume`, `--print`, and `--output-format`. There is no `--workspace` flag.

## Changes
Instead of passing `--workspace` as a command line argument, this PR uses Node's `spawn` `cwd` option to set the working directory for the `cursor-agent` process.

**Before:**
```typescript
cursorAgentArgs.push("--workspace", options.workspace || process.cwd());

spawn("cursor-agent", cursorAgentArgs, {
  stdio: ["pipe", "pipe", "pipe"],
  env: { ...process.env },
});
```

**After:**
```typescript
const workingDirectory = options?.workspace || process.cwd();

spawn("cursor-agent", cursorAgentArgs, {
  stdio: ["pipe", "pipe", "pipe"],
  env: { ...process.env },
  cwd: workingDirectory,
});
```

This achieves the same result (running cursor-agent in the specified directory) without using an unsupported CLI flag.