### PR TITLE
feat: persist keyboard-selected element through click for copy

### DIFF
--- a/packages/react-grab/e2e/keyboard-navigation.spec.ts
+++ b/packages/react-grab/e2e/keyboard-navigation.spec.ts
@@ -95,6 +95,35 @@ test.describe("Keyboard Navigation", () => {
     expect(clipboardContent).toBeTruthy();
   });
 
+  test("should copy keyboard-selected element when clicking after mouse movement", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.activate();
+    await reactGrab.hoverElement("[data-testid='todo-list'] li:first-child");
+    await reactGrab.waitForSelectionBox();
+
+    const initialBounds = await reactGrab.getSelectionBoxBounds();
+    expect(initialBounds).not.toBeNull();
+
+    await reactGrab.page.keyboard.press("ArrowUp");
+    await reactGrab.waitForSelectionBox();
+
+    const selectionBoundsAfterArrow = await reactGrab.getSelectionBoxBounds();
+    expect(selectionBoundsAfterArrow).not.toBeNull();
+
+    await reactGrab.page.mouse.move(10, 10);
+    await reactGrab.page.waitForTimeout(50);
+
+    await reactGrab.page.mouse.click(
+      selectionBoundsAfterArrow!.x + selectionBoundsAfterArrow!.width / 2,
+      selectionBoundsAfterArrow!.y + selectionBoundsAfterArrow!.height / 2,
+    );
+    await reactGrab.page.waitForTimeout(500);
+
+    const clipboardContent = await reactGrab.getClipboardContent();
+    expect(clipboardContent).toBeTruthy();
+  });
+
   test("should freeze selection when navigating with arrow keys", async ({
     reactGrab,
   }) => {

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -73,6 +73,13 @@ export const MODIFIER_KEYS: readonly string[] = [
   "Alt",
 ];
 
+export const ARROW_KEYS = new Set([
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+]);
+
 export const FROZEN_ELEMENT_ATTRIBUTE = "data-react-grab-frozen";
 export const IGNORE_EVENTS_ATTRIBUTE = "data-react-grab-ignore-events";
 


### PR DESCRIPTION
## Summary
- Clicking after arrow key navigation now copies the keyboard-selected element
- Arrow key navigation works when focus is on toolbar after activation
- Added `ARROW_KEYS` constant to `constants.ts`

## Test plan
- [x] E2E test added for click-to-copy after arrow navigation
- [x] All 417 tests pass
- [x] Lint passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core input handling and element selection precedence during clicks/keyboard events, which can cause subtle behavior regressions across activation/freeze/copy flows.
> 
> **Overview**
> Click-to-copy now prefers the most recent **keyboard-selected** element after arrow-key navigation, so mouse movement doesn’t cause the click to copy whatever is under the cursor; the keyboard-selected state is cleared on deactivate and after copy/context-menu copy.
> 
> Arrow navigation is tightened up by centralizing arrow-key detection in a new `ARROW_KEYS` constant, allowing navigation to work even when the key event originates from the overlay/toolbar, and handling the “no prior selection” case by starting from the viewport center. Adds an E2E regression test for clicking-to-copy after arrow navigation plus mouse movement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74d997bf6752aacc19c89c7c59a3a8375d16553c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clicking after arrow-key navigation now copies the keyboard-selected element, even after mouse movement. Arrow navigation also works when focus is on the toolbar.

- **New Features**
  - Persist keyboard-selected element through mouse movement and click; use element center for click/copy.
  - Enable arrow-key navigation when events originate from the overlay/toolbar after activation.
  - Add ARROW_KEYS constant for key checks and an E2E test for click-to-copy after arrow navigation.

<sup>Written for commit 74d997bf6752aacc19c89c7c59a3a8375d16553c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

