### PR TITLE
docs: add SSR-friendly initialization example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,32 @@ Your `index.html` could look like this:
 </html>
 ```
 
+#### Customizing (SSR Friendly - Vite, Next.js, Tanstack Start, React Router, etc.)
+
+If you want to customize options or have more control over the initialization, create a component that dynamically imports and initializes react-grab in a `useEffect`:
+
+```tsx
+import { useEffect } from "react";
+
+  useEffect(() => {
+function ReactGrabInit() {
+    // for Next.js and others:
+    // if (process.env.NODE_ENV === 'development')
+    if (import.meta.env.DEV) {
+      import("react-grab/core")
+        .then(({ init }) => init({
+          // Example: increase the amount of context lines copied
+          maxContextLines: 5
+        }))
+        .catch((err) => console.warn("Failed to load react-grab:", err));
+    }
+  }, []);
+  return null;
+}
+
+// Then render <ReactGrabInit /> in your app e.g: `root.tsx`, `_app.tsx`, `layout.tsx`
+```
+
 #### Webpack
 
 First, install React Grab:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an SSR-friendly customization section to `README.md` for initializing React Grab in frameworks (Vite, Next.js, TanStack Start, React Router).
> 
> - Introduces a `ReactGrabInit` component pattern using `useEffect` with dev-only dynamic import of `react-grab/core`
> - Demonstrates calling `init({...})` with optional config (e.g., `maxContextLines`) and where to render the component (e.g., `root.tsx`, `_app.tsx`, `layout.tsx`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f3540fa96218ea7e017e1536cbfb0b2d4388d25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an SSR-friendly initialization example to the README to help integrate react-grab in frameworks like Vite, Next, TanStack Start, and React Router.
Shows dynamic import in useEffect with dev-only loading and optional config (e.g., maxContextLines), plus guidance on where to render the init component.

<sup>Written for commit 5f3540fa96218ea7e017e1536cbfb0b2d4388d25. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



