### PR TITLE
fix

### DIFF
--- a/packages/react-grab/e2e/agent-integration.spec.ts
+++ b/packages/react-grab/e2e/agent-integration.spec.ts
@@ -373,9 +373,9 @@ test.describe("Agent Integration", () => {
         await reactGrab.typeInInput(`Prompt ${i}`);
         await reactGrab.submitInput();
 
-        await reactGrab.waitForAgentSession(3000);
+        await reactGrab.waitForAgentSession(5000);
         await reactGrab.clickAgentDismiss();
-        await reactGrab.page.waitForTimeout(200);
+        await reactGrab.page.waitForTimeout(500);
       }
 
       const state = await reactGrab.getState();

--- a/packages/react-grab/e2e/freeze-updates.spec.ts
+++ b/packages/react-grab/e2e/freeze-updates.spec.ts
@@ -118,10 +118,10 @@ test.describe("Freeze Updates", () => {
 
         await reactGrab.enterPromptMode("[data-testid='dynamic-element-1']");
         await reactGrab.pressEscape();
-        await reactGrab.page.waitForTimeout(200);
+        await reactGrab.page.waitForTimeout(500);
 
         await reactGrab.page.click("[data-testid='add-element-button']");
-        await reactGrab.page.waitForTimeout(100);
+        await reactGrab.page.waitForTimeout(300);
 
         const countAfter = await getElementCount();
         expect(countAfter).toBe(countBefore + 1);

--- a/packages/react-grab/e2e/history-items.spec.ts
+++ b/packages/react-grab/e2e/history-items.spec.ts
@@ -840,4 +840,168 @@ test.describe("History Items", () => {
         .toBeGreaterThan(0);
     });
   });
+
+  test.describe("Selection Label Lifecycle on Copy", () => {
+    test("should show selection label when hovering a history item", async ({
+      reactGrab,
+    }) => {
+      await copyElement(reactGrab, "li:first-child");
+      await reactGrab.clickHistoryButton();
+      await reactGrab.page.waitForTimeout(200);
+
+      await reactGrab.hoverHistoryItem(0);
+
+      await expect
+        .poll(
+          async () => {
+            const labels = await reactGrab.getLabelInstancesInfo();
+            return labels.filter(
+              (label) => label.status === "idle" && label.createdAt === 0,
+            ).length;
+          },
+          { timeout: 5000 },
+        )
+        .toBeGreaterThan(0);
+    });
+
+    test("should clear idle labels and show copied label after copy all", async ({
+      reactGrab,
+    }) => {
+      await copyElement(reactGrab, "li:first-child");
+      await copyElement(reactGrab, "li:last-child");
+
+      await reactGrab.clickHistoryButton();
+      await reactGrab.page.waitForTimeout(200);
+
+      await reactGrab.hoverCopyAllButton();
+      await expect
+        .poll(
+          async () => {
+            const labels = await reactGrab.getLabelInstancesInfo();
+            return labels.filter(
+              (label) => label.status === "idle" && label.createdAt === 0,
+            ).length;
+          },
+          { timeout: 5000 },
+        )
+        .toBeGreaterThanOrEqual(2);
+
+      await reactGrab.clickHistoryCopyAll();
+
+      await expect
+        .poll(
+          async () => {
+            const labels = await reactGrab.getLabelInstancesInfo();
+            const idlePreviewLabels = labels.filter(
+              (label) => label.status === "idle" && label.createdAt === 0,
+            );
+            return idlePreviewLabels.length;
+          },
+          { timeout: 5000 },
+        )
+        .toBe(0);
+
+      await expect
+        .poll(
+          async () => {
+            const labels = await reactGrab.getLabelInstancesInfo();
+            return labels.filter((label) => label.status === "copied").length;
+          },
+          { timeout: 5000 },
+        )
+        .toBeGreaterThanOrEqual(1);
+    });
+
+    test("should clear idle labels and show copied label after individual copy", async ({
+      reactGrab,
+    }) => {
+      await copyElement(reactGrab, "li:first-child");
+      await reactGrab.clickHistoryButton();
+      await reactGrab.page.waitForTimeout(200);
+
+      await reactGrab.hoverHistoryItem(0);
+      await expect
+        .poll(
+          async () => {
+            const labels = await reactGrab.getLabelInstancesInfo();
+            return labels.filter(
+              (label) => label.status === "idle" && label.createdAt === 0,
+            ).length;
+          },
+          { timeout: 5000 },
+        )
+        .toBeGreaterThan(0);
+
+      await reactGrab.clickHistoryItem(0);
+
+      await expect
+        .poll(
+          async () => {
+            const labels = await reactGrab.getLabelInstancesInfo();
+            const idlePreviewLabels = labels.filter(
+              (label) => label.status === "idle" && label.createdAt === 0,
+            );
+            return idlePreviewLabels.length;
+          },
+          { timeout: 5000 },
+        )
+        .toBe(0);
+
+      await expect
+        .poll(
+          async () => {
+            const labels = await reactGrab.getLabelInstancesInfo();
+            return labels.filter((label) => label.status === "copied").length;
+          },
+          { timeout: 5000 },
+        )
+        .toBeGreaterThanOrEqual(1);
+    });
+
+    test("should clear idle labels and show copied label after copy button click", async ({
+      reactGrab,
+    }) => {
+      await copyElement(reactGrab, "li:first-child");
+      await reactGrab.clickHistoryButton();
+      await reactGrab.page.waitForTimeout(200);
+
+      await reactGrab.hoverHistoryItem(0);
+      await expect
+        .poll(
+          async () => {
+            const labels = await reactGrab.getLabelInstancesInfo();
+            return labels.filter(
+              (label) => label.status === "idle" && label.createdAt === 0,
+            ).length;
+          },
+          { timeout: 5000 },
+        )
+        .toBeGreaterThan(0);
+
+      await reactGrab.clickHistoryItemCopy(0);
+
+      await expect
+        .poll(
+          async () => {
+            const labels = await reactGrab.getLabelInstancesInfo();
+            const idlePreviewLabels = labels.filter(
+              (label) => label.status === "idle" && label.createdAt === 0,
+            );
+            return idlePreviewLabels.length;
+          },
+          { timeout: 5000 },
+        )
+        .toBe(0);
+
+      await expect
+        .poll(
+          async () => {
+            const labels = await reactGrab.getLabelInstancesInfo();
+            return labels.filter((label) => label.status === "copied").length;
+          },
+          { timeout: 5000 },
+        )
+        .toBeGreaterThanOrEqual(1);
+    });
+  });
 });

