### PR TITLE
fix: scale selection label arrow for narrow labels

### DIFF
--- a/packages/react-grab/src/components/selection-label/arrow.tsx
+++ b/packages/react-grab/src/components/selection-label/arrow.tsx
@@ -1,9 +1,11 @@
 import type { Component } from "solid-js";
 import type { ArrowProps } from "../../types.js";
+import { getArrowSize } from "../../utils/get-arrow-size.js";
 
 export const Arrow: Component<ArrowProps> = (props) => {
   const arrowColor = () => props.color ?? "white";
   const isBottom = () => props.position === "bottom";
+  const arrowSize = () => getArrowSize(props.labelWidth ?? 0);
 
   return (
     <div
@@ -16,10 +18,14 @@ export const Arrow: Component<ArrowProps> = (props) => {
         transform: isBottom()
           ? "translateX(-50%) translateY(-100%)"
           : "translateX(-50%) translateY(100%)",
-        "border-left": "8px solid transparent",
-        "border-right": "8px solid transparent",
-        "border-bottom": isBottom() ? `8px solid ${arrowColor()}` : undefined,
-        "border-top": isBottom() ? undefined : `8px solid ${arrowColor()}`,
+        "border-left": `${arrowSize()}px solid transparent`,
+        "border-right": `${arrowSize()}px solid transparent`,
+        "border-bottom": isBottom()
+          ? `${arrowSize()}px solid ${arrowColor()}`
+          : undefined,
+        "border-top": isBottom()
+          ? undefined
+          : `${arrowSize()}px solid ${arrowColor()}`,
         filter: isBottom()
           ? "drop-shadow(-1px -1px 0 rgba(0,0,0,0.06)) drop-shadow(1px -1px 0 rgba(0,0,0,0.06))"
           : "drop-shadow(-1px 1px 0 rgba(0,0,0,0.06)) drop-shadow(1px 1px 0 rgba(0,0,0,0.06))",

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -57,6 +57,8 @@ export const FROZEN_GLOW_COLOR = `rgba(${GRAB_PURPLE_RGB}, 0.15)`;
 export const FROZEN_GLOW_EDGE_PX = 50;
 
 export const ARROW_HEIGHT_PX = 8;
+export const ARROW_MIN_SIZE_PX = 4;
+export const ARROW_MAX_LABEL_WIDTH_RATIO = 0.2;
 export const ARROW_CENTER_PERCENT = 50;
 export const ARROW_LABEL_MARGIN_PX = 16;
 export const LABEL_GAP_PX = 4;

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -544,6 +544,7 @@ export interface ArrowProps {
   leftPercent: number;
   leftOffsetPx: number;
   color?: string;
+  labelWidth?: number;
 }
 
 export interface TagBadgeProps {

--- a/packages/react-grab/src/utils/get-arrow-size.ts
+++ b/packages/react-grab/src/utils/get-arrow-size.ts
@@ -1,0 +1,11 @@
+import {
+  ARROW_HEIGHT_PX,
+  ARROW_MIN_SIZE_PX,
+  ARROW_MAX_LABEL_WIDTH_RATIO,
+} from "../constants.js";
+
+export const getArrowSize = (labelWidth: number): number => {
+  if (labelWidth <= 0) return ARROW_HEIGHT_PX;
+  const scaledSize = labelWidth * ARROW_MAX_LABEL_WIDTH_RATIO;
+  return Math.max(ARROW_MIN_SIZE_PX, Math.min(ARROW_HEIGHT_PX, scaledSize));
+};


### PR DESCRIPTION
## Summary

- Scale the selection label arrow size proportionally to the inner panel width so it no longer overflows on short tag names like `p`
- Extract arrow sizing into a shared `getArrowSize` utility used by both the `Arrow` component and label positioning logic
- Use actual computed arrow height for label positioning to eliminate the gap between arrow and panel

## Test plan

- [ ] Hover over elements with short tag names (e.g. `p`, `b`, `i`) and verify the arrow fits within the label
- [ ] Hover over elements with longer tag names (e.g. `div`, `section`) and verify the arrow remains the default size
- [ ] Verify no gap between arrow and label panel in both above/below positions

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only sizing/positioning changes scoped to the selection label arrow, with minimal blast radius and no data/security impact.
> 
> **Overview**
> Fixes selection label arrows overflowing narrow labels by scaling the CSS triangle size dynamically via a shared `getArrowSize` utility.
> 
> `SelectionLabel` now measures the inner panel width and uses the computed arrow height for above/below positioning, while `ArrowProps` gains an optional `labelWidth` to drive the new sizing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 767780982322ddb45c7d2f2758ebf596a234abd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scaled the selection label arrow to fit narrow labels and used the real arrow height for positioning to remove the gap. Wide labels keep the default arrow size.

- **Bug Fixes**
  - Scales arrow via label width to prevent overflow on short tags (e.g., p, b, i).
  - Uses computed arrow height for positioning to eliminate the panel gap.
  - Clamps size between a minimum and the default to keep wide labels unchanged.

- **Refactors**
  - Added a shared getArrowSize utility used by the Arrow and positioning logic.
  - Measured panel width and passed it to Arrow; extended ArrowProps with labelWidth.

<sup>Written for commit 767780982322ddb45c7d2f2758ebf596a234abd5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

