### PR TITLE
feat: make component name ignore list configurable

### DIFF
--- a/packages/react-grab/src/core/agent/manager.ts
+++ b/packages/react-grab/src/core/agent/manager.ts
@@ -5,6 +5,7 @@ import type {
   AgentSession,
   AgentOptions,
   OverlayBounds,
+  SettableOptions,
 } from "../../types.js";
 import {
   createSession,
@@ -68,6 +69,7 @@ export interface AgentManager {
 
 export const createAgentManager = (
   initialAgentOptions: AgentOptions | undefined,
+  getPluginOptions?: () => SettableOptions | undefined,
 ): AgentManager => {
   const [sessions, setSessions] = createSignal<Map<string, AgentSession>>(
     new Map(),
@@ -339,7 +341,10 @@ export const createAgentManager = (
 
     const content = existingSession
       ? existingSession.context.content
-      : await generateSnippet(elements, { maxLines: Infinity });
+      : await generateSnippet(elements, {
+        maxLines: Infinity,
+        ignoreComponents: getPluginOptions?.()?.ignoreComponents,
+      });
 
     const context: AgentContext = {
       content,
@@ -367,7 +372,10 @@ export const createAgentManager = (
       const componentName =
         elements.length > 1
           ? undefined
-          : (await getNearestComponentName(firstElement)) || undefined;
+          : (await getNearestComponentName(
+            firstElement,
+            getPluginOptions?.()?.ignoreComponents,
+          )) || undefined;
 
       session = createSession(
         context,

--- a/packages/react-grab/src/core/copy.ts
+++ b/packages/react-grab/src/core/copy.ts
@@ -1,9 +1,11 @@
 import { copyContent } from "../utils/copy-content.js";
 import { generateSnippet } from "../utils/generate-snippet.js";
+import { IgnoreComponentsOption } from "../types.js";
 
 interface CopyOptions {
   maxContextLines?: number;
   getContent?: (elements: Element[]) => Promise<string> | string;
+  ignoreComponents?: IgnoreComponentsOption;
 }
 
 interface CopyHooks {
@@ -37,6 +39,7 @@ export const tryCopyWithFallback = async (
     } else {
       const snippets = await generateSnippet(elements, {
         maxLines: options.maxContextLines,
+        ignoreComponents: options.ignoreComponents,
       });
       const combinedSnippets = snippets.join("\n\n");
 

--- a/packages/react-grab/src/core/plugin-registry.ts
+++ b/packages/react-grab/src/core/plugin-registry.ts
@@ -15,6 +15,7 @@ import type {
   ActivationMode,
   ActivationKey,
   SettableOptions,
+  IgnoreComponentsOption,
 } from "../types.js";
 import { DEFAULT_THEME, deepMergeTheme } from "./theme.js";
 import { DEFAULT_KEY_HOLD_DURATION_MS } from "../constants.js";
@@ -31,6 +32,7 @@ interface OptionsState {
   maxContextLines: number;
   activationKey: ActivationKey | undefined;
   getContent: ((elements: Element[]) => Promise<string> | string) | undefined;
+  ignoreComponents: IgnoreComponentsOption | undefined;
   freezeReactUpdates: boolean;
 }
 
@@ -41,6 +43,7 @@ const DEFAULT_OPTIONS: OptionsState = {
   maxContextLines: 3,
   activationKey: undefined,
   getContent: undefined,
+  ignoreComponents: undefined,
   freezeReactUpdates: true,
 };
 

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -275,6 +275,10 @@ export interface Plugin {
   setup?: (api: ReactGrabAPI) => PluginConfig | void;
 }
 
+export type IgnoreComponentsOption =
+  | Array<string | RegExp>
+  | ((name: string) => boolean);
+
 export interface Options {
   enabled?: boolean;
   activationMode?: ActivationMode;
@@ -283,6 +287,10 @@ export interface Options {
   maxContextLines?: number;
   activationKey?: ActivationKey;
   getContent?: (elements: Element[]) => Promise<string> | string;
+  /**
+   * Component names to ignore when searching for the nearest component.
+   */
+  ignoreComponents?: IgnoreComponentsOption;
   /**
    * Whether to freeze React state updates while React Grab is active.
    * This prevents UI changes from interfering with element selection.

--- a/packages/react-grab/src/utils/generate-snippet.ts
+++ b/packages/react-grab/src/utils/generate-snippet.ts
@@ -1,7 +1,9 @@
 import { getElementContext } from "../core/context.js";
+import { IgnoreComponentsOption } from "../types.js";
 
 interface GenerateSnippetOptions {
   maxLines?: number;
+  ignoreComponents?: IgnoreComponentsOption;
 }
 
 export const generateSnippet = async (


### PR DESCRIPTION
Closes #122. Exposes a configurable option to ignore specific component names when searching for the nearest component.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a configurable ignoreComponents option to filter out specific component names when detecting the nearest component and generating context/snippets. This improves accuracy in apps with wrapper or utility components.

- **New Features**
  - Added Options.ignoreComponents to React Grab. Accepts strings, regexes, or a predicate function.
  - Applied to getNearestComponentName, getComponentDisplayName, generateSnippet, copy, and element context.
  - AgentManager now accepts getPluginOptions to pass the option through plugins and runtime.
  - Introduced IgnoreComponentsOption type in the public API.

- **Bug Fixes**
  - Component filtering now ignores names containing “Provider” or “Context” (previously required both).

<sup>Written for commit 396586aef67139e37d26aa29311e0afb53c46c8f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