--- a/packages/react-grab/e2e/hold-activation.spec.ts
+++ b/packages/react-grab/e2e/hold-activation.spec.ts
@@ -62,6 +62,27 @@ test.describe("Hold Activation Mode", () => {
     await reactGrab.page.mouse.up();
   });
 
+  test("should cancel hold when pressing a non-activation key during hold", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.page.click("body");
+
+    await reactGrab.page.keyboard.down(reactGrab.modifierKey);
+    await reactGrab.page.keyboard.down("c");
+    await reactGrab.page.waitForTimeout(50);
+
+    await reactGrab.page.keyboard.down("a");
+    await reactGrab.page.keyboard.up("c");
+
+    await reactGrab.page.waitForTimeout(500);
+
+    const isVisible = await reactGrab.isOverlayVisible();
+    expect(isVisible).toBe(false);
+
+    await reactGrab.page.keyboard.up("a");
+    await reactGrab.page.keyboard.up(reactGrab.modifierKey);
+  });
+
   test("should copy heading element after API activation", async ({
     reactGrab,
   }) => {

--- a/packages/react-grab/e2e/toolbar.spec.ts
+++ b/packages/react-grab/e2e/toolbar.spec.ts
@@ -16,16 +16,21 @@ test.describe("Toolbar", () => {
         .toBe(true);
     });
 
-    test("toolbar should be hidden on mobile viewport", async ({
+    test("toolbar should be visible on mobile viewport after reload", async ({
       reactGrab,
     }) => {
       await reactGrab.setViewportSize(375, 667);
       await reactGrab.page.reload();
       await reactGrab.page.waitForLoadState("domcontentloaded");
+      await reactGrab.page.waitForFunction(
+        () =>
+          (window as { __REACT_GRAB__?: unknown }).__REACT_GRAB__ !== undefined,
+        { timeout: 10000 },
+      );
 
       await expect
-        .poll(() => reactGrab.isToolbarVisible(), { timeout: 2000 })
-        .toBe(false);
+        .poll(() => reactGrab.isToolbarVisible(), { timeout: 3000 })
+        .toBe(true);
 
       await reactGrab.setViewportSize(1280, 720);
     });

--- a/packages/react-grab/src/components/history-dropdown.tsx
+++ b/packages/react-grab/src/components/history-dropdown.tsx
@@ -298,7 +298,9 @@ export const HistoryDropdown: Component<HistoryDropdownProps> = (props) => {
                     }}
                     onMouseEnter={() => {
                       setActiveHeaderTooltip("copy");
-                      props.onCopyAllHover?.(true);
+                      if (!isCopyAllConfirmed()) {
+                        props.onCopyAllHover?.(true);
+                      }
                     }}
                     onMouseLeave={() => {
                       setActiveHeaderTooltip(null);

--- a/packages/react-grab/src/components/toolbar/index.tsx
+++ b/packages/react-grab/src/components/toolbar/index.tsx
@@ -1466,7 +1466,7 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
                     visible={isSelectTooltipVisible() && !isCollapsed()}
                     position={tooltipPosition()}
                   >
-                    Select
+                    Select element
                   </Tooltip>
                 </div>
               </div>
@@ -1514,7 +1514,7 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
                     visible={isCommentTooltipVisible() && !isCollapsed()}
                     position={tooltipPosition()}
                   >
-                    Comment
+                    Add comment
                   </Tooltip>
                 </div>
               </div>

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -98,6 +98,13 @@ export interface ReactGrabState {
     bounds: OverlayBounds;
     createdAt: number;
   }>;
+  labelInstances: Array<{
+    id: string;
+    status: SelectionLabelStatus;
+    tagName: string;
+    componentName?: string;
+    createdAt: number;
+  }>;
   selectionFilePath: string | null;
   toolbarState: ToolbarState | null;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core keyboard activation and history-copy rendering timing, which can affect fundamental UX flows; changes are localized and backed by expanded E2E tests.
> 
> **Overview**
> Fixes overlay interaction edge cases by **canceling hold-to-activate when other Cmd/Ctrl shortcuts are pressed**, and by tightening history copy UX so preview selection labels are cleared before showing the post-copy “copied” label (using deferred/batched updates).
> 
> Exposes `labelInstances` on the public `ReactGrabState`/debug API and updates E2E fixtures to query them; adds new E2E coverage for selection-label lifecycle during history hover/copy, adds a hold-cancel test, and loosens several timing-sensitive waits (agent sessions, freeze/unfreeze, toolbar mobile reload). Also prevents `onCopyAllHover` from firing while the copy-all confirmation state is active and updates toolbar tooltip copy text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2389f2819d9bdfd0559726bf646fa87d646ed761. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes selection label behavior in the history dropdown and improves hold-activation reliability. Adds labelInstances to the public state for better debugging and test coverage.

- **Bug Fixes**
  - Selection labels: show idle preview on history hover; clear previews before displaying "copied" labels on copy and copy-all; defer and batch updates to remove flicker.
  - Activation and UI: cancel hold when a non-activation key is pressed; ensure toolbar is visible on mobile after reload; only trigger copy-all hover when not confirmed; clearer tooltips; longer waits in tests for stability.

- **New Features**
  - Expose labelInstances in ReactGrabState and window.__REACT_GRAB__.getState; add test helpers for hovering "Copy all" and reading labelInstances.

<sup>Written for commit 2389f2819d9bdfd0559726bf646fa87d646ed761. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

