### PR TITLE
fix: clamp selection label arrow to stay within label bounds at viewport edges

### DIFF
--- a/packages/react-grab/e2e/visual-feedback.spec.ts
+++ b/packages/react-grab/e2e/visual-feedback.spec.ts
@@ -244,6 +244,75 @@ test.describe("Visual Feedback", () => {
       const labelInfo = await reactGrab.getSelectionLabelInfo();
       expect(labelInfo.isVisible).toBe(true);
     });
+
+    test("label and arrow should stay within bounds at left edge", async ({
+      reactGrab,
+    }) => {
+      await reactGrab.activate();
+      await reactGrab.hoverElement("[data-testid='edge-top-left']");
+      await reactGrab.waitForSelectionBox();
+      await reactGrab.waitForSelectionLabel();
+
+      const bounds = await reactGrab.getSelectionLabelBounds();
+      expect(bounds).not.toBeNull();
+      expect(bounds?.arrow).not.toBeNull();
+      if (bounds?.arrow) {
+        expect(bounds.label.x).toBeGreaterThanOrEqual(0);
+        expect(bounds.label.x + bounds.label.width).toBeLessThanOrEqual(
+          bounds.viewport.width,
+        );
+        expect(bounds.arrow.x).toBeGreaterThanOrEqual(bounds.label.x);
+        expect(bounds.arrow.x + bounds.arrow.width).toBeLessThanOrEqual(
+          bounds.label.x + bounds.label.width,
+        );
+      }
+    });
+
+    test("label and arrow should stay within bounds at right edge", async ({
+      reactGrab,
+    }) => {
+      await reactGrab.activate();
+      await reactGrab.hoverElement("[data-testid='edge-top-right']");
+      await reactGrab.waitForSelectionBox();
+      await reactGrab.waitForSelectionLabel();
+
+      const bounds = await reactGrab.getSelectionLabelBounds();
+      expect(bounds).not.toBeNull();
+      expect(bounds?.arrow).not.toBeNull();
+      if (bounds?.arrow) {
+        expect(bounds.label.x).toBeGreaterThanOrEqual(0);
+        expect(bounds.label.x + bounds.label.width).toBeLessThanOrEqual(
+          bounds.viewport.width,
+        );
+        expect(bounds.arrow.x).toBeGreaterThanOrEqual(bounds.label.x);
+        expect(bounds.arrow.x + bounds.arrow.width).toBeLessThanOrEqual(
+          bounds.label.x + bounds.label.width,
+        );
+      }
+    });
+
+    test("label and arrow should stay within bounds at bottom-left edge", async ({
+      reactGrab,
+    }) => {
+      await reactGrab.activate();
+      await reactGrab.hoverElement("[data-testid='edge-bottom-left']");
+      await reactGrab.waitForSelectionBox();
+      await reactGrab.waitForSelectionLabel();
+
+      const bounds = await reactGrab.getSelectionLabelBounds();
+      expect(bounds).not.toBeNull();
+      expect(bounds?.arrow).not.toBeNull();
+      if (bounds?.arrow) {
+        expect(bounds.label.x).toBeGreaterThanOrEqual(0);
+        expect(bounds.label.x + bounds.label.width).toBeLessThanOrEqual(
+          bounds.viewport.width,
+        );
+        expect(bounds.arrow.x).toBeGreaterThanOrEqual(bounds.label.x);
+        expect(bounds.arrow.x + bounds.arrow.width).toBeLessThanOrEqual(
+          bounds.label.x + bounds.label.width,
+        );
+      }
+    });
   });
 
   test.describe("Status Transitions", () => {

--- a/packages/react-grab/src/components/selection-label/arrow.tsx
+++ b/packages/react-grab/src/components/selection-label/arrow.tsx
@@ -7,6 +7,7 @@ export const Arrow: Component<ArrowProps> = (props) => {
 
   return (
     <div
+      data-react-grab-arrow
       class="absolute w-0 h-0 z-10"
       style={{
         left: `calc(${props.leftPercent}% + ${props.leftOffsetPx}px)`,

--- a/packages/react-grab/src/components/selection-label/index.tsx
+++ b/packages/react-grab/src/components/selection-label/index.tsx
@@ -12,6 +12,7 @@ import {
   VIEWPORT_MARGIN_PX,
   ARROW_HEIGHT_PX,
   ARROW_CENTER_PERCENT,
+  ARROW_LABEL_MARGIN_PX,
   LABEL_GAP_PX,
   PANEL_STYLES,
 } from "../../constants.js";
@@ -248,10 +249,19 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
       positionTop = VIEWPORT_MARGIN_PX;
     }
 
-    // Arrow is centered by default, offset by edge clamping
-    // When edgeOffsetX is 0, arrow is at center. When label shifts, arrow compensates.
     const arrowLeftPercent = ARROW_CENTER_PERCENT;
-    const arrowLeftOffset = -edgeOffsetX; // px offset to keep arrow pointing at cursor
+    const labelHalfWidth = labelWidth / 2;
+    const arrowCenterPx = labelHalfWidth - edgeOffsetX;
+    const arrowMinPx = Math.min(ARROW_LABEL_MARGIN_PX, labelHalfWidth);
+    const arrowMaxPx = Math.max(
+      labelWidth - ARROW_LABEL_MARGIN_PX,
+      labelHalfWidth,
+    );
+    const clampedArrowCenterPx = Math.max(
+      arrowMinPx,
+      Math.min(arrowMaxPx, arrowCenterPx),
+    );
+    const arrowLeftOffset = clampedArrowCenterPx - labelHalfWidth;
 
     const position = {
       left: anchorX,

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -58,6 +58,7 @@ export const FROZEN_GLOW_EDGE_PX = 50;
 
 export const ARROW_HEIGHT_PX = 8;
 export const ARROW_CENTER_PERCENT = 50;
+export const ARROW_LABEL_MARGIN_PX = 16;
 export const LABEL_GAP_PX = 4;
 export const PREVIEW_ATTR_VALUE_MAX_LENGTH = 15;
 export const PREVIEW_MAX_ATTRS = 3;


### PR DESCRIPTION
## Summary

- Fixes a bug where the selection label's arrow escapes the label panel when selecting elements near the viewport edge. The label's horizontal edge clamping (`edgeOffsetX`) shifts the label inward, but the arrow's compensating offset (`-edgeOffsetX`) had no bounds — at extreme edges (e.g., cursor at x=5 with a 160px label), the arrow ends up at a negative position outside the label.
- Adds `ARROW_LABEL_MARGIN_PX` (16px) clamping so the arrow stays within the label's rounded corners, gracefully falling back to center for narrow labels.
- Adds `data-react-grab-arrow` attribute and `getSelectionLabelBounds()` e2e helper for testing label/arrow positioning.
- Adds 3 e2e tests verifying label and arrow stay within bounds at left, right, and bottom-left viewport edges.

## Test plan

- [x] `pnpm typecheck` passes
- [x] All 419 Playwright e2e tests pass (chromium project)
- [x] New edge-clamping tests pass for left, right, and bottom-left corners


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI positioning tweak plus new E2E tests; low blast radius aside from potential visual regressions at extreme edge cases.
> 
> **Overview**
> Fixes selection-label positioning so the arrow offset is **clamped within the label panel** when the label is shifted inward due to viewport edge clamping, using a new `ARROW_LABEL_MARGIN_PX` constant.
> 
> Adds a `data-react-grab-arrow` hook and a new Playwright helper `getSelectionLabelBounds()` to read label/arrow DOM rects, plus new E2E assertions ensuring the label and arrow stay within bounds at left/right/bottom-left viewport edges.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05abedb3438bcb818e1b2187ee29eaa8197a1f78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamps the selection label arrow so it stays inside the label when the label shifts at viewport edges. Adds a small margin to avoid rounded corners and covers the behavior with new e2e tests.

- **Bug Fixes**
  - Clamp arrow X offset within the label using ARROW_LABEL_MARGIN_PX (16px).
  - Add data-react-grab-arrow and getSelectionLabelBounds() to support bounds checks.
  - Add e2e tests for left, right, and bottom-left edges to ensure label and arrow stay within bounds.

<sup>Written for commit 05abedb3438bcb818e1b2187ee29eaa8197a1f78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

