### PR TITLE
Mobile restart demo display

### DIFF
--- a/packages/website/components/demo-footer.tsx
+++ b/packages/website/components/demo-footer.tsx
@@ -19,12 +19,12 @@ export const DemoFooter = () => {
       <button
         type="button"
         onClick={handleRestartClick}
-        className="inline-flex items-center gap-1 hover:text-white/80"
+        className="hidden items-center gap-1 hover:text-white/80 sm:inline-flex"
       >
         <span className="underline underline-offset-4">restart demo</span>
         <RotateCcw size={13} className="align-middle" />
-      </button>{" "}
-      &middot;{" "}
+      </button>
+      <span className="hidden sm:inline"> &middot; </span>
       <a
         href="/blog"
         className="underline underline-offset-4 hover:text-white/80"


### PR DESCRIPTION
Hide the "restart demo" button and its separator on mobile to simplify the footer.

---
<a href="https://cursor.com/background-agent?bcId=bc-462a7625-ceb2-4e53-9366-0a9309e2a183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-462a7625-ceb2-4e53-9366-0a9309e2a183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the "restart demo" button and the separator on mobile to simplify the demo footer. They now only appear at sm+ breakpoints; the blog link stays visible.

<sup>Written for commit 20c563a0370e9b9cecb2fed87eb456f85a1c447a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies the demo footer’s mobile layout by hiding the restart control on small screens.
> 
> - Update `demo-footer.tsx` to make the `restart demo` button `hidden sm:inline-flex`
> - Replace inline middot after the button with a `span` that is `hidden sm:inline` to match responsive visibility
> - No changes to restart logic; links remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20c563a0370e9b9cecb2fed87eb456f85a1c447a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->