### PR TITLE
general refactor

### DIFF
--- a/packages/react-grab/src/components/clear-history-prompt.tsx
+++ b/packages/react-grab/src/components/clear-history-prompt.tsx
@@ -16,7 +16,7 @@ import {
   DROPDOWN_VIEWPORT_PADDING_PX,
   PANEL_STYLES,
 } from "../constants.js";
-import { clampToViewport } from "../utils/clamp-to-viewport.js";
+import { getAnchoredDropdownPosition } from "../utils/get-anchored-dropdown-position.js";
 import { cn } from "../utils/cn.js";
 import { isEventFromOverlay } from "../utils/is-event-from-overlay.js";
 import { isKeyboardEventTriggeredByInput } from "../utils/is-keyboard-event-triggered-by-input.js";
@@ -78,53 +78,18 @@ export const ClearHistoryPrompt: Component<ClearHistoryPromptProps> = (
     }
   });
 
-  const computedPosition = () => {
-    const anchor = props.position;
-    const width = measuredWidth();
-    const height = measuredHeight();
-
-    if (!anchor || width === 0 || height === 0) {
-      return DROPDOWN_OFFSCREEN_POSITION;
-    }
-
-    const { edge } = anchor;
-
-    let rawLeft: number;
-    let rawTop: number;
-
-    if (edge === "left" || edge === "right") {
-      rawLeft =
-        edge === "left"
-          ? anchor.x + DROPDOWN_ANCHOR_GAP_PX
-          : anchor.x - width - DROPDOWN_ANCHOR_GAP_PX;
-      rawTop = anchor.y - height / 2;
-    } else {
-      rawLeft = anchor.x - width / 2;
-      rawTop =
-        edge === "top"
-          ? anchor.y + DROPDOWN_ANCHOR_GAP_PX
-          : anchor.y - height - DROPDOWN_ANCHOR_GAP_PX;
-    }
-
-    return {
-      left: clampToViewport(
-        rawLeft,
-        width,
-        window.innerWidth,
-        DROPDOWN_VIEWPORT_PADDING_PX,
-      ),
-      top: clampToViewport(
-        rawTop,
-        height,
-        window.innerHeight,
-        DROPDOWN_VIEWPORT_PADDING_PX,
-      ),
-    };
-  };
-
   const displayPosition = createMemo(
     (previousPosition: { left: number; top: number }) => {
-      const position = computedPosition();
+      const position = getAnchoredDropdownPosition({
+        anchor: props.position,
+        measuredWidth: measuredWidth(),
+        measuredHeight: measuredHeight(),
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+        anchorGapPx: DROPDOWN_ANCHOR_GAP_PX,
+        viewportPaddingPx: DROPDOWN_VIEWPORT_PADDING_PX,
+        offscreenPosition: DROPDOWN_OFFSCREEN_POSITION,
+      });
       if (position.left !== DROPDOWN_OFFSCREEN_POSITION.left) {
         return position;
       }

--- a/packages/react-grab/src/components/history-dropdown.tsx
+++ b/packages/react-grab/src/components/history-dropdown.tsx
@@ -24,7 +24,7 @@ import {
   PANEL_STYLES,
 } from "../constants.js";
 import { createSafePolygonTracker } from "../utils/safe-polygon.js";
-import { clampToViewport } from "../utils/clamp-to-viewport.js";
+import { getAnchoredDropdownPosition } from "../utils/get-anchored-dropdown-position.js";
 import { cn } from "../utils/cn.js";
 import { IconTrash } from "./icons/icon-trash.jsx";
 import { IconCopy } from "./icons/icon-copy.jsx";
@@ -158,53 +158,18 @@ export const HistoryDropdown: Component<HistoryDropdownProps> = (props) => {
     ),
   );
 
-  const computedPosition = () => {
-    const anchor = props.position;
-    const width = measuredWidth();
-    const height = measuredHeight();
-
-    if (!anchor || width === 0 || height === 0) {
-      return DROPDOWN_OFFSCREEN_POSITION;
-    }
-
-    const { edge } = anchor;
-
-    let rawLeft: number;
-    let rawTop: number;
-
-    if (edge === "left" || edge === "right") {
-      rawLeft =
-        edge === "left"
-          ? anchor.x + DROPDOWN_ANCHOR_GAP_PX
-          : anchor.x - width - DROPDOWN_ANCHOR_GAP_PX;
-      rawTop = anchor.y - height / 2;
-    } else {
-      rawLeft = anchor.x - width / 2;
-      rawTop =
-        edge === "top"
-          ? anchor.y + DROPDOWN_ANCHOR_GAP_PX
-          : anchor.y - height - DROPDOWN_ANCHOR_GAP_PX;
-    }
-
-    return {
-      left: clampToViewport(
-        rawLeft,
-        width,
-        window.innerWidth,
-        DROPDOWN_VIEWPORT_PADDING_PX,
-      ),
-      top: clampToViewport(
-        rawTop,
-        height,
-        window.innerHeight,
-        DROPDOWN_VIEWPORT_PADDING_PX,
-      ),
-    };
-  };
-
   const displayPosition = createMemo(
     (previousPosition: { left: number; top: number }) => {
-      const position = computedPosition();
+      const position = getAnchoredDropdownPosition({
+        anchor: props.position,
+        measuredWidth: measuredWidth(),
+        measuredHeight: measuredHeight(),
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+        anchorGapPx: DROPDOWN_ANCHOR_GAP_PX,
+        viewportPaddingPx: DROPDOWN_VIEWPORT_PADDING_PX,
+        offscreenPosition: DROPDOWN_OFFSCREEN_POSITION,
+      });
       if (position.left !== DROPDOWN_OFFSCREEN_POSITION.left) {
         return position;
       }

--- a/packages/react-grab/src/components/selection-label/index.tsx
+++ b/packages/react-grab/src/components/selection-label/index.tsx
@@ -274,8 +274,6 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
     };
   });
 
