### PR TITLE
Install tabs agent prompt

### DIFF
--- a/packages/website/components/install-tabs.tsx
+++ b/packages/website/components/install-tabs.tsx
@@ -26,7 +26,8 @@ interface InstallTab {
   id: string;
   label: string;
   description: React.ReactNode;
-  lang?: "tsx" | "bash" | "text";
+  variant: "code" | "command" | "prompt";
+  lang?: "tsx" | "bash";
   getCode: (hotkey: RecordedHotkey | null) => string;
   getChangedLines: (hotkey: RecordedHotkey | null) => number[];
 }
@@ -40,6 +41,7 @@ const installTabsData: InstallTab[] = [
     id: "cli",
     label: "CLI",
     description: "Run this command at your project root",
+    variant: "command",
     lang: "bash",
     getCode: (hotkey) => {
       if (hotkey) {
@@ -53,7 +55,7 @@ const installTabsData: InstallTab[] = [
     id: "prompt",
     label: "Prompt",
     description: "Paste this prompt in your coding agent's chat",
-    lang: "text",
+    variant: "prompt",
     getCode: (hotkey) => {
       const command = hotkey
         ? `npx -y grab@latest init --key "${hotkeyToString(hotkey)}"`
@@ -70,6 +72,7 @@ const installTabsData: InstallTab[] = [
         Add this inside of your <InlineCode>app/layout.tsx</InlineCode>
       </>
     ),
+    variant: "code",
     getCode: (hotkey) => {
       const dataOptionsAttr = hotkey
         ? `\n            data-options='{"activationKey":"${hotkeyToString(
@@ -106,6 +109,7 @@ export default function RootLayout({ children }) {
         Add this into your <InlineCode>pages/_document.tsx</InlineCode>
       </>
     ),
+    variant: "code",
     getCode: (hotkey) => {
       const dataOptionsAttr = hotkey
         ? `\n            data-options='{"activationKey":"${hotkeyToString(
@@ -147,6 +151,7 @@ export default function Document() {
         development
       </>
     ),
+    variant: "code",
     getCode: (hotkey) => {
       if (hotkey) {
         return `<!doctype html>
@@ -196,6 +201,7 @@ export default function Document() {
         the top of your main entry file
       </>
     ),
+    variant: "code",
     getCode: (hotkey) => {
       if (hotkey) {
         return `import React from "react";
@@ -244,6 +250,7 @@ root.render(
         Add this inside your <InlineCode>src/routes/__root.tsx</InlineCode>
       </>
     ),
+    variant: "code",
     getCode: (hotkey) => {
       if (hotkey) {
         return `import { useEffect } from "react";
@@ -287,6 +294,12 @@ function RootComponent() {
   },
 ];
 
+const HEADING_TEXT_BY_VARIANT: Record<InstallTab["variant"], string> = {
+  prompt: "Copy this to your agent:",
+  command: "Run this command to get started:",
+  code: "It takes 1 script tag to get started:",
+};
+
 interface InstallTabsProps {
   showHeading?: boolean;
   showAgentNote?: boolean;
@@ -322,7 +335,7 @@ export const InstallTabs = ({
         installTabsData.map(async (tab) => ({
           id: tab.id,
           html:
-            tab.lang === "text"
+            tab.variant === "prompt"
               ? ""
               : await highlightCode({
                   code: tab.getCode(hotkey),
@@ -371,21 +384,14 @@ export const InstallTabs = ({
     return null;
   }
 
-  const hasSimpleLayout = activeTabId === "cli" || activeTabId === "prompt";
-
-  const headingText =
-    activeTabId === "prompt"
-      ? "Copy this to your agent:"
-      : activeTabId === "cli"
-        ? "Run this command to get started:"
-        : "It takes 1 script tag to get started:";
+  const headingText = HEADING_TEXT_BY_VARIANT[activeTab.variant];
 
   return (
     <div>
       {showHeading && (
         <span className="hidden sm:inline text-white">
           {headingText}
-          {hasSimpleLayout && (
+          {activeTab.variant !== "code" && (
             <button
               type="button"
               onClick={() => setActiveTabId("next-app")}
@@ -420,13 +426,13 @@ export const InstallTabs = ({
         </div>
         <div className="bg-black/60 relative">
           <div className="relative">
-            {hasSimpleLayout ? (
+            {activeTab.variant !== "code" ? (
               <button
                 type="button"
                 onClick={handleCopyClick}
                 className="group flex w-full items-center justify-between gap-4 px-4 py-6 transition-colors hover:bg-white/5"
               >
-                {activeTabId === "prompt" ? (
+                {activeTab.variant === "prompt" ? (
                   <p className="text-left text-base leading-relaxed text-white/80 text-pretty">
                     {activeCode}
                   </p>
@@ -468,12 +474,12 @@ export const InstallTabs = ({
           </div>
         </div>
       </div>
-      {!hasSimpleLayout && (
+      {activeTab.variant === "code" && (
         <span className="mt-4 block text-sm text-white/50 sm:text-base">
           {activeTab.description}
         </span>
       )}
-      {showAgentNote && !hasSimpleLayout && (
+      {showAgentNote && activeTab.variant === "code" && (
         <span className="mt-2 block text-sm text-white/50 sm:text-base">
           Want to connect directly to your coding agent?{" "}
           <a href="/blog/agent" className="underline hover:text-white/70">


### PR DESCRIPTION
Add a "Prompt" tab to the Install Tabs component to provide users with an agent installation prompt.

---
<p><a href="https://cursor.com/agents/bc-5f776875-899d-4cc4-8282-60019e6f156c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f776875-899d-4cc4-8282-60019e6f156c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Prompt tab to Install Tabs so users can copy a natural-language agent prompt that finds the React project first, then runs the init command. Also simplifies tab rendering by using a variant property for layout and headings.

- New Features
  - Prompt tab to paste into a coding agent’s chat
  - Guides the agent to locate the React project (scan package.json for react), ask if multiple, then run init in that root
  - Includes hotkey in the command when available
  - Click-to-copy layout with heading “Copy this to your agent:”

- Refactors
  - Use a variant property ("code" | "command" | "prompt") for rendering and heading text
  - Prompt variant skips syntax highlighting and has no lang
  - Description and agent note show only for code tabs

<sup>Written for commit e7ebfa1e78aaafb7f065337dd65219a4e16fe8aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds a new install option and refactors tab rendering based on a `variant`; main risk is minor display/copy behavior regressions in the install widget.
> 
> **Overview**
> Adds a new **"Prompt"** install tab that generates a natural-language instruction (including the hotkey-aware `npx grab init` command) for users to paste into a coding agent chat.
> 
> Refactors `InstallTabs` to classify each tab by `variant` (`code`/`command`/`prompt`) and drives heading text, syntax-highlighting (skipped for prompts), and layout/description visibility from that variant (including when to show "Prefer manual install?").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7ebfa1e78aaafb7f065337dd65219a4e16fe8aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->