### PR TITLE
Screenshot utility export

### DIFF
--- a/packages/react-grab/src/index.ts
+++ b/packages/react-grab/src/index.ts
@@ -6,6 +6,13 @@ export {
   DEFAULT_THEME,
 } from "./core/index.js";
 export { generateSnippet } from "./utils/generate-snippet.js";
+export {
+  captureElementScreenshot,
+  copyImageToClipboard,
+  combineBounds,
+} from "./utils/capture-screenshot.js";
+export type { ElementBounds } from "./utils/capture-screenshot.js";
+export { isScreenshotSupported } from "./utils/is-screenshot-supported.js";
 export type {
   Options,
   ReactGrabAPI,

--- a/packages/react-grab/src/utils/capture-screenshot.ts
+++ b/packages/react-grab/src/utils/capture-screenshot.ts
@@ -4,7 +4,7 @@ import {
   VIDEO_READY_TIMEOUT_MS,
 } from "../constants.js";
 
-interface ElementBounds {
+export interface ElementBounds {
   x: number;
   y: number;
   width: number;


### PR DESCRIPTION
Export screenshot utilities and the `ElementBounds` type to make them publicly available for `react-grab` users.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e643462-d794-47df-905b-440e5da54bed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6e643462-d794-47df-905b-440e5da54bed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose screenshot utilities and the ElementBounds type in the react-grab public API so apps can capture element screenshots and check support.

- **New Features**
  - Export captureElementScreenshot, copyImageToClipboard, combineBounds, and ElementBounds.
  - Export isScreenshotSupported for feature detection.

<sup>Written for commit 733afa48e85013d59f4d75ff17b5182de8c44ba1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes screenshot capabilities part of the public API for `react-grab`.
> 
> - Export `captureElementScreenshot`, `copyImageToClipboard`, and `combineBounds` from `index.ts`
> - Export `ElementBounds` type and mark its interface as `export` in `capture-screenshot.ts`
> - Export `isScreenshotSupported` for feature detection
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 733afa48e85013d59f4d75ff17b5182de8c44ba1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->