-  const computedPosition = () => positionComputation().position;
-
   createEffect(() => {
     const result = positionComputation();
     if (result.computedArrowPosition !== null) {
@@ -364,9 +362,9 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
           "fixed font-sans text-[13px] antialiased filter-[drop-shadow(0px_1px_2px_#51515140)] select-none transition-opacity duration-100 ease-out",
         )}
         style={{
-          top: `${computedPosition().top}px`,
-          left: `${computedPosition().left}px`,
-          transform: `translateX(calc(-50% + ${computedPosition().edgeOffsetX}px))`,
+          top: `${positionComputation().position.top}px`,
+          left: `${positionComputation().position.left}px`,
+          transform: `translateX(calc(-50% + ${positionComputation().position.edgeOffsetX}px))`,
           "z-index": "2147483647",
           "pointer-events": shouldEnablePointerEvents() ? "auto" : "none",
           opacity: props.status === "fading" || isInternalFading() ? 0 : 1,
@@ -381,8 +379,8 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
         <Show when={!props.hideArrow}>
           <Arrow
             position={arrowPosition()}
-            leftPercent={computedPosition().arrowLeftPercent}
-            leftOffsetPx={computedPosition().arrowLeftOffset}
+            leftPercent={positionComputation().position.arrowLeftPercent}
+            leftOffsetPx={positionComputation().position.arrowLeftOffset}
             labelWidth={panelWidth()}
           />
         </Show>

--- a/packages/react-grab/src/components/toolbar/index.tsx
+++ b/packages/react-grab/src/components/toolbar/index.tsx
@@ -1561,6 +1561,10 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
                   <button
                     data-react-grab-ignore-events
                     data-react-grab-toolbar-toggle
+                    aria-label={
+                      props.isActive ? "Stop selecting element" : "Select element"
+                    }
+                    aria-pressed={Boolean(props.isActive)}
                     class={cn(
                       "contain-layout flex items-center justify-center cursor-pointer interactive-scale touch-hitbox",
                       buttonSpacingClass(),
@@ -1610,6 +1614,13 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
                   <button
                     data-react-grab-ignore-events
                     data-react-grab-toolbar-history
+                    aria-label={`Open history${
+                      (props.historyItemCount ?? 0) > 0
+                        ? ` (${props.historyItemCount ?? 0} items)`
+                        : ""
+                    }`}
+                    aria-haspopup="menu"
+                    aria-expanded={Boolean(props.isHistoryDropdownOpen)}
                     class={cn(
                       "contain-layout flex items-center justify-center cursor-pointer interactive-scale touch-hitbox",
                       buttonSpacingClass(),
@@ -1677,6 +1688,7 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
                   <button
                     data-react-grab-ignore-events
                     data-react-grab-toolbar-copy-all
+                    aria-label="Copy all history items"
                     class={cn(
                       "contain-layout flex items-center justify-center cursor-pointer interactive-scale touch-hitbox",
                       buttonSpacingClass(),
@@ -1733,6 +1745,13 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
                   <button
                     data-react-grab-ignore-events
                     data-react-grab-toolbar-menu
+                    aria-label={
+                      props.isMenuOpen
+                        ? "Close more actions menu"
+                        : "Open more actions menu"
+                    }
+                    aria-haspopup="menu"
+                    aria-expanded={Boolean(props.isMenuOpen)}
                     class={cn(
                       "contain-layout flex items-center justify-center cursor-pointer interactive-scale touch-hitbox",
                       buttonSpacingClass(),
@@ -1776,6 +1795,10 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
               <button
                 data-react-grab-ignore-events
                 data-react-grab-toolbar-enabled
+                aria-label={
+                  props.enabled ? "Disable React Grab" : "Enable React Grab"
+                }
+                aria-pressed={Boolean(props.enabled)}
                 class={cn(
                   "contain-layout flex items-center justify-center cursor-pointer interactive-scale outline-none",
                   isVertical() ? "my-0.5" : "mx-0.5",
@@ -1816,6 +1839,7 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
         <button
           data-react-grab-ignore-events
           data-react-grab-toolbar-collapse
+          aria-label={isCollapsed() ? "Expand toolbar" : "Collapse toolbar"}
           class="contain-layout shrink-0 flex items-center justify-center cursor-pointer interactive-scale"
           onClick={handleToggleCollapse}
         >

--- a/packages/react-grab/src/components/toolbar/toolbar-content.tsx
+++ b/packages/react-grab/src/components/toolbar/toolbar-content.tsx
@@ -69,6 +69,8 @@ export const ToolbarContent: Component<ToolbarContentProps> = (props) => {
 
   const defaultSelectButton = () => (
     <button
+      aria-label={props.isActive ? "Stop selecting element" : "Select element"}
+      aria-pressed={Boolean(props.isActive)}
       class={cn(
         "contain-layout flex items-center justify-center cursor-pointer interactive-scale touch-hitbox",
         buttonSpacingClass(),
@@ -87,6 +89,8 @@ export const ToolbarContent: Component<ToolbarContentProps> = (props) => {
 
   const defaultToggleButton = () => (
     <button
+      aria-label={props.enabled ? "Disable React Grab" : "Enable React Grab"}
+      aria-pressed={Boolean(props.enabled)}
       class={cn(
         "contain-layout flex items-center justify-center cursor-pointer interactive-scale outline-none",
         isVertical() ? "my-0.5" : "mx-0.5",
@@ -112,7 +116,10 @@ export const ToolbarContent: Component<ToolbarContentProps> = (props) => {
   );
 
   const defaultCollapseButton = () => (
-    <button class="contain-layout shrink-0 flex items-center justify-center cursor-pointer interactive-scale">
+    <button
+      aria-label={props.isCollapsed ? "Expand toolbar" : "Collapse toolbar"}
+      class="contain-layout shrink-0 flex items-center justify-center cursor-pointer interactive-scale"
+    >
       <IconChevron
         class={cn(
           "text-[#B3B3B3] transition-transform duration-150",

--- a/packages/react-grab/src/components/toolbar/toolbar-menu.tsx
+++ b/packages/react-grab/src/components/toolbar/toolbar-menu.tsx
@@ -18,7 +18,7 @@ import {
   TOOLBAR_MENU_MIN_WIDTH_PX,
   PANEL_STYLES,
 } from "../../constants.js";
-import { clampToViewport } from "../../utils/clamp-to-viewport.js";
+import { getAnchoredDropdownPosition } from "../../utils/get-anchored-dropdown-position.js";
 import { cn } from "../../utils/cn.js";
 import { formatShortcut } from "../../utils/format-shortcut.js";
 import { isEventFromOverlay } from "../../utils/is-event-from-overlay.js";
@@ -79,53 +79,18 @@ export const ToolbarMenu: Component<ToolbarMenuProps> = (props) => {
     }
   });
 
-  const computedPosition = () => {
-    const anchor = props.position;
-    const width = measuredWidth();
-    const height = measuredHeight();
-
-    if (!anchor || width === 0 || height === 0) {
-      return DROPDOWN_OFFSCREEN_POSITION;
-    }
-
-    const { edge } = anchor;
-
-    let rawLeft: number;
-    let rawTop: number;
-
-    if (edge === "left" || edge === "right") {
-      rawLeft =
-        edge === "left"
-          ? anchor.x + DROPDOWN_ANCHOR_GAP_PX
-          : anchor.x - width - DROPDOWN_ANCHOR_GAP_PX;
-      rawTop = anchor.y - height / 2;
-    } else {
-      rawLeft = anchor.x - width / 2;
-      rawTop =
-        edge === "top"
-          ? anchor.y + DROPDOWN_ANCHOR_GAP_PX
-          : anchor.y - height - DROPDOWN_ANCHOR_GAP_PX;
-    }
-
-    return {
-      left: clampToViewport(
-        rawLeft,
-        width,
-        window.innerWidth,
-        DROPDOWN_VIEWPORT_PADDING_PX,
-      ),
-      top: clampToViewport(
-        rawTop,
-        height,
-        window.innerHeight,
-        DROPDOWN_VIEWPORT_PADDING_PX,
-      ),
-    };
-  };
-
   const displayPosition = createMemo(
     (previousPosition: { left: number; top: number }) => {
-      const position = computedPosition();
+      const position = getAnchoredDropdownPosition({
+        anchor: props.position,
+        measuredWidth: measuredWidth(),
+        measuredHeight: measuredHeight(),
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+        anchorGapPx: DROPDOWN_ANCHOR_GAP_PX,
+        viewportPaddingPx: DROPDOWN_VIEWPORT_PADDING_PX,
+        offscreenPosition: DROPDOWN_OFFSCREEN_POSITION,
+      });
       if (position.left !== DROPDOWN_OFFSCREEN_POSITION.left) {
         return position;
       }

--- a/packages/react-grab/src/core/agent/manager.ts
+++ b/packages/react-grab/src/core/agent/manager.ts
@@ -18,6 +18,7 @@ import {
 import { createElementBounds } from "../../utils/create-element-bounds.js";
 import { isElementConnected } from "../../utils/is-element-connected.js";
 import { generateSnippet } from "../../utils/generate-snippet.js";
+import { recalculateSessionPosition } from "../../utils/recalculate-session-position.js";
 import { getNearestComponentName } from "../context.js";
 import {
   DISMISS_ANIMATION_BUFFER_MS,
@@ -689,20 +690,11 @@ export const createAgentManager = (
         if (newBounds.length > 0) {
           const oldFirstBounds = session.selectionBounds[0];
           const newFirstBounds = newBounds[0];
-          let updatedPosition = session.position;
-
-          if (oldFirstBounds && newFirstBounds) {
-            const oldCenterX = oldFirstBounds.x + oldFirstBounds.width / 2;
-            const oldHalfWidth = oldFirstBounds.width / 2;
-            const offsetX = session.position.x - oldCenterX;
-            const offsetRatio = oldHalfWidth > 0 ? offsetX / oldHalfWidth : 0;
-            const newCenterX = newFirstBounds.x + newFirstBounds.width / 2;
-            const newHalfWidth = newFirstBounds.width / 2;
-            updatedPosition = {
-              ...session.position,
-              x: newCenterX + offsetRatio * newHalfWidth,
-            };
-          }
+          const updatedPosition = recalculateSessionPosition({
+            currentPosition: session.position,
+            previousBounds: oldFirstBounds,
+            nextBounds: newFirstBounds,
+          });
 
           updatedSessions.set(sessionId, {
             ...session,

--- a/packages/react-grab/src/core/store.ts
+++ b/packages/react-grab/src/core/store.ts
@@ -9,6 +9,7 @@ import type {
 import { OFFSCREEN_POSITION } from "../constants.js";
 import { createElementBounds } from "../utils/create-element-bounds.js";
 import { isElementConnected } from "../utils/is-element-connected.js";
+import { recalculateSessionPosition } from "../utils/recalculate-session-position.js";
 
 interface Position {
   x: number;
@@ -656,20 +657,11 @@ const createGrabStore = (input: GrabStoreInput) => {
         if (isElementConnected(element)) {
           const newBounds = createElementBounds(element);
           const oldFirstBounds = session.selectionBounds[0];
-          let updatedPosition = session.position;
-
-          if (oldFirstBounds) {
-            const oldCenterX = oldFirstBounds.x + oldFirstBounds.width / 2;
-            const oldHalfWidth = oldFirstBounds.width / 2;
-            const offsetX = session.position.x - oldCenterX;
-            const offsetRatio = oldHalfWidth > 0 ? offsetX / oldHalfWidth : 0;
-            const newCenterX = newBounds.x + newBounds.width / 2;
-            const newHalfWidth = newBounds.width / 2;
-            updatedPosition = {
-              ...session.position,
-              x: newCenterX + offsetRatio * newHalfWidth,
-            };
-          }
+          const updatedPosition = recalculateSessionPosition({
+            currentPosition: session.position,
+            previousBounds: oldFirstBounds,
+            nextBounds: newBounds,
+          });
 
           updatedSessions.set(sessionId, {
             ...session,

--- a/packages/react-grab/src/utils/get-anchored-dropdown-position.ts
+++ b/packages/react-grab/src/utils/get-anchored-dropdown-position.ts
@@ -1,0 +1,65 @@
+import type { DropdownAnchor } from "../types.js";
+import { clampToViewport } from "./clamp-to-viewport.js";
+
+interface DropdownPosition {
+  left: number;
+  top: number;
+}
+
+interface GetAnchoredDropdownPositionOptions {
+  anchor: DropdownAnchor | null;
+  measuredWidth: number;
+  measuredHeight: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  anchorGapPx: number;
+  viewportPaddingPx: number;
+  offscreenPosition: DropdownPosition;
+}
+
+export const getAnchoredDropdownPosition = ({
+  anchor,
+  measuredWidth,
+  measuredHeight,
+  viewportWidth,
+  viewportHeight,
+  anchorGapPx,
+  viewportPaddingPx,
+  offscreenPosition,
+}: GetAnchoredDropdownPositionOptions): DropdownPosition => {
+  if (!anchor || measuredWidth === 0 || measuredHeight === 0) {
+    return offscreenPosition;
+  }
+
+  let rawLeft: number;
+  let rawTop: number;
+
+  if (anchor.edge === "left" || anchor.edge === "right") {
+    rawLeft =
+      anchor.edge === "left"
+        ? anchor.x + anchorGapPx
+        : anchor.x - measuredWidth - anchorGapPx;
+    rawTop = anchor.y - measuredHeight / 2;
+  } else {
+    rawLeft = anchor.x - measuredWidth / 2;
+    rawTop =
+      anchor.edge === "top"
+        ? anchor.y + anchorGapPx
+        : anchor.y - measuredHeight - anchorGapPx;
+  }
+
+  return {
+    left: clampToViewport(
+      rawLeft,
+      measuredWidth,
+      viewportWidth,
+      viewportPaddingPx,
+    ),
+    top: clampToViewport(
+      rawTop,
+      measuredHeight,
+      viewportHeight,
+      viewportPaddingPx,
+    ),
+  };
+};

--- a/packages/react-grab/src/utils/recalculate-session-position.ts
+++ b/packages/react-grab/src/utils/recalculate-session-position.ts
@@ -1,0 +1,38 @@
+import type { OverlayBounds } from "../types.js";
+import { getBoundsCenter } from "./get-bounds-center.js";
+
+interface Position {
+  x: number;
+  y: number;
+}
+
+interface RecalculateSessionPositionOptions {
+  currentPosition: Position;
+  previousBounds: OverlayBounds | undefined;
+  nextBounds: OverlayBounds | undefined;
+}
+
+export const recalculateSessionPosition = ({
+  currentPosition,
+  previousBounds,
+  nextBounds,
+}: RecalculateSessionPositionOptions): Position => {
+  if (!previousBounds || !nextBounds) {
+    return currentPosition;
+  }
+
+  const previousBoundsCenter = getBoundsCenter(previousBounds);
+  const nextBoundsCenter = getBoundsCenter(nextBounds);
+  const previousBoundsHalfWidth = previousBounds.width / 2;
+  const positionOffsetFromCenterX = currentPosition.x - previousBoundsCenter.x;
+  const positionOffsetRatio =
+    previousBoundsHalfWidth > 0
+      ? positionOffsetFromCenterX / previousBoundsHalfWidth
+      : 0;
+  const nextBoundsHalfWidth = nextBounds.width / 2;
+
+  return {
+    ...currentPosition,
+    x: nextBoundsCenter.x + positionOffsetRatio * nextBoundsHalfWidth,
+  };
+};


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly refactors, but it touches positioning calculations and global animation freezing logic, which can cause subtle UI regressions if edge cases differ from the previous implementations.
> 
> **Overview**
> Refactors dropdown positioning by extracting the repeated anchor + viewport clamping math into `getAnchoredDropdownPosition` and wiring `ClearHistoryPrompt`, `HistoryDropdown`, and `ToolbarMenu` to use it.
> 
> Extracts agent session X-position recalculation on bounds changes into `recalculateSessionPosition` and reuses it in both the agent manager and the core store.
> 
> Improves UI polish/accessibility by adding `aria-label`/`aria-pressed`/`aria-expanded`/`aria-haspopup` attributes to toolbar buttons, and updates `freeze-animations` to also pause/resume SVG SMIL animations (with reference counting to handle nested freezes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 752a38a2bea54ef482d2073851c6b93521a9ba0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized dropdown and session positioning into shared utilities, extended animation freezing to include SVG, and improved toolbar accessibility with ARIA attributes. This reduces duplicated logic and makes overlays more consistent.

- **Refactors**
  - Use getAnchoredDropdownPosition in ClearHistoryPrompt, HistoryDropdown, and ToolbarMenu for consistent anchored positioning and viewport clamping.
  - Extract recalculateSessionPosition and apply in agent manager and store to preserve relative X offset when bounds change.
  - Simplify SelectionLabel to use positionComputation directly.

- **Bug Fixes**
  - Freeze and resume SVG animations during global and element-level freezes, with depth tracking for nested freezes.
  - Add ARIA labels and states (aria-pressed, aria-expanded, aria-haspopup) to select, history, copy all, menu, enable/disable, and collapse buttons.

<sup>Written for commit 752a38a2bea54ef482d2073851c6b93521a9ba0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

