### PR TITLE
feat: add WSS support for HTTPS environments

### DIFF
--- a/packages/gym/.gitignore
+++ b/packages/gym/.gitignore
@@ -1,1 +1,3 @@
 .next
+
+certificates

--- a/packages/provider-amp/src/cli.ts
+++ b/packages/provider-amp/src/cli.ts
@@ -1,10 +1,4 @@
 #!/usr/bin/env node
-import { realpathSync } from "node:fs";
-import { dirname, join } from "node:path";
 import { spawnDetachedServer } from "@react-grab/utils/server";
 
-const realScriptPath = realpathSync(process.argv[1]);
-const scriptDir = dirname(realScriptPath);
-const serverPath = join(scriptDir, "server.cjs");
-
-spawnDetachedServer(serverPath);
+spawnDetachedServer();

--- a/packages/provider-amp/src/cli.ts
+++ b/packages/provider-amp/src/cli.ts
@@ -1,17 +1,10 @@
 #!/usr/bin/env node
-import { spawn } from "node:child_process";
 import { realpathSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { spawnDetachedServer } from "@react-grab/utils/server";
 
 const realScriptPath = realpathSync(process.argv[1]);
 const scriptDir = dirname(realScriptPath);
 const serverPath = join(scriptDir, "server.cjs");
-const userArgs = process.argv.slice(2);
 
-const child = spawn(process.execPath, [serverPath, ...userArgs], {
-  detached: true,
-  stdio: "inherit",
-});
-
-child.unref();
-process.exit(0);
+spawnDetachedServer(serverPath);

--- a/packages/provider-amp/src/cli.ts
+++ b/packages/provider-amp/src/cli.ts
@@ -6,8 +6,9 @@ import { dirname, join } from "node:path";
 const realScriptPath = realpathSync(process.argv[1]);
 const scriptDir = dirname(realScriptPath);
 const serverPath = join(scriptDir, "server.cjs");
+const userArgs = process.argv.slice(2);
 
-const child = spawn(process.execPath, [serverPath], {
+const child = spawn(process.execPath, [serverPath, ...userArgs], {
   detached: true,
   stdio: "inherit",
 });

--- a/packages/provider-amp/src/server.ts
+++ b/packages/provider-amp/src/server.ts
@@ -2,8 +2,10 @@
 import { connectRelay } from "@react-grab/relay";
 import { ampAgentHandler } from "./handler.js";
 
+const isSecureConnection = process.argv.includes("--secure");
+
 fetch(
   `https://www.react-grab.com/api/version?source=amp&t=${Date.now()}`,
 ).catch(() => {});
 
-connectRelay({ handler: ampAgentHandler });
+connectRelay({ handler: ampAgentHandler, secure: isSecureConnection });

--- a/packages/provider-claude-code/src/cli.ts
+++ b/packages/provider-claude-code/src/cli.ts
@@ -1,10 +1,4 @@
 #!/usr/bin/env node
-import { realpathSync } from "node:fs";
-import { dirname, join } from "node:path";
 import { spawnDetachedServer } from "@react-grab/utils/server";
 
-const realScriptPath = realpathSync(process.argv[1]);
-const scriptDir = dirname(realScriptPath);
-const serverPath = join(scriptDir, "server.cjs");
-
-spawnDetachedServer(serverPath);
+spawnDetachedServer();

--- a/packages/provider-claude-code/src/cli.ts
+++ b/packages/provider-claude-code/src/cli.ts
@@ -1,17 +1,10 @@
 #!/usr/bin/env node
-import { spawn } from "node:child_process";
 import { realpathSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { spawnDetachedServer } from "@react-grab/utils/server";
 
 const realScriptPath = realpathSync(process.argv[1]);
 const scriptDir = dirname(realScriptPath);
 const serverPath = join(scriptDir, "server.cjs");
-const userArgs = process.argv.slice(2);
 
-const child = spawn(process.execPath, [serverPath, ...userArgs], {
-  detached: true,
-  stdio: "inherit",
-});
-
-child.unref();
-process.exit(0);
+spawnDetachedServer(serverPath);

--- a/packages/provider-claude-code/src/cli.ts
+++ b/packages/provider-claude-code/src/cli.ts
@@ -6,8 +6,9 @@ import { dirname, join } from "node:path";
 const realScriptPath = realpathSync(process.argv[1]);
 const scriptDir = dirname(realScriptPath);
 const serverPath = join(scriptDir, "server.cjs");
+const userArgs = process.argv.slice(2);
 
-const child = spawn(process.execPath, [serverPath], {
+const child = spawn(process.execPath, [serverPath, ...userArgs], {
   detached: true,
   stdio: "inherit",
 });

--- a/packages/provider-claude-code/src/server.ts
+++ b/packages/provider-claude-code/src/server.ts
@@ -2,8 +2,10 @@
 import { connectRelay } from "@react-grab/relay";
 import { claudeAgentHandler } from "./handler.js";
 
+const isSecureConnection = process.argv.includes("--secure");
+
 fetch(
   `https://www.react-grab.com/api/version?source=claude-code&t=${Date.now()}`,
 ).catch(() => {});
 
-connectRelay({ handler: claudeAgentHandler });
+connectRelay({ handler: claudeAgentHandler, secure: isSecureConnection });

--- a/packages/provider-codex/src/cli.ts
+++ b/packages/provider-codex/src/cli.ts
@@ -1,10 +1,4 @@
 #!/usr/bin/env node
-import { realpathSync } from "node:fs";
-import { dirname, join } from "node:path";
 import { spawnDetachedServer } from "@react-grab/utils/server";
 
-const realScriptPath = realpathSync(process.argv[1]);
-const scriptDir = dirname(realScriptPath);
-const serverPath = join(scriptDir, "server.cjs");
-
-spawnDetachedServer(serverPath);
+spawnDetachedServer();

--- a/packages/provider-codex/src/cli.ts
+++ b/packages/provider-codex/src/cli.ts
@@ -1,17 +1,10 @@
 #!/usr/bin/env node
-import { spawn } from "node:child_process";
 import { realpathSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { spawnDetachedServer } from "@react-grab/utils/server";
 
 const realScriptPath = realpathSync(process.argv[1]);
 const scriptDir = dirname(realScriptPath);
 const serverPath = join(scriptDir, "server.cjs");
-const userArgs = process.argv.slice(2);
 
-const child = spawn(process.execPath, [serverPath, ...userArgs], {
-  detached: true,
-  stdio: "inherit",
-});
-
-child.unref();
-process.exit(0);
+spawnDetachedServer(serverPath);

--- a/packages/provider-codex/src/cli.ts
+++ b/packages/provider-codex/src/cli.ts
@@ -6,8 +6,9 @@ import { dirname, join } from "node:path";
 const realScriptPath = realpathSync(process.argv[1]);
 const scriptDir = dirname(realScriptPath);
 const serverPath = join(scriptDir, "server.cjs");
+const userArgs = process.argv.slice(2);
 
-const child = spawn(process.execPath, [serverPath], {
+const child = spawn(process.execPath, [serverPath, ...userArgs], {
   detached: true,
   stdio: "inherit",
 });

--- a/packages/provider-codex/src/server.ts
+++ b/packages/provider-codex/src/server.ts
@@ -2,8 +2,10 @@
 import { connectRelay } from "@react-grab/relay";
 import { codexAgentHandler } from "./handler.js";
 
+const isSecureConnection = process.argv.includes("--secure");
+
 fetch(
   `https://www.react-grab.com/api/version?source=codex&t=${Date.now()}`,
 ).catch(() => {});
 
-connectRelay({ handler: codexAgentHandler });
+connectRelay({ handler: codexAgentHandler, secure: isSecureConnection });

--- a/packages/provider-cursor/src/cli.ts
+++ b/packages/provider-cursor/src/cli.ts
@@ -1,10 +1,4 @@
 #!/usr/bin/env node
-import { realpathSync } from "node:fs";
-import { dirname, join } from "node:path";
 import { spawnDetachedServer } from "@react-grab/utils/server";
 
-const realScriptPath = realpathSync(process.argv[1]);
-const scriptDir = dirname(realScriptPath);
-const serverPath = join(scriptDir, "server.cjs");
-
-spawnDetachedServer(serverPath);
+spawnDetachedServer();

--- a/packages/provider-cursor/src/cli.ts
+++ b/packages/provider-cursor/src/cli.ts
@@ -1,17 +1,10 @@
 #!/usr/bin/env node
-import { spawn } from "node:child_process";
 import { realpathSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { spawnDetachedServer } from "@react-grab/utils/server";
 
 const realScriptPath = realpathSync(process.argv[1]);
 const scriptDir = dirname(realScriptPath);
 const serverPath = join(scriptDir, "server.cjs");
-const userArgs = process.argv.slice(2);
 
-const child = spawn(process.execPath, [serverPath, ...userArgs], {
-  detached: true,
-  stdio: "inherit",
-});
-
-child.unref();
-process.exit(0);
+spawnDetachedServer(serverPath);

--- a/packages/provider-cursor/src/cli.ts
+++ b/packages/provider-cursor/src/cli.ts
@@ -6,8 +6,9 @@ import { dirname, join } from "node:path";
 const realScriptPath = realpathSync(process.argv[1]);
 const scriptDir = dirname(realScriptPath);
 const serverPath = join(scriptDir, "server.cjs");
+const userArgs = process.argv.slice(2);
 
-const child = spawn(process.execPath, [serverPath], {
+const child = spawn(process.execPath, [serverPath, ...userArgs], {
   detached: true,
   stdio: "inherit",
 });

--- a/packages/provider-cursor/src/server.ts
+++ b/packages/provider-cursor/src/server.ts
@@ -2,8 +2,10 @@
 import { connectRelay } from "@react-grab/relay";
 import { cursorAgentHandler } from "./handler.js";
 
+const isSecureConnection = process.argv.includes("--secure");
+
 fetch(
   `https://www.react-grab.com/api/version?source=cursor&t=${Date.now()}`,
 ).catch(() => {});
 
-connectRelay({ handler: cursorAgentHandler });
+connectRelay({ handler: cursorAgentHandler, secure: isSecureConnection });

--- a/packages/provider-droid/src/cli.ts
+++ b/packages/provider-droid/src/cli.ts
@@ -1,10 +1,4 @@
 #!/usr/bin/env node
-import { realpathSync } from "node:fs";
-import { dirname, join } from "node:path";
 import { spawnDetachedServer } from "@react-grab/utils/server";
 
-const realScriptPath = realpathSync(process.argv[1]);
-const scriptDir = dirname(realScriptPath);
-const serverPath = join(scriptDir, "server.cjs");
-
-spawnDetachedServer(serverPath);
+spawnDetachedServer();

--- a/packages/provider-droid/src/cli.ts
+++ b/packages/provider-droid/src/cli.ts
@@ -1,17 +1,10 @@
 #!/usr/bin/env node
-import { spawn } from "node:child_process";
 import { realpathSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { spawnDetachedServer } from "@react-grab/utils/server";
 
 const realScriptPath = realpathSync(process.argv[1]);
 const scriptDir = dirname(realScriptPath);
 const serverPath = join(scriptDir, "server.cjs");
-const userArgs = process.argv.slice(2);
 
-const child = spawn(process.execPath, [serverPath, ...userArgs], {
-  detached: true,
-  stdio: "inherit",
-});
-
-child.unref();
-process.exit(0);
+spawnDetachedServer(serverPath);

--- a/packages/provider-droid/src/cli.ts
+++ b/packages/provider-droid/src/cli.ts
@@ -6,8 +6,9 @@ import { dirname, join } from "node:path";
 const realScriptPath = realpathSync(process.argv[1]);
 const scriptDir = dirname(realScriptPath);
 const serverPath = join(scriptDir, "server.cjs");
+const userArgs = process.argv.slice(2);
 
-const child = spawn(process.execPath, [serverPath], {
+const child = spawn(process.execPath, [serverPath, ...userArgs], {
   detached: true,
   stdio: "inherit",
 });

--- a/packages/provider-droid/src/server.ts
+++ b/packages/provider-droid/src/server.ts
@@ -2,8 +2,10 @@
 import { connectRelay } from "@react-grab/relay";
 import { droidAgentHandler } from "./handler.js";
 
+const isSecureConnection = process.argv.includes("--secure");
+
 fetch(
   `https://www.react-grab.com/api/version?source=droid&t=${Date.now()}`,
 ).catch(() => {});
 
-connectRelay({ handler: droidAgentHandler });
+connectRelay({ handler: droidAgentHandler, secure: isSecureConnection });

--- a/packages/provider-gemini/src/cli.ts
+++ b/packages/provider-gemini/src/cli.ts
@@ -1,10 +1,4 @@
 #!/usr/bin/env node
-import { realpathSync } from "node:fs";
-import { dirname, join } from "node:path";
 import { spawnDetachedServer } from "@react-grab/utils/server";
 
-const realScriptPath = realpathSync(process.argv[1]);
-const scriptDir = dirname(realScriptPath);
-const serverPath = join(scriptDir, "server.cjs");
-
-spawnDetachedServer(serverPath);
+spawnDetachedServer();

--- a/packages/provider-gemini/src/cli.ts
+++ b/packages/provider-gemini/src/cli.ts
@@ -1,17 +1,10 @@
 #!/usr/bin/env node
-import { spawn } from "node:child_process";
 import { realpathSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { spawnDetachedServer } from "@react-grab/utils/server";
 
 const realScriptPath = realpathSync(process.argv[1]);
 const scriptDir = dirname(realScriptPath);
 const serverPath = join(scriptDir, "server.cjs");
-const userArgs = process.argv.slice(2);
 
-const child = spawn(process.execPath, [serverPath, ...userArgs], {
-  detached: true,
-  stdio: "inherit",
-});
-
-child.unref();
-process.exit(0);
+spawnDetachedServer(serverPath);

--- a/packages/provider-gemini/src/cli.ts
+++ b/packages/provider-gemini/src/cli.ts
@@ -6,8 +6,9 @@ import { dirname, join } from "node:path";
 const realScriptPath = realpathSync(process.argv[1]);
 const scriptDir = dirname(realScriptPath);
 const serverPath = join(scriptDir, "server.cjs");
+const userArgs = process.argv.slice(2);
 
-const child = spawn(process.execPath, [serverPath], {
+const child = spawn(process.execPath, [serverPath, ...userArgs], {
   detached: true,
   stdio: "inherit",
 });

--- a/packages/provider-gemini/src/server.ts
+++ b/packages/provider-gemini/src/server.ts
@@ -2,8 +2,10 @@
 import { connectRelay } from "@react-grab/relay";
 import { geminiAgentHandler } from "./handler.js";
 
+const isSecureConnection = process.argv.includes("--secure");
+
 fetch(
   `https://www.react-grab.com/api/version?source=gemini&t=${Date.now()}`,
 ).catch(() => {});
 
-connectRelay({ handler: geminiAgentHandler });
+connectRelay({ handler: geminiAgentHandler, secure: isSecureConnection });

--- a/packages/provider-opencode/src/cli.ts
+++ b/packages/provider-opencode/src/cli.ts
@@ -1,10 +1,4 @@
 #!/usr/bin/env node
-import { realpathSync } from "node:fs";
-import { dirname, join } from "node:path";
 import { spawnDetachedServer } from "@react-grab/utils/server";
 
-const realScriptPath = realpathSync(process.argv[1]);
-const scriptDir = dirname(realScriptPath);
-const serverPath = join(scriptDir, "server.cjs");
-
-spawnDetachedServer(serverPath);
+spawnDetachedServer();

--- a/packages/provider-opencode/src/cli.ts
+++ b/packages/provider-opencode/src/cli.ts
@@ -1,17 +1,10 @@
 #!/usr/bin/env node
-import { spawn } from "node:child_process";
 import { realpathSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { spawnDetachedServer } from "@react-grab/utils/server";
 
 const realScriptPath = realpathSync(process.argv[1]);
 const scriptDir = dirname(realScriptPath);
 const serverPath = join(scriptDir, "server.cjs");
-const userArgs = process.argv.slice(2);
 
-const child = spawn(process.execPath, [serverPath, ...userArgs], {
-  detached: true,
-  stdio: "inherit",
-});
-
-child.unref();
-process.exit(0);
+spawnDetachedServer(serverPath);

--- a/packages/provider-opencode/src/cli.ts
+++ b/packages/provider-opencode/src/cli.ts
@@ -6,8 +6,9 @@ import { dirname, join } from "node:path";
 const realScriptPath = realpathSync(process.argv[1]);
 const scriptDir = dirname(realScriptPath);
 const serverPath = join(scriptDir, "server.cjs");
+const userArgs = process.argv.slice(2);
 
-const child = spawn(process.execPath, [serverPath], {
+const child = spawn(process.execPath, [serverPath, ...userArgs], {
   detached: true,
   stdio: "inherit",
 });

--- a/packages/provider-opencode/src/server.ts
+++ b/packages/provider-opencode/src/server.ts
@@ -2,8 +2,10 @@
 import { connectRelay } from "@react-grab/relay";
 import { openCodeAgentHandler } from "./handler.js";
 
+const isSecureConnection = process.argv.includes("--secure");
+
 fetch(
   `https://www.react-grab.com/api/version?source=opencode&t=${Date.now()}`,
 ).catch(() => {});
 
-connectRelay({ handler: openCodeAgentHandler });
+connectRelay({ handler: openCodeAgentHandler, secure: isSecureConnection });

--- a/packages/react-grab/e2e/freeze-animations.spec.ts
+++ b/packages/react-grab/e2e/freeze-animations.spec.ts
@@ -9,8 +9,9 @@ test.describe("Freeze Animations", () => {
     }) => {
       const getPageAnimationStates = async () => {
         return reactGrab.page.evaluate((attrName) => {
-          return document.getAnimations().reduce<string[]>(
-            (states, animation) => {
+          return document
+            .getAnimations()
+            .reduce<string[]>((states, animation) => {
               if (animation.effect instanceof KeyframeEffect) {
                 const target = animation.effect.target;
                 if (target instanceof Element) {
@@ -25,9 +26,7 @@ test.describe("Freeze Animations", () => {
               }
               states.push(animation.playState);
               return states;
-            },
-            [],
-          );
+            }, []);
         }, ATTRIBUTE_NAME);
       };
 

--- a/packages/react-grab/src/components/toolbar/index.tsx
+++ b/packages/react-grab/src/components/toolbar/index.tsx
@@ -456,7 +456,9 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
     props.onToggleEnabled?.();
 
     if (expandableWidth > 0) {
-      const widthChange = isCurrentlyEnabled ? -expandableWidth : expandableWidth;
+      const widthChange = isCurrentlyEnabled
+        ? -expandableWidth
+        : expandableWidth;
       expandedDimensions = {
         width: expandedDimensions.width + widthChange,
         height: expandedDimensions.height,
@@ -465,9 +467,15 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
 
     if (shouldCompensatePosition) {
       const viewport = getVisualViewport();
-      const positionOffset = isCurrentlyEnabled ? expandableWidth : -expandableWidth;
+      const positionOffset = isCurrentlyEnabled
+        ? expandableWidth
+        : -expandableWidth;
       const clampMin = viewport.offsetLeft + TOOLBAR_SNAP_MARGIN_PX;
-      const clampMax = viewport.offsetLeft + viewport.width - expandedDimensions.width - TOOLBAR_SNAP_MARGIN_PX;
+      const clampMax =
+        viewport.offsetLeft +
+        viewport.width -
+        expandedDimensions.width -
+        TOOLBAR_SNAP_MARGIN_PX;
       const compensatedX = clampToViewport(
         preTogglePosition.x + positionOffset,
         clampMin,

--- a/packages/relay/src/client.ts
+++ b/packages/relay/src/client.ts
@@ -31,9 +31,12 @@ interface RelayClientOptions {
 }
 
 const getDefaultWebSocketUrl = (): string => {
-  const isSecure =
-    typeof window !== "undefined" && window.location.protocol === "https:";
-  return `${isSecure ? "wss" : "ws"}://localhost:${DEFAULT_RELAY_PORT}`;
+  if (typeof window === "undefined") {
+    return `ws://localhost:${DEFAULT_RELAY_PORT}`;
+  }
+  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  const hostname = window.location.hostname;
+  return `${protocol}//${hostname}:${DEFAULT_RELAY_PORT}`;
 };
 
 export const createRelayClient = (

--- a/packages/relay/src/client.ts
+++ b/packages/relay/src/client.ts
@@ -126,7 +126,10 @@ export const createRelayClient = (
         }
         return;
       } catch {
-        return;
+        await new Promise((resolve) =>
+          setTimeout(resolve, UPGRADE_RETRY_DELAY_MS),
+        );
+        continue;
       }
     }
   };

--- a/packages/relay/src/client.ts
+++ b/packages/relay/src/client.ts
@@ -134,6 +134,8 @@ export const createRelayClient = (
         return;
       }
     }
+
+    throw new Error("Server upgrade timed out after maximum retries");
   };
 
   const connect = (): Promise<void> => {
@@ -149,6 +151,10 @@ export const createRelayClient = (
 
     pendingConnectionPromise = (async () => {
       await ensureServerReady();
+
+      if (isIntentionalDisconnect) {
+        throw new Error("Connection aborted");
+      }
 
       return new Promise<void>((resolve, reject) => {
         pendingConnectionReject = reject;

--- a/packages/relay/src/client.ts
+++ b/packages/relay/src/client.ts
@@ -110,7 +110,12 @@ export const createRelayClient = (
     for (let attempt = 0; attempt < MAX_UPGRADE_RETRIES; attempt++) {
       try {
         const response = await fetch(healthUrl);
-        if (!response.ok) continue;
+        if (!response.ok) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, UPGRADE_RETRY_DELAY_MS),
+          );
+          continue;
+        }
 
         const data = (await response.json()) as { status: string };
         if (data.status === "upgrading") {

--- a/packages/relay/src/client.ts
+++ b/packages/relay/src/client.ts
@@ -42,9 +42,7 @@ const getDefaultWebSocketUrl = (): string => {
 };
 
 const getHealthCheckUrl = (wsUrl: string, token?: string): string => {
-  const url = new URL(
-    wsUrl.replace(/^wss:/, "https:").replace(/^ws:/, "http:"),
-  );
+  const url = new URL(wsUrl.replace(/^wss?:/, "http:"));
   url.pathname = "/health";
   if (isSecureContext()) {
     url.searchParams.set("secure", "true");

--- a/packages/relay/src/client.ts
+++ b/packages/relay/src/client.ts
@@ -42,7 +42,8 @@ const getDefaultWebSocketUrl = (): string => {
 };
 
 const getHealthCheckUrl = (wsUrl: string, token?: string): string => {
-  const url = new URL(wsUrl.replace(/^wss?:/, "http:"));
+  const httpProtocol = wsUrl.startsWith("wss:") ? "https:" : "http:";
+  const url = new URL(wsUrl.replace(/^wss?:/, httpProtocol));
   url.pathname = "/health";
   if (isSecureContext()) {
     url.searchParams.set("secure", "true");

--- a/packages/relay/src/client.ts
+++ b/packages/relay/src/client.ts
@@ -30,10 +30,16 @@ interface RelayClientOptions {
   token?: string;
 }
 
+const getDefaultWebSocketUrl = (): string => {
+  const isSecure =
+    typeof window !== "undefined" && window.location.protocol === "https:";
+  return `${isSecure ? "wss" : "ws"}://localhost:${DEFAULT_RELAY_PORT}`;
+};
+
 export const createRelayClient = (
   options: RelayClientOptions = {},
 ): RelayClient => {
-  const serverUrl = options.serverUrl ?? `ws://localhost:${DEFAULT_RELAY_PORT}`;
+  const serverUrl = options.serverUrl ?? getDefaultWebSocketUrl();
   const autoReconnect = options.autoReconnect ?? true;
   const reconnectIntervalMs =
     options.reconnectIntervalMs ?? DEFAULT_RECONNECT_INTERVAL_MS;

--- a/packages/relay/src/client.ts
+++ b/packages/relay/src/client.ts
@@ -131,7 +131,6 @@ export const createRelayClient = (
           );
           continue;
         }
-        return;
       }
     }
 

--- a/packages/relay/src/connection.ts
+++ b/packages/relay/src/connection.ts
@@ -33,10 +33,20 @@ const checkIfRelayServerIsRunning = async (
     const healthUrl = token
       ? `${httpProtocol}://localhost:${port}/health?${RELAY_TOKEN_PARAM}=${encodeURIComponent(token)}`
       : `${httpProtocol}://localhost:${port}/health`;
-    const response = await fetch(healthUrl, {
+
+    const fetchOptions: RequestInit & { dispatcher?: unknown } = {
       method: "GET",
       signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS),
-    });
+    };
+
+    if (secure) {
+      const { Agent } = await import("undici");
+      fetchOptions.dispatcher = new Agent({
+        connect: { rejectUnauthorized: false },
+      });
+    }
+
+    const response = await fetch(healthUrl, fetchOptions);
     return response.ok;
   } catch {
     return false;

--- a/packages/relay/src/connection.ts
+++ b/packages/relay/src/connection.ts
@@ -182,13 +182,13 @@ export const connectRelay = async (
         relayPort,
         handler,
         token,
-        useSecure,
+        isNowRunning.isSecure,
       );
     }
   };
 
   if (isRelayServerRunning) {
-    const actualSecure = secure ?? detectedSecure;
+    const actualSecure = detectedSecure ?? secure;
     relayServer = await connectToExistingRelay(
       relayPort,
       handler,

--- a/packages/relay/src/connection.ts
+++ b/packages/relay/src/connection.ts
@@ -177,12 +177,14 @@ export const connectRelay = async (
   };
 
   if (isRelayServerRunning) {
+    const actualSecure = detectedSecure ?? secure;
     relayServer = await connectToExistingRelay(
       relayPort,
       handler,
       token,
-      detectedSecure ?? secure,
+      actualSecure,
     );
+    isSecureMode = actualSecure ?? false;
   } else {
     await fkill(`:${relayPort}`, { force: true, silent: true }).catch(() => {});
     await sleep(POST_KILL_DELAY_MS);

--- a/packages/relay/src/connection.ts
+++ b/packages/relay/src/connection.ts
@@ -91,17 +91,25 @@ export const connectRelay = async (
 
       await relayServer?.stop();
 
-      relayServer = createRelayServer({
-        port: relayPort,
-        token,
-        secure: true,
-        onSecureUpgradeRequested,
-        certHostnames,
-      });
-      relayServer.registerHandler(handler);
-      await relayServer.start();
+      try {
+        relayServer = createRelayServer({
+          port: relayPort,
+          token,
+          secure: true,
+          onSecureUpgradeRequested,
+          certHostnames,
+        });
+        relayServer.registerHandler(handler);
+        await relayServer.start();
 
-      printStartupMessage(handler.agentId, relayPort, true);
+        printStartupMessage(handler.agentId, relayPort, true);
+      } catch (error) {
+        console.error(
+          pc.red("Failed to upgrade to HTTPS:"),
+          error instanceof Error ? error.message : error,
+        );
+        process.exit(1);
+      }
     };
 
     relayServer = createRelayServer({

--- a/packages/relay/src/connection.ts
+++ b/packages/relay/src/connection.ts
@@ -17,6 +17,7 @@ interface ConnectRelayOptions {
   handler: AgentHandler;
   token?: string;
   secure?: boolean;
+  certHostnames?: string[];
 }
 
 interface RelayConnection {
@@ -64,7 +65,7 @@ export const connectRelay = async (
   options: ConnectRelayOptions,
 ): Promise<RelayConnection> => {
   const relayPort = options.port ?? DEFAULT_RELAY_PORT;
-  const { handler, token, secure } = options;
+  const { handler, token, secure, certHostnames } = options;
 
   let relayServer: RelayServer | null = null;
   let isRelayHost = false;
@@ -80,6 +81,7 @@ export const connectRelay = async (
   const startServer = async (useSecure: boolean): Promise<void> => {
     const onSecureUpgradeRequested = async () => {
       if (isSecureMode || !isRelayHost) return;
+      isSecureMode = true;
 
       console.log(
         pc.yellow(
@@ -88,13 +90,13 @@ export const connectRelay = async (
       );
 
       await relayServer?.stop();
-      isSecureMode = true;
 
       relayServer = createRelayServer({
         port: relayPort,
         token,
         secure: true,
         onSecureUpgradeRequested,
+        certHostnames,
       });
       relayServer.registerHandler(handler);
       await relayServer.start();
@@ -107,6 +109,7 @@ export const connectRelay = async (
       token,
       secure: useSecure,
       onSecureUpgradeRequested,
+      certHostnames,
     });
     relayServer.registerHandler(handler);
 

--- a/packages/relay/src/connection.ts
+++ b/packages/relay/src/connection.ts
@@ -36,6 +36,7 @@ const checkIfRelayServerIsRunning = async (
       : `${httpProtocol}://localhost:${port}/health`;
 
     if (secure) {
+      // HACK: rejectUnauthorized: false is needed because mkcert generates self-signed certs
       const https = await import("node:https");
       return new Promise((resolve) => {
         const request = https.get(
@@ -104,6 +105,7 @@ export const connectRelay = async (
 
         printStartupMessage(handler.agentId, relayPort, true);
       } catch (error) {
+        // HACK: process.exit(1) because the old HTTP server is already stopped, so fallback isn't possible
         console.error(
           pc.red("Failed to upgrade to HTTPS:"),
           error instanceof Error ? error.message : error,
@@ -203,6 +205,7 @@ const connectToExistingRelay = async (
     const connectionUrl = token
       ? `${webSocketProtocol}://localhost:${port}?${RELAY_TOKEN_PARAM}=${encodeURIComponent(token)}`
       : `${webSocketProtocol}://localhost:${port}`;
+    // HACK: rejectUnauthorized: false is needed because mkcert generates self-signed certs
     const socket = new WebSocket(connectionUrl, {
       headers: { "x-relay-handler": "true" },
       rejectUnauthorized: false,

--- a/packages/relay/src/mkcert.ts
+++ b/packages/relay/src/mkcert.ts
@@ -85,6 +85,9 @@ export interface Certificate {
 const CA_INSTALLED_FLAG = join(DATA_DIR, ".ca-installed");
 
 const validateHostname = (hostname: string): void => {
+  if (hostname.startsWith("-")) {
+    throw new Error(`Invalid hostname (leading hyphen): ${hostname}`);
+  }
   if (!/^[a-zA-Z0-9.-]+$/.test(hostname)) {
     throw new Error(`Invalid hostname: ${hostname}`);
   }
@@ -131,7 +134,7 @@ export const ensureCertificates = async (
 
   if (shouldRegenerateCerts) {
     await runMkcert(
-      `-key-file "${KEY_PATH}" -cert-file "${CERT_PATH}" ${hosts.join(" ")}`,
+      `-key-file "${KEY_PATH}" -cert-file "${CERT_PATH}" -- ${hosts.join(" ")}`,
     );
     await writeFile(HOSTS_METADATA_PATH, JSON.stringify(hosts));
   }

--- a/packages/relay/src/mkcert.ts
+++ b/packages/relay/src/mkcert.ts
@@ -25,7 +25,6 @@ interface GithubReleaseAsset {
 }
 
 interface GithubReleaseResponse {
-  tag_name: string;
   assets: GithubReleaseAsset[];
 }
 

--- a/packages/relay/src/mkcert.ts
+++ b/packages/relay/src/mkcert.ts
@@ -17,7 +17,21 @@ const KEY_PATH = join(DATA_DIR, "localhost-key.pem");
 const CERT_PATH = join(DATA_DIR, "localhost.pem");
 const HOSTS_METADATA_PATH = join(DATA_DIR, "cert-hosts.json");
 
-const MKCERT_ENV = { env: { ...process.env, CAROOT: DATA_DIR } };
+const getDefaultCaRoot = (): string => {
+  if (platform() === "win32") {
+    const localAppData =
+      process.env.LOCALAPPDATA ?? join(homedir(), "AppData", "Local");
+    return join(localAppData, "mkcert");
+  }
+  if (platform() === "darwin") {
+    return join(homedir(), "Library", "Application Support", "mkcert");
+  }
+  const dataHome =
+    process.env.XDG_DATA_HOME ?? join(homedir(), ".local", "share");
+  return join(dataHome, "mkcert");
+};
+
+const MKCERT_ENV = { env: { ...process.env, CAROOT: getDefaultCaRoot() } };
 
 interface GithubReleaseAsset {
   name: string;

--- a/packages/relay/src/mkcert.ts
+++ b/packages/relay/src/mkcert.ts
@@ -1,6 +1,6 @@
 import { exec as execCallback } from "node:child_process";
 import { createWriteStream, existsSync } from "node:fs";
-import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { homedir, platform, arch } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -68,7 +68,6 @@ const downloadMkcert = async (downloadUrl: string): Promise<void> => {
     );
     await chmod(MKCERT_PATH, 0o755);
   } catch (error) {
-    const { unlink } = await import("node:fs/promises");
     await unlink(MKCERT_PATH).catch(() => {});
     throw error;
   }

--- a/packages/relay/src/mkcert.ts
+++ b/packages/relay/src/mkcert.ts
@@ -84,9 +84,17 @@ export interface Certificate {
 
 const CA_INSTALLED_FLAG = join(DATA_DIR, ".ca-installed");
 
+const validateHostname = (hostname: string): void => {
+  if (!/^[a-zA-Z0-9.-]+$/.test(hostname)) {
+    throw new Error(`Invalid hostname: ${hostname}`);
+  }
+};
+
 export const ensureCertificates = async (
   hosts: string[] = ["localhost", "127.0.0.1"],
 ): Promise<Certificate> => {
+  hosts.forEach(validateHostname);
+
   if (!existsSync(MKCERT_PATH)) {
     const downloadUrl = await fetchMkcertDownloadUrl();
     if (!downloadUrl) {

--- a/packages/relay/src/mkcert.ts
+++ b/packages/relay/src/mkcert.ts
@@ -1,0 +1,101 @@
+import { exec as execCallback } from "node:child_process";
+import { createWriteStream, existsSync } from "node:fs";
+import { chmod, mkdir, readFile } from "node:fs/promises";
+import { homedir, platform, arch } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { pipeline } from "node:stream/promises";
+
+const exec = promisify(execCallback);
+
+const DATA_DIR = join(homedir(), ".react-grab");
+const MKCERT_PATH = join(
+  DATA_DIR,
+  platform() === "win32" ? "mkcert.exe" : "mkcert",
+);
+const KEY_PATH = join(DATA_DIR, "localhost-key.pem");
+const CERT_PATH = join(DATA_DIR, "localhost.pem");
+
+const MKCERT_ENV = { env: { ...process.env, CAROOT: DATA_DIR } };
+
+interface GithubReleaseAsset {
+  name: string;
+  browser_download_url: string;
+}
+
+interface GithubReleaseResponse {
+  tag_name: string;
+  assets: GithubReleaseAsset[];
+}
+
+const getPlatformIdentifier = (): string => {
+  const architecture = arch() === "x64" ? "amd64" : arch();
+  return platform() === "win32"
+    ? `windows-${architecture}.exe`
+    : `${platform()}-${architecture}`;
+};
+
+const fetchMkcertDownloadUrl = async (): Promise<string | undefined> => {
+  const response = await fetch(
+    "https://api.github.com/repos/FiloSottile/mkcert/releases/latest",
+  );
+  if (!response.ok) return undefined;
+
+  const releaseData: GithubReleaseResponse = await response.json();
+  const platformIdentifier = getPlatformIdentifier();
+  const matchingAsset = releaseData.assets.find((asset) =>
+    asset.name.includes(platformIdentifier),
+  );
+
+  return matchingAsset?.browser_download_url;
+};
+
+const downloadMkcert = async (downloadUrl: string): Promise<void> => {
+  await mkdir(DATA_DIR, { recursive: true });
+
+  const response = await fetch(downloadUrl);
+  if (!response.ok || !response.body) {
+    throw new Error(`Failed to download mkcert: ${response.statusText}`);
+  }
+
+  const fileStream = createWriteStream(MKCERT_PATH);
+  // HACK: Web ReadableStream and Node.js ReadableStream types are incompatible but work at runtime
+  await pipeline(response.body as unknown as NodeJS.ReadableStream, fileStream);
+  await chmod(MKCERT_PATH, 0o755);
+};
+
+const runMkcert = async (args: string): Promise<void> => {
+  await exec(`"${MKCERT_PATH}" ${args}`, MKCERT_ENV);
+};
+
+export interface Certificate {
+  key: Buffer;
+  cert: Buffer;
+}
+
+export const ensureCertificates = async (
+  hosts: string[] = ["localhost", "127.0.0.1"],
+): Promise<Certificate> => {
+  if (!existsSync(MKCERT_PATH)) {
+    const downloadUrl = await fetchMkcertDownloadUrl();
+    if (!downloadUrl) {
+      throw new Error(
+        `Unsupported platform: ${platform()} ${arch()}. Cannot download mkcert.`,
+      );
+    }
+    await downloadMkcert(downloadUrl);
+    await runMkcert("-install");
+  }
+
+  if (!existsSync(KEY_PATH) || !existsSync(CERT_PATH)) {
+    await runMkcert(
+      `-key-file "${KEY_PATH}" -cert-file "${CERT_PATH}" ${hosts.join(" ")}`,
+    );
+  }
+
+  const [key, cert] = await Promise.all([
+    readFile(KEY_PATH),
+    readFile(CERT_PATH),
+  ]);
+  return { key, cert };
+};

--- a/packages/relay/src/mkcert.ts
+++ b/packages/relay/src/mkcert.ts
@@ -114,13 +114,17 @@ export const ensureCertificates = async (
   let shouldRegenerateCerts = !existsSync(KEY_PATH) || !existsSync(CERT_PATH);
 
   if (!shouldRegenerateCerts && existsSync(HOSTS_METADATA_PATH)) {
-    const storedHostsData = await readFile(HOSTS_METADATA_PATH, "utf-8");
-    const storedHosts = JSON.parse(storedHostsData) as string[];
-    const sortedStoredHosts = [...storedHosts].sort();
-    const sortedRequestedHosts = [...hosts].sort();
-    shouldRegenerateCerts =
-      JSON.stringify(sortedStoredHosts) !==
-      JSON.stringify(sortedRequestedHosts);
+    try {
+      const storedHostsData = await readFile(HOSTS_METADATA_PATH, "utf-8");
+      const storedHosts = JSON.parse(storedHostsData) as string[];
+      const sortedStoredHosts = [...storedHosts].sort();
+      const sortedRequestedHosts = [...hosts].sort();
+      shouldRegenerateCerts =
+        JSON.stringify(sortedStoredHosts) !==
+        JSON.stringify(sortedRequestedHosts);
+    } catch {
+      shouldRegenerateCerts = true;
+    }
   } else if (!shouldRegenerateCerts) {
     shouldRegenerateCerts = true;
   }

--- a/packages/relay/src/protocol.ts
+++ b/packages/relay/src/protocol.ts
@@ -4,6 +4,8 @@ export const HEALTH_CHECK_TIMEOUT_MS = 1000;
 export const POST_KILL_DELAY_MS = 100;
 export const RELAY_TOKEN_PARAM = "token";
 export const COMPLETED_STATUS = "Completed";
+export const UPGRADE_RETRY_DELAY_MS = 1000;
+export const MAX_UPGRADE_RETRIES = 5;
 
 export interface AgentMessage {
   type: "status" | "error" | "done";

--- a/packages/relay/src/protocol.ts
+++ b/packages/relay/src/protocol.ts
@@ -5,7 +5,8 @@ export const POST_KILL_DELAY_MS = 100;
 export const RELAY_TOKEN_PARAM = "token";
 export const COMPLETED_STATUS = "Completed";
 export const UPGRADE_RETRY_DELAY_MS = 1000;
-export const MAX_UPGRADE_RETRIES = 5;
+export const MAX_UPGRADE_RETRIES = 15;
+export const HANDLER_RECONNECT_DELAY_MS = 1000;
 
 export interface AgentMessage {
   type: "status" | "error" | "done";

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -91,6 +91,7 @@ interface RelayServerOptions {
   token?: string;
   secure?: boolean;
   onSecureUpgradeRequested?: () => void;
+  certHostnames?: string[];
 }
 
 export interface RelayServer {
@@ -108,6 +109,7 @@ export const createRelayServer = (
   const token = options.token;
   const secure = options.secure ?? false;
   const onSecureUpgradeRequested = options.onSecureUpgradeRequested;
+  const certHostnames = options.certHostnames;
 
   const registeredHandlers = new Map<string, RegisteredHandler>();
   const activeSessions = new Map<string, ActiveSession>();
@@ -529,7 +531,7 @@ export const createRelayServer = (
   };
 
   const start = async (): Promise<void> => {
-    const certificate = secure ? await ensureCertificates() : null;
+    const certificate = secure ? await ensureCertificates(certHostnames) : null;
 
     return new Promise((resolve, reject) => {
       const requestHandler = (req: IncomingMessage, res: ServerResponse) => {

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -702,8 +702,30 @@ export const createRelayServer = (
     }
     handlerSockets.clear();
 
-    webSocketServer?.close();
-    httpServer?.close();
+    const webSocketClosePromise = new Promise<void>((resolve) => {
+      if (webSocketServer) {
+        webSocketServer.close(() => resolve());
+      } else {
+        resolve();
+      }
+    });
+
+    const httpServerClosePromise = new Promise<void>((resolve, reject) => {
+      if (httpServer) {
+        httpServer.close((error) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      } else {
+        resolve();
+      }
+    });
+
+    await webSocketClosePromise;
+    await httpServerClosePromise;
   };
 
   const registerHandler = (handler: AgentHandler) => {

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -90,7 +90,7 @@ interface RelayServerOptions {
   port?: number;
   token?: string;
   secure?: boolean;
-  onSecureUpgradeRequested?: () => void;
+  onSecureUpgradeRequested?: () => Promise<void>;
   certHostnames?: string[];
 }
 

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -557,7 +557,7 @@ export const createRelayServer = (
                 handlers: getRegisteredHandlerIds(),
               }),
             );
-            onSecureUpgradeRequested();
+            onSecureUpgradeRequested().catch(() => {});
             return;
           }
 

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -557,7 +557,12 @@ export const createRelayServer = (
                 handlers: getRegisteredHandlerIds(),
               }),
             );
-            onSecureUpgradeRequested().catch(() => {});
+            onSecureUpgradeRequested().catch((error) => {
+              console.error(
+                "Failed to upgrade to secure connection:",
+                error instanceof Error ? error.message : error,
+              );
+            });
             return;
           }
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -22,6 +22,7 @@
     "build": "rm -rf dist && NODE_ENV=production tsup"
   },
   "devDependencies": {
+    "@types/node": "^25.2.0",
     "tsup": "^8.4.0"
   }
 }

--- a/packages/utils/src/server.ts
+++ b/packages/utils/src/server.ts
@@ -1,4 +1,6 @@
 import { spawn } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { dirname, join } from "node:path";
 
 export const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
@@ -58,7 +60,11 @@ export const formatSpawnError = (error: Error, commandName: string): string => {
   return error.message;
 };
 
-export const spawnDetachedServer = (serverPath: string): void => {
+export const spawnDetachedServer = (serverFilename = "server.cjs"): void => {
+  const realScriptPath = realpathSync(process.argv[1]);
+  const scriptDir = dirname(realScriptPath);
+  const serverPath = join(scriptDir, serverFilename);
+
   const userArgs = process.argv.slice(2);
   const child = spawn(process.execPath, [serverPath, ...userArgs], {
     detached: true,

--- a/packages/utils/src/server.ts
+++ b/packages/utils/src/server.ts
@@ -55,3 +55,14 @@ export const formatSpawnError = (error: Error, commandName: string): string => {
 
   return error.message;
 };
+
+export const spawnDetachedServer = (serverPath: string): void => {
+  const { spawn } = require("node:child_process");
+  const userArgs = process.argv.slice(2);
+  const child = spawn(process.execPath, [serverPath, ...userArgs], {
+    detached: true,
+    stdio: "inherit",
+  });
+  child.unref();
+  process.exit(0);
+};

--- a/packages/utils/src/server.ts
+++ b/packages/utils/src/server.ts
@@ -1,3 +1,5 @@
+import { spawn } from "node:child_process";
+
 export const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -57,7 +59,6 @@ export const formatSpawnError = (error: Error, commandName: string): string => {
 };
 
 export const spawnDetachedServer = (serverPath: string): void => {
-  const { spawn } = require("node:child_process");
   const userArgs = process.argv.slice(2);
   const child = spawn(process.execPath, [serverPath, ...userArgs], {
     detached: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@changesets/cli':
         specifier: ^2.27.10
-        version: 2.29.7(@types/node@24.10.2)
+        version: 2.29.7(@types/node@25.2.0)
       oxfmt:
         specifier: ^0.27.0
         version: 0.27.0
@@ -38,7 +38,7 @@ importers:
     devDependencies:
       vite:
         specifier: ^6.0.7
-        version: 6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
 
   packages/cli:
     dependencies:
@@ -66,7 +66,7 @@ importers:
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 3.2.4(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
 
   packages/design-system:
     dependencies:
@@ -113,7 +113,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: 4.0.0-beta.8
-        version: 4.0.0-beta.8(vite@6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 4.0.0-beta.8(vite@6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1))
       '@types/react':
         specifier: ^19.0.4
         version: 19.2.7
@@ -122,7 +122,7 @@ importers:
         version: 19.2.2(@types/react@19.2.7)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 4.7.0(vite@6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1))
       tailwindcss:
         specifier: 4.0.0-beta.8
         version: 4.0.0-beta.8
@@ -131,7 +131,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.0.2
-        version: 6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
 
   packages/grab:
     dependencies:
@@ -607,6 +607,9 @@ importers:
 
   packages/utils:
     devDependencies:
+      '@types/node':
+        specifier: ^25.2.0
+        version: 25.2.0
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -637,7 +640,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: 4.0.0-beta.8
-        version: 4.0.0-beta.8(vite@6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 4.0.0-beta.8(vite@6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1))
       '@types/react':
         specifier: ^19.0.4
         version: 19.2.2
@@ -646,7 +649,7 @@ importers:
         version: 19.2.2(@types/react@19.2.2)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 4.7.0(vite@6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1))
       tailwindcss:
         specifier: 4.0.0-beta.8
         version: 4.0.0-beta.8
@@ -655,7 +658,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.0.2
-        version: 6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
 
   packages/web-extension:
     dependencies:
@@ -692,16 +695,16 @@ importers:
         version: 0.12.4
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 4.7.0(vite@6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1))
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
       vite:
         specifier: ^6.0.2
-        version: 6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
       vite-plugin-web-extension:
         specifier: ^4.1.6
-        version: 4.5.0(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)
+        version: 4.5.0(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)
 
   packages/website:
     dependencies:
@@ -3467,8 +3470,8 @@ packages:
   '@types/node@22.19.2':
     resolution: {integrity: sha512-LPM2G3Syo1GLzXLGJAKdqoU35XvrWzGJ21/7sgZTUpbkBaOasTj8tjwn6w+hCkqaa1TfJ/w67rJSwYItlJ2mYw==}
 
-  '@types/node@24.10.2':
-    resolution: {integrity: sha512-WOhQTZ4G8xZ1tjJTvKOpyEVSGgOTvJAfDK3FNFgELyaTpzhdgHVHeqW8V+UJvzF5BT+/B54T/1S2K6gd9c7bbA==}
+  '@types/node@25.2.0':
+    resolution: {integrity: sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==}
 
   '@types/prompts@2.4.9':
     resolution: {integrity: sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==}
@@ -7664,7 +7667,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.29.7(@types/node@24.10.2)':
+  '@changesets/cli@2.29.7(@types/node@25.2.0)':
     dependencies:
       '@changesets/apply-release-plan': 7.0.13
       '@changesets/assemble-release-plan': 6.0.9
@@ -7680,7 +7683,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.2(@types/node@24.10.2)
+      '@inquirer/external-editor': 1.0.2(@types/node@25.2.0)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       ci-info: 3.9.0
@@ -8364,12 +8367,12 @@ snapshots:
   '@img/sharp-win32-x64@0.34.4':
     optional: true
 
-  '@inquirer/external-editor@1.0.2(@types/node@24.10.2)':
+  '@inquirer/external-editor@1.0.2(@types/node@25.2.0)':
     dependencies:
       chardet: 2.1.0
       iconv-lite: 0.7.0
     optionalDependencies:
-      '@types/node': 24.10.2
+      '@types/node': 25.2.0
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -9518,13 +9521,13 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 4.1.15
 
-  '@tailwindcss/vite@4.0.0-beta.8(vite@6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1))':
+  '@tailwindcss/vite@4.0.0-beta.8(vite@6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       '@tailwindcss/node': 4.0.0-beta.8
       '@tailwindcss/oxide': 4.0.0-beta.8
       lightningcss: 1.30.2
       tailwindcss: 4.0.0-beta.8
-      vite: 6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
+      vite: 6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
 
   '@tanstack/react-table@8.21.3(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
     dependencies:
@@ -9630,10 +9633,9 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@24.10.2':
+  '@types/node@25.2.0':
     dependencies:
       undici-types: 7.16.0
-    optional: true
 
   '@types/prompts@2.4.9':
     dependencies:
@@ -9845,7 +9847,7 @@ snapshots:
 
   '@vercel/oidc@3.0.5': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -9853,7 +9855,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
+      vite: 6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9865,13 +9867,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1))':
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
+      vite: 6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -13511,8 +13513,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@7.16.0:
-    optional: true
+  undici-types@7.16.0: {}
 
   unicorn-magic@0.3.0: {}
 
@@ -13680,13 +13681,13 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-node@3.2.4(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1):
+  vite-node@3.2.4(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
+      vite: 6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -13701,7 +13702,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-web-extension@4.5.0(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6):
+  vite-plugin-web-extension@4.5.0(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6):
     dependencies:
       ajv: 8.17.1
       async-lock: 1.4.1
@@ -13711,7 +13712,7 @@ snapshots:
       lodash.uniq: 4.5.0
       lodash.uniqby: 4.7.0
       md5: 2.3.0
-      vite: 6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
+      vite: 6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
       web-ext-option-types: 8.3.1
       web-ext-run: 0.2.4
       webextension-polyfill: 0.10.0
@@ -13729,7 +13730,7 @@ snapshots:
       - terser
       - tsx
 
-  vite@6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1):
+  vite@6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.11
       fdir: 6.5.0(picomatch@4.0.3)
@@ -13738,7 +13739,7 @@ snapshots:
       rollup: 4.52.5
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 24.10.2
+      '@types/node': 25.2.0
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.2
@@ -13746,11 +13747,11 @@ snapshots:
       tsx: 4.20.6
       yaml: 2.8.1
 
-  vitest@3.2.4(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1):
+  vitest@3.2.4(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -13768,11 +13769,11 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
-      vite-node: 3.2.4(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
+      vite: 6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 24.10.2
+      '@types/node': 25.2.0
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
## Summary

- Browser client auto-detects `https:` protocol and uses `wss://` instead of `ws://`
- Relay server supports HTTPS mode with auto-generated certificates via mkcert
- All providers accept `--secure` flag for WSS connections

## Usage

```bash
npx @anthropic/react-grab-cursor --secure
```

This enables:
1. HTTPS relay server with auto-generated trusted certificates
2. WSS WebSocket connections
3. Compatibility with local SSL setups (e.g., localias)

## Test plan

- [ ] Test browser auto-detection of protocol
- [ ] Test `--secure` flag with providers
- [ ] Test certificate generation on first run

Closes #156

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core relay connectivity (protocol selection, upgrade flow, and TLS certificate generation), which can cause connection failures or upgrade loops if misbehaving, but changes are scoped and include retries/health checks and explicit `--secure` opt-in.
> 
> **Overview**
> Enables **secure relay connections (HTTPS + WSS)** end-to-end: the browser `RelayClient` now defaults to `wss://` when running on `https:` pages, preflights `/health` with retries, and can trigger/await an HTTP→HTTPS upgrade before opening the WebSocket.
> 
> The relay server can now run in secure mode using locally generated certificates via new `mkcert` integration, exposes `secure` status (and an `upgrading` state) on `/health`, supports CORS/OPTIONS, and improves shutdown semantics to avoid port races. Provider CLIs are simplified to a shared `spawnDetachedServer` helper and provider servers now accept `--secure` to request secure relay mode; handler connections gain ws/wss-aware health checks and automatic reconnect behavior.
> 
> Minor cleanups include formatting-only tweaks in UI/e2e tests, adding `certificates` to `packages/gym/.gitignore`, and updating `@types/node` for `@react-grab/utils`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2472f4261378eaf366e7bfa2f3eae9cc00271ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds WSS support for HTTPS pages with auto‑upgrade, mkcert certs, and hostname‑aware client defaults. Improves reliability with protocol‑aware health checks, handler auto‑reconnect, safer upgrade/cert handling, honors the --secure flag; closes #156.

- **New Features**
  - Browser client auto-selects ws/wss, uses window.location.hostname, and preflights /health with retry/backoff.
  - Relay runs in HTTPS with mkcert certs, supports certHostnames, exposes secure state in /health, and auto-upgrades on secure browser requests.
  - Providers accept --secure and use a shared spawnDetachedServer; remote handlers auto-reconnect on drops.

- **Bug Fixes**
  - Upgrade flow: HTTP→HTTPS preflight with retry/backoff, delays on non-OK and network errors, HTTP/HTTPS fallback in health checks, and timeout after max retries.
  - Protocol/reconnect: prioritize server‑detected ws/wss when connecting to existing relays, use detected isSecure in EADDRINUSE recovery, await full shutdown to avoid EADDRINUSE, respect explicit --secure when starting the server, and clear reconnect timers on stop/unregister.
  - Security/certs: validate cert hostnames, track/regenerate certs when hosts change, tolerate self-signed certs in HTTPS health checks, and add CORS/OPTIONS on /health.

<sup>Written for commit c2472f4261378eaf366e7bfa2f3eae9cc00271ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

