### PR TITLE
refactor: replace cross-tab chrome.storage sync with sinking

### DIFF
--- a/packages/react-grab/src/components/renderer.tsx
+++ b/packages/react-grab/src/components/renderer.tsx
@@ -192,6 +192,7 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
           onStateChange={props.onToolbarStateChange}
           onSubscribeToStateChanges={props.onSubscribeToToolbarStateChanges}
           onSelectHoverChange={props.onToolbarSelectHoverChange}
+          persistToolbarState={props.persistToolbarState}
         />
       </Show>
 

--- a/packages/react-grab/src/components/toolbar/index.tsx
+++ b/packages/react-grab/src/components/toolbar/index.tsx
@@ -57,6 +57,7 @@ interface ToolbarProps {
     callback: (state: ToolbarState) => void,
   ) => () => void;
   onSelectHoverChange?: (isHovered: boolean) => void;
+  persistToolbarState?: boolean;
 }
 
 export const Toolbar: Component<ToolbarProps> = (props) => {
@@ -757,12 +758,12 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
   };
 
   const saveAndNotify = (state: ToolbarState) => {
-    saveToolbarState(state);
+    saveToolbarState(state, props.persistToolbarState);
     props.onStateChange?.(state);
   };
 
   onMount(() => {
-    const savedState = loadToolbarState();
+    const savedState = loadToolbarState(props.persistToolbarState);
     const rect = containerRef?.getBoundingClientRect();
     const viewport = getVisualViewport();
 

--- a/packages/react-grab/src/components/toolbar/state.ts
+++ b/packages/react-grab/src/components/toolbar/state.ts
@@ -5,7 +5,10 @@ export type SnapEdge = "top" | "bottom" | "left" | "right";
 
 const STORAGE_KEY = "react-grab-toolbar-state";
 
-export const loadToolbarState = (): ToolbarState | null => {
+export const loadToolbarState = (
+  persistToolbarState = true,
+): ToolbarState | null => {
+  if (!persistToolbarState) return null;
   try {
     const serializedToolbarState = localStorage.getItem(STORAGE_KEY);
     if (!serializedToolbarState) return null;
@@ -28,7 +31,11 @@ export const loadToolbarState = (): ToolbarState | null => {
   return null;
 };
 
-export const saveToolbarState = (state: ToolbarState): void => {
+export const saveToolbarState = (
+  state: ToolbarState,
+  persistToolbarState = true,
+): void => {
+  if (!persistToolbarState) return;
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
   } catch (error) {

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -247,7 +247,11 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         store.current.isPendingDismiss,
     );
 
-    const savedToolbarState = loadToolbarState();
+    const shouldPersistToolbarState = () =>
+      pluginRegistry.store.options.persistToolbarState !== false;
+    const savedToolbarState = loadToolbarState(
+      initialOptions.persistToolbarState !== false,
+    );
     const [isEnabled, setIsEnabled] = createSignal(
       savedToolbarState?.enabled ?? true,
     );
@@ -1514,14 +1518,16 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     const handleToggleEnabled = () => {
       const newEnabled = !isEnabled();
       setIsEnabled(newEnabled);
-      const currentState = loadToolbarState();
+      const persistEnabled = shouldPersistToolbarState();
+      const currentState =
+        loadToolbarState(persistEnabled) ?? currentToolbarState();
       const newState = {
         edge: currentState?.edge ?? "bottom",
         ratio: currentState?.ratio ?? 0.5,
         collapsed: currentState?.collapsed ?? false,
         enabled: newEnabled,
       };
-      saveToolbarState(newState);
+      saveToolbarState(newState, persistEnabled);
       setCurrentToolbarState(newState);
       toolbarStateChangeCallbacks.forEach((cb) => cb(newState));
       if (!newEnabled) {
@@ -3395,6 +3401,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
               };
             }}
             onToolbarSelectHoverChange={setIsToolbarSelectHovered}
+            persistToolbarState={shouldPersistToolbarState()}
             contextMenuPosition={contextMenuPosition()}
             contextMenuBounds={contextMenuBounds()}
             contextMenuTagName={contextMenuTagName()}
@@ -3505,16 +3512,21 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           inToggleFeedbackPeriod = false;
         }
       },
-      getToolbarState: () => loadToolbarState(),
+      getToolbarState: () => {
+        const persistEnabled = shouldPersistToolbarState();
+        return loadToolbarState(persistEnabled) ?? currentToolbarState();
+      },
       setToolbarState: (state: Partial<ToolbarState>) => {
-        const currentState = loadToolbarState();
+        const persistEnabled = shouldPersistToolbarState();
+        const currentState =
+          loadToolbarState(persistEnabled) ?? currentToolbarState();
         const newState = {
           edge: state.edge ?? currentState?.edge ?? "bottom",
           ratio: state.ratio ?? currentState?.ratio ?? 0.5,
           collapsed: state.collapsed ?? currentState?.collapsed ?? false,
           enabled: state.enabled ?? currentState?.enabled ?? true,
         };
-        saveToolbarState(newState);
+        saveToolbarState(newState, persistEnabled);
         setCurrentToolbarState(newState);
         if (state.enabled !== undefined && state.enabled !== isEnabled()) {
           setIsEnabled(state.enabled);

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -249,6 +249,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
     const shouldPersistToolbarState = () =>
       pluginRegistry.store.options.persistToolbarState !== false;
+    const resolveToolbarState = (): ToolbarState | null =>
+      loadToolbarState(shouldPersistToolbarState()) ?? currentToolbarState();
     const savedToolbarState = loadToolbarState(
       initialOptions.persistToolbarState !== false,
     );
@@ -1518,16 +1520,14 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     const handleToggleEnabled = () => {
       const newEnabled = !isEnabled();
       setIsEnabled(newEnabled);
-      const persistEnabled = shouldPersistToolbarState();
-      const currentState =
-        loadToolbarState(persistEnabled) ?? currentToolbarState();
+      const currentState = resolveToolbarState();
       const newState = {
         edge: currentState?.edge ?? "bottom",
         ratio: currentState?.ratio ?? 0.5,
         collapsed: currentState?.collapsed ?? false,
         enabled: newEnabled,
       };
-      saveToolbarState(newState, persistEnabled);
+      saveToolbarState(newState, shouldPersistToolbarState());
       setCurrentToolbarState(newState);
       toolbarStateChangeCallbacks.forEach((cb) => cb(newState));
       if (!newEnabled) {
@@ -3512,21 +3512,16 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           inToggleFeedbackPeriod = false;
         }
       },
-      getToolbarState: () => {
-        const persistEnabled = shouldPersistToolbarState();
-        return loadToolbarState(persistEnabled) ?? currentToolbarState();
-      },
+      getToolbarState: () => resolveToolbarState(),
       setToolbarState: (state: Partial<ToolbarState>) => {
-        const persistEnabled = shouldPersistToolbarState();
-        const currentState =
-          loadToolbarState(persistEnabled) ?? currentToolbarState();
+        const currentState = resolveToolbarState();
         const newState = {
           edge: state.edge ?? currentState?.edge ?? "bottom",
           ratio: state.ratio ?? currentState?.ratio ?? 0.5,
           collapsed: state.collapsed ?? currentState?.collapsed ?? false,
           enabled: state.enabled ?? currentState?.enabled ?? true,
         };
-        saveToolbarState(newState, persistEnabled);
+        saveToolbarState(newState, shouldPersistToolbarState());
         setCurrentToolbarState(newState);
         if (state.enabled !== undefined && state.enabled !== isEnabled()) {
           setIsEnabled(state.enabled);

--- a/packages/react-grab/src/core/plugin-registry.ts
+++ b/packages/react-grab/src/core/plugin-registry.ts
@@ -35,6 +35,7 @@ interface OptionsState {
   activationKey: ActivationKey | undefined;
   getContent: ((elements: Element[]) => Promise<string> | string) | undefined;
   freezeReactUpdates: boolean;
+  persistToolbarState: boolean;
 }
 
 const DEFAULT_OPTIONS: OptionsState = {
@@ -45,6 +46,7 @@ const DEFAULT_OPTIONS: OptionsState = {
   activationKey: undefined,
   getContent: undefined,
   freezeReactUpdates: true,
+  persistToolbarState: true,
 };
 
 interface PluginStoreState {

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -366,6 +366,12 @@ export interface Options {
    * @default true
    */
   freezeReactUpdates?: boolean;
+  /**
+   * Whether to persist toolbar state (position, collapsed, enabled) to localStorage.
+   * Set to false when an external consumer (e.g. web extension) handles persistence.
+   * @default true
+   */
+  persistToolbarState?: boolean;
 }
 
 export interface SettableOptions extends Options {
@@ -505,6 +511,7 @@ export interface ReactGrabRendererProps {
     callback: (state: ToolbarState) => void,
   ) => () => void;
   onToolbarSelectHoverChange?: (isHovered: boolean) => void;
+  persistToolbarState?: boolean;
   contextMenuPosition?: { x: number; y: number } | null;
   contextMenuBounds?: OverlayBounds | null;
   contextMenuTagName?: string;

--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -13,6 +13,7 @@
     "react": "19.1.2",
     "react-dom": "19.1.2",
     "react-grab": "workspace:*",
+    "sinking": "^0.0.6",
     "turndown": "^7.2.0",
     "webextension-polyfill": "^0.12.0"
   },

--- a/packages/web-extension/src/content/bridge.ts
+++ b/packages/web-extension/src/content/bridge.ts
@@ -8,16 +8,6 @@ chrome.storage.onChanged.addListener((changes) => {
       "*",
     );
   }
-
-  if (changes.react_grab_toolbar_state) {
-    const newState = changes.react_grab_toolbar_state.newValue;
-    if (newState) {
-      window.postMessage(
-        { type: "__REACT_GRAB_TOOLBAR_STATE_CHANGE__", state: newState },
-        "*",
-      );
-    }
-  }
 });
 
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
@@ -38,25 +28,21 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 
 window.addEventListener("message", (event) => {
   if (event.data?.type === "__REACT_GRAB_QUERY_STATE__") {
-    chrome.storage.local.get(
-      ["react_grab_enabled", "react_grab_toolbar_state"],
-      (result) => {
-        const enabled = result.react_grab_enabled ?? true;
-        const toolbarState = result.react_grab_toolbar_state ?? null;
+    chrome.storage.local.get(["react_grab_enabled"], (result) => {
+      const enabled = result.react_grab_enabled ?? true;
 
-        window.postMessage(
-          {
-            type: "__REACT_GRAB_STATE_RESPONSE__",
-            enabled,
-            toolbarState,
-          },
-          "*",
-        );
-      },
-    );
+      window.postMessage(
+        {
+          type: "__REACT_GRAB_STATE_RESPONSE__",
+          enabled,
+        },
+        "*",
+      );
+    });
   }
 
-  if (event.data?.type === "__REACT_GRAB_TOOLBAR_STATE_SAVE__") {
-    chrome.storage.local.set({ react_grab_toolbar_state: event.data.state });
+  if (event.data?.type === "__REACT_GRAB_GET_WORKER_URL__") {
+    const workerUrl = chrome.runtime.getURL("src/worker.ts");
+    window.postMessage({ type: "__REACT_GRAB_WORKER_URL__", workerUrl }, "*");
   }
 });

--- a/packages/web-extension/src/content/react-grab.ts
+++ b/packages/web-extension/src/content/react-grab.ts
@@ -1,5 +1,5 @@
 import { init } from "react-grab/core";
-import type { Options, ReactGrabAPI } from "react-grab";
+import type { Options, ReactGrabAPI, ToolbarState } from "react-grab";
 import TurndownService from "turndown";
 import {
   LOCALHOST_INIT_DELAY_MS,
@@ -25,13 +25,6 @@ const isLocalhost =
   window.location.hostname.endsWith(".localhost");
 
 const turndownService = new TurndownService();
-
-interface ToolbarState {
-  edge: "top" | "bottom" | "left" | "right";
-  ratio: number;
-  collapsed: boolean;
-  enabled: boolean;
-}
 
 let extensionApi: ReactGrabAPI | null = null;
 let lastToolbarState: ToolbarState | null = null;
@@ -76,16 +69,10 @@ const handleSinkingChange = (): void => {
 };
 
 const subscribeToStateChanges = (api: ReactGrabAPI): void => {
-  if (stateChangeUnsubscribe) {
-    stateChangeUnsubscribe();
-  }
-  stateChangeUnsubscribe = api.onToolbarStateChange((state) => {
-    handleToolbarStateFromApi(state);
-  });
+  stateChangeUnsubscribe?.();
+  stateChangeUnsubscribe = api.onToolbarStateChange(handleToolbarStateFromApi);
 
-  if (sinkingUnsubscribe) {
-    sinkingUnsubscribe();
-  }
+  sinkingUnsubscribe?.();
   sinkingUnsubscribe = subscribeToToolbarState(handleSinkingChange);
 };
 

--- a/packages/web-extension/src/content/react-grab.ts
+++ b/packages/web-extension/src/content/react-grab.ts
@@ -210,6 +210,12 @@ const startup = async (): Promise<void> => {
 
   if (workerUrl) {
     initSinkingClient(workerUrl);
+
+    const existingApi = getActiveApi();
+    if (existingApi) {
+      sinkingUnsubscribe?.();
+      sinkingUnsubscribe = subscribeToToolbarState(handleSinkingChange);
+    }
   }
 
   const api = await initializeReactGrab();

--- a/packages/web-extension/src/manifest.json
+++ b/packages/web-extension/src/manifest.json
@@ -37,6 +37,12 @@
       "world": "MAIN"
     }
   ],
+  "web_accessible_resources": [
+    {
+      "resources": ["src/worker.ts"],
+      "matches": ["<all_urls>"]
+    }
+  ],
   "host_permissions": ["<all_urls>"],
   "permissions": ["storage"]
 }

--- a/packages/web-extension/src/storage/client.ts
+++ b/packages/web-extension/src/storage/client.ts
@@ -1,0 +1,82 @@
+import { Sinking, type DatabaseSchema } from "sinking/core";
+
+interface ToolbarState {
+  edge: "top" | "bottom" | "left" | "right";
+  ratio: number;
+  collapsed: boolean;
+  enabled: boolean;
+}
+
+interface ToolbarStateRecord extends ToolbarState {
+  id: string;
+}
+
+const TOOLBAR_STATE_STORE = "toolbar-state";
+const TOOLBAR_STATE_KEY = "default";
+
+const schema: DatabaseSchema = {
+  name: "react-grab",
+  version: 1,
+  stores: {
+    [TOOLBAR_STATE_STORE]: { keyPath: "id" },
+  },
+};
+
+let sinkingClient: Sinking | null = null;
+
+export const initSinkingClient = (workerUrl: string | URL): Sinking => {
+  if (sinkingClient) return sinkingClient;
+  sinkingClient = new Sinking({ workerUrl, schema });
+  return sinkingClient;
+};
+
+export const getSinkingClient = (): Sinking | null => sinkingClient;
+
+export const loadToolbarStateFromSinking =
+  async (): Promise<ToolbarState | null> => {
+    if (!sinkingClient) return null;
+    const record = await sinkingClient.get<ToolbarStateRecord>(
+      TOOLBAR_STATE_STORE,
+      TOOLBAR_STATE_KEY,
+    );
+    if (!record) return null;
+    return {
+      edge: record.edge,
+      ratio: record.ratio,
+      collapsed: record.collapsed,
+      enabled: record.enabled,
+    };
+  };
+
+export const saveToolbarStateToSinking = async (
+  state: ToolbarState,
+): Promise<void> => {
+  if (!sinkingClient) return;
+  const record: ToolbarStateRecord = { ...state, id: TOOLBAR_STATE_KEY };
+  await sinkingClient.put(TOOLBAR_STATE_STORE, TOOLBAR_STATE_KEY, record);
+};
+
+export const subscribeToToolbarState = (listener: () => void): (() => void) => {
+  if (!sinkingClient) return () => {};
+  const query = sinkingClient.get<ToolbarStateRecord>(
+    TOOLBAR_STATE_STORE,
+    TOOLBAR_STATE_KEY,
+  );
+  return sinkingClient.subscribe(query.description, listener);
+};
+
+export const getCachedToolbarState = (): ToolbarState | null => {
+  if (!sinkingClient) return null;
+  const query = sinkingClient.get<ToolbarStateRecord>(
+    TOOLBAR_STATE_STORE,
+    TOOLBAR_STATE_KEY,
+  );
+  const record = sinkingClient.getCached<ToolbarStateRecord>(query.description);
+  if (!record) return null;
+  return {
+    edge: record.edge,
+    ratio: record.ratio,
+    collapsed: record.collapsed,
+    enabled: record.enabled,
+  };
+};

--- a/packages/web-extension/src/worker.ts
+++ b/packages/web-extension/src/worker.ts
@@ -1,0 +1,1 @@
+import "sinking/worker";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -646,6 +646,9 @@ importers:
       react-grab:
         specifier: workspace:*
         version: link:../react-grab
+      sinking:
+        specifier: ^0.0.6
+        version: 0.0.6(react@19.1.2)
       turndown:
         specifier: ^7.2.0
         version: 7.2.2
@@ -3051,8 +3054,8 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
-  '@sourcegraph/amp@0.0.1770231444-g53361d':
-    resolution: {integrity: sha512-TuwM7W9QSkJ7J3ZouQBGu7G3snjtsWCBl61+e2zdmF8YjHwYFhNbUjeK7PHDu7NSSqOvR7Wu04Chmgpx50HIWA==}
+  '@sourcegraph/amp@0.0.1770352274-gd36e02':
+    resolution: {integrity: sha512-Gs7m7nomhJ79jGneQcHYoG8jWvb1aLfxVci3KgzCeIOya19662nEi/Y+T8LsnZa5eI3tSJWa2mDRFeojECVahg==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -6341,6 +6344,11 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  sinking@0.0.6:
+    resolution: {integrity: sha512-VzNzbrkZdsirp6QfjqysKgv223uB8QhP15WwYoQi+DPCi9lwjLBDFBFq280jP8AuXqbySlHZ/ZogoJqtMJHuJg==}
+    peerDependencies:
+      react: '>=19'
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -9033,14 +9041,14 @@ snapshots:
 
   '@sourcegraph/amp-sdk@0.1.0-20251210081226-g90e3892':
     dependencies:
-      '@sourcegraph/amp': 0.0.1770231444-g53361d
+      '@sourcegraph/amp': 0.0.1770352274-gd36e02
       zod: 3.25.76
 
   '@sourcegraph/amp@0.0.1767830505-ga62310':
     dependencies:
       '@napi-rs/keyring': 1.1.9
 
-  '@sourcegraph/amp@0.0.1770231444-g53361d':
+  '@sourcegraph/amp@0.0.1770352274-gd36e02':
     dependencies:
       '@napi-rs/keyring': 1.1.9
 
@@ -12573,6 +12581,10 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  sinking@0.0.6(react@19.1.2):
+    dependencies:
+      react: 19.1.2
 
   sisteransi@1.0.5: {}
 


### PR DESCRIPTION
## Summary

- Add `persistToolbarState` option to core (default `true`) so localStorage persistence can be disabled by external consumers
- Replace web extension's `chrome.storage`-based toolbar state sync with [sinking](https://github.com/alii/sinking) (IndexedDB + SharedWorker) for cross-tab sync
- Keep `chrome.storage` only for the extension icon enable/disable toggle (cross-origin)

## Changes

**Core (`react-grab`):**
- `types.ts`: Add `persistToolbarState?: boolean` to `Options`, `SettableOptions`, `ReactGrabRendererProps`
- `plugin-registry.ts`: Add `persistToolbarState` to `OptionsState` (default `true`)
- `toolbar/state.ts`: Guard `loadToolbarState`/`saveToolbarState` behind the flag
- `toolbar/index.tsx`: Pass flag to load/save calls
- `renderer.tsx`: Pass `persistToolbarState` prop to Toolbar
- `core/index.tsx`: Track flag via plugin registry, guard all localStorage calls, fall back to in-memory state when disabled

**Web extension:**
- Add `sinking` dependency
- New `src/worker.ts` (SharedWorker entry)
- New `src/storage/client.ts` (sinking client with typed helpers)
- `manifest.json`: Add `web_accessible_resources` for worker
- `bridge.ts`: Remove toolbar state chrome.storage handling, add worker URL relay
- `react-grab.ts`: Disable core localStorage, init sinking client, load/save/subscribe via sinking

## Behavior

- **No extension**: localStorage works exactly as before (default)
- **Extension present**: Core localStorage disabled, sinking handles persistence + cross-tab sync via SharedWorker

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm format` passes
- [x] `pnpm test` passes (429 tests)
- [ ] Manual: verify toolbar state persists across page reloads without extension
- [ ] Manual: verify toolbar state syncs across tabs with extension installed

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the web extension’s cross‑tab toolbar state sync from chrome.storage to sinking (IndexedDB + SharedWorker) for reliable, real‑time sync. Added a persistToolbarState option to core so external consumers can disable localStorage persistence (default stays true).

- **Refactors**
  - Core: added persistToolbarState (default true) and guarded all localStorage reads/writes; falls back to in‑memory when disabled.
  - Extension: uses sinking to load/save/subscribe toolbar state and disables core persistence at init; chrome.storage kept only for the icon enable/disable toggle.
  - Behavior: without the extension, localStorage works as before; with the extension, toolbar state persists and syncs across tabs via sinking.

- **Migration**
  - If you manage persistence externally, set persistToolbarState: false via init or setOptions.

<sup>Written for commit 7fe1b47c6410978b8435df7fd78e7be816147c68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persistence and synchronization paths for toolbar state and changes extension storage backends, which could cause state loss/desync across reloads/tabs if misconfigured or if the worker/client init fails.
> 
> **Overview**
> Decouples toolbar persistence from core `localStorage` by introducing `persistToolbarState` (default `true`) and threading it through renderer/toolbar/core state helpers; when disabled, core state reads fall back to in-memory `currentToolbarState` and writes are skipped.
> 
> Refactors the web extension to stop syncing toolbar state via `chrome.storage` messages and instead persist/sync it across tabs using `sinking` (IndexedDB + SharedWorker). This adds a `sinking` client wrapper plus a web-accessible worker entry, updates the content-script bridge to only handle enabled/disabled state and to provide the worker URL, and ensures the extension disables core persistence and hydrates/applies toolbar state from `sinking` on startup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7fe1b47c6410978b8435df7fd78e7be816147c68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->