### PR TITLE
Reduce style invalidation cost during element detection

### DIFF
--- a/packages/react-grab/src/utils/freeze-pseudo-states.ts
+++ b/packages/react-grab/src/utils/freeze-pseudo-states.ts
@@ -1,7 +1,7 @@
 import { clearElementPositionCache } from "./get-element-at-position.js";
 import { createStyleElement } from "./create-style-element.js";
 
-const POINTER_EVENTS_STYLES = "* { pointer-events: none !important; }";
+const POINTER_EVENTS_STYLES = "html { pointer-events: none !important; }";
 
 const MOUSE_EVENTS_TO_BLOCK = [
   "mouseenter",

--- a/packages/react-grab/src/utils/get-element-at-position.ts
+++ b/packages/react-grab/src/utils/get-element-at-position.ts
@@ -8,7 +8,6 @@ import {
   suspendPointerEventsFreeze,
   resumePointerEventsFreeze,
 } from "./freeze-pseudo-states.js";
-import { createElementBounds } from "./create-element-bounds.js";
 
 interface PositionCache {
   clientX: number;
@@ -102,10 +101,6 @@ export const getElementAtPosition = (
         break;
       }
     }
-  }
-
-  if (result) {
-    createElementBounds(result);
   }
 
   scheduleResume();


### PR DESCRIPTION
## Summary
- Use `html` instead of `*` for the `pointer-events: none` freeze stylesheet. Since `pointer-events` is inherited, toggling on `html` invalidates one element (O(1)) instead of every DOM node (O(N)), fixing lag on dense DOMs like diff viewers.
- Remove redundant eager `createElementBounds()` call in `getElementAtPosition` — the reactive system already computes bounds when the selected element changes.

## Test plan
- [ ] Activate grab on a dense DOM page (e.g., large diff viewer) and verify hover detection is no longer laggy
- [ ] Verify element selection, overlay, and bounds still work correctly
- [ ] Verify `:hover` styles are still frozen on activation
- [ ] Check elements with explicit `pointer-events` (e.g., Tailwind `pointer-events-auto`) don't cause visible flicker during grab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how pointer-events freezing is applied (from `*` to `html`), which could alter hit-testing behavior for elements that explicitly set `pointer-events` and impact grab interactions. Also removes an eager bounds calculation, which may surface any hidden reliance on that side effect.
> 
> **Overview**
> Reduces DOM-wide style invalidation during grab hit-testing by applying the `pointer-events: none !important` freeze rule on `html` instead of `*`.
> 
> Removes the eager `createElementBounds()` call from `getElementAtPosition`, relying on downstream logic to compute bounds when the selected element changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0489e7661389f0a16fc23c8c6cb8d204d44ea670. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce lag during element detection on dense DOMs (e.g., diff viewers) by applying pointer-events: none to html instead of *, cutting style invalidation from O(N) to O(1).
Also removed the redundant createElementBounds call in getElementAtPosition; bounds are already computed when the selection changes.

<sup>Written for commit 0489e7661389f0a16fc23c8c6cb8d204d44ea670. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

