### PR TITLE
fix shadcn dropdowns

### DIFF
--- a/packages/react-grab/src/components/clear-history-prompt.tsx
+++ b/packages/react-grab/src/components/clear-history-prompt.tsx
@@ -150,7 +150,6 @@ export const ClearHistoryPrompt: Component<ClearHistoryPromptProps> = (
       const isEscape = event.code === "Escape";
       if (isEnter || isEscape) {
         event.preventDefault();
-        event.stopPropagation();
         event.stopImmediatePropagation();
         if (isEscape) {
           props.onCancel();

--- a/packages/react-grab/src/components/selection-label/completion-view.tsx
+++ b/packages/react-grab/src/components/selection-label/completion-view.tsx
@@ -28,11 +28,9 @@ const MoreOptionsButton: Component<MoreOptionsButtonProps> = (props) => {
       class="flex items-center justify-center size-[18px] rounded-sm cursor-pointer bg-transparent hover:bg-black/10 text-black/30 hover:text-black border-none outline-none p-0 shrink-0 press-scale"
       // HACK: Native events with stopImmediatePropagation needed to block document-level handlers in the overlay system
       on:pointerdown={(event) => {
-        event.stopPropagation();
         event.stopImmediatePropagation();
       }}
       on:click={(event) => {
-        event.stopPropagation();
         event.stopImmediatePropagation();
         props.onClick();
       }}
@@ -94,7 +92,6 @@ export const CompletionView: Component<CompletionViewProps> = (props) => {
     const isEscape = event.code === "Escape";
 
     if (!isUndoRedo) {
-      event.stopPropagation();
       event.stopImmediatePropagation();
     }
 

--- a/packages/react-grab/src/components/selection-label/index.tsx
+++ b/packages/react-grab/src/components/selection-label/index.tsx
@@ -112,12 +112,10 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
 
     if (isEnterToExpand) {
       event.preventDefault();
-      event.stopPropagation();
       event.stopImmediatePropagation();
       props.onToggleExpand?.();
     } else if (isCtrlCToAbort) {
       event.preventDefault();
-      event.stopPropagation();
       event.stopImmediatePropagation();
       props.onAbort?.();
     }
@@ -292,7 +290,6 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
       return;
     }
 
-    event.stopPropagation();
     event.stopImmediatePropagation();
 
     const isEnterWithoutShift = event.code === "Enter" && !event.shiftKey;
@@ -329,7 +326,6 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
   const isActionCycleVisible = () => Boolean(props.actionCycleState?.isVisible);
 
   const handleTagClick = (event: MouseEvent) => {
-    event.stopPropagation();
     event.stopImmediatePropagation();
     if (props.filePath && props.onOpen) {
       props.onOpen();
@@ -339,7 +335,6 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
   const isTagClickable = () => Boolean(props.filePath && props.onOpen);
 
   const handleContainerPointerDown = (event: PointerEvent) => {
-    event.stopPropagation();
     event.stopImmediatePropagation();
     const isEditableInputVisible =
       canInteract() &&
@@ -378,7 +373,6 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
         }}
         onPointerDown={handleContainerPointerDown}
         onClick={(event) => {
-          event.stopPropagation();
           event.stopImmediatePropagation();
         }}
         onMouseEnter={() => props.onHoverChange?.(true)}

--- a/packages/react-grab/src/components/toolbar/index.tsx
+++ b/packages/react-grab/src/components/toolbar/index.tsx
@@ -236,7 +236,6 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
   };
 
   const stopEventPropagation = (event: Event) => {
-    event.stopPropagation();
     event.stopImmediatePropagation();
   };
 
@@ -675,7 +674,6 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
 
   const createDragAwareHandler =
     (callback: () => void) => (event: MouseEvent) => {
-      event.stopPropagation();
       event.stopImmediatePropagation();
       if (didDragOccur) {
         didDragOccur = false;

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -2053,7 +2053,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       if (shouldBlockEnter) {
         keyboardClaimer.claimedEvents.add(event);
         event.preventDefault();
-        event.stopPropagation();
         event.stopImmediatePropagation();
         return true;
       }
@@ -2155,7 +2154,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
       if (canActivateFromCopied) {
         event.preventDefault();
-        event.stopPropagation();
         event.stopImmediatePropagation();
 
         const center = getBoundsCenter(createElementBounds(copiedElement));
@@ -2176,7 +2174,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
       if (canActivateFromHolding) {
         event.preventDefault();
-        event.stopPropagation();
         event.stopImmediatePropagation();
 
         const element = store.frozenElement || targetElement();
@@ -2407,7 +2404,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       if ((isActivated() || isHoldingKeys()) && !isPromptMode()) {
         event.preventDefault();
         if (isEnterCode(event.code)) {
-          event.stopPropagation();
           event.stopImmediatePropagation();
         }
       }
@@ -2760,7 +2756,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         if (didHandle) {
           document.documentElement.setPointerCapture(event.pointerId);
           event.preventDefault();
-          event.stopPropagation();
           event.stopImmediatePropagation();
         }
       },
@@ -2832,7 +2827,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
         if (isRendererActive() || isCopying() || didJustDrag()) {
           event.preventDefault();
-          event.stopPropagation();
           event.stopImmediatePropagation();
 
           if (store.wasActivatedByToggle && !isCopying() && !isPromptMode()) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes global input/mouse event propagation semantics and the pseudo-state freeze/restore mechanism, which can affect host-page interactions and visual state restoration in subtle ways.
> 
> **Overview**
> Tightens the overlay/event-blocking behavior by **removing most `event.stopPropagation()` calls** across the selection label, completion view, clear-history prompt, toolbar, and core event listeners, relying on `event.stopImmediatePropagation()` to prevent page-level (e.g. dropdown) handlers from firing.
> 
> Refactors `freeze-pseudo-states.ts` to **freeze/restore hover/focus styling by tracking and restoring only the affected inline style properties** (via per-property maps) instead of restoring full `cssText`, simplifying the logic and avoiding clobbering unrelated inline styles while pseudo-states are frozen.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 475bfb6a9b3b8ea5f03a9ec07cf0e7e43a33821b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Shadcn dropdowns by relaxing event propagation and improving pseudo‑state freezing. Menus now open and interact reliably without keyboard/pointer conflicts or style flicker.

- **Bug Fixes**
  - Removed stopPropagation in UI/core handlers; kept stopImmediatePropagation so Shadcn dropdown events can bubble while still blocking our overlay listeners.
  - Scoped Enter/Escape prevention to relevant cases and preserved undo/redo behavior.

- **Refactors**
  - Reworked freezePseudoStates to capture and restore only the specific style properties we modify, not entire cssText, preventing animation resets and visual flashes.
  - Unified hover/focus collection and skip already-frozen elements for safer, predictable style restoration.

<sup>Written for commit 475bfb6a9b3b8ea5f03a9ec07cf0e7e43a33821b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

