### PR TITLE
Input bot default interaction

### DIFF
--- a/packages/react-grab/e2e/prompt-mode.spec.ts
+++ b/packages/react-grab/e2e/prompt-mode.spec.ts
@@ -28,6 +28,19 @@ test.describe("Prompt Mode", () => {
       await expect.poll(() => reactGrab.getClipboardContent()).toBeTruthy();
     });
 
+    test("single click should enter prompt mode when agent is configured", async ({
+      reactGrab,
+    }) => {
+      await reactGrab.setupMockAgent();
+      await reactGrab.activate();
+      await reactGrab.hoverElement("li:first-child");
+      await reactGrab.waitForSelectionBox();
+
+      await reactGrab.clickElement("li:first-child");
+
+      await expect.poll(() => reactGrab.isPromptModeActive()).toBe(true);
+    });
+
     test("should focus input textarea when entering prompt mode", async ({
       reactGrab,
     }) => {
@@ -144,6 +157,15 @@ test.describe("Prompt Mode", () => {
       await reactGrab.submitInput();
 
       await expect.poll(() => reactGrab.isPromptModeActive()).toBe(false);
+    });
+
+    test("empty submit should copy to clipboard", async ({ reactGrab }) => {
+      await reactGrab.setupMockAgent();
+      await reactGrab.enterPromptMode("li:first-child");
+
+      await reactGrab.submitInput();
+
+      await expect.poll(() => reactGrab.getClipboardContent()).toBeTruthy();
     });
 
     test("Escape should cancel prompt mode", async ({ reactGrab }) => {

--- a/packages/react-grab/src/components/selection-label/index.tsx
+++ b/packages/react-grab/src/components/selection-label/index.tsx
@@ -508,15 +508,12 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
                     value={props.inputValue ?? ""}
                     onInput={handleInput}
                     onKeyDown={handleKeyDown}
-                    placeholder="type prompt"
+                    placeholder="enter to copy"
                     rows={1}
                   />
                   <button
                     data-react-grab-submit
-                    class={cn(
-                      "contain-layout shrink-0 flex items-center justify-center size-4 rounded-full bg-black cursor-pointer ml-1 interactive-scale",
-                      !props.inputValue?.trim() && "opacity-35",
-                    )}
+                    class="contain-layout shrink-0 flex items-center justify-center size-4 rounded-full bg-black cursor-pointer ml-1 interactive-scale"
                     onClick={handleSubmit}
                   >
                     <IconSubmit size={10} class="text-white" />

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -1606,10 +1606,19 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       const positionX = validFrozenElement ? store.pointer.x : clientX;
       const positionY = validFrozenElement ? store.pointer.y : clientY;
 
+      actions.setLastGrabbed(element);
+
+      if (hasAgentProvider()) {
+        preparePromptMode(element, positionX, positionY);
+        actions.setPointer({ x: positionX, y: positionY });
+        actions.setFrozenElement(element);
+        activatePromptMode();
+        return;
+      }
+
       const shouldDeactivateAfter =
         store.wasActivatedByToggle && !hasModifierKeyHeld;
 
-      actions.setLastGrabbed(element);
       performCopyWithLabel({
         element,
         positionX,


### PR DESCRIPTION
Make single-click enter prompt mode by default when an agent is configured, allowing empty submission to copy.

Previously, a single click would directly copy the element when an agent was configured. This change prioritizes agent interaction by immediately showing the input bot, while still providing a clear path to copy the element by submitting an empty prompt. The placeholder text and submit button styling have been updated to reflect this new interaction flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-be15621d-3805-4995-82fa-2d87f04da083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-be15621d-3805-4995-82fa-2d87f04da083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Single-click now opens prompt mode when an agent is configured, prioritizing interaction. Submitting an empty prompt copies the element to the clipboard.

- **New Features**
  - Enter prompt mode on single click when an agent is available.
  - Empty submit copies to clipboard.
  - Placeholder updated to "enter to copy"; submit button always enabled.
  - Added e2e tests for single-click prompt mode and empty-submit copy.

<sup>Written for commit 420809d6d90ca2f70ddf1682b82c0263bed4cfb7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

