### PR TITLE
Runtime modifier alias normalization

### DIFF
--- a/packages/react-grab/package.json
+++ b/packages/react-grab/package.json
@@ -75,7 +75,9 @@
     "lint:fix": "eslint src/**/*.ts --fix",
     "format": "prettier --write .",
     "check": "eslint src/**/*.ts && prettier --check .",
-    "test": "playwright test",
+    "test": "vitest run && playwright test",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest",
     "publint": "publint",
     "prepublishOnly": "pnpm build",
     "test:e2e": "playwright test",
@@ -97,7 +99,8 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss": "^4.1.0",
     "tsup": "^8.2.4",
-    "typescript-eslint": "^8.46.1"
+    "typescript-eslint": "^8.46.1",
+    "vitest": "^3.2.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -73,6 +73,7 @@ import { logIntro } from "./log-intro.js";
 import { onIdle } from "../utils/on-idle.js";
 import { getScriptOptions } from "../utils/get-script-options.js";
 import { isEnterCode } from "../utils/is-enter-code.js";
+import { normalizeActivationKey } from "../utils/parse-activation-key.js";
 
 let hasInited = false;
 
@@ -83,6 +84,18 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
   const scriptOptions = getScriptOptions();
 
+  // Normalize activationKey if it's provided as a string (e.g., "Win+K")
+  const normalizedRawOptions = rawOptions
+    ? {
+        ...rawOptions,
+        activationKey: rawOptions.activationKey
+          ? (normalizeActivationKey(
+              rawOptions.activationKey as string | Options["activationKey"],
+            ) ?? rawOptions.activationKey)
+          : undefined,
+      }
+    : undefined;
+
   const initialOptions: Options = {
     enabled: true,
     activationMode: "toggle",
@@ -90,7 +103,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     allowActivationInsideInput: true,
     maxContextLines: 3,
     ...scriptOptions,
-    ...rawOptions,
+    ...normalizedRawOptions,
   };
 
   if (initialOptions.enabled === false || hasInited) {

--- a/packages/react-grab/src/index.ts
+++ b/packages/react-grab/src/index.ts
@@ -13,6 +13,11 @@ export {
 } from "./utils/capture-screenshot.js";
 export type { ElementBounds } from "./utils/capture-screenshot.js";
 export { isScreenshotSupported } from "./utils/is-screenshot-supported.js";
+export {
+  parseActivationKeyString,
+  normalizeActivationKey,
+  MODIFIER_MAP,
+} from "./utils/parse-activation-key.js";
 export type {
   Options,
   ReactGrabAPI,
@@ -35,6 +40,7 @@ export type {
   AgentCompleteResult,
   SettableOptions,
   ActivationMode,
+  ActivationKey,
   ContextMenuAction,
   ActionContext,
   Plugin,

--- a/packages/react-grab/src/utils/get-script-options.ts
+++ b/packages/react-grab/src/utils/get-script-options.ts
@@ -1,11 +1,22 @@
 import type { Options } from "../types.js";
+import { normalizeActivationKey } from "./parse-activation-key.js";
 
 export const getScriptOptions = (): Partial<Options> | null => {
   if (typeof window === "undefined") return null;
   try {
     const dataOptions = document.currentScript?.getAttribute("data-options");
     if (!dataOptions) return null;
-    return JSON.parse(dataOptions) as Partial<Options>;
+    const parsed = JSON.parse(dataOptions) as Partial<Options> & {
+      activationKey?: string | Options["activationKey"];
+    };
+    // Normalize activationKey if it's a string (e.g., "Win+K")
+    if (parsed.activationKey) {
+      const normalized = normalizeActivationKey(parsed.activationKey);
+      if (normalized) {
+        parsed.activationKey = normalized;
+      }
+    }
+    return parsed;
   } catch {
     return null;
   }

--- a/packages/react-grab/src/utils/parse-activation-key.ts
+++ b/packages/react-grab/src/utils/parse-activation-key.ts
@@ -1,0 +1,103 @@
+import type { ActivationKey } from "../types.js";
+
+/**
+ * Map of modifier aliases to their canonical KeyboardEvent property names.
+ * Includes common abbreviations and platform-specific names.
+ */
+export const MODIFIER_MAP: Record<string, keyof Omit<ActivationKey, "key">> = {
+  // Meta/Command/Windows key
+  meta: "metaKey",
+  cmd: "metaKey",
+  command: "metaKey",
+  win: "metaKey",
+  windows: "metaKey",
+  super: "metaKey",
+
+  // Control key
+  ctrl: "ctrlKey",
+  control: "ctrlKey",
+
+  // Shift key
+  shift: "shiftKey",
+
+  // Alt/Option key
+  alt: "altKey",
+  opt: "altKey",
+  option: "altKey",
+};
+
+/**
+ * Parses a string representation of an activation key combination into an ActivationKey object.
+ *
+ * @example
+ * parseActivationKeyString("Win+K") // { metaKey: true, key: "k" }
+ * parseActivationKeyString("Cmd+Shift+G") // { metaKey: true, shiftKey: true, key: "g" }
+ * parseActivationKeyString("Opt+Alt") // { altKey: true } (modifier-only)
+ * parseActivationKeyString("Ctrl+C") // { ctrlKey: true, key: "c" }
+ *
+ * @param keyString - A string like "Win+K", "Cmd+Shift+G", "Opt+K", etc.
+ * @returns An ActivationKey object with the parsed modifiers and key
+ */
+export const parseActivationKeyString = (
+  keyString: string,
+): ActivationKey | null => {
+  if (!keyString || typeof keyString !== "string") {
+    return null;
+  }
+
+  const parts = keyString.split("+").map((part) => part.trim().toLowerCase());
+  if (parts.length === 0) {
+    return null;
+  }
+
+  const result: ActivationKey = {};
+  let hasValidPart = false;
+
+  for (const part of parts) {
+    const modifierKey = MODIFIER_MAP[part];
+    if (modifierKey) {
+      result[modifierKey] = true;
+      hasValidPart = true;
+    } else if (part.length > 0) {
+      // If it's not a modifier, treat it as the key value
+      // Only set the key if we haven't already set one
+      if (!result.key) {
+        result.key = part;
+        hasValidPart = true;
+      }
+    }
+  }
+
+  return hasValidPart ? result : null;
+};
+
+/**
+ * Normalizes an activation key input to a consistent ActivationKey object.
+ * Accepts either a string (e.g., "Win+K") or an ActivationKey object.
+ *
+ * @param input - Either a string like "Win+K" or an ActivationKey object
+ * @returns An ActivationKey object, or null if the input is invalid
+ */
+export const normalizeActivationKey = (
+  input: string | ActivationKey | undefined | null,
+): ActivationKey | null => {
+  if (!input) {
+    return null;
+  }
+
+  if (typeof input === "string") {
+    return parseActivationKeyString(input);
+  }
+
+  // If it's already an object, validate it has at least one valid property
+  if (typeof input === "object") {
+    const hasModifier =
+      input.metaKey || input.ctrlKey || input.shiftKey || input.altKey;
+    const hasKey = Boolean(input.key);
+    if (hasModifier || hasKey) {
+      return input;
+    }
+  }
+
+  return null;
+};

--- a/packages/react-grab/test/parse-activation-key.test.ts
+++ b/packages/react-grab/test/parse-activation-key.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+import {
+  MODIFIER_MAP,
+  parseActivationKeyString,
+  normalizeActivationKey,
+} from "../src/utils/parse-activation-key.js";
+
+describe("MODIFIER_MAP", () => {
+  it("should map win and windows to metaKey", () => {
+    expect(MODIFIER_MAP.win).toBe("metaKey");
+    expect(MODIFIER_MAP.windows).toBe("metaKey");
+  });
+
+  it("should map cmd and command to metaKey", () => {
+    expect(MODIFIER_MAP.cmd).toBe("metaKey");
+    expect(MODIFIER_MAP.command).toBe("metaKey");
+  });
+
+  it("should map meta and super to metaKey", () => {
+    expect(MODIFIER_MAP.meta).toBe("metaKey");
+    expect(MODIFIER_MAP.super).toBe("metaKey");
+  });
+
+  it("should map ctrl and control to ctrlKey", () => {
+    expect(MODIFIER_MAP.ctrl).toBe("ctrlKey");
+    expect(MODIFIER_MAP.control).toBe("ctrlKey");
+  });
+
+  it("should map shift to shiftKey", () => {
+    expect(MODIFIER_MAP.shift).toBe("shiftKey");
+  });
+
+  it("should map alt to altKey", () => {
+    expect(MODIFIER_MAP.alt).toBe("altKey");
+  });
+
+  it("should map opt and option to altKey", () => {
+    expect(MODIFIER_MAP.opt).toBe("altKey");
+    expect(MODIFIER_MAP.option).toBe("altKey");
+  });
+});
+
+describe("parseActivationKeyString", () => {
+  it("should parse Win+K correctly", () => {
+    const result = parseActivationKeyString("Win+K");
+    expect(result).toEqual({ metaKey: true, key: "k" });
+  });
+
+  it("should parse Windows+G correctly", () => {
+    const result = parseActivationKeyString("Windows+G");
+    expect(result).toEqual({ metaKey: true, key: "g" });
+  });
+
+  it("should parse Cmd+Shift+G correctly", () => {
+    const result = parseActivationKeyString("Cmd+Shift+G");
+    expect(result).toEqual({ metaKey: true, shiftKey: true, key: "g" });
+  });
+
+  it("should parse Opt+K correctly", () => {
+    const result = parseActivationKeyString("Opt+K");
+    expect(result).toEqual({ altKey: true, key: "k" });
+  });
+
+  it("should parse Option+C correctly", () => {
+    const result = parseActivationKeyString("Option+C");
+    expect(result).toEqual({ altKey: true, key: "c" });
+  });
+
+  it("should parse Ctrl+C correctly", () => {
+    const result = parseActivationKeyString("Ctrl+C");
+    expect(result).toEqual({ ctrlKey: true, key: "c" });
+  });
+
+  it("should parse Control+Alt+Delete correctly", () => {
+    const result = parseActivationKeyString("Control+Alt+Delete");
+    expect(result).toEqual({ ctrlKey: true, altKey: true, key: "delete" });
+  });
+
+  it("should parse modifier-only combinations like Opt+Alt", () => {
+    const result = parseActivationKeyString("Opt+Alt");
+    // Both opt and alt map to altKey, so the result should just have altKey
+    expect(result).toEqual({ altKey: true });
+  });
+
+  it("should be case-insensitive", () => {
+    const result1 = parseActivationKeyString("WIN+K");
+    const result2 = parseActivationKeyString("win+k");
+    const result3 = parseActivationKeyString("Win+k");
+    expect(result1).toEqual({ metaKey: true, key: "k" });
+    expect(result2).toEqual({ metaKey: true, key: "k" });
+    expect(result3).toEqual({ metaKey: true, key: "k" });
+  });
+
+  it("should handle spaces around plus signs", () => {
+    const result = parseActivationKeyString("Win + K");
+    expect(result).toEqual({ metaKey: true, key: "k" });
+  });
+
+  it("should return null for empty string", () => {
+    expect(parseActivationKeyString("")).toBe(null);
+  });
+
+  it("should return null for null input", () => {
+    expect(parseActivationKeyString(null as unknown as string)).toBe(null);
+  });
+
+  it("should return null for undefined input", () => {
+    expect(parseActivationKeyString(undefined as unknown as string)).toBe(null);
+  });
+
+  it("should parse Super+Space correctly", () => {
+    const result = parseActivationKeyString("Super+Space");
+    expect(result).toEqual({ metaKey: true, key: "space" });
+  });
+
+  it("should handle multiple modifiers", () => {
+    const result = parseActivationKeyString("Ctrl+Shift+Alt+K");
+    expect(result).toEqual({
+      ctrlKey: true,
+      shiftKey: true,
+      altKey: true,
+      key: "k",
+    });
+  });
+
+  it("should handle all four modifiers with a key", () => {
+    const result = parseActivationKeyString("Cmd+Ctrl+Shift+Alt+K");
+    expect(result).toEqual({
+      metaKey: true,
+      ctrlKey: true,
+      shiftKey: true,
+      altKey: true,
+      key: "k",
+    });
+  });
+
+  it("should only use the first non-modifier as the key", () => {
+    const result = parseActivationKeyString("Ctrl+A+B");
+    expect(result).toEqual({ ctrlKey: true, key: "a" });
+  });
+});
+
+describe("normalizeActivationKey", () => {
+  it("should parse string input", () => {
+    const result = normalizeActivationKey("Win+K");
+    expect(result).toEqual({ metaKey: true, key: "k" });
+  });
+
+  it("should return object input as-is if valid", () => {
+    const input = { metaKey: true, key: "k" };
+    const result = normalizeActivationKey(input);
+    expect(result).toEqual(input);
+  });
+
+  it("should return object input with just modifier", () => {
+    const input = { altKey: true };
+    const result = normalizeActivationKey(input);
+    expect(result).toEqual(input);
+  });
+
+  it("should return object input with just key", () => {
+    const input = { key: "k" };
+    const result = normalizeActivationKey(input);
+    expect(result).toEqual(input);
+  });
+
+  it("should return null for empty object", () => {
+    const result = normalizeActivationKey({});
+    expect(result).toBe(null);
+  });
+
+  it("should return null for null input", () => {
+    expect(normalizeActivationKey(null)).toBe(null);
+  });
+
+  it("should return null for undefined input", () => {
+    expect(normalizeActivationKey(undefined)).toBe(null);
+  });
+
+  it("should return null for empty string", () => {
+    expect(normalizeActivationKey("")).toBe(null);
+  });
+});

--- a/packages/react-grab/vitest.config.ts
+++ b/packages/react-grab/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    exclude: ["e2e/**/*"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -442,6 +442,9 @@ importers:
       typescript-eslint:
         specifier: ^8.46.1
         version: 8.46.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@20.19.23)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
 
   packages/relay:
     dependencies:
@@ -2208,8 +2211,8 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
-  '@sourcegraph/amp@0.0.1767845655-gffe829':
-    resolution: {integrity: sha512-yyKwPHSSr3ZSrdgsvW8zhnRwE0WiR9DupSHb0SylkPoPrkE9Qqv1QkSZe3oCUQDuDPUoEv/WPJz58/zOHvidFQ==}
+  '@sourcegraph/amp@0.0.1767937288-g8b9247':
+    resolution: {integrity: sha512-JjhjK+LX2rglQPenUKx2TZVEI1/8ss+gUdTlvCpB2q3VNhcw06uE995Jt1ShVCyIFVitM1GXxro+yCKaeJKK8w==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -6205,7 +6208,7 @@ snapshots:
       '@babel/types': 7.28.5
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.0
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -6422,7 +6425,7 @@ snapshots:
       '@babel/parser': 7.28.4
       '@babel/template': 7.27.2
       '@babel/types': 7.28.5
-      debug: 4.4.0
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -7451,14 +7454,14 @@ snapshots:
 
   '@sourcegraph/amp-sdk@0.1.0-20251210081226-g90e3892':
     dependencies:
-      '@sourcegraph/amp': 0.0.1767845655-gffe829
+      '@sourcegraph/amp': 0.0.1767937288-g8b9247
       zod: 3.25.76
 
   '@sourcegraph/amp@0.0.1767830505-ga62310':
     dependencies:
       '@napi-rs/keyring': 1.1.9
 
-  '@sourcegraph/amp@0.0.1767845655-gffe829':
+  '@sourcegraph/amp@0.0.1767937288-g8b9247':
     dependencies:
       '@napi-rs/keyring': 1.1.9
 
@@ -8002,6 +8005,14 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@20.19.23)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.1(@types/node@20.19.23)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
@@ -8891,7 +8902,7 @@ snapshots:
       '@typescript-eslint/parser': 8.46.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.37.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.37.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.37.0(jiti@2.6.1))
@@ -8909,7 +8920,7 @@ snapshots:
       eslint: 9.37.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.37.0(jiti@2.6.1))
@@ -8931,22 +8942,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.37.0(jiti@2.6.1)
-      get-tsconfig: 4.13.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.37.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -8961,14 +8957,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.37.0(jiti@2.6.1)
+      get-tsconfig: 4.13.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.46.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.37.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.37.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -8993,7 +9004,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.37.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -9011,7 +9022,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11466,6 +11477,27 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite-node@3.2.4(@types/node@20.19.23)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.4.1(@types/node@20.19.23)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-node@3.2.4(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
@@ -11515,6 +11547,23 @@ snapshots:
       - terser
       - tsx
 
+  vite@6.4.1(@types/node@20.19.23)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1):
+    dependencies:
+      esbuild: 0.25.11
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.52.5
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.19.23
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.30.2
+      terser: 5.37.0
+      tsx: 4.20.6
+      yaml: 2.8.1
+
   vite@6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.11
@@ -11531,6 +11580,47 @@ snapshots:
       terser: 5.37.0
       tsx: 4.20.6
       yaml: 2.8.1
+
+  vitest@3.2.4(@types/node@20.19.23)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@20.19.23)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.2.2
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.1(@types/node@20.19.23)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@20.19.23)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.23
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@3.2.4(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:


### PR DESCRIPTION
Implement runtime parsing and normalization for string-based activation keys.

Fixes an issue where modifier aliases like `win`, `windows`, and `opt` were not recognized at runtime, causing activation keys specified as strings (e.g., `--key "Win+K"`) to be parsed incorrectly.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d7ebee8-7a7e-4970-9986-063e25363e8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9d7ebee8-7a7e-4970-9986-063e25363e8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds runtime parsing and normalization for string activation keys so modifier aliases (win/windows/opt/cmd/super/etc.) work consistently. Fixes incorrect parsing of values like "Win+K" from both options and data-options.

- **Bug Fixes**
  - Parse and normalize string activation keys (e.g., "Win+K") at runtime.
  - Recognize modifier aliases for meta, ctrl, shift, and alt (win/windows/cmd/super/ctrl/opt/option).
  - Support modifier-only combos, case-insensitive input, and spaces around "+".
  - Apply normalization in init() and getScriptOptions().
  - Expose parseActivationKeyString, normalizeActivationKey, MODIFIER_MAP, and ActivationKey in the public API.

- **Dependencies**
  - Add Vitest and unit tests for activation key parsing.
  - Update test scripts (vitest runs before Playwright) and add vitest.config.ts.

<sup>Written for commit 945982cca49a19bfadc381e32538b3cf550d8e35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

