### PR TITLE
Proxy subroute with injection

### DIFF
--- a/packages/website/app/proxy/asset/route.ts
+++ b/packages/website/app/proxy/asset/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+  "Access-Control-Allow-Headers": "*",
+  "Access-Control-Expose-Headers": "*",
+};
+
+export const OPTIONS = (): Response => {
+  return new Response(null, {
+    status: 204,
+    headers: CORS_HEADERS,
+  });
+};
+
+export const GET = async (request: NextRequest): Promise<Response> => {
+  const targetUrl = request.nextUrl.searchParams.get("url");
+
+  if (!targetUrl) {
+    return new Response(JSON.stringify({ error: "Missing url parameter" }), {
+      status: 400,
+      headers: { ...CORS_HEADERS, "Content-Type": "application/json" },
+    });
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(targetUrl);
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid URL" }), {
+      status: 400,
+      headers: { ...CORS_HEADERS, "Content-Type": "application/json" },
+    });
+  }
+
+  if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+    return new Response(
+      JSON.stringify({ error: "Only HTTP/HTTPS supported" }),
+      {
+        status: 400,
+        headers: { ...CORS_HEADERS, "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  try {
+    const response = await fetch(targetUrl, {
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (compatible; ReactGrabProxy/1.0; +https://react-grab.com)",
+        Accept: request.headers.get("accept") || "*/*",
+        "Accept-Language": "en-US,en;q=0.5",
+      },
+      redirect: "follow",
+    });
+
+    const contentType =
+      response.headers.get("content-type") || "application/octet-stream";
+    const body = await response.arrayBuffer();
+
+    return new Response(body, {
+      status: response.status,
+      headers: {
+        ...CORS_HEADERS,
+        "Content-Type": contentType,
+        "Cache-Control": "public, max-age=31536000, immutable",
+      },
+    });
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    return new Response(JSON.stringify({ error: errorMessage }), {
+      status: 500,
+      headers: { ...CORS_HEADERS, "Content-Type": "application/json" },
+    });
+  }
+};

--- a/packages/website/app/proxy/route.ts
+++ b/packages/website/app/proxy/route.ts
@@ -1,0 +1,139 @@
+import { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+const REACT_GRAB_SCRIPT_TAG = `<script src="https://react-grab.com/script.js"></script>`;
+
+const rewriteUrlsToAbsolute = (html: string, baseUrl: URL): string => {
+  const origin = baseUrl.origin;
+  const basePath = baseUrl.pathname.replace(/\/[^/]*$/, "/");
+
+  return html
+    .replace(/(href|src|action)="\/(?!\/)/g, `$1="${origin}/`)
+    .replace(/(href|src|action)='\/(?!\/)/g, `$1='${origin}/`)
+    .replace(/(href|src|action)="\.(?!\.)/g, `$1="${origin}${basePath}`)
+    .replace(/(href|src|action)='\.(?!\.)/g, `$1='${origin}${basePath}`)
+    .replace(/url\(["']?\/(?!\/)/g, `url("${origin}/`)
+    .replace(/url\(["']?\.(?!\.)/g, `url("${origin}${basePath}`);
+};
+
+const injectReactGrabScript = (html: string): string => {
+  const headMatch = html.match(/<head[^>]*>/i);
+  if (headMatch) {
+    const headTag = headMatch[0];
+    return html.replace(headTag, `${headTag}\n${REACT_GRAB_SCRIPT_TAG}`);
+  }
+
+  const htmlMatch = html.match(/<html[^>]*>/i);
+  if (htmlMatch) {
+    const htmlTag = htmlMatch[0];
+    return html.replace(
+      htmlTag,
+      `${htmlTag}\n<head>${REACT_GRAB_SCRIPT_TAG}</head>`,
+    );
+  }
+
+  return `${REACT_GRAB_SCRIPT_TAG}\n${html}`;
+};
+
+export const GET = async (request: NextRequest): Promise<Response> => {
+  const searchParams = request.nextUrl.searchParams;
+  const targetUrl = searchParams.get("url");
+
+  if (!targetUrl) {
+    return new Response(
+      JSON.stringify({
+        error: "Missing url parameter",
+        usage: "/proxy?url=https://example.com",
+      }),
+      {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(targetUrl);
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid URL provided" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+    return new Response(
+      JSON.stringify({ error: "Only HTTP and HTTPS URLs are supported" }),
+      {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  try {
+    const response = await fetch(targetUrl, {
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (compatible; ReactGrabProxy/1.0; +https://react-grab.com)",
+        Accept:
+          "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.5",
+      },
+      redirect: "follow",
+    });
+
+    if (!response.ok) {
+      return new Response(
+        JSON.stringify({
+          error: `Failed to fetch URL: ${response.status} ${response.statusText}`,
+        }),
+        {
+          status: response.status,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const contentType = response.headers.get("content-type") || "";
+    const isHtml = contentType.includes("text/html");
+
+    if (!isHtml) {
+      return new Response(
+        JSON.stringify({
+          error: "URL does not return HTML content",
+          contentType,
+        }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    let html = await response.text();
+
+    html = rewriteUrlsToAbsolute(html, parsedUrl);
+    html = injectReactGrabScript(html);
+
+    return new Response(html, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/html; charset=utf-8",
+        "X-Proxied-From": targetUrl,
+      },
+    });
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    return new Response(
+      JSON.stringify({ error: `Failed to proxy URL: ${errorMessage}` }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+};


### PR DESCRIPTION
Add a `/proxy` route to fetch and inject React Grab into external HTML content.

This allows users to proxy any website by providing its URL as a query parameter (`/proxy?url=https://example.com`), injecting the React Grab script into the page's head, and rewriting relative URLs to absolute ones for proper asset loading.

---
[Slack Thread](https://million-js.slack.com/archives/C0A0DT6B538/p1770273688438429?thread_ts=1770273688.438429&cid=C0A0DT6B538)

<p><a href="https://cursor.com/background-agent?bcId=bc-89e98819-8cdc-52b2-af0a-e7e37e6a33a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-89e98819-8cdc-52b2-af0a-e7e37e6a33a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a /proxy route that fetches external pages, injects React Grab, and rewrites navigation to stay within the proxy. Adds an asset proxy with CORS and caching, and patches History/fetch/XHR so SPAs and assets work without CORS errors.

- **New Features**
  - Accepts url via /proxy?url=..., follows redirects.
  - Validates HTTP/HTTPS and HTML; returns JSON errors.
  - Rewrites <a>/<form>/meta-refresh to /proxy; injects <base> (preserves hash/mailto/tel/javascript).
  - Adds /proxy/asset with CORS headers and immutable caching; patches fetch/XHR to proxy asset requests and avoid CORS.
  - Patches History API to proxy SPA navigation and prevent SecurityError; responses send text/html and X-Proxied-From; routes are force-dynamic.

<sup>Written for commit 6280b2329bec7cafc6885af313a4325918f68be3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

