### PR TITLE
fix(react-grab): enter not trigger when activate by cmd + c

### DIFF
--- a/packages/react-grab/src/core.tsx
+++ b/packages/react-grab/src/core.tsx
@@ -1741,6 +1741,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           if (isEnterCode(event.code)) {
             event.stopPropagation();
             event.stopImmediatePropagation();
+            
+            const element = frozenElement() || targetElement();
+            if (element) {
+              handleToggleExpand();
+              return;
+            }
           }
         }
 


### PR DESCRIPTION
Change-Id: Ie34ba1c52ead57fc26737f14b011b82cdc432ae2

When activate grab mode by `cmd + c`, click `Enter` won't trigger prompt input.

![20251220140548_rec_-convert](https://github.com/user-attachments/assets/cc9acee8-5148-4a53-b219-9c404070a27c)
