### PR TITLE
fix(react-grab): expose styles.css in package exports

### DIFF
--- a/packages/react-grab/package.json
+++ b/packages/react-grab/package.json
@@ -45,6 +45,8 @@
         "default": "./dist/core.cjs"
       }
     },
+    "./styles.css": "./dist/styles.css",
+    "./dist/styles.css": "./dist/styles.css",
     "./dist/*": "./dist/*.js",
     "./dist/*.js": "./dist/*.js",
     "./dist/*.cjs": "./dist/*.cjs",


### PR DESCRIPTION
### Problem
Users attempting to import the required CSS file (`import "react-grab/dist/styles.css"`) in modern bundlers like Vite were encountering errors. This is because the `exports` field in `package.json` used a wildcard that only included JavaScript files (`"./dist/*": "./dist/*.js"`), effectively making the CSS file private and inaccessible to module resolvers.

### Solution
Updated `package.json` to explicitly expose the generated CSS file.
- Added `"./styles.css": "./dist/styles.css"` to allow a cleaner root import.
- Added `"./dist/styles.css": "./dist/styles.css"` to support the existing/expected path.

### Usage
Users can now import styles using either method:
```ts
// Recommended
import "react-grab/styles.css";

// or legacy path
import "react-grab/dist/styles.css";
```