### PR TITLE
fix: prevent form submission during IME composition

### DIFF
--- a/.changeset/fix-ime-composition.md
+++ b/.changeset/fix-ime-composition.md
@@ -1,0 +1,7 @@
+---
+"react-grab": patch
+---
+
+fix: prevent form submission during IME composition
+
+When typing CJK (Chinese, Japanese, Korean) characters using IME, pressing Enter to confirm character selection no longer incorrectly submits the form. Added `event.isComposing` check to skip form submission during active IME composition.

--- a/packages/react-grab/src/components/selection-label/completion-view.tsx
+++ b/packages/react-grab/src/components/selection-label/completion-view.tsx
@@ -68,6 +68,10 @@ export const CompletionView: Component<CompletionViewProps> = (props) => {
   };
 
   const handleInputKeyDown = (event: KeyboardEvent) => {
+    if (event.isComposing || event.keyCode === 229) {
+      return;
+    }
+
     const isUndoRedo =
       event.code === "KeyZ" && (event.metaKey || event.ctrlKey);
     const isEnterWithoutShift = event.code === "Enter" && !event.shiftKey;

--- a/packages/react-grab/src/components/selection-label/index.tsx
+++ b/packages/react-grab/src/components/selection-label/index.tsx
@@ -231,6 +231,10 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
   };
 
   const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.isComposing || event.keyCode === 229) {
+      return;
+    }
+
     event.stopPropagation();
     event.stopImmediatePropagation();
 


### PR DESCRIPTION
  Thanks for building such an awesome product!

  ## Problem

  When typing CJK (Chinese, Japanese, Korean) characters using IME, pressing Enter to confirm character selection incorrectly submits the form instead of confirming the character.

  ## Solution

  Add `event.isComposing` and `event.keyCode === 229` checks to skip form submission during active IME composition.

  - `event.isComposing` - Standard API for detecting IME composition
  - `event.keyCode === 229` - Fallback for Safari (WebKit bug [#165004](https://bugs.webkit.org/show_bug.cgi?id=165004))

  ## Changes

  - `packages/react-grab/src/components/selection-label/index.tsx` - Initial prompt input
  - `packages/react-grab/src/components/selection-label/completion-view.tsx` - Follow-up prompt input

  ## Testing

  - [x] Chrome - Verified with Japanese IME
  - [x] Safari - Verified with Japanese IME
  - [x] All 364 e2e tests passing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents accidental submissions when confirming CJK characters with IME.
> 
> - Add `event.isComposing` (with Safari fallback `event.keyCode === 229`) guards in `handleKeyDown` of `selection-label` and `handleInputKeyDown` of `completion-view` to skip Enter handling during composition
> - Add changeset for a patch release
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ffdf20c641b39215f336489161100e588c3adb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent form submission during IME composition. Enter now confirms CJK characters instead of submitting the prompt.

- **Bug Fixes**
  - Skip submit on keydown when event.isComposing or keyCode 229 (Safari fallback).
  - Applied to SelectionLabel and CompletionView inputs.

<sup>Written for commit 2ffdf20c641b39215f336489161100e588c3adb0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

