### PR TITLE
Vite demo examples

### DIFF
--- a/packages/e2e-playground/src/App.tsx
+++ b/packages/e2e-playground/src/App.tsx
@@ -627,9 +627,7 @@ const PointerUpModalSection = () => {
             className="relative bg-white rounded-lg shadow-xl p-6 w-96 z-10"
             data-testid="pointerup-modal-content"
           >
-            <h3 className="text-lg font-bold mb-2">
-              Headless UI Style Modal
-            </h3>
+            <h3 className="text-lg font-bold mb-2">Headless UI Style Modal</h3>
             <p className="mb-4">
               Uses pointerdown+pointerup pair for outside detection.
             </p>

--- a/packages/react-grab/src/utils/freeze-updates.ts
+++ b/packages/react-grab/src/utils/freeze-updates.ts
@@ -196,9 +196,7 @@ const pauseHookQueue = (queue: HookQueue): void => {
   pausedQueueStates.set(queue, pauseState);
 };
 
-const extractActionsFromChain = (
-  pending: PendingUpdate | null,
-): unknown[] => {
+const extractActionsFromChain = (pending: PendingUpdate | null): unknown[] => {
   if (!pending) return [];
   const actions: unknown[] = [];
   const first = pending.next;

--- a/packages/vite-playground/src/App.tsx
+++ b/packages/vite-playground/src/App.tsx
@@ -1,9 +1,34 @@
-import { TodoList } from "@react-grab/next-playground/components/todo-list";
+import { NotificationFeed } from "./components/notification-feed";
+import { PricingCards } from "./components/pricing-cards";
+import { UserProfileCard } from "./components/user-profile-card";
 
-export default function App() {
+const App = () => {
   return (
-    <div className="p-12 flex flex-col gap-4">
-      <TodoList />
+    <div className="max-w-5xl mx-auto px-6 py-16 flex flex-col gap-16">
+      <header>
+        <h1 className="text-3xl font-bold tracking-tight">React Grab Demo</h1>
+        <p className="text-muted-foreground mt-2">
+          Hover over any element and press ⌘C to grab its context. Can you spot
+          the bugs?
+        </p>
+      </header>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-4">User Profile</h2>
+        <UserProfileCard />
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-4">Pricing</h2>
+        <PricingCards />
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-4">Notifications</h2>
+        <NotificationFeed />
+      </section>
     </div>
   );
-}
+};
+
+export default App;

--- a/packages/vite-playground/src/components/notification-feed.tsx
+++ b/packages/vite-playground/src/components/notification-feed.tsx
@@ -1,0 +1,206 @@
+interface Notification {
+  id: number;
+  title: string;
+  description: string;
+  timestamp: string;
+  variant: "info" | "success" | "warning" | "error";
+  isRead: boolean;
+}
+
+const VARIANT_ICON_CLASSES: Record<Notification["variant"], string> = {
+  info: "text-blue-500",
+  success: "text-green-500",
+  warning: "text-amber-500",
+  error: "text-red-500",
+};
+
+interface NotificationIconProps {
+  variant: Notification["variant"];
+}
+
+const NotificationIcon = (props: NotificationIconProps) => {
+  const iconColorClassName = VARIANT_ICON_CLASSES[props.variant];
+
+  if (props.variant === "info") {
+    return (
+      <svg
+        className={`w-5 h-5 shrink-0 ${iconColorClassName}`}
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+        />
+      </svg>
+    );
+  }
+
+  if (props.variant === "success") {
+    return (
+      <svg
+        className={`w-5 h-5 shrink-0 ${iconColorClassName}`}
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+        />
+      </svg>
+    );
+  }
+
+  if (props.variant === "warning") {
+    return (
+      <svg
+        className={`w-5 h-5 shrink-0 ${iconColorClassName}`}
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"
+        />
+      </svg>
+    );
+  }
+
+  return (
+    <svg
+      className={`w-5 h-5 shrink-0 ${iconColorClassName}`}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+  );
+};
+
+interface NotificationItemProps {
+  notification: Notification;
+}
+
+const NotificationItem = (props: NotificationItemProps) => {
+  const descriptionClassName =
+    props.notification.variant === "success"
+      ? "text-green-200"
+      : "text-muted-foreground";
+
+  return (
+    <div className="flex items-start gap-3 p-4 hover:bg-muted overflow-hidden relative">
+      <NotificationIcon variant={props.notification.variant} />
+
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium">{props.notification.title}</p>
+        <p className={`text-sm ${descriptionClassName}`}>
+          {props.notification.description}
+        </p>
+      </div>
+
+      <span className="text-xs text-muted-foreground whitespace-nowrap pt-0.5">
+        {props.notification.timestamp}
+      </span>
+
+      {!props.notification.isRead && (
+        <div className="absolute -right-2 top-1/2 -translate-y-1/2 w-2.5 h-2.5 rounded-full bg-primary" />
+      )}
+    </div>
+  );
+};
+
+const NOTIFICATIONS: Notification[] = [
+  {
+    id: 1,
+    title: "New comment on your post",
+    description: "Alex replied to your design review",
+    timestamp: "2 min ago",
+    variant: "info",
+    isRead: false,
+  },
+  {
+    id: 2,
+    title: "Deployment successful",
+    description: "v2.4.0 deployed to production",
+    timestamp: "15 min ago",
+    variant: "success",
+    isRead: false,
+  },
+  {
+    id: 3,
+    title: "Storage almost full",
+    description: "You've used 90% of your storage",
+    timestamp: "1 hour ago",
+    variant: "warning",
+    isRead: true,
+  },
+  {
+    id: 4,
+    title: "Build failed",
+    description: "CI pipeline failed on main branch",
+    timestamp: "2 hours ago",
+    variant: "error",
+    isRead: true,
+  },
+  {
+    id: 5,
+    title: "Team meeting in 30 min",
+    description: "Daily standup starting soon",
+    timestamp: "25 min ago",
+    variant: "info",
+    isRead: false,
+  },
+  {
+    id: 6,
+    title: "Payment received",
+    description: "$49.00 from Acme Corp",
+    timestamp: "3 hours ago",
+    variant: "success",
+    isRead: true,
+  },
+];
+
+export const NotificationFeed = () => {
+  const unreadCount = NOTIFICATIONS.filter(
+    (notification) => !notification.isRead,
+  ).length;
+
+  return (
+    <div className="rounded-xl border border-border bg-card text-card-foreground shadow-sm max-w-lg">
+      <div className="flex items-center justify-between p-4 border-b border-border">
+        <div className="flex items-center gap-2">
+          <h3 className="text-base font-semibold">Notifications</h3>
+          {unreadCount > 0 && (
+            <span className="rounded-full bg-primary text-primary-foreground px-2 py-0.5 text-xs font-medium">
+              {unreadCount}
+            </span>
+          )}
+        </div>
+        <button className="text-sm text-muted-foreground hover:text-foreground">
+          Mark all read
+        </button>
+      </div>
+
+      <div className="divide-y divide-border">
+        {NOTIFICATIONS.map((notification) => (
+          <NotificationItem key={notification.id} notification={notification} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/packages/vite-playground/src/components/pricing-cards.tsx
+++ b/packages/vite-playground/src/components/pricing-cards.tsx
@@ -1,0 +1,151 @@
+interface FeatureItemProps {
+  text: string;
+  iconClassName?: string;
+}
+
+const FeatureItem = (props: FeatureItemProps) => {
+  return (
+    <li className="flex items-center gap-2">
+      <svg
+        className={`w-4 h-4 shrink-0 ${props.iconClassName ?? "text-green-500"}`}
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+      </svg>
+      <span className="text-sm">{props.text}</span>
+    </li>
+  );
+};
+
+interface PricingPlan {
+  name: string;
+  price: string;
+  period: string;
+  description: string;
+  features: string[];
+  isPopular: boolean;
+  iconClassName?: string;
+  cardClassName?: string;
+}
+
+interface PricingCardProps {
+  plan: PricingPlan;
+}
+
+const PricingCard = (props: PricingCardProps) => {
+  const cardRounding = props.plan.cardClassName ?? "rounded-xl";
+
+  return (
+    <div
+      className={`${cardRounding} border bg-card text-card-foreground shadow-sm flex flex-col relative ${
+        props.plan.isPopular ? "border-primary border-2" : "border-border"
+      }`}
+    >
+      {props.plan.isPopular && (
+        <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-primary text-primary-foreground px-3 py-0.5 text-xs font-medium">
+          Popular
+        </div>
+      )}
+
+      <div className="p-6 flex flex-col gap-4 flex-1">
+        <div>
+          <h3 className="text-lg font-semibold">{props.plan.name}</h3>
+          <p className="text-sm text-muted-foreground">
+            {props.plan.description}
+          </p>
+        </div>
+
+        <div className="flex items-baseline gap-1">
+          <span className="text-4xl font-bold tracking-tight">
+            {props.plan.price}
+          </span>
+          <span className="text-sm text-muted-foreground">
+            /{props.plan.period}
+          </span>
+        </div>
+
+        <ul className="flex flex-col gap-2.5 flex-1">
+          {props.plan.features.map((feature) => (
+            <FeatureItem
+              key={feature}
+              text={feature}
+              iconClassName={props.plan.iconClassName}
+            />
+          ))}
+        </ul>
+
+        <button
+          className={`w-full rounded-md px-4 py-2 text-sm font-medium ${
+            props.plan.isPopular
+              ? "bg-primary text-primary-foreground hover:bg-primary/90"
+              : "border border-input bg-background text-foreground hover:bg-accent hover:text-accent-foreground"
+          }`}
+        >
+          Get started
+        </button>
+      </div>
+    </div>
+  );
+};
+
+const PLANS: PricingPlan[] = [
+  {
+    name: "Starter",
+    price: "$9",
+    period: "month",
+    description: "Perfect for side projects",
+    features: [
+      "Up to 3 projects",
+      "1 GB storage",
+      "Basic analytics",
+      "Email support",
+      "API access",
+    ],
+    isPopular: false,
+  },
+  {
+    name: "Pro",
+    price: "$29",
+    period: "month",
+    description: "For growing teams",
+    features: [
+      "Unlimited projects",
+      "50 GB storage",
+      "Advanced analytics",
+      "Priority support",
+      "API access",
+      "Custom integrations",
+    ],
+    isPopular: true,
+    iconClassName: "text-blue-500",
+    cardClassName: "rounded-none",
+  },
+  {
+    name: "Enterprise",
+    price: "$99",
+    period: "month",
+    description: "For large organizations",
+    features: [
+      "Unlimited everything",
+      "500 GB storage",
+      "Custom analytics",
+      "24/7 phone support",
+      "API access",
+      "Custom integrations",
+    ],
+    isPopular: false,
+  },
+];
+
+export const PricingCards = () => {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+      {PLANS.map((plan) => (
+        <PricingCard key={plan.name} plan={plan} />
+      ))}
+    </div>
+  );
+};

--- a/packages/vite-playground/src/components/user-profile-card.tsx
+++ b/packages/vite-playground/src/components/user-profile-card.tsx
@@ -1,0 +1,68 @@
+interface StatItemProps {
+  value: string;
+  label: string;
+  valueClassName?: string;
+}
+
+const StatItem = (props: StatItemProps) => {
+  return (
+    <div className="flex flex-col items-center">
+      <span className={props.valueClassName ?? "text-2xl font-bold"}>
+        {props.value}
+      </span>
+      <span className="text-sm text-muted-foreground">{props.label}</span>
+    </div>
+  );
+};
+
+const AvatarBadge = () => {
+  return (
+    <div className="relative">
+      <div className="w-20 h-20 rounded-full bg-gradient-to-br from-violet-500 to-indigo-600 flex items-center justify-center text-white text-2xl font-bold">
+        SC
+      </div>
+      <div className="absolute bottom-1 right-1 w-4 h-4 rounded-full bg-green-500 border-2 border-card" />
+    </div>
+  );
+};
+
+export const UserProfileCard = () => {
+  return (
+    <div className="rounded-xl border border-border bg-card text-card-foreground shadow-sm max-w-sm">
+      <div className="p-6 flex flex-col items-center gap-4">
+        <AvatarBadge />
+
+        <div className="text-center">
+          <h3 className="text-lg font-semibold">Sarah Chen</h3>
+          <p className="text-sm text-muted-foreground">
+            Product Designer at Figma
+          </p>
+        </div>
+
+        <p className="text-sm text-center text-muted-foreground">
+          Designing interfaces that make people's lives simpler. Passionate
+          about design systems and accessibility.
+        </p>
+
+        <div className="flex gap-8 py-2">
+          <StatItem value="2.4k" label="Followers" />
+          <StatItem value="891" label="Following" />
+          <StatItem
+            value="142"
+            label="Posts"
+            valueClassName="text-lg font-bold"
+          />
+        </div>
+
+        <div className="flex gap-3 w-full">
+          <button className="flex-1 rounded-md bg-primary text-primary-foreground px-4 py-2 text-sm font-medium hover:bg-white hover:text-white">
+            Follow
+          </button>
+          <button className="flex-1 rounded-md border border-input bg-background text-foreground px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground">
+            Message
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/vite-playground/src/index.css
+++ b/packages/vite-playground/src/index.css
@@ -2,25 +2,57 @@
 
 :root {
   --background: #ffffff;
-  --foreground: #171717;
+  --foreground: #0a0a0a;
+  --card: #ffffff;
+  --card-foreground: #0a0a0a;
+  --primary: #171717;
+  --primary-foreground: #fafafa;
+  --secondary: #f5f5f5;
+  --secondary-foreground: #171717;
+  --muted: #f5f5f5;
+  --muted-foreground: #737373;
+  --accent: #f5f5f5;
+  --accent-foreground: #171717;
+  --destructive: #ef4444;
+  --destructive-foreground: #fafafa;
+  --border: #e5e5e5;
+  --input: #e5e5e5;
+  --ring: #171717;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
   margin: 0;
   padding: 0;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }

--- a/packages/website/app/blog/agent/page.tsx
+++ b/packages/website/app/blog/agent/page.tsx
@@ -284,7 +284,9 @@ const AgentPage = () => {
           <p>
             The browser had the best view of your intent. The agent had the
             power to edit the code. Why not put the agent{" "}
-            <span className="text-foreground/70 font-medium">in the browser</span>
+            <span className="text-foreground/70 font-medium">
+              in the browser
+            </span>
             ?
           </p>
           <p className="text-sm text-neutral-500 mt-2">

--- a/packages/website/app/blog/intro/page.tsx
+++ b/packages/website/app/blog/intro/page.tsx
@@ -311,7 +311,9 @@ const BlogPostPage = () => {
 
         <ul className="list-disc list-inside space-y-2 pl-2">
           <li>
-            <span className="text-foreground/80 font-medium">Prompt better:</span>{" "}
+            <span className="text-foreground/80 font-medium">
+              Prompt better:
+            </span>{" "}
             Use @ to add additional context, write longer and more specific
             prompts (this is something YOU control)
           </li>
@@ -374,8 +376,8 @@ const BlogPostPage = () => {
               className=&quot;flex flex-col gap-5 text-shimmer&quot;
             </code>
             ) made the coding agent{" "}
-            <span className="text-foreground/80 font-medium">much</span> faster at
-            finding what I was referencing. In short - there are shortcuts to
+            <span className="text-foreground/80 font-medium">much</span> faster
+            at finding what I was referencing. In short - there are shortcuts to
             reduce the number of steps needed to search!
           </p>
           <p>

--- a/packages/website/app/open-file/page.tsx
+++ b/packages/website/app/open-file/page.tsx
@@ -266,10 +266,7 @@ const OpenFileContent = () => {
       {isInfoOpen && (
         <p className="mt-2 text-center text-xs text-muted-foreground/60">
           Select any element in your React app and copy its context to AI tools.{" "}
-          <Link
-            href="/"
-            className="underline hover:text-muted-foreground"
-          >
+          <Link href="/" className="underline hover:text-muted-foreground">
             Learn more
           </Link>
         </p>

--- a/packages/website/app/privacy/page.tsx
+++ b/packages/website/app/privacy/page.tsx
@@ -93,7 +93,9 @@ const PrivacyPage = () => {
           </section>
 
           <section>
-            <p className="text-foreground font-bold mb-2">How React Grab Works</p>
+            <p className="text-foreground font-bold mb-2">
+              How React Grab Works
+            </p>
             <p className="mb-2">
               React Grab operates entirely locally in your browser. When you use
               the extension:
@@ -124,8 +126,8 @@ const PrivacyPage = () => {
                 webpage you visit.
               </li>
               <li>
-                <span className="text-foreground">Storage:</span> Used only to store
-                your extension preferences locally on your device.
+                <span className="text-foreground">Storage:</span> Used only to
+                store your extension preferences locally on your device.
               </li>
               <li>
                 <span className="text-foreground">Active Tab:</span> Needed to
@@ -150,7 +152,9 @@ const PrivacyPage = () => {
           </section>
 
           <section>
-            <p className="text-foreground font-bold mb-2">Third-Party Services</p>
+            <p className="text-foreground font-bold mb-2">
+              Third-Party Services
+            </p>
             <p>
               React Grab does not integrate with any third-party analytics,
               tracking, or advertising services. The extension operates entirely
@@ -176,7 +180,9 @@ const PrivacyPage = () => {
           </section>
 
           <section>
-            <p className="text-foreground font-bold mb-2">Changes to This Policy</p>
+            <p className="text-foreground font-bold mb-2">
+              Changes to This Policy
+            </p>
             <p>
               We may update this privacy policy from time to time. Any changes
               will be posted on this page with an updated revision date.

--- a/packages/website/components/benchmarks/benchmark-detailed-table.tsx
+++ b/packages/website/components/benchmarks/benchmark-detailed-table.tsx
@@ -332,7 +332,10 @@ export const BenchmarkDetailedTable = ({
           <tbody className="divide-y divide-border">
             {filteredAndSortedResults.length === 0 ? (
               <tr>
-                <td colSpan={11} className="py-8 text-center text-muted-foreground">
+                <td
+                  colSpan={11}
+                  className="py-8 text-center text-muted-foreground"
+                >
                   No results found matching &quot;{searchQuery}&quot;
                 </td>
               </tr>

--- a/packages/website/components/mobile-demo-animation.tsx
+++ b/packages/website/components/mobile-demo-animation.tsx
@@ -650,7 +650,9 @@ export const MobileDemoAnimation = (): ReactElement => {
               <div className="text-[13px] font-semibold text-foreground">
                 Overview
               </div>
-              <div className="text-[11px] text-muted-foreground">Last 30 days</div>
+              <div className="text-[11px] text-muted-foreground">
+                Last 30 days
+              </div>
             </div>
             <div
               ref={exportButtonRef}
@@ -674,7 +676,9 @@ export const MobileDemoAnimation = (): ReactElement => {
               >
                 $12.4k
               </div>
-              <div className="mt-1 text-[10px] text-muted-foreground">+12.5%</div>
+              <div className="mt-1 text-[10px] text-muted-foreground">
+                +12.5%
+              </div>
             </div>
 
             <div className="rounded-lg border border-border bg-muted/50 p-2.5">
@@ -684,7 +688,9 @@ export const MobileDemoAnimation = (): ReactElement => {
               <div className="text-[18px] font-semibold tabular-nums text-foreground">
                 2,847
               </div>
-              <div className="mt-1 text-[10px] text-muted-foreground">+8.2%</div>
+              <div className="mt-1 text-[10px] text-muted-foreground">
+                +8.2%
+              </div>
             </div>
 
             <div className="rounded-lg border border-border bg-muted/50 p-2.5">
@@ -694,7 +700,9 @@ export const MobileDemoAnimation = (): ReactElement => {
               <div className="text-[18px] font-semibold tabular-nums text-foreground">
                 384
               </div>
-              <div className="mt-1 text-[10px] text-muted-foreground">-2.1%</div>
+              <div className="mt-1 text-[10px] text-muted-foreground">
+                -2.1%
+              </div>
             </div>
           </div>
 

--- a/packages/website/components/ui/button.tsx
+++ b/packages/website/components/ui/button.tsx
@@ -1,9 +1,9 @@
-"use client"
+"use client";
 
-import { Button as ButtonPrimitive } from "@base-ui/react/button"
-import { cva, type VariantProps } from "class-variance-authority"
+import { Button as ButtonPrimitive } from "@base-ui/react/button";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/utils/cn"
+import { cn } from "@/utils/cn";
 
 const buttonVariants = cva(
   "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-sm font-normal whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
@@ -39,8 +39,8 @@ const buttonVariants = cva(
       variant: "default",
       size: "default",
     },
-  }
-)
+  },
+);
 
 function Button({
   className,
@@ -54,7 +54,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/packages/website/public/script.js
+++ b/packages/website/public/script.js
@@ -1,70 +1,15482 @@
-this.globalThis=this.globalThis||{};this.globalThis.__REACT_GRAB_MODULE__=(function(exports){'use strict';/**
- * @license MIT
- *
- * Copyright (c) 2025 Aiden Bai
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-var op=(e,t)=>e===t,nn=Symbol("solid-proxy"),rp=typeof Proxy=="function",Nr=Symbol("solid-track"),zi={equals:op},bc=Ec,Ft=1,Mr=2,yc={owned:null,cleanups:null,context:null,owner:null},ma={},$e=null,J=null,Fo=null,Ye=null,ft=null,Ct=null,Ui=0;function Tn(e,t){let n=Ye,o=$e,i=e.length===0,s=t===void 0?o:t,r=i?yc:{owned:null,cleanups:null,context:s?s.context:null,owner:s},c=i?e:()=>e(()=>Et(()=>Gn(r)));$e=r,Ye=null;try{return Ot(c,!0)}finally{Ye=n,$e=o;}}function U(e,t){t=t?Object.assign({},zi,t):zi;let n={value:e,observers:null,observerSlots:null,comparator:t.equals||void 0},o=i=>(typeof i=="function"&&(i=i(n.value)),Cc(n,i));return [vc.bind(n),o]}function mc(e,t,n){let o=Ki(e,t,true,Ft);Ho(o);}function te(e,t,n){let o=Ki(e,t,false,Ft);Ho(o);}function be(e,t,n){bc=cp;let o=Ki(e,t,false,Ft);(o.user=true),Ct?Ct.push(o):Ho(o);}function se(e,t,n){n=n?Object.assign({},zi,n):zi;let o=Ki(e,t,true,0);return o.observers=null,o.observerSlots=null,o.comparator=n.equals||void 0,Ho(o),vc.bind(o)}function ip(e){return e&&typeof e=="object"&&"then"in e}function ba(e,t,n){let o,i,s;typeof t=="function"?(o=e,i=t,s={}):(o=true,i=e,s=t||{});let r=null,c=ma,f=false,p="initialValue"in s,b=typeof o=="function"&&se(o),x=new Set,[H,M]=(s.storage||U)(s.initialValue),[Y,m]=U(void 0),[E,T]=U(void 0,{equals:false}),[C,R]=U(p?"ready":"unresolved");function X(L,A,y,h){return r===L&&(r=null,h!==void 0&&(p=true),(L===c||A===c)&&s.onHydrated&&queueMicrotask(()=>s.onHydrated(h,{value:A})),c=ma,fe(A,y)),A}function fe(L,A){Ot(()=>{A===void 0&&M(()=>L),R(A!==void 0?"errored":p?"ready":"unresolved"),m(A);for(let y of x.keys())y.decrement();x.clear();},false);}function j(){let L=Rr,A=H(),y=Y();if(y!==void 0&&!r)throw y;return Ye&&!Ye.user&&L,A}function le(L=true){if(L!==false&&f)return;f=false;let A=b?b():o;if(A==null||A===false){X(r,Et(H));return}let y,h=c!==ma?c:Et(()=>{try{return i(A,{value:H(),refetching:L})}catch(S){y=S;}});if(y!==void 0){X(r,void 0,Bi(y),A);return}else if(!ip(h))return X(r,h,void 0,A),h;return r=h,"v"in h?(h.s===1?X(r,h.v,void 0,A):X(r,void 0,Bi(h.v),A),h):(f=true,queueMicrotask(()=>f=false),Ot(()=>{R(p?"refreshing":"pending"),T();},false),h.then(S=>X(h,S,void 0,A),S=>X(h,void 0,Bi(S),A)))}Object.defineProperties(j,{state:{get:()=>C()},error:{get:()=>Y()},loading:{get(){let L=C();return L==="pending"||L==="refreshing"}},latest:{get(){if(!p)return j();let L=Y();if(L&&!r)throw L;return H()}}});let ue=$e;return b?mc(()=>(ue=$e,le(false))):le(false),[j,{refetch:L=>wc(ue,()=>le(L)),mutate:M}]}function ji(e){return Ot(e,false)}function Et(e){if(Ye===null)return e();let t=Ye;Ye=null;try{return Fo?Fo.untrack(e):e()}finally{Ye=t;}}function He(e,t,n){let o=Array.isArray(e),i,s=n&&n.defer;return r=>{let c;if(o){c=Array(e.length);for(let u=0;u<e.length;u++)c[u]=e[u]();}else c=e();if(s)return s=false,r;let l=Et(()=>t(c,i,r));return i=c,l}}function mt(e){be(()=>Et(e));}function Me(e){return $e===null||($e.cleanups===null?$e.cleanups=[e]:$e.cleanups.push(e)),e}function Wi(){return Ye}function wc(e,t){let n=$e,o=Ye;$e=e,Ye=null;try{return Ot(t,!0)}catch(i){Xi(i);}finally{$e=n,Ye=o;}}var[Cw,pc]=U(false);var Rr;function vc(){let e=J;if(this.sources&&(this.state))if((this.state)===Ft)Ho(this);else {let t=ft;ft=null,Ot(()=>Vi(this),false),ft=t;}if(Ye){let t=this.observers?this.observers.length:0;Ye.sources?(Ye.sources.push(this),Ye.sourceSlots.push(t)):(Ye.sources=[this],Ye.sourceSlots=[t]),this.observers?(this.observers.push(Ye),this.observerSlots.push(Ye.sources.length-1)):(this.observers=[Ye],this.observerSlots=[Ye.sources.length-1]);}return e&&J.sources.has(this)?this.tValue:this.value}function Cc(e,t,n){let o=e.value;if(!e.comparator||!e.comparator(o,t)){e.value=t;e.observers&&e.observers.length&&Ot(()=>{for(let i=0;i<e.observers.length;i+=1){let s=e.observers[i],r=J&&J.running;r&&J.disposed.has(s)||((r?!s.tState:!s.state)&&(s.pure?ft.push(s):Ct.push(s),s.observers&&Sc(s)),r?s.tState=Ft:s.state=Ft);}if(ft.length>1e6)throw ft=[],new Error},false);}return t}function Ho(e){if(!e.fn)return;Gn(e);let t=Ui;gc(e,e.value,t);}function gc(e,t,n){let o,i=$e,s=Ye;Ye=$e=e;try{o=e.fn(t);}catch(r){return e.pure&&((e.state=Ft,e.owned&&e.owned.forEach(Gn),e.owned=null)),e.updatedAt=n+1,Xi(r)}finally{Ye=s,$e=i;}(!e.updatedAt||e.updatedAt<=n)&&(e.updatedAt!=null&&"observers"in e?Cc(e,o):e.value=o,e.updatedAt=n);}function Ki(e,t,n,o=Ft,i){let s={fn:e,state:o,updatedAt:null,owned:null,sources:null,sourceSlots:null,cleanups:null,value:t,owner:$e,context:$e?$e.context:null,pure:n};if($e===null||$e!==yc&&($e.owned?$e.owned.push(s):$e.owned=[s]),Fo);return s}function Ir(e){let t=J;if((e.state)===0)return;if((e.state)===Mr)return Vi(e);if(e.suspense&&Et(e.suspense.inFallback))return e.suspense.effects.push(e);let n=[e];for(;(e=e.owner)&&(!e.updatedAt||e.updatedAt<Ui);){(e.state)&&n.push(e);}for(let o=n.length-1;o>=0;o--){if(e=n[o],t);if((e.state)===Ft)Ho(e);else if((e.state)===Mr){let i=ft;ft=null,Ot(()=>Vi(e,n[0]),false),ft=i;}}}function Ot(e,t){if(ft)return e();let n=false;t||(ft=[]),Ct?n=true:Ct=[],Ui++;try{let o=e();return ap(n),o}catch(o){n||(Ct=null),ft=null,Xi(o);}}function ap(e){if(ft&&(Ec(ft),ft=null),e)return;let n=Ct;Ct=null,n.length&&Ot(()=>bc(n),false);}function Ec(e){for(let t=0;t<e.length;t++)Ir(e[t]);}function cp(e){let t,n=0;for(t=0;t<e.length;t++){let o=e[t];o.user?e[n++]=o:Ir(o);}for(t=0;t<n;t++)Ir(e[t]);}function Vi(e,t){e.state=0;for(let o=0;o<e.sources.length;o+=1){let i=e.sources[o];if(i.sources){let s=i.state;s===Ft?i!==t&&(!i.updatedAt||i.updatedAt<Ui)&&Ir(i):s===Mr&&Vi(i,t);}}}function Sc(e){for(let n=0;n<e.observers.length;n+=1){let o=e.observers[n];(!o.state)&&(o.state=Mr,o.pure?ft.push(o):Ct.push(o),o.observers&&Sc(o));}}function Gn(e){let t;if(e.sources)for(;e.sources.length;){let n=e.sources.pop(),o=e.sourceSlots.pop(),i=n.observers;if(i&&i.length){let s=i.pop(),r=n.observerSlots.pop();o<i.length&&(s.sourceSlots[r]=o,i[o]=s,n.observerSlots[o]=r);}}if(e.tOwned){for(t=e.tOwned.length-1;t>=0;t--)Gn(e.tOwned[t]);delete e.tOwned;}if(e.owned){for(t=e.owned.length-1;t>=0;t--)Gn(e.owned[t]);e.owned=null;}if(e.cleanups){for(t=e.cleanups.length-1;t>=0;t--)e.cleanups[t]();e.cleanups=null;}e.state=0;}function Bi(e){return e instanceof Error?e:new Error(typeof e=="string"?e:"Unknown error",{cause:e})}function Xi(e,t=$e){let o=Bi(e);throw o;}var ha=Symbol("fallback");function Gi(e){for(let t=0;t<e.length;t++)e[t]();}function up(e,t,n={}){let o=[],i=[],s=[],r=0,c=t.length>1?[]:null;return Me(()=>Gi(s)),()=>{let l=e()||[],u=l.length,f,p;return l[Nr],Et(()=>{let x,H,M,Y,m,E,T,C,R;if(u===0)r!==0&&(Gi(s),s=[],o=[],i=[],r=0,c&&(c=[])),n.fallback&&(o=[ha],i[0]=Tn(X=>(s[0]=X,n.fallback())),r=1);else if(r===0){for(i=new Array(u),p=0;p<u;p++)o[p]=l[p],i[p]=Tn(b);r=u;}else {for(M=new Array(u),Y=new Array(u),c&&(m=new Array(u)),E=0,T=Math.min(r,u);E<T&&o[E]===l[E];E++);for(T=r-1,C=u-1;T>=E&&C>=E&&o[T]===l[C];T--,C--)M[C]=i[T],Y[C]=s[T],c&&(m[C]=c[T]);for(x=new Map,H=new Array(C+1),p=C;p>=E;p--)R=l[p],f=x.get(R),H[p]=f===void 0?-1:f,x.set(R,p);for(f=E;f<=T;f++)R=o[f],p=x.get(R),p!==void 0&&p!==-1?(M[p]=i[f],Y[p]=s[f],c&&(m[p]=c[f]),p=H[p],x.set(R,p)):s[f]();for(p=E;p<u;p++)p in M?(i[p]=M[p],s[p]=Y[p],c&&(c[p]=m[p],c[p](p))):i[p]=Tn(b);i=i.slice(0,r=u),o=l.slice(0);}return i});function b(x){if(s[p]=x,c){let[H,M]=U(p);return c[p]=M,t(l[p],H)}return t(l[p])}}}function dp(e,t,n={}){let o=[],i=[],s=[],r=[],c=0,l;return Me(()=>Gi(s)),()=>{let u=e()||[],f=u.length;return u[Nr],Et(()=>{if(f===0)return c!==0&&(Gi(s),s=[],o=[],i=[],c=0,r=[]),n.fallback&&(o=[ha],i[0]=Tn(b=>(s[0]=b,n.fallback())),c=1),i;for(o[0]===ha&&(s[0](),s=[],o=[],i=[],c=0),l=0;l<f;l++)l<o.length&&o[l]!==u[l]?r[l](()=>u[l]):l>=o.length&&(i[l]=Tn(p));for(;l<o.length;l++)s[l]();return c=r.length=s.length=f,o=u.slice(0),i=i.slice(0,c)});function p(b){s[l]=b;let[x,H]=U(u[l]);return r[l]=H,t(x,l)}}}function O(e,t){return Et(()=>e(t||{}))}function Hi(){return  true}var mp={get(e,t,n){return t===nn?n:e.get(t)},has(e,t){return t===nn?true:e.has(t)},set:Hi,deleteProperty:Hi,getOwnPropertyDescriptor(e,t){return {configurable:true,enumerable:true,get(){return e.get(t)},set:Hi,deleteProperty:Hi}},ownKeys(e){return e.keys()}};function pa(e){return (e=typeof e=="function"?e():e)?e:{}}function pp(){for(let e=0,t=this.length;e<t;++e){let n=this[e]();if(n!==void 0)return n}}function Bo(...e){let t=false;for(let r=0;r<e.length;r++){let c=e[r];t=t||!!c&&nn in c,e[r]=typeof c=="function"?(t=true,se(c)):c;}if(rp&&t)return new Proxy({get(r){for(let c=e.length-1;c>=0;c--){let l=pa(e[c])[r];if(l!==void 0)return l}},has(r){for(let c=e.length-1;c>=0;c--)if(r in pa(e[c]))return  true;return  false},keys(){let r=[];for(let c=0;c<e.length;c++)r.push(...Object.keys(pa(e[c])));return [...new Set(r)]}},mp);let n={},o=Object.create(null);for(let r=e.length-1;r>=0;r--){let c=e[r];if(!c)continue;let l=Object.getOwnPropertyNames(c);for(let u=l.length-1;u>=0;u--){let f=l[u];if(f==="__proto__"||f==="constructor")continue;let p=Object.getOwnPropertyDescriptor(c,f);if(!o[f])o[f]=p.get?{enumerable:true,configurable:true,get:pp.bind(n[f]=[p.get.bind(c)])}:p.value!==void 0?p:void 0;else {let b=n[f];b&&(p.get?b.push(p.get.bind(c)):p.value!==void 0&&b.push(()=>p.value));}}}let i={},s=Object.keys(o);for(let r=s.length-1;r>=0;r--){let c=s[r],l=o[c];l&&l.get?Object.defineProperty(i,c,l):i[c]=l?l.value:void 0;}return i}var gp=e=>`Stale read from <${e}>.`;function on(e){let t="fallback"in e&&{fallback:()=>e.fallback};return se(up(()=>e.each,e.children,t||void 0))}function Yi(e){let t="fallback"in e&&{fallback:()=>e.fallback};return se(dp(()=>e.each,e.children,t||void 0))}function ye(e){let t=e.keyed,n=se(()=>e.when,void 0,void 0),o=t?n:se(n,void 0,{equals:(i,s)=>!i==!s});return se(()=>{let i=o();if(i){let s=e.children;return typeof s=="function"&&s.length>0?Et(()=>s(t?i:()=>{if(!Et(o))throw gp("Show");return n()})):s}return e.fallback},void 0,void 0)}var bp=["allowfullscreen","async","alpha","autofocus","autoplay","checked","controls","default","disabled","formnovalidate","hidden","indeterminate","inert","ismap","loop","multiple","muted","nomodule","novalidate","open","playsinline","readonly","required","reversed","seamless","selected","adauctionheaders","browsingtopics","credentialless","defaultchecked","defaultmuted","defaultselected","defer","disablepictureinpicture","disableremoteplayback","preservespitch","shadowrootclonable","shadowrootcustomelementregistry","shadowrootdelegatesfocus","shadowrootserializable","sharedstoragewritable"],yp=new Set(["className","value","readOnly","noValidate","formNoValidate","isMap","noModule","playsInline","adAuctionHeaders","allowFullscreen","browsingTopics","defaultChecked","defaultMuted","defaultSelected","disablePictureInPicture","disableRemotePlayback","preservesPitch","shadowRootClonable","shadowRootCustomElementRegistry","shadowRootDelegatesFocus","shadowRootSerializable","sharedStorageWritable",...bp]),wp=new Set(["innerHTML","textContent","innerText","children"]),xp=Object.assign(Object.create(null),{className:"class",htmlFor:"for"}),vp=Object.assign(Object.create(null),{class:"className",novalidate:{$:"noValidate",FORM:1},formnovalidate:{$:"formNoValidate",BUTTON:1,INPUT:1},ismap:{$:"isMap",IMG:1},nomodule:{$:"noModule",SCRIPT:1},playsinline:{$:"playsInline",VIDEO:1},readonly:{$:"readOnly",INPUT:1,TEXTAREA:1},adauctionheaders:{$:"adAuctionHeaders",IFRAME:1},allowfullscreen:{$:"allowFullscreen",IFRAME:1},browsingtopics:{$:"browsingTopics",IMG:1},defaultchecked:{$:"defaultChecked",INPUT:1},defaultmuted:{$:"defaultMuted",AUDIO:1,VIDEO:1},defaultselected:{$:"defaultSelected",OPTION:1},disablepictureinpicture:{$:"disablePictureInPicture",VIDEO:1},disableremoteplayback:{$:"disableRemotePlayback",AUDIO:1,VIDEO:1},preservespitch:{$:"preservesPitch",AUDIO:1,VIDEO:1},shadowrootclonable:{$:"shadowRootClonable",TEMPLATE:1},shadowrootdelegatesfocus:{$:"shadowRootDelegatesFocus",TEMPLATE:1},shadowrootserializable:{$:"shadowRootSerializable",TEMPLATE:1},sharedstoragewritable:{$:"sharedStorageWritable",IFRAME:1,IMG:1}});function Cp(e,t){let n=vp[e];return typeof n=="object"?n[t]?n.$:void 0:n}var Ep=new Set(["beforeinput","click","dblclick","contextmenu","focusin","focusout","input","keydown","keyup","mousedown","mousemove","mouseout","mouseover","mouseup","pointerdown","pointermove","pointerout","pointerover","pointerup","touchend","touchmove","touchstart"]);var Be=e=>se(()=>e());function Ap(e,t,n){let o=n.length,i=t.length,s=o,r=0,c=0,l=t[i-1].nextSibling,u=null;for(;r<i||c<s;){if(t[r]===n[c]){r++,c++;continue}for(;t[i-1]===n[s-1];)i--,s--;if(i===r){let f=s<o?c?n[c-1].nextSibling:n[s-c]:l;for(;c<s;)e.insertBefore(n[c++],f);}else if(s===c)for(;r<i;)(!u||!u.has(t[r]))&&t[r].remove(),r++;else if(t[r]===n[s-1]&&n[c]===t[i-1]){let f=t[--i].nextSibling;e.insertBefore(n[c++],t[r++].nextSibling),e.insertBefore(n[--s],f),t[i]=n[s];}else {if(!u){u=new Map;let p=c;for(;p<s;)u.set(n[p],p++);}let f=u.get(t[r]);if(f!=null)if(c<f&&f<s){let p=r,b=1,x;for(;++p<i&&p<s&&!((x=u.get(t[p]))==null||x!==f+b);)b++;if(b>f-c){let H=t[r];for(;c<f;)e.insertBefore(n[c++],H);}else e.replaceChild(n[c++],t[r++]);}else r++;else t[r++].remove();}}}var Tc="_$DX_DELEGATE";function Oc(e,t,n,o={}){let i;return Tn(s=>{i=s,t===document?e():z(t,e(),t.firstChild?null:void 0,n);},o.owner),()=>{i(),t.textContent="";}}function K(e,t,n,o){let i,s=()=>{let c=document.createElement("template");return c.innerHTML=e,c.content.firstChild},r=()=>(i||(i=s())).cloneNode(true);return r.cloneNode=r,r}function it(e,t=window.document){let n=t[Tc]||(t[Tc]=new Set);for(let o=0,i=e.length;o<i;o++){let s=e[o];n.has(s)||(n.add(s),t.addEventListener(s,Mp));}}function ae(e,t,n){(n==null?e.removeAttribute(t):e.setAttribute(t,n));}function _p(e,t,n){(n?e.setAttribute(t,""):e.removeAttribute(t));}function Re(e,t){(t==null?e.removeAttribute("class"):e.className=t);}function Je(e,t,n,o){if(o)Array.isArray(n)?(e[`$$${t}`]=n[0],e[`$$${t}Data`]=n[1]):e[`$$${t}`]=n;else if(Array.isArray(n)){let i=n[0];e.addEventListener(t,n[0]=s=>i.call(e,n[1],s));}else e.addEventListener(t,n,typeof n!="function"&&n);}function co(e,t,n={}){let o=Object.keys(t||{}),i=Object.keys(n),s,r;for(s=0,r=i.length;s<r;s++){let c=i[s];!c||c==="undefined"||t[c]||(_c(e,c,false),delete n[c]);}for(s=0,r=o.length;s<r;s++){let c=o[s],l=!!t[c];!c||c==="undefined"||n[c]===l||!l||(_c(e,c,true),n[c]=l);}return n}function Pp(e,t,n){if(!t)return n?ae(e,"style"):t;let o=e.style;if(typeof t=="string")return o.cssText=t;typeof n=="string"&&(o.cssText=n=void 0),n||(n={}),t||(t={});let i,s;for(s in n)t[s]==null&&o.removeProperty(s),delete n[s];for(s in t)i=t[s],i!==n[s]&&(o.setProperty(s,i),n[s]=i);return n}function we(e,t,n){n!=null?e.style.setProperty(t,n):e.style.removeProperty(t);}function Lr(e,t={},n,o){let i={};return te(()=>typeof t.ref=="function"&&Ke(t.ref,e)),te(()=>kp(e,t,n,true,i,true)),i}function Ke(e,t,n){return Et(()=>e(t,n))}function z(e,t,n,o){if(n!==void 0&&!o&&(o=[]),typeof t!="function")return Vo(e,t,o,n);te(i=>Vo(e,t(),i,n),o);}function kp(e,t,n,o,i={},s=false){t||(t={});for(let r in i)if(!(r in t)){if(r==="children")continue;i[r]=Pc(e,r,null,i[r],n,s,t);}for(let r in t){if(r==="children"){continue}let c=t[r];i[r]=Pc(e,r,c,i[r],n,s,t);}}function Op(e){return e.toLowerCase().replace(/-([a-z])/g,(t,n)=>n.toUpperCase())}function _c(e,t,n){let o=t.trim().split(/\s+/);for(let i=0,s=o.length;i<s;i++)e.classList.toggle(o[i],n);}function Pc(e,t,n,o,i,s,r){let c,l,u,f,p;if(t==="style")return Pp(e,n,o);if(t==="classList")return co(e,n,o);if(n===o)return o;if(t==="ref")s||n(e);else if(t.slice(0,3)==="on:"){let b=t.slice(3);o&&e.removeEventListener(b,o,typeof o!="function"&&o),n&&e.addEventListener(b,n,typeof n!="function"&&n);}else if(t.slice(0,10)==="oncapture:"){let b=t.slice(10);o&&e.removeEventListener(b,o,true),n&&e.addEventListener(b,n,true);}else if(t.slice(0,2)==="on"){let b=t.slice(2).toLowerCase(),x=Ep.has(b);if(!x&&o){let H=Array.isArray(o)?o[0]:o;e.removeEventListener(b,H);}(x||n)&&(Je(e,b,n,x),x&&it([b]));}else if(t.slice(0,5)==="attr:")ae(e,t.slice(5),n);else if(t.slice(0,5)==="bool:")_p(e,t.slice(5),n);else if((p=t.slice(0,5)==="prop:")||(u=wp.has(t))||((f=Cp(t,e.tagName))||(l=yp.has(t)))||(c=e.nodeName.includes("-")||"is"in r)){if(p)t=t.slice(5),l=true;t==="class"||t==="className"?Re(e,n):c&&!l&&!u?e[Op(t)]=n:e[f||t]=n;}else {ae(e,xp[t]||t,n);}return n}function Mp(e){let t=e.target,n=`$$${e.type}`,o=e.target,i=e.currentTarget,s=l=>Object.defineProperty(e,"target",{configurable:true,value:l}),r=()=>{let l=t[n];if(l&&!t.disabled){let u=t[`${n}Data`];if(u!==void 0?l.call(t,u,e):l.call(t,e),e.cancelBubble)return}return t.host&&typeof t.host!="string"&&!t.host._$host&&t.contains(e.target)&&s(t.host),true},c=()=>{for(;r()&&(t=t._$host||t.parentNode||t.host););};if(Object.defineProperty(e,"currentTarget",{configurable:true,get(){return t||document}}),e.composedPath){let l=e.composedPath();s(l[0]);for(let u=0;u<l.length-2&&(t=l[u],!!r());u++){if(t._$host){t=t._$host,c();break}if(t.parentNode===i)break}}else c();s(o);}function Vo(e,t,n,o,i){for(;typeof n=="function";)n=n();if(t===n)return n;let r=typeof t,c=o!==void 0;if(e=c&&n[0]&&n[0].parentNode||e,r==="string"||r==="number"){if(r==="number"&&(t=t.toString(),t===n))return n;if(c){let l=n[0];l&&l.nodeType===3?l.data!==t&&(l.data=t):l=document.createTextNode(t),n=zo(e,n,o,l);}else n!==""&&typeof n=="string"?n=e.firstChild.data=t:n=e.textContent=t;}else if(t==null||r==="boolean"){n=zo(e,n,o);}else {if(r==="function")return te(()=>{let l=t();for(;typeof l=="function";)l=l();n=Vo(e,l,n,o);}),()=>n;if(Array.isArray(t)){let l=[],u=n&&Array.isArray(n);if(ya(l,t,n,i))return te(()=>n=Vo(e,l,n,o,true)),()=>n;if(l.length===0){if(n=zo(e,n,o),c)return n}else u?n.length===0?kc(e,l,o):Ap(e,n,l):(n&&zo(e),kc(e,l));n=l;}else if(t.nodeType){if(Array.isArray(n)){if(c)return n=zo(e,n,o,t);zo(e,n,null,t);}else n==null||n===""||!e.firstChild?e.appendChild(t):e.replaceChild(t,e.firstChild);n=t;}}return n}function ya(e,t,n,o){let i=false;for(let s=0,r=t.length;s<r;s++){let c=t[s],l=n&&n[e.length],u;if(!(c==null||c===true||c===false))if((u=typeof c)=="object"&&c.nodeType)e.push(c);else if(Array.isArray(c))i=ya(e,c,l)||i;else if(u==="function")if(o){for(;typeof c=="function";)c=c();i=ya(e,Array.isArray(c)?c:[c],Array.isArray(l)?l:[l])||i;}else e.push(c),i=true;else {let f=String(c);l&&l.nodeType===3&&l.data===f?e.push(l):e.push(document.createTextNode(f));}}return i}function kc(e,t,n=null){for(let o=0,i=t.length;o<i;o++)e.insertBefore(t[o],n);}function zo(e,t,n,o){if(n===void 0)return e.textContent="";let i=o||document.createTextNode("");if(t.length){let s=false;for(let r=t.length-1;r>=0;r--){let c=t[r];if(i!==c){let l=c.parentNode===e;!s&&!r?l?e.replaceChild(i,c):e.insertBefore(i,n):l&&c.remove();}else s=true;}}else e.insertBefore(i,n);return [i]}var Mc=`/*! tailwindcss v4.1.17 | MIT License | https://tailwindcss.com */
-@layer properties{@supports (((-webkit-hyphens:none)) and (not (margin-trim:inline))) or ((-moz-orient:inline) and (not (color:rgb(from red r g b)))){*,:before,:after,::backdrop{--tw-translate-x:0;--tw-translate-y:0;--tw-translate-z:0;--tw-scale-x:1;--tw-scale-y:1;--tw-scale-z:1;--tw-rotate-x:initial;--tw-rotate-y:initial;--tw-rotate-z:initial;--tw-skew-x:initial;--tw-skew-y:initial;--tw-border-style:solid;--tw-leading:initial;--tw-font-weight:initial;--tw-ordinal:initial;--tw-slashed-zero:initial;--tw-numeric-figure:initial;--tw-numeric-spacing:initial;--tw-numeric-fraction:initial;--tw-shadow:0 0 #0000;--tw-shadow-color:initial;--tw-shadow-alpha:100%;--tw-inset-shadow:0 0 #0000;--tw-inset-shadow-color:initial;--tw-inset-shadow-alpha:100%;--tw-ring-color:initial;--tw-ring-shadow:0 0 #0000;--tw-inset-ring-color:initial;--tw-inset-ring-shadow:0 0 #0000;--tw-ring-inset:initial;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-offset-shadow:0 0 #0000;--tw-outline-style:solid;--tw-blur:initial;--tw-brightness:initial;--tw-contrast:initial;--tw-grayscale:initial;--tw-hue-rotate:initial;--tw-invert:initial;--tw-opacity:initial;--tw-saturate:initial;--tw-sepia:initial;--tw-drop-shadow:initial;--tw-drop-shadow-color:initial;--tw-drop-shadow-alpha:100%;--tw-drop-shadow-size:initial;--tw-backdrop-blur:initial;--tw-backdrop-brightness:initial;--tw-backdrop-contrast:initial;--tw-backdrop-grayscale:initial;--tw-backdrop-hue-rotate:initial;--tw-backdrop-invert:initial;--tw-backdrop-opacity:initial;--tw-backdrop-saturate:initial;--tw-backdrop-sepia:initial;--tw-duration:initial;--tw-ease:initial;--tw-contain-size:initial;--tw-contain-layout:initial;--tw-contain-paint:initial;--tw-contain-style:initial;--tw-content:""}}}@layer theme{:root,:host{--font-sans:"Geist",ui-sans-serif,system-ui,sans-serif;--font-mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;--color-yellow-500:oklch(79.5% .184 86.047);--color-black:#000;--color-white:#fff;--spacing:4px;--text-sm:14px;--text-sm--line-height:calc(1.25/.875);--font-weight-medium:500;--radius-sm:4px;--ease-out:cubic-bezier(0,0,.2,1);--animate-ping:ping 1s cubic-bezier(0,0,.2,1)infinite;--animate-pulse:pulse 2s cubic-bezier(.4,0,.6,1)infinite;--default-transition-duration:.15s;--default-transition-timing-function:cubic-bezier(.4,0,.2,1);--default-font-family:var(--font-sans);--default-mono-font-family:var(--font-mono);--transition-fast:.1s;--transition-normal:.15s;--transition-slow:.2s}}@layer base{*,:after,:before,::backdrop{box-sizing:border-box;border:0 solid;margin:0;padding:0}::file-selector-button{box-sizing:border-box;border:0 solid;margin:0;padding:0}html,:host{-webkit-text-size-adjust:100%;tab-size:4;line-height:1.5;font-family:var(--default-font-family,ui-sans-serif,system-ui,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji");font-feature-settings:var(--default-font-feature-settings,normal);font-variation-settings:var(--default-font-variation-settings,normal);-webkit-tap-highlight-color:transparent}hr{height:0;color:inherit;border-top-width:1px}abbr:where([title]){-webkit-text-decoration:underline dotted;text-decoration:underline dotted}h1,h2,h3,h4,h5,h6{font-size:inherit;font-weight:inherit}a{color:inherit;-webkit-text-decoration:inherit;-webkit-text-decoration:inherit;-webkit-text-decoration:inherit;text-decoration:inherit}b,strong{font-weight:bolder}code,kbd,samp,pre{font-family:var(--default-mono-font-family,ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace);font-feature-settings:var(--default-mono-font-feature-settings,normal);font-variation-settings:var(--default-mono-font-variation-settings,normal);font-size:1em}small{font-size:80%}sub,sup{vertical-align:baseline;font-size:75%;line-height:0;position:relative}sub{bottom:-.25em}sup{top:-.5em}table{text-indent:0;border-color:inherit;border-collapse:collapse}:-moz-focusring{outline:auto}progress{vertical-align:baseline}summary{display:list-item}ol,ul,menu{list-style:none}img,svg,video,canvas,audio,iframe,embed,object{vertical-align:middle;display:block}img,video{max-width:100%;height:auto}button,input,select,optgroup,textarea{font:inherit;font-feature-settings:inherit;font-variation-settings:inherit;letter-spacing:inherit;color:inherit;opacity:1;background-color:#0000;border-radius:0}::file-selector-button{font:inherit;font-feature-settings:inherit;font-variation-settings:inherit;letter-spacing:inherit;color:inherit;opacity:1;background-color:#0000;border-radius:0}:where(select:is([multiple],[size])) optgroup{font-weight:bolder}:where(select:is([multiple],[size])) optgroup option{padding-inline-start:20px}::file-selector-button{margin-inline-end:4px}::placeholder{opacity:1}@supports (not ((-webkit-appearance:-apple-pay-button))) or (contain-intrinsic-size:1px){::placeholder{color:currentColor}@supports (color:color-mix(in lab, red, red)){::placeholder{color:color-mix(in oklab,currentcolor 50%,transparent)}}}textarea{resize:vertical}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-date-and-time-value{min-height:1lh;text-align:inherit}::-webkit-datetime-edit{display:inline-flex}::-webkit-datetime-edit-fields-wrapper{padding:0}::-webkit-datetime-edit{padding-block:0}::-webkit-datetime-edit-year-field{padding-block:0}::-webkit-datetime-edit-month-field{padding-block:0}::-webkit-datetime-edit-day-field{padding-block:0}::-webkit-datetime-edit-hour-field{padding-block:0}::-webkit-datetime-edit-minute-field{padding-block:0}::-webkit-datetime-edit-second-field{padding-block:0}::-webkit-datetime-edit-millisecond-field{padding-block:0}::-webkit-datetime-edit-meridiem-field{padding-block:0}::-webkit-calendar-picker-indicator{line-height:1}:-moz-ui-invalid{box-shadow:none}button,input:where([type=button],[type=reset],[type=submit]){appearance:button}::file-selector-button{appearance:button}::-webkit-inner-spin-button{height:auto}::-webkit-outer-spin-button{height:auto}[hidden]:where(:not([hidden=until-found])){display:none!important}}@layer components;@layer utilities{.pointer-events-auto{pointer-events:auto}.pointer-events-none{pointer-events:none}.collapse{visibility:collapse}.invisible{visibility:hidden}.visible{visibility:visible}.touch-hitbox{position:relative}.touch-hitbox:before{content:"";width:100%;min-width:44px;height:100%;min-height:44px;display:block;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%)}.absolute{position:absolute}.fixed{position:fixed}.relative{position:relative}.-top-0\\.5{top:calc(var(--spacing)*-.5)}.top-0{top:calc(var(--spacing)*0)}.top-0\\.5{top:calc(var(--spacing)*.5)}.top-1\\/2{top:50%}.top-full{top:100%}.-right-0\\.5{right:calc(var(--spacing)*-.5)}.right-full{right:100%}.bottom-full{bottom:100%}.left-0{left:calc(var(--spacing)*0)}.left-0\\.5{left:calc(var(--spacing)*.5)}.left-1\\.5{left:calc(var(--spacing)*1.5)}.left-1\\/2{left:50%}.left-2\\.5{left:calc(var(--spacing)*2.5)}.left-full{left:100%}.z-1{z-index:1}.z-10{z-index:10}.container{width:100%}@media (min-width:640px){.container{max-width:640px}}@media (min-width:768px){.container{max-width:768px}}@media (min-width:1024px){.container{max-width:1024px}}@media (min-width:1280px){.container{max-width:1280px}}@media (min-width:1536px){.container{max-width:1536px}}.m-0{margin:calc(var(--spacing)*0)}.-mx-2{margin-inline:calc(var(--spacing)*-2)}.mx-0\\.5{margin-inline:calc(var(--spacing)*.5)}.-my-1\\.5{margin-block:calc(var(--spacing)*-1.5)}.my-0\\.5{margin-block:calc(var(--spacing)*.5)}.mt-0\\.5{margin-top:calc(var(--spacing)*.5)}.mt-2\\.5{margin-top:calc(var(--spacing)*2.5)}.mr-0\\.5{margin-right:calc(var(--spacing)*.5)}.mr-1\\.5{margin-right:calc(var(--spacing)*1.5)}.mr-2\\.5{margin-right:calc(var(--spacing)*2.5)}.mb-0\\.5{margin-bottom:calc(var(--spacing)*.5)}.mb-1{margin-bottom:calc(var(--spacing)*1)}.mb-1\\.5{margin-bottom:calc(var(--spacing)*1.5)}.mb-2\\.5{margin-bottom:calc(var(--spacing)*2.5)}.-ml-\\[2px\\]{margin-left:-2px}.ml-0\\.5{margin-left:calc(var(--spacing)*.5)}.ml-1{margin-left:calc(var(--spacing)*1)}.ml-2\\.5{margin-left:calc(var(--spacing)*2.5)}.ml-4{margin-left:calc(var(--spacing)*4)}.ml-auto{margin-left:auto}.line-clamp-5{-webkit-line-clamp:5;-webkit-box-orient:vertical;display:-webkit-box;overflow:hidden}.block{display:block}.contents{display:contents}.flex{display:flex}.grid{display:grid}.hidden{display:none}.inline-block{display:inline-block}.inline-flex{display:inline-flex}.size-1\\.5{width:calc(var(--spacing)*1.5);height:calc(var(--spacing)*1.5)}.size-4{width:calc(var(--spacing)*4);height:calc(var(--spacing)*4)}.size-\\[18px\\]{width:18px;height:18px}.h-0{height:calc(var(--spacing)*0)}.h-1\\.5{height:calc(var(--spacing)*1.5)}.h-2{height:calc(var(--spacing)*2)}.h-2\\.5{height:calc(var(--spacing)*2.5)}.h-3{height:calc(var(--spacing)*3)}.h-4{height:calc(var(--spacing)*4)}.h-\\[17px\\]{height:17px}.h-fit{height:fit-content}.max-h-\\[240px\\]{max-height:240px}.min-h-0{min-height:calc(var(--spacing)*0)}.min-h-4{min-height:calc(var(--spacing)*4)}.w-0{width:calc(var(--spacing)*0)}.w-1\\.5{width:calc(var(--spacing)*1.5)}.w-2{width:calc(var(--spacing)*2)}.w-3\\.5{width:calc(var(--spacing)*3.5)}.w-4{width:calc(var(--spacing)*4)}.w-5{width:calc(var(--spacing)*5)}.w-\\[calc\\(100\\%\\+16px\\)\\]{width:calc(100% + 16px)}.w-auto{width:auto}.w-fit{width:fit-content}.w-full{width:100%}.max-w-\\[280px\\]{max-width:280px}.max-w-full{max-width:100%}.min-w-0{min-width:calc(var(--spacing)*0)}.min-w-\\[100px\\]{min-width:100px}.min-w-\\[150px\\]{min-width:150px}.flex-1{flex:1}.flex-shrink,.shrink{flex-shrink:1}.shrink-0{flex-shrink:0}.flex-grow,.grow{flex-grow:1}.-translate-x-1\\/2{--tw-translate-x:calc(calc(1/2*100%)*-1);translate:var(--tw-translate-x)var(--tw-translate-y)}.-translate-y-1\\/2{--tw-translate-y:calc(calc(1/2*100%)*-1);translate:var(--tw-translate-x)var(--tw-translate-y)}.scale-75{--tw-scale-x:75%;--tw-scale-y:75%;--tw-scale-z:75%;scale:var(--tw-scale-x)var(--tw-scale-y)}.scale-100{--tw-scale-x:100%;--tw-scale-y:100%;--tw-scale-z:100%;scale:var(--tw-scale-x)var(--tw-scale-y)}.-rotate-90{rotate:-90deg}.rotate-0{rotate:none}.rotate-90{rotate:90deg}.rotate-180{rotate:180deg}.interactive-scale{transition-property:transform;transition-duration:var(--transition-normal);transition-timing-function:cubic-bezier(.34,1.56,.64,1)}@media (hover:hover) and (pointer:fine){.interactive-scale:hover{transform:scale(1.05)}}.interactive-scale:active{transform:scale(.97)}.press-scale{transition-property:transform;transition-duration:var(--transition-fast);transition-timing-function:ease-out}.press-scale:active{transform:scale(.97)}.transform{transform:var(--tw-rotate-x,)var(--tw-rotate-y,)var(--tw-rotate-z,)var(--tw-skew-x,)var(--tw-skew-y,)}.animate-ping{animation:var(--animate-ping)}.animate-pulse{animation:var(--animate-pulse)}.cursor-grab{cursor:grab}.cursor-grabbing{cursor:grabbing}.cursor-pointer{cursor:pointer}.resize{resize:both}.resize-none{resize:none}.grid-cols-\\[0fr\\]{grid-template-columns:0fr}.grid-cols-\\[1fr\\]{grid-template-columns:1fr}.grid-rows-\\[0fr\\]{grid-template-rows:0fr}.grid-rows-\\[1fr\\]{grid-template-rows:1fr}.flex-col{flex-direction:column}.flex-wrap{flex-wrap:wrap}.items-center{align-items:center}.items-end{align-items:flex-end}.items-start{align-items:flex-start}.justify-between{justify-content:space-between}.justify-center{justify-content:center}.justify-end{justify-content:flex-end}.gap-0\\.5{gap:calc(var(--spacing)*.5)}.gap-1{gap:calc(var(--spacing)*1)}.gap-1\\.5{gap:calc(var(--spacing)*1.5)}.gap-2{gap:calc(var(--spacing)*2)}.gap-\\[5px\\]{gap:5px}.self-stretch{align-self:stretch}.truncate{text-overflow:ellipsis;white-space:nowrap;overflow:hidden}.overflow-hidden{overflow:hidden}.overflow-visible{overflow:visible}.overflow-y-auto{overflow-y:auto}.rounded-\\[1px\\]{border-radius:1px}.rounded-\\[10px\\]{border-radius:10px}.rounded-full{border-radius:3.40282e38px}.rounded-sm{border-radius:var(--radius-sm)}.rounded-t-\\[10px\\]{border-top-left-radius:10px;border-top-right-radius:10px}.rounded-t-none{border-top-left-radius:0;border-top-right-radius:0}.rounded-l-\\[10px\\]{border-top-left-radius:10px;border-bottom-left-radius:10px}.rounded-l-none{border-top-left-radius:0;border-bottom-left-radius:0}.rounded-r-\\[10px\\]{border-top-right-radius:10px;border-bottom-right-radius:10px}.rounded-r-none{border-top-right-radius:0;border-bottom-right-radius:0}.rounded-b-\\[6px\\]{border-bottom-right-radius:6px;border-bottom-left-radius:6px}.rounded-b-\\[10px\\]{border-bottom-right-radius:10px;border-bottom-left-radius:10px}.rounded-b-none{border-bottom-right-radius:0;border-bottom-left-radius:0}.border{border-style:var(--tw-border-style);border-width:1px}.\\[border-width\\:0\\.5px\\]{border-width:.5px}.\\[border-top-width\\:0\\.5px\\]{border-top-width:.5px}.border-none{--tw-border-style:none;border-style:none}.border-solid{--tw-border-style:solid;border-style:solid}.border-\\[\\#B3B3B3\\]{border-color:#b3b3b3}.border-t-\\[\\#D9D9D9\\]{border-top-color:#d9d9d9}.bg-\\[\\#404040\\]{background-color:#404040}.bg-\\[\\#FEF2F2\\]{background-color:#fef2f2}.bg-black{background-color:var(--color-black)}.bg-black\\/5{background-color:#0000000d}@supports (color:color-mix(in lab, red, red)){.bg-black\\/5{background-color:color-mix(in oklab,var(--color-black)5%,transparent)}}.bg-black\\/25{background-color:#00000040}@supports (color:color-mix(in lab, red, red)){.bg-black\\/25{background-color:color-mix(in oklab,var(--color-black)25%,transparent)}}.bg-transparent{background-color:#0000}.bg-white{background-color:var(--color-white)}.bg-yellow-500{background-color:var(--color-yellow-500)}.p-0{padding:calc(var(--spacing)*0)}.px-0\\.25{padding-inline:calc(var(--spacing)*.25)}.px-1\\.5{padding-inline:calc(var(--spacing)*1.5)}.px-2{padding-inline:calc(var(--spacing)*2)}.px-\\[3px\\]{padding-inline:3px}.py-0\\.5{padding-block:calc(var(--spacing)*.5)}.py-0\\.25{padding-block:calc(var(--spacing)*.25)}.py-1{padding-block:calc(var(--spacing)*1)}.py-1\\.5{padding-block:calc(var(--spacing)*1.5)}.py-2{padding-block:calc(var(--spacing)*2)}.py-px{padding-block:1px}.pt-1\\.5{padding-top:calc(var(--spacing)*1.5)}.pb-1{padding-bottom:calc(var(--spacing)*1)}.text-left{text-align:left}.font-sans{font-family:var(--font-sans)}.text-sm{font-size:var(--text-sm);line-height:var(--tw-leading,var(--text-sm--line-height))}.text-\\[10px\\]{font-size:10px}.text-\\[11px\\]{font-size:11px}.text-\\[12px\\]{font-size:12px}.text-\\[13px\\]{font-size:13px}.leading-3{--tw-leading:calc(var(--spacing)*3);line-height:calc(var(--spacing)*3)}.leading-3\\.5{--tw-leading:calc(var(--spacing)*3.5);line-height:calc(var(--spacing)*3.5)}.leading-4{--tw-leading:calc(var(--spacing)*4);line-height:calc(var(--spacing)*4)}.font-medium{--tw-font-weight:var(--font-weight-medium);font-weight:var(--font-weight-medium)}.wrap-break-word{overflow-wrap:break-word}.text-ellipsis{text-overflow:ellipsis}.whitespace-nowrap{white-space:nowrap}.text-\\[\\#71717a\\]{color:#71717a}.text-\\[\\#B3B3B3\\]{color:#b3b3b3}.text-\\[\\#B91C1C\\]{color:#b91c1c}.text-\\[\\#B91C1C\\]\\/50{color:oklab(50.542% .168942 .0880134/.5)}.text-black{color:var(--color-black)}.text-black\\/25{color:#00000040}@supports (color:color-mix(in lab, red, red)){.text-black\\/25{color:color-mix(in oklab,var(--color-black)25%,transparent)}}.text-black\\/30{color:#0000004d}@supports (color:color-mix(in lab, red, red)){.text-black\\/30{color:color-mix(in oklab,var(--color-black)30%,transparent)}}.text-black\\/40{color:#0006}@supports (color:color-mix(in lab, red, red)){.text-black\\/40{color:color-mix(in oklab,var(--color-black)40%,transparent)}}.text-black\\/50{color:#00000080}@supports (color:color-mix(in lab, red, red)){.text-black\\/50{color:color-mix(in oklab,var(--color-black)50%,transparent)}}.text-black\\/60{color:#0009}@supports (color:color-mix(in lab, red, red)){.text-black\\/60{color:color-mix(in oklab,var(--color-black)60%,transparent)}}.text-black\\/70{color:#000000b3}@supports (color:color-mix(in lab, red, red)){.text-black\\/70{color:color-mix(in oklab,var(--color-black)70%,transparent)}}.text-black\\/80{color:#000c}@supports (color:color-mix(in lab, red, red)){.text-black\\/80{color:color-mix(in oklab,var(--color-black)80%,transparent)}}.text-black\\/85{color:#000000d9}@supports (color:color-mix(in lab, red, red)){.text-black\\/85{color:color-mix(in oklab,var(--color-black)85%,transparent)}}.text-white{color:var(--color-white)}.italic{font-style:italic}.tabular-nums{--tw-numeric-spacing:tabular-nums;font-variant-numeric:var(--tw-ordinal,)var(--tw-slashed-zero,)var(--tw-numeric-figure,)var(--tw-numeric-spacing,)var(--tw-numeric-fraction,)}.antialiased{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}.opacity-0{opacity:0}.opacity-35{opacity:.35}.opacity-40{opacity:.4}.opacity-50{opacity:.5}.opacity-100{opacity:1}.shadow{--tw-shadow:0 1px 3px 0 var(--tw-shadow-color,#0000001a),0 1px 2px -1px var(--tw-shadow-color,#0000001a);box-shadow:var(--tw-inset-shadow),var(--tw-inset-ring-shadow),var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow)}.outline{outline-style:var(--tw-outline-style);outline-width:1px}.blur{--tw-blur:blur(8px);filter:var(--tw-blur,)var(--tw-brightness,)var(--tw-contrast,)var(--tw-grayscale,)var(--tw-hue-rotate,)var(--tw-invert,)var(--tw-saturate,)var(--tw-sepia,)var(--tw-drop-shadow,)}.filter{filter:var(--tw-blur,)var(--tw-brightness,)var(--tw-contrast,)var(--tw-grayscale,)var(--tw-hue-rotate,)var(--tw-invert,)var(--tw-saturate,)var(--tw-sepia,)var(--tw-drop-shadow,)}.filter-\\[drop-shadow\\(0px_1px_2px_\\#51515140\\)\\]{filter:drop-shadow(0 1px 2px #51515140)}.backdrop-filter{-webkit-backdrop-filter:var(--tw-backdrop-blur,)var(--tw-backdrop-brightness,)var(--tw-backdrop-contrast,)var(--tw-backdrop-grayscale,)var(--tw-backdrop-hue-rotate,)var(--tw-backdrop-invert,)var(--tw-backdrop-opacity,)var(--tw-backdrop-saturate,)var(--tw-backdrop-sepia,);backdrop-filter:var(--tw-backdrop-blur,)var(--tw-backdrop-brightness,)var(--tw-backdrop-contrast,)var(--tw-backdrop-grayscale,)var(--tw-backdrop-hue-rotate,)var(--tw-backdrop-invert,)var(--tw-backdrop-opacity,)var(--tw-backdrop-saturate,)var(--tw-backdrop-sepia,)}.transition{transition-property:color,background-color,border-color,outline-color,text-decoration-color,fill,stroke,--tw-gradient-from,--tw-gradient-via,--tw-gradient-to,opacity,box-shadow,transform,translate,scale,rotate,filter,-webkit-backdrop-filter,backdrop-filter,display,content-visibility,overlay,pointer-events;transition-timing-function:var(--tw-ease,var(--default-transition-timing-function));transition-duration:var(--tw-duration,var(--default-transition-duration))}.transition-\\[grid-template-columns\\,opacity\\]{transition-property:grid-template-columns,opacity;transition-timing-function:var(--tw-ease,var(--default-transition-timing-function));transition-duration:var(--tw-duration,var(--default-transition-duration))}.transition-\\[grid-template-rows\\,opacity\\]{transition-property:grid-template-rows,opacity;transition-timing-function:var(--tw-ease,var(--default-transition-timing-function));transition-duration:var(--tw-duration,var(--default-transition-duration))}.transition-\\[opacity\\,transform\\]{transition-property:opacity,transform;transition-timing-function:var(--tw-ease,var(--default-transition-timing-function));transition-duration:var(--tw-duration,var(--default-transition-duration))}.transition-\\[top\\,left\\,width\\,height\\,opacity\\]{transition-property:top,left,width,height,opacity;transition-timing-function:var(--tw-ease,var(--default-transition-timing-function));transition-duration:var(--tw-duration,var(--default-transition-duration))}.transition-\\[transform\\,opacity\\]{transition-property:transform,opacity;transition-timing-function:var(--tw-ease,var(--default-transition-timing-function));transition-duration:var(--tw-duration,var(--default-transition-duration))}.transition-all{transition-property:all;transition-timing-function:var(--tw-ease,var(--default-transition-timing-function));transition-duration:var(--tw-duration,var(--default-transition-duration))}.transition-colors{transition-property:color,background-color,border-color,outline-color,text-decoration-color,fill,stroke,--tw-gradient-from,--tw-gradient-via,--tw-gradient-to;transition-timing-function:var(--tw-ease,var(--default-transition-timing-function));transition-duration:var(--tw-duration,var(--default-transition-duration))}.transition-opacity{transition-property:opacity;transition-timing-function:var(--tw-ease,var(--default-transition-timing-function));transition-duration:var(--tw-duration,var(--default-transition-duration))}.transition-transform{transition-property:transform,translate,scale,rotate;transition-timing-function:var(--tw-ease,var(--default-transition-timing-function));transition-duration:var(--tw-duration,var(--default-transition-duration))}.duration-75{--tw-duration:75ms;transition-duration:75ms}.duration-100{--tw-duration:.1s;transition-duration:.1s}.duration-150{--tw-duration:.15s;transition-duration:.15s}.duration-300{--tw-duration:.3s;transition-duration:.3s}.ease-out{--tw-ease:var(--ease-out);transition-timing-function:var(--ease-out)}.will-change-\\[opacity\\,transform\\]{will-change:opacity,transform}.contain-layout{--tw-contain-layout:layout;contain:var(--tw-contain-size,)var(--tw-contain-layout,)var(--tw-contain-paint,)var(--tw-contain-style,)}.outline-none{--tw-outline-style:none;outline-style:none}.select-none{-webkit-user-select:none;user-select:none}.\\[corner-shape\\:superellipse\\(1\\.25\\)\\]{corner-shape:superellipse(1.25)}.\\[font-synthesis\\:none\\]{font-synthesis:none}.\\[grid-area\\:1\\/1\\]{grid-area:1/1}.\\[scrollbar-color\\:transparent_transparent\\]{scrollbar-color:transparent transparent}.\\[scrollbar-width\\:thin\\]{scrollbar-width:thin}.group-focus-within\\:invisible:is(:where(.group):focus-within *){visibility:hidden}.group-focus-within\\:visible:is(:where(.group):focus-within *){visibility:visible}@media (hover:hover){.group-hover\\:invisible:is(:where(.group):hover *){visibility:hidden}.group-hover\\:visible:is(:where(.group):hover *){visibility:visible}}.before\\:\\!min-h-full:before{content:var(--tw-content);min-height:100%!important}.before\\:\\!min-w-full:before{content:var(--tw-content);min-width:100%!important}@media (hover:hover){.hover\\:bg-\\[\\#F5F5F5\\]:hover{background-color:#f5f5f5}.hover\\:bg-\\[\\#FEE2E2\\]:hover{background-color:#fee2e2}.hover\\:bg-black\\/10:hover{background-color:#0000001a}@supports (color:color-mix(in lab, red, red)){.hover\\:bg-black\\/10:hover{background-color:color-mix(in oklab,var(--color-black)10%,transparent)}}.hover\\:text-\\[\\#B91C1C\\]:hover{color:#b91c1c}.hover\\:text-black:hover{color:var(--color-black)}.hover\\:text-black\\/60:hover{color:#0009}@supports (color:color-mix(in lab, red, red)){.hover\\:text-black\\/60:hover{color:color-mix(in oklab,var(--color-black)60%,transparent)}}.hover\\:opacity-100:hover{opacity:1}.hover\\:\\[scrollbar-color\\:rgba\\(0\\,0\\,0\\,0\\.15\\)_transparent\\]:hover{scrollbar-color:#00000026 transparent}}.disabled\\:cursor-default:disabled{cursor:default}.disabled\\:opacity-40:disabled{opacity:.4}}:host{all:initial;direction:ltr}@keyframes shake{0%,to{transform:translate(0)}15%{transform:translate(-3px)}30%{transform:translate(3px)}45%{transform:translate(-3px)}60%{transform:translate(3px)}75%{transform:translate(-2px)}90%{transform:translate(2px)}}@keyframes pop-in{0%{opacity:0;transform:scale(.9)}70%{opacity:1;transform:scale(1.02)}to{opacity:1;transform:scale(1)}}@keyframes pop-out{0%{opacity:1;transform:scale(1)}to{opacity:0;transform:scale(.95)}}@keyframes slide-in-bottom{0%{opacity:0;transform:translateY(8px)}to{opacity:1;transform:translateY(0)}}@keyframes slide-in-top{0%{opacity:0;transform:translateY(-8px)}to{opacity:1;transform:translateY(0)}}@keyframes slide-in-left{0%{opacity:0;transform:translate(-8px)}to{opacity:1;transform:translate(0)}}@keyframes slide-in-right{0%{opacity:0;transform:translate(8px)}to{opacity:1;transform:translate(0)}}@keyframes success-pop{0%{opacity:0;transform:scale(.9)}60%{opacity:1;transform:scale(1.1)}80%{transform:scale(.95)}to{opacity:1;transform:scale(1)}}@keyframes tooltip-fade-in{0%{opacity:0;transform:scale(.97)}to{opacity:1;transform:scale(1)}}@keyframes icon-loader-spin{0%{opacity:1}50%{opacity:.5}to{opacity:.2}}.icon-loader-bar{animation:.5s linear infinite icon-loader-spin}@keyframes shimmer{0%{background-position:200% 0}to{background-position:-200% 0}}.shimmer-text{color:#0000;background:linear-gradient(90deg,#71717a 0%,#a1a1aa 25%,#71717a 50%,#a1a1aa 75%,#71717a 100%) 0 0/200% 100%;-webkit-background-clip:text;background-clip:text;animation:2.5s linear infinite shimmer}@keyframes clock-flash{0%{transform:scale(1)}25%{transform:scale(1.2)}50%{transform:scale(.92)}75%{transform:scale(1.05)}to{transform:scale(1)}}.animate-clock-flash{will-change:transform;animation:.4s ease-out clock-flash}.animate-shake{will-change:transform;animation:.3s ease-out shake}.animate-pop-in{animation:pop-in var(--transition-normal)ease-out;will-change:transform,opacity}.animate-pop-out{animation:pop-out var(--transition-normal)ease-out forwards;will-change:transform,opacity}.animate-slide-in-bottom{animation:slide-in-bottom var(--transition-slow)ease-out;will-change:transform,opacity}.animate-slide-in-top{animation:slide-in-top var(--transition-slow)ease-out;will-change:transform,opacity}.animate-slide-in-left{animation:slide-in-left var(--transition-slow)ease-out;will-change:transform,opacity}.animate-slide-in-right{animation:slide-in-right var(--transition-slow)ease-out;will-change:transform,opacity}.animate-success-pop{will-change:transform,opacity;animation:.25s ease-out success-pop}.animate-tooltip-fade-in{animation:tooltip-fade-in var(--transition-fast)ease-out;will-change:transform,opacity}@property --tw-translate-x{syntax:"*";inherits:false;initial-value:0}@property --tw-translate-y{syntax:"*";inherits:false;initial-value:0}@property --tw-translate-z{syntax:"*";inherits:false;initial-value:0}@property --tw-scale-x{syntax:"*";inherits:false;initial-value:1}@property --tw-scale-y{syntax:"*";inherits:false;initial-value:1}@property --tw-scale-z{syntax:"*";inherits:false;initial-value:1}@property --tw-rotate-x{syntax:"*";inherits:false}@property --tw-rotate-y{syntax:"*";inherits:false}@property --tw-rotate-z{syntax:"*";inherits:false}@property --tw-skew-x{syntax:"*";inherits:false}@property --tw-skew-y{syntax:"*";inherits:false}@property --tw-border-style{syntax:"*";inherits:false;initial-value:solid}@property --tw-leading{syntax:"*";inherits:false}@property --tw-font-weight{syntax:"*";inherits:false}@property --tw-ordinal{syntax:"*";inherits:false}@property --tw-slashed-zero{syntax:"*";inherits:false}@property --tw-numeric-figure{syntax:"*";inherits:false}@property --tw-numeric-spacing{syntax:"*";inherits:false}@property --tw-numeric-fraction{syntax:"*";inherits:false}@property --tw-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-shadow-color{syntax:"*";inherits:false}@property --tw-shadow-alpha{syntax:"<percentage>";inherits:false;initial-value:100%}@property --tw-inset-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-inset-shadow-color{syntax:"*";inherits:false}@property --tw-inset-shadow-alpha{syntax:"<percentage>";inherits:false;initial-value:100%}@property --tw-ring-color{syntax:"*";inherits:false}@property --tw-ring-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-inset-ring-color{syntax:"*";inherits:false}@property --tw-inset-ring-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-ring-inset{syntax:"*";inherits:false}@property --tw-ring-offset-width{syntax:"<length>";inherits:false;initial-value:0}@property --tw-ring-offset-color{syntax:"*";inherits:false;initial-value:#fff}@property --tw-ring-offset-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-outline-style{syntax:"*";inherits:false;initial-value:solid}@property --tw-blur{syntax:"*";inherits:false}@property --tw-brightness{syntax:"*";inherits:false}@property --tw-contrast{syntax:"*";inherits:false}@property --tw-grayscale{syntax:"*";inherits:false}@property --tw-hue-rotate{syntax:"*";inherits:false}@property --tw-invert{syntax:"*";inherits:false}@property --tw-opacity{syntax:"*";inherits:false}@property --tw-saturate{syntax:"*";inherits:false}@property --tw-sepia{syntax:"*";inherits:false}@property --tw-drop-shadow{syntax:"*";inherits:false}@property --tw-drop-shadow-color{syntax:"*";inherits:false}@property --tw-drop-shadow-alpha{syntax:"<percentage>";inherits:false;initial-value:100%}@property --tw-drop-shadow-size{syntax:"*";inherits:false}@property --tw-backdrop-blur{syntax:"*";inherits:false}@property --tw-backdrop-brightness{syntax:"*";inherits:false}@property --tw-backdrop-contrast{syntax:"*";inherits:false}@property --tw-backdrop-grayscale{syntax:"*";inherits:false}@property --tw-backdrop-hue-rotate{syntax:"*";inherits:false}@property --tw-backdrop-invert{syntax:"*";inherits:false}@property --tw-backdrop-opacity{syntax:"*";inherits:false}@property --tw-backdrop-saturate{syntax:"*";inherits:false}@property --tw-backdrop-sepia{syntax:"*";inherits:false}@property --tw-duration{syntax:"*";inherits:false}@property --tw-ease{syntax:"*";inherits:false}@property --tw-contain-size{syntax:"*";inherits:false}@property --tw-contain-layout{syntax:"*";inherits:false}@property --tw-contain-paint{syntax:"*";inherits:false}@property --tw-contain-style{syntax:"*";inherits:false}@property --tw-content{syntax:"*";inherits:false;initial-value:""}@keyframes ping{75%,to{opacity:0;transform:scale(2)}}@keyframes pulse{50%{opacity:.5}}`;var qi=Symbol("store-raw"),Uo=Symbol("store-node"),_n=Symbol("store-has"),Rc=Symbol("store-self");function Ic(e){let t=e[nn];if(!t&&(Object.defineProperty(e,nn,{value:t=new Proxy(e,Lp)}),!Array.isArray(e))){let n=Object.keys(e),o=Object.getOwnPropertyDescriptors(e);for(let i=0,s=n.length;i<s;i++){let r=n[i];o[r].get&&Object.defineProperty(e,r,{enumerable:o[r].enumerable,get:o[r].get.bind(t)});}}return t}function jo(e){let t;return e!=null&&typeof e=="object"&&(e[nn]||!(t=Object.getPrototypeOf(e))||t===Object.prototype||Array.isArray(e))}function Wo(e,t=new Set){let n,o,i,s;if(n=e!=null&&e[qi])return n;if(!jo(e)||t.has(e))return e;if(Array.isArray(e)){Object.isFrozen(e)?e=e.slice(0):t.add(e);for(let r=0,c=e.length;r<c;r++)i=e[r],(o=Wo(i,t))!==i&&(e[r]=o);}else {Object.isFrozen(e)?e=Object.assign({},e):t.add(e);let r=Object.keys(e),c=Object.getOwnPropertyDescriptors(e);for(let l=0,u=r.length;l<u;l++)s=r[l],!c[s].get&&(i=e[s],(o=Wo(i,t))!==i&&(e[s]=o));}return e}function Zi(e,t){let n=e[t];return n||Object.defineProperty(e,t,{value:n=Object.create(null)}),n}function Fr(e,t,n){if(e[t])return e[t];let[o,i]=U(n,{equals:false,internal:true});return o.$=i,e[t]=o}function Ip(e,t){let n=Reflect.getOwnPropertyDescriptor(e,t);return !n||n.get||!n.configurable||t===nn||t===Uo||(delete n.value,delete n.writable,n.get=()=>e[nn][t]),n}function Nc(e){Wi()&&Fr(Zi(e,Uo),Rc)();}function Np(e){return Nc(e),Reflect.ownKeys(e)}var Lp={get(e,t,n){if(t===qi)return e;if(t===nn)return n;if(t===Nr)return Nc(e),n;let o=Zi(e,Uo),i=o[t],s=i?i():e[t];if(t===Uo||t===_n||t==="__proto__")return s;if(!i){let r=Object.getOwnPropertyDescriptor(e,t);Wi()&&(typeof s!="function"||e.hasOwnProperty(t))&&!(r&&r.get)&&(s=Fr(o,t,s)());}return jo(s)?Ic(s):s},has(e,t){return t===qi||t===nn||t===Nr||t===Uo||t===_n||t==="__proto__"?true:(Wi()&&Fr(Zi(e,_n),t)(),t in e)},set(){return  true},deleteProperty(){return  true},ownKeys:Np,getOwnPropertyDescriptor:Ip};function Ko(e,t,n,o=false){if(!o&&e[t]===n)return;let i=e[t],s=e.length;n===void 0?(delete e[t],e[_n]&&e[_n][t]&&i!==void 0&&e[_n][t].$()):(e[t]=n,e[_n]&&e[_n][t]&&i===void 0&&e[_n][t].$());let r=Zi(e,Uo),c;if((c=Fr(r,t,i))&&c.$(()=>n),Array.isArray(e)&&e.length!==s){for(let l=e.length;l<s;l++)(c=r[l])&&c.$();(c=Fr(r,"length",s))&&c.$(e.length);}(c=r[Rc])&&c.$();}function Lc(e,t){let n=Object.keys(t);for(let o=0;o<n.length;o+=1){let i=n[o];Ko(e,i,t[i]);}}function Dp(e,t){if(typeof t=="function"&&(t=t(e)),t=Wo(t),Array.isArray(t)){if(e===t)return;let n=0,o=t.length;for(;n<o;n++){let i=t[n];e[n]!==i&&Ko(e,n,i);}Ko(e,"length",o);}else Lc(e,t);}function Dr(e,t,n=[]){let o,i=e;if(t.length>1){o=t.shift();let r=typeof o,c=Array.isArray(e);if(Array.isArray(o)){for(let l=0;l<o.length;l++)Dr(e,[o[l]].concat(t),n);return}else if(c&&r==="function"){for(let l=0;l<e.length;l++)o(e[l],l)&&Dr(e,[l].concat(t),n);return}else if(c&&r==="object"){let{from:l=0,to:u=e.length-1,by:f=1}=o;for(let p=l;p<=u;p+=f)Dr(e,[p].concat(t),n);return}else if(t.length>1){Dr(e[o],t,[o].concat(n));return}i=e[o],n=[o].concat(n);}let s=t[0];typeof s=="function"&&(s=s(i,n),s===i)||o===void 0&&s==null||(s=Wo(s),o===void 0||jo(i)&&jo(s)&&!Array.isArray(s)?Lc(i,s):Ko(e,o,s));}function Qi(...[e,t]){let n=Wo(e||{}),o=Array.isArray(n),i=Ic(n);function s(...r){ji(()=>{o&&r.length===1?Dp(n,r[0]):Dr(n,r);});}return [i,s]}var Ji=new WeakMap,Dc={get(e,t){if(t===qi)return e;let n=e[t],o;return jo(n)?Ji.get(n)||(Ji.set(n,o=new Proxy(n,Dc)),o):n},set(e,t,n){return Ko(e,t,Wo(n)),true},deleteProperty(e,t){return Ko(e,t,void 0,true),true}};function Wt(e){return t=>{if(jo(t)){let n;(n=Ji.get(t))||Ji.set(t,n=new Proxy(t,Dc)),e(n);}return t}}var Fc="0.1.21";var Xo="210, 57, 192",$c=`rgba(${Xo}, 1)`,Hc=`rgba(${Xo}, 0.4)`,Bc=`rgba(${Xo}, 0.05)`,es=`rgba(${Xo}, 0.5)`,ts=`rgba(${Xo}, 0.08)`,zc=`rgba(${Xo}, 0.15)`,Vc=50,Un=8,Gc=4,Uc=.2,wa=50,xa=16,rn=4,$r=100,jc=15,Wc=3,va=["id","class","aria-label","data-testid","role","name","title"],Kc=5e3,Xc=["Meta","Control","Shift","Alt"],Ca=new Set(["ArrowUp","ArrowDown","ArrowLeft","ArrowRight"]),Hr="data-react-grab-frozen",Ea="data-react-grab-ignore",Br=.9,Yc=1e3,qc=2147483600,Zc=400,Jc=100,_e=16,Sa=500,Qc=300,eu=5,Aa=150,uo=14,Ta=28,Pn=150,tu=50,nu=78,ou=28,ru=1500,iu=.75,_a=32,zr=3,Vr=20,Pa=100,$t=1,ka=50,su=50,au=6,lu=3,Oa=2,cu=16,uu=100,du=50,Ma=.01,fu=1e3,mu=20,pu=2*1024*1024,Yo=100,Gr=200,jn=8,qo=8,mn=8,fo=11,gu=180,hu=280,bu=100,ht="bg-white",Kt={left:-9999,top:-9999},Zo={left:"left center",right:"right center",top:"center top",bottom:"center bottom"},yu='<svg width="294" height="294" viewBox="0 0 294 294" fill="none" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#clip0_0_3)"><mask id="mask0_0_3" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="0" y="0" width="294" height="294"><path d="M294 0H0V294H294V0Z" fill="white"/></mask><g mask="url(#mask0_0_3)"><path d="M144.599 47.4924C169.712 27.3959 194.548 20.0265 212.132 30.1797C227.847 39.2555 234.881 60.3243 231.926 89.516C231.677 92.0069 231.328 94.5423 230.94 97.1058L228.526 110.14C228.517 110.136 228.505 110.132 228.495 110.127C228.486 110.165 228.479 110.203 228.468 110.24L216.255 105.741C216.256 105.736 216.248 105.728 216.248 105.723C207.915 103.125 199.421 101.075 190.82 99.5888L190.696 99.5588L173.526 97.2648L173.511 97.2631C173.492 97.236 173.467 97.2176 173.447 97.1905C163.862 96.2064 154.233 95.7166 144.599 95.7223C134.943 95.7162 125.295 96.219 115.693 97.2286C110.075 105.033 104.859 113.118 100.063 121.453C95.2426 129.798 90.8624 138.391 86.939 147.193C90.8624 155.996 95.2426 164.588 100.063 172.933C104.866 181.302 110.099 189.417 115.741 197.245C115.749 197.245 115.758 197.246 115.766 197.247L115.752 197.27L115.745 197.283L115.754 197.296L126.501 211.013L126.574 211.089C132.136 217.767 138.126 224.075 144.507 229.974L144.609 230.082L154.572 238.287C154.539 238.319 154.506 238.35 154.472 238.38C154.485 238.392 154.499 238.402 154.513 238.412L143.846 247.482L143.827 247.497C126.56 261.128 109.472 268.745 94.8019 268.745C88.5916 268.837 82.4687 267.272 77.0657 264.208C61.3496 255.132 54.3164 234.062 57.2707 204.871C57.528 202.307 57.8806 199.694 58.2904 197.054C28.3363 185.327 9.52301 167.51 9.52301 147.193C9.52301 129.042 24.2476 112.396 50.9901 100.375C53.3443 99.3163 55.7938 98.3058 58.2904 97.3526C57.8806 94.7023 57.528 92.0803 57.2707 89.516C54.3164 60.3243 61.3496 39.2555 77.0657 30.1797C94.6494 20.0265 119.486 27.3959 144.599 47.4924ZM70.6423 201.315C70.423 202.955 70.2229 204.566 70.0704 206.168C67.6686 229.567 72.5478 246.628 83.3615 252.988L83.5176 253.062C95.0399 259.717 114.015 254.426 134.782 238.38C125.298 229.45 116.594 219.725 108.764 209.314C95.8516 207.742 83.0977 205.066 70.6423 201.315ZM80.3534 163.438C77.34 171.677 74.8666 180.104 72.9484 188.664C81.1787 191.224 89.5657 193.247 98.0572 194.724L98.4618 194.813C95.2115 189.865 92.0191 184.66 88.9311 179.378C85.8433 174.097 83.003 168.768 80.3534 163.438ZM60.759 110.203C59.234 110.839 57.7378 111.475 56.27 112.11C34.7788 121.806 22.3891 134.591 22.3891 147.193C22.3891 160.493 36.4657 174.297 60.7494 184.26C63.7439 171.581 67.8124 159.182 72.9104 147.193C67.822 135.23 63.7566 122.855 60.759 110.203ZM98.4137 99.6404C89.8078 101.145 81.3075 103.206 72.9676 105.809C74.854 114.203 77.2741 122.468 80.2132 130.554L80.3059 130.939C82.9938 125.6 85.8049 120.338 88.8834 115.008C91.9618 109.679 95.1544 104.569 98.4137 99.6404ZM94.9258 38.5215C90.9331 38.4284 86.9866 39.3955 83.4891 41.3243C72.6291 47.6015 67.6975 64.5954 70.0424 87.9446L70.0416 88.2194C70.194 89.8208 70.3941 91.4325 70.6134 93.0624C83.0737 89.3364 95.8263 86.6703 108.736 85.0924C116.57 74.6779 125.28 64.9532 134.773 56.0249C119.877 44.5087 105.895 38.5215 94.9258 38.5215ZM205.737 41.3148C202.268 39.398 198.355 38.4308 194.394 38.5099L194.29 38.512C183.321 38.512 169.34 44.4991 154.444 56.0153C163.93 64.9374 172.634 74.6557 180.462 85.064C193.375 86.6345 206.128 89.3102 218.584 93.0624C218.812 91.4325 219.003 89.8118 219.165 88.2098C221.548 64.7099 216.65 47.6164 205.737 41.3148ZM144.552 64.3097C138.104 70.2614 132.054 76.6306 126.443 83.3765C132.39 82.995 138.426 82.8046 144.552 82.8046C150.727 82.8046 156.778 83.0143 162.707 83.3765C157.08 76.6293 151.015 70.2596 144.552 64.3097Z" fill="white"/><path d="M144.598 47.4924C169.712 27.3959 194.547 20.0265 212.131 30.1797C227.847 39.2555 234.88 60.3243 231.926 89.516C231.677 92.0069 231.327 94.5423 230.941 97.1058L228.526 110.14L228.496 110.127C228.487 110.165 228.478 110.203 228.469 110.24L216.255 105.741L216.249 105.723C207.916 103.125 199.42 101.075 190.82 99.5888L190.696 99.5588L173.525 97.2648L173.511 97.263C173.492 97.236 173.468 97.2176 173.447 97.1905C163.863 96.2064 154.234 95.7166 144.598 95.7223C134.943 95.7162 125.295 96.219 115.693 97.2286C110.075 105.033 104.859 113.118 100.063 121.453C95.2426 129.798 90.8622 138.391 86.939 147.193C90.8622 155.996 95.2426 164.588 100.063 172.933C104.866 181.302 110.099 189.417 115.741 197.245L115.766 197.247L115.752 197.27L115.745 197.283L115.754 197.296L126.501 211.013L126.574 211.089C132.136 217.767 138.126 224.075 144.506 229.974L144.61 230.082L154.572 238.287C154.539 238.319 154.506 238.35 154.473 238.38L154.512 238.412L143.847 247.482L143.827 247.497C126.56 261.13 109.472 268.745 94.8018 268.745C88.5915 268.837 82.4687 267.272 77.0657 264.208C61.3496 255.132 54.3162 234.062 57.2707 204.871C57.528 202.307 57.8806 199.694 58.2904 197.054C28.3362 185.327 9.52298 167.51 9.52298 147.193C9.52298 129.042 24.2476 112.396 50.9901 100.375C53.3443 99.3163 55.7938 98.3058 58.2904 97.3526C57.8806 94.7023 57.528 92.0803 57.2707 89.516C54.3162 60.3243 61.3496 39.2555 77.0657 30.1797C94.6493 20.0265 119.486 27.3959 144.598 47.4924ZM70.6422 201.315C70.423 202.955 70.2229 204.566 70.0704 206.168C67.6686 229.567 72.5478 246.628 83.3615 252.988L83.5175 253.062C95.0399 259.717 114.015 254.426 134.782 238.38C125.298 229.45 116.594 219.725 108.764 209.314C95.8515 207.742 83.0977 205.066 70.6422 201.315ZM80.3534 163.438C77.34 171.677 74.8666 180.104 72.9484 188.664C81.1786 191.224 89.5657 193.247 98.0572 194.724L98.4618 194.813C95.2115 189.865 92.0191 184.66 88.931 179.378C85.8433 174.097 83.003 168.768 80.3534 163.438ZM60.7589 110.203C59.234 110.839 57.7378 111.475 56.2699 112.11C34.7788 121.806 22.3891 134.591 22.3891 147.193C22.3891 160.493 36.4657 174.297 60.7494 184.26C63.7439 171.581 67.8124 159.182 72.9103 147.193C67.822 135.23 63.7566 122.855 60.7589 110.203ZM98.4137 99.6404C89.8078 101.145 81.3075 103.206 72.9676 105.809C74.8539 114.203 77.2741 122.468 80.2132 130.554L80.3059 130.939C82.9938 125.6 85.8049 120.338 88.8834 115.008C91.9618 109.679 95.1544 104.569 98.4137 99.6404ZM94.9258 38.5215C90.9331 38.4284 86.9866 39.3955 83.4891 41.3243C72.629 47.6015 67.6975 64.5954 70.0424 87.9446L70.0415 88.2194C70.194 89.8208 70.3941 91.4325 70.6134 93.0624C83.0737 89.3364 95.8262 86.6703 108.736 85.0924C116.57 74.6779 125.28 64.9532 134.772 56.0249C119.877 44.5087 105.895 38.5215 94.9258 38.5215ZM205.737 41.3148C202.268 39.398 198.355 38.4308 194.394 38.5099L194.291 38.512C183.321 38.512 169.34 44.4991 154.443 56.0153C163.929 64.9374 172.634 74.6557 180.462 85.064C193.374 86.6345 206.129 89.3102 218.584 93.0624C218.813 91.4325 219.003 89.8118 219.166 88.2098C221.548 64.7099 216.65 47.6164 205.737 41.3148ZM144.551 64.3097C138.103 70.2614 132.055 76.6306 126.443 83.3765C132.389 82.995 138.427 82.8046 144.551 82.8046C150.727 82.8046 156.779 83.0143 162.707 83.3765C157.079 76.6293 151.015 70.2596 144.551 64.3097Z" fill="#FF40E0"/></g><mask id="mask1_0_3" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="102" y="84" width="161" height="162"><path d="M235.282 84.827L102.261 112.259L129.693 245.28L262.714 217.848L235.282 84.827Z" fill="white"/></mask><g mask="url(#mask1_0_3)"><path d="M136.863 129.916L213.258 141.224C220.669 142.322 222.495 152.179 215.967 155.856L187.592 171.843L184.135 204.227C183.339 211.678 173.564 213.901 169.624 207.526L129.021 141.831C125.503 136.14 130.245 128.936 136.863 129.916Z" fill="#FF40E0" stroke="#FF40E0" stroke-width="0.817337" stroke-linecap="round" stroke-linejoin="round"/></g></g><defs><clipPath id="clip0_0_3"><rect width="294" height="294" fill="white"/></clipPath></defs></svg>',wu=1e3,xu=229,Ra=-9999,Ia=new Set(["display","position","top","right","bottom","left","z-index","overflow","overflow-x","overflow-y","width","height","min-width","min-height","max-width","max-height","margin-top","margin-right","margin-bottom","margin-left","padding-top","padding-right","padding-bottom","padding-left","flex-direction","flex-wrap","justify-content","align-items","align-self","align-content","flex-grow","flex-shrink","flex-basis","order","gap","row-gap","column-gap","grid-template-columns","grid-template-rows","grid-template-areas","font-family","font-size","font-weight","font-style","line-height","letter-spacing","text-align","text-decoration-line","text-decoration-style","text-transform","text-overflow","text-shadow","white-space","word-break","overflow-wrap","vertical-align","color","background-color","background-image","background-position","background-size","background-repeat","border-top-width","border-right-width","border-bottom-width","border-left-width","border-top-style","border-right-style","border-bottom-style","border-left-style","border-top-color","border-right-color","border-bottom-color","border-left-color","border-top-left-radius","border-top-right-radius","border-bottom-left-radius","border-bottom-right-radius","box-shadow","opacity","transform","filter","backdrop-filter","object-fit","object-position"]);var Fp=e=>typeof e=="number"&&!Number.isNaN(e)&&Number.isFinite(e),$p=e=>{let t=e.trim();if(!t)return null;let n=parseFloat(t);return Fp(n)?n:null},vu=(e,t)=>{let n=e.split(",");if(n.length!==t)return null;let o=[];for(let i of n){let s=$p(i);if(s===null)return null;o.push(s);}return o},Cu=(e,t,n,o)=>e===1&&t===0&&n===0&&o===1,Hp=e=>e[0]===1&&e[1]===0&&e[2]===0&&e[3]===0&&e[4]===0&&e[5]===1&&e[6]===0&&e[7]===0&&e[8]===0&&e[9]===0&&e[10]===1&&e[11]===0&&e[15]===1,Eu=e=>{if(!e||e==="none")return "none";if(e.charCodeAt(0)===109)if(e.charCodeAt(6)===51){let n=e.length-1,o=vu(e.slice(9,n),16);if(o)return o[12]=0,o[13]=0,o[14]=0,Hp(o)?"none":`matrix3d(${o[0]}, ${o[1]}, ${o[2]}, ${o[3]}, ${o[4]}, ${o[5]}, ${o[6]}, ${o[7]}, ${o[8]}, ${o[9]}, ${o[10]}, ${o[11]}, 0, 0, 0, ${o[15]})`}else {let n=e.length-1,o=vu(e.slice(7,n),6);if(o){let i=o[0],s=o[1],r=o[2],c=o[3];return Cu(i,s,r,c)?"none":`matrix(${i}, ${s}, ${r}, ${c}, 0, 0)`}}return "none"},Su=e=>e.isIdentity?"none":e.is2D?Cu(e.a,e.b,e.c,e.d)?"none":`matrix(${e.a}, ${e.b}, ${e.c}, ${e.d}, 0, 0)`:e.m11===1&&e.m12===0&&e.m13===0&&e.m14===0&&e.m21===0&&e.m22===1&&e.m23===0&&e.m24===0&&e.m31===0&&e.m32===0&&e.m33===1&&e.m34===0&&e.m44===1?"none":`matrix3d(${e.m11}, ${e.m12}, ${e.m13}, ${e.m14}, ${e.m21}, ${e.m22}, ${e.m23}, ${e.m24}, ${e.m31}, ${e.m32}, ${e.m33}, ${e.m34}, 0, 0, 0, ${e.m44})`;var Na=new WeakMap,Au=()=>{Na=new WeakMap;},zp=(e,t)=>{let n=t&&t!=="none",o=null,i=e.parentElement,s=0;for(;i&&i!==document.documentElement&&s<au;){let r=window.getComputedStyle(i).transform;if(r&&r!=="none")o=o?new DOMMatrix(r).multiply(o):new DOMMatrix(r);else if(!n&&!o&&s>=lu)return "none";i=i.parentElement,s++;}return o?(n&&(o=o.multiply(new DOMMatrix(t))),Su(o)):n?Eu(t):"none"},ze=e=>{let t=performance.now(),n=Na.get(e);if(n&&t-n.timestamp<16)return n.bounds;let o=e.getBoundingClientRect(),i=window.getComputedStyle(e),s=zp(e,i.transform),r;if(s!=="none"&&e instanceof HTMLElement){let c=e.offsetWidth,l=e.offsetHeight;if(c>0&&l>0){let u=o.left+o.width*.5,f=o.top+o.height*.5;r={borderRadius:i.borderRadius||"0px",height:l,transform:s,width:c,x:u-c*.5,y:f-l*.5};}else r={borderRadius:i.borderRadius||"0px",height:o.height,transform:s,width:o.width,x:o.left,y:o.top};}else r={borderRadius:i.borderRadius||"0px",height:o.height,transform:s,width:o.width,x:o.left,y:o.top};return Na.set(e,{bounds:r,timestamp:t}),r};var et=e=>!!(e?.isConnected??e?.ownerDocument?.contains(e));var kn=e=>({x:e.x+e.width/2,y:e.y+e.height/2});var ns=({currentPosition:e,previousBounds:t,nextBounds:n})=>{if(!t||!n)return e;let o=kn(t),i=kn(n),s=t.width/2,r=e.x-o.x,c=s>0?r/s:0,l=n.width/2;return {...e,x:i.x+c*l}};var Vp=e=>({current:{state:"idle"},wasActivatedByToggle:false,pendingCommentMode:false,hasAgentProvider:e.hasAgentProvider,keyHoldDuration:e.keyHoldDuration,pointer:{x:-1e3,y:-1e3},dragStart:{x:-1e3,y:-1e3},copyStart:{x:-1e3,y:-1e3},copyOffsetFromCenterX:0,detectedElement:null,frozenElement:null,frozenElements:[],frozenDragRect:null,lastGrabbedElement:null,lastCopiedElement:null,selectionFilePath:null,selectionLineNumber:null,inputText:"",pendingClickData:null,replySessionId:null,viewportVersion:0,grabbedBoxes:[],labelInstances:[],agentSessions:new Map,sessionElements:new Map,isTouchMode:false,theme:e.theme,activationTimestamp:null,previouslyFocusedElement:null,isAgentConnected:false,supportsUndo:false,supportsFollowUp:false,dismissButtonText:void 0,pendingAbortSessionId:null,contextMenuPosition:null,contextMenuElement:null,contextMenuClickOffset:null,selectedAgent:null}),Tu=e=>{let[t,n]=Qi(Vp(e)),o=()=>t.current.state==="active",i=()=>t.current.state==="holding",s={startHold:r=>{r!==void 0&&n("keyHoldDuration",r),n("current",{state:"holding",startedAt:Date.now()});},release:()=>{t.current.state==="holding"&&n("current",{state:"idle"});},activate:()=>{n("current",{state:"active",phase:"hovering",isPromptMode:false,isPendingDismiss:false}),n("activationTimestamp",Date.now()),n("previouslyFocusedElement",document.activeElement);},deactivate:()=>{n(Wt(r=>{r.current={state:"idle"},r.wasActivatedByToggle=false,r.pendingCommentMode=false,r.inputText="",r.frozenElement=null,r.frozenElements=[],r.frozenDragRect=null,r.pendingClickData=null,r.replySessionId=null,r.pendingAbortSessionId=null,r.activationTimestamp=null,r.previouslyFocusedElement=null,r.contextMenuPosition=null,r.contextMenuElement=null,r.contextMenuClickOffset=null,r.selectedAgent=null,r.lastCopiedElement=null;}));},toggle:()=>{t.activationTimestamp!==null?s.deactivate():(n("wasActivatedByToggle",true),s.activate());},freeze:()=>{if(t.current.state==="active"){let r=t.frozenElement??t.detectedElement;r&&n("frozenElement",r),n("current",Wt(c=>{c.state==="active"&&(c.phase="frozen");}));}},unfreeze:()=>{t.current.state==="active"&&(n("frozenElement",null),n("frozenElements",[]),n("frozenDragRect",null),n("current",Wt(r=>{r.state==="active"&&(r.phase="hovering");})));},startDrag:r=>{t.current.state==="active"&&(s.clearFrozenElement(),n("dragStart",{x:r.x+window.scrollX,y:r.y+window.scrollY}),n("current",Wt(c=>{c.state==="active"&&(c.phase="dragging");})));},endDrag:()=>{t.current.state==="active"&&t.current.phase==="dragging"&&(n("dragStart",{x:-1e3,y:-1e3}),n("current",Wt(r=>{r.state==="active"&&(r.phase="justDragged");})));},cancelDrag:()=>{t.current.state==="active"&&t.current.phase==="dragging"&&(n("dragStart",{x:-1e3,y:-1e3}),n("current",Wt(r=>{r.state==="active"&&(r.phase="hovering");})));},finishJustDragged:()=>{t.current.state==="active"&&t.current.phase==="justDragged"&&n("current",Wt(r=>{r.state==="active"&&(r.phase="hovering");}));},startCopy:()=>{let r=t.current.state==="active";n("current",{state:"copying",startedAt:Date.now(),wasActive:r});},completeCopy:r=>{n("pendingClickData",null),r&&n("lastCopiedElement",r);let c=t.current.state==="copying"?t.current.wasActive:false;n("current",{state:"justCopied",copiedAt:Date.now(),wasActive:c});},finishJustCopied:()=>{t.current.state==="justCopied"&&(t.current.wasActive&&!t.wasActivatedByToggle?n("current",{state:"active",phase:"hovering",isPromptMode:false,isPendingDismiss:false}):s.deactivate());},enterPromptMode:(r,c)=>{let l=ze(c),u=l.x+l.width/2;n("copyStart",r),n("copyOffsetFromCenterX",r.x-u),n("pointer",r),n("frozenElement",c),n("wasActivatedByToggle",true),t.current.state!=="active"?(n("current",{state:"active",phase:"frozen",isPromptMode:true,isPendingDismiss:false}),n("activationTimestamp",Date.now()),n("previouslyFocusedElement",document.activeElement)):n("current",Wt(f=>{f.state==="active"&&(f.isPromptMode=true,f.phase="frozen");}));},exitPromptMode:()=>{t.current.state==="active"&&n("current",Wt(r=>{r.state==="active"&&(r.isPromptMode=false,r.isPendingDismiss=false);}));},setInputText:r=>{n("inputText",r);},clearInputText:()=>{n("inputText","");},setPendingDismiss:r=>{t.current.state==="active"&&n("current",Wt(c=>{c.state==="active"&&(c.isPendingDismiss=r);}));},setPointer:r=>{n("pointer",r);},setDetectedElement:r=>{n("detectedElement",r);},setFrozenElement:r=>{n("frozenElement",r),n("frozenElements",[r]),n("frozenDragRect",null);},setFrozenElements:r=>{n("frozenElements",r),n("frozenElement",r.length>0?r[0]:null),n("frozenDragRect",null);},setFrozenDragRect:r=>{n("frozenDragRect",r);},clearFrozenElement:()=>{n("frozenElement",null),n("frozenElements",[]),n("frozenDragRect",null);},setCopyStart:(r,c)=>{let l=ze(c),u=l.x+l.width/2;n("copyStart",r),n("copyOffsetFromCenterX",r.x-u);},setLastGrabbed:r=>{n("lastGrabbedElement",r);},clearLastCopied:()=>{n("lastCopiedElement",null);},setWasActivatedByToggle:r=>{n("wasActivatedByToggle",r);},setPendingCommentMode:r=>{n("pendingCommentMode",r);},setTouchMode:r=>{n("isTouchMode",r);},setSelectionSource:(r,c)=>{n("selectionFilePath",r),n("selectionLineNumber",c);},setPendingClickData:r=>{n("pendingClickData",r);},clearReplySessionId:()=>{n("replySessionId",null);},incrementViewportVersion:()=>{n("viewportVersion",r=>r+1);},addGrabbedBox:r=>{n("grabbedBoxes",c=>[...c,r]);},removeGrabbedBox:r=>{n("grabbedBoxes",c=>c.filter(l=>l.id!==r));},clearGrabbedBoxes:()=>{n("grabbedBoxes",[]);},addLabelInstance:r=>{n("labelInstances",c=>[...c,r]);},updateLabelInstance:(r,c,l)=>{let u=t.labelInstances.findIndex(f=>f.id===r);u!==-1&&n("labelInstances",u,Wt(f=>{f.status=c,l!==void 0&&(f.errorMessage=l);}));},removeLabelInstance:r=>{n("labelInstances",c=>c.filter(l=>l.id!==r));},clearLabelInstances:()=>{n("labelInstances",[]);},setHasAgentProvider:r=>{n("hasAgentProvider",r);},setAgentCapabilities:r=>{n("supportsUndo",r.supportsUndo),n("supportsFollowUp",r.supportsFollowUp),n("dismissButtonText",r.dismissButtonText),n("isAgentConnected",r.isAgentConnected);},setPendingAbortSessionId:r=>{n("pendingAbortSessionId",r);},updateSessionBounds:()=>{let r=t.agentSessions;if(r.size===0)return;let c=new Map(r),l=false;for(let[u,f]of r){let p=t.sessionElements.get(u)??null;if(et(p)){let b=ze(p),x=f.selectionBounds[0],H=ns({currentPosition:f.position,previousBounds:x,nextBounds:b});c.set(u,{...f,selectionBounds:[b],position:H}),l=true;}}l&&n("agentSessions",c);},addAgentSession:(r,c,l)=>{let u=new Map(t.agentSessions);u.set(r,c),n("agentSessions",u);let f=new Map(t.sessionElements);f.set(r,l),n("sessionElements",f);},updateAgentSessionStatus:(r,c)=>{let l=t.agentSessions.get(r);if(!l)return;let u=new Map(t.agentSessions);u.set(r,{...l,lastStatus:c}),n("agentSessions",u);},completeAgentSession:(r,c)=>{let l=t.agentSessions.get(r);if(!l)return;let u=new Map(t.agentSessions);u.set(r,{...l,isStreaming:false,lastStatus:c??l.lastStatus}),n("agentSessions",u);},setAgentSessionError:(r,c)=>{let l=t.agentSessions.get(r);if(!l)return;let u=new Map(t.agentSessions);u.set(r,{...l,isStreaming:false,error:c}),n("agentSessions",u);},removeAgentSession:r=>{let c=new Map(t.agentSessions);c.delete(r),n("agentSessions",c);let l=new Map(t.sessionElements);l.delete(r),n("sessionElements",l);},showContextMenu:(r,c)=>{let l=ze(c),u=l.x+l.width/2,f=l.y+l.height/2;n("contextMenuPosition",r),n("contextMenuElement",c),n("contextMenuClickOffset",{x:r.x-u,y:r.y-f});},hideContextMenu:()=>{n("contextMenuPosition",null),n("contextMenuElement",null),n("contextMenuClickOffset",null);},updateContextMenuPosition:()=>{let r=t.contextMenuElement,c=t.contextMenuClickOffset;if(!r||!c||!et(r))return;let l=ze(r),u=l.x+l.width/2,f=l.y+l.height/2;n("contextMenuPosition",{x:u+c.x,y:f+c.y});},setSelectedAgent:r=>{n("selectedAgent",r);}};return {store:t,setStore:n,actions:s,isActive:o,isHolding:i}};var pt=e=>(e.tagName||"").toLowerCase();var Gp=["input","textarea","select","searchbox","slider","spinbutton","menuitem","menuitemcheckbox","menuitemradio","option","radio","textbox","combobox"],Up=e=>{if(e.composed){let t=e.composedPath()[0];if(t instanceof HTMLElement)return t}else if(e.target instanceof HTMLElement)return e.target},St=e=>{if(document.designMode==="on")return  true;let t=Up(e);if(!t)return  false;if(t.isContentEditable)return  true;let n=pt(t);return Gp.some(o=>o===n||o===t.role)},_u=e=>{let t=e.target;if(t instanceof HTMLInputElement||t instanceof HTMLTextAreaElement){let n=t.selectionStart??0;return (t.selectionEnd??0)-n>0}return  false},Pu=()=>{let e=window.getSelection();return e?e.toString().length>0:false};var os="data-react-grab",ku="react-grab-fonts",Wp="https://fonts.googleapis.com/css2?family=Geist:wght@500&display=swap",Kp=()=>{if(document.getElementById(ku)||!document.head)return;let e=document.createElement("link");e.id=ku,e.rel="stylesheet",e.href=Wp,document.head.appendChild(e);},Ou=e=>{Kp();let t=document.querySelector(`[${os}]`);if(t){let r=t.shadowRoot?.querySelector(`[${os}]`);if(r instanceof HTMLDivElement&&t.shadowRoot)return r}let n=document.createElement("div");n.setAttribute(os,"true"),n.style.zIndex=String(2147483647),n.style.position="fixed",n.style.inset="0",n.style.pointerEvents="none";let o=n.attachShadow({mode:"open"});{let r=document.createElement("style");r.textContent=e,o.appendChild(r);}let i=document.createElement("div");i.setAttribute(os,"true"),o.appendChild(i);let s=document.body??document.documentElement;return s.appendChild(n),setTimeout(()=>{s.appendChild(n);},fu),i};var La=typeof window<"u",Xp=e=>0,Yp=e=>{},Ve=La?(Object.getOwnPropertyDescriptor(Window.prototype,"requestAnimationFrame")?.value??window.requestAnimationFrame).bind(window):Xp,Ge=La?(Object.getOwnPropertyDescriptor(Window.prototype,"cancelAnimationFrame")?.value??window.cancelAnimationFrame).bind(window):Yp,Mu=()=>La?new Promise(e=>Ve(()=>e())):Promise.resolve();var Nu="0.5.30",ss=`bippy-${Nu}`,Ru=Object.defineProperty,qp=Object.prototype.hasOwnProperty,Ur=()=>{},Lu=e=>{try{Function.prototype.toString.call(e).indexOf("^_^")>-1&&setTimeout(()=>{throw Error("React is running in production mode, but dead code elimination has not been applied. Read how to correctly configure React for production: https://reactjs.org/link/perf-use-production-build")});}catch{}},as=(e=globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__)=>!!(e&&"getFiberRoots"in e),Du=false,Iu,jr=(e=globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__)=>Du?true:(e&&typeof e.inject=="function"&&(Iu=e.inject.toString()),!!Iu?.includes("(injected)")),rs=new Set,mo=new Set,Fu=e=>{let t=new Map,n=0,o={_instrumentationIsActive:false,_instrumentationSource:ss,checkDCE:Lu,hasUnsupportedRendererAttached:false,inject(i){let s=++n;return t.set(s,i),mo.add(i),o._instrumentationIsActive||(o._instrumentationIsActive=true,rs.forEach(r=>r())),s},on:Ur,onCommitFiberRoot:Ur,onCommitFiberUnmount:Ur,onPostCommitFiberRoot:Ur,renderers:t,supportsFiber:true,supportsFlight:true};try{Ru(globalThis,"__REACT_DEVTOOLS_GLOBAL_HOOK__",{configurable:!0,enumerable:!0,get(){return o},set(r){if(r&&typeof r=="object"){let c=o.renderers;o=r,c.size>0&&(c.forEach((l,u)=>{mo.add(l),r.renderers.set(u,l);}),is(e));}}});let i=window.hasOwnProperty,s=!1;Ru(window,"hasOwnProperty",{configurable:!0,value:function(...r){try{if(!s&&r[0]==="__REACT_DEVTOOLS_GLOBAL_HOOK__")return globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__=void 0,s=!0,-0}catch{}return i.apply(this,r)},writable:!0});}catch{is(e);}return o},is=e=>{try{let t=globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;if(!t)return;if(!t._instrumentationSource){t.checkDCE=Lu,t.supportsFiber=!0,t.supportsFlight=!0,t.hasUnsupportedRendererAttached=!1,t._instrumentationSource=ss,t._instrumentationIsActive=!1;let n=as(t);if(n||(t.on=Ur),t.renderers.size){t._instrumentationIsActive=!0,rs.forEach(s=>s());return}let o=t.inject,i=jr(t);i&&!n&&(Du=!0,t.inject({scheduleRefresh(){}})&&(t._instrumentationIsActive=!0)),t.inject=s=>{let r=o(s);return mo.add(s),i&&t.renderers.set(r,s),t._instrumentationIsActive=!0,rs.forEach(c=>c()),r};}(t.renderers.size||t._instrumentationIsActive||jr())&&e?.();}catch{}},Da=()=>qp.call(globalThis,"__REACT_DEVTOOLS_GLOBAL_HOOK__"),Wn=e=>Da()?(is(e),globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__):Fu(e),$u=()=>!!(typeof window<"u"&&(window.document?.createElement||window.navigator?.product==="ReactNative")),Fa=()=>{try{$u()&&Wn();}catch{}};var ls=0,cs=1;var $a=5;var us=11,Ha=13,Hu=14,ds=15,Ba=16;var za=19;var Va=26,Ga=27,Ua=28,ja=30;var Jo=e=>{switch(e.tag){case cs:case us:case ls:case Hu:case ds:return  true;default:return  false}};function Qo(e,t,n=false){if(!e)return null;let o=t(e);if(o instanceof Promise)return (async()=>{if(await o===true)return e;let s=n?e.return:e.child;for(;s;){let r=await Ka(s,t,n);if(r)return r;s=n?null:s.sibling;}return null})();if(o===true)return e;let i=n?e.return:e.child;for(;i;){let s=Wa(i,t,n);if(s)return s;i=n?null:i.sibling;}return null}var Wa=(e,t,n=false)=>{if(!e)return null;if(t(e)===true)return e;let o=n?e.return:e.child;for(;o;){let i=Wa(o,t,n);if(i)return i;o=n?null:o.sibling;}return null},Ka=async(e,t,n=false)=>{if(!e)return null;if(await t(e)===true)return e;let o=n?e.return:e.child;for(;o;){let i=await Ka(o,t,n);if(i)return i;o=n?null:o.sibling;}return null};var Xa=e=>{let t=e;return typeof t=="function"?t:typeof t=="object"&&t?Xa(t.type||t.render):null},Kn=e=>{let t=e;if(typeof t=="string")return t;if(typeof t!="function"&&!(typeof t=="object"&&t))return null;let n=t.displayName||t.name||null;if(n)return n;let o=Xa(t);return o&&(o.displayName||o.name)||null};var Xn=()=>{let e=globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;return !!e?._instrumentationIsActive||as(e)||jr(e)};var po=e=>{let t=globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;if(t?.renderers)for(let n of t.renderers.values())try{let o=n.findFiberByHostInstance?.(e);if(o)return o}catch{}if(typeof e=="object"&&e){if("_reactRootContainer"in e)return e._reactRootContainer?._internalRoot?.current?.child;for(let n in e)if(n.startsWith("__reactContainer$")||n.startsWith("__reactInternalInstance$")||n.startsWith("__reactFiber"))return e[n]||null}return null},Ya=new Set;var ig=Object.create,Xu=Object.defineProperty,sg=Object.getOwnPropertyDescriptor,ag=Object.getOwnPropertyNames,lg=Object.getPrototypeOf,cg=Object.prototype.hasOwnProperty,ug=(e,t)=>()=>(t||e((t={exports:{}}).exports,t),t.exports),dg=(e,t,n,o)=>{if(t&&typeof t=="object"||typeof t=="function")for(var i=ag(t),s=0,r=i.length,c;s<r;s++)c=i[s],!cg.call(e,c)&&c!==n&&Xu(e,c,{get:(l=>t[l]).bind(null,c),enumerable:!(o=sg(t,c))||o.enumerable});return e},fg=(e,t,n)=>(n=e==null?{}:ig(lg(e)),dg(Xu(n,"default",{value:e,enumerable:true}),e)),Bu=/^[a-zA-Z][a-zA-Z\d+\-.]*:/,mg=["rsc://","file:///","webpack://","webpack-internal://","node:","turbopack://","metro://","/app-pages-browser/"],zu="about://React/",pg=["<anonymous>","eval",""],Yu=/\.(jsx|tsx|ts|js)$/,gg=/(\.min|bundle|chunk|vendor|vendors|runtime|polyfill|polyfills)\.(js|mjs|cjs)$|(chunk|bundle|vendor|vendors|runtime|polyfill|polyfills|framework|app|main|index)[-_.][A-Za-z0-9_-]{4,}\.(js|mjs|cjs)$|[\da-f]{8,}\.(js|mjs|cjs)$|[-_.][\da-f]{20,}\.(js|mjs|cjs)$|\/dist\/|\/build\/|\/.next\/|\/out\/|\/node_modules\/|\.webpack\.|\.vite\.|\.turbopack\./i,hg=/^\?[\w~.-]+(?:=[^&#]*)?(?:&[\w~.-]+(?:=[^&#]*)?)*$/,qu="(at Server)",bg=/(^|@)\S+:\d+/,Zu=/^\s*at .*(\S+:\d+|\(native\))/m,yg=/^(eval@)?(\[native code\])?$/;var ms=(e,t)=>{{let n=e.split(`
-`),o=[];for(let i of n)if(/^\s*at\s+/.test(i)){let s=Vu(i,void 0)[0];s&&o.push(s);}else if(/^\s*in\s+/.test(i)){let s=i.replace(/^\s*in\s+/,"").replace(/\s*\(at .*\)$/,"");o.push({functionName:s,source:i});}else if(i.match(bg)){let s=Gu(i,void 0)[0];s&&o.push(s);}return Ja(o,t)}},Ju=e=>{if(!e.includes(":"))return [e,void 0,void 0];let t=e.startsWith("(")&&/:\d+\)$/.test(e),n=t?e.slice(1,-1):e,o=/(.+?)(?::(\d+))?(?::(\d+))?$/,i=o.exec(n);return i?[i[1],i[2]||void 0,i[3]||void 0]:[n,void 0,void 0]},Ja=(e,t)=>t&&t.slice!=null?Array.isArray(t.slice)?e.slice(t.slice[0],t.slice[1]):e.slice(0,t.slice):e;var Vu=(e,t)=>Ja(e.split(`
-`).filter(o=>!!o.match(Zu)),t).map(o=>{let i=o;i.includes("(eval ")&&(i=i.replace(/eval code/g,"eval").replace(/(\(eval at [^()]*)|(,.*$)/g,""));let s=i.replace(/^\s+/,"").replace(/\(eval code/g,"(").replace(/^.*?\s+/,""),r=s.match(/ (\(.+\)$)/);s=r?s.replace(r[0],""):s;let c=Ju(r?r[1]:s),l=r&&s||void 0,u=["eval","<anonymous>"].includes(c[0])?void 0:c[0];return {functionName:l,fileName:u,lineNumber:c[1]?+c[1]:void 0,columnNumber:c[2]?+c[2]:void 0,source:i}});var Gu=(e,t)=>Ja(e.split(`
-`).filter(o=>!o.match(yg)),t).map(o=>{let i=o;if(i.includes(" > eval")&&(i=i.replace(/ line (\d+)(?: > eval line \d+)* > eval:\d+:\d+/g,":$1")),!i.includes("@")&&!i.includes(":"))return {functionName:i};{let s=/(([^\n\r"\u2028\u2029]*".[^\n\r"\u2028\u2029]*"[^\n\r@\u2028\u2029]*(?:@[^\n\r"\u2028\u2029]*"[^\n\r@\u2028\u2029]*)*(?:[\n\r\u2028\u2029][^@]*)?)?[^@]*)@/,r=i.match(s),c=r&&r[1]?r[1]:void 0,l=Ju(i.replace(s,""));return {functionName:c,fileName:l[0],lineNumber:l[1]?+l[1]:void 0,columnNumber:l[2]?+l[2]:void 0,source:i}}});var wg=ug((e,t)=>{(function(n,o){typeof e=="object"&&t!==void 0?o(e):typeof define=="function"&&define.amd?define(["exports"],o):(n=typeof globalThis<"u"?globalThis:n||self,o(n.sourcemapCodec={}));})(void 0,function(n){let o=44,i=59,s="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/",r=new Uint8Array(64),c=new Uint8Array(128);for(let L=0;L<s.length;L++){let A=s.charCodeAt(L);r[L]=A,c[A]=L;}function l(L,A){let y=0,h=0,S=0;do{let B=L.next();S=c[B],y|=(S&31)<<h,h+=5;}while(S&32);let D=y&1;return y>>>=1,D&&(y=-2147483648|-y),A+y}function u(L,A,y){let h=A-y;h=h<0?-h<<1|1:h<<1;do{let S=h&31;h>>>=5,h>0&&(S|=32),L.write(r[S]);}while(h>0);return A}function f(L,A){return L.pos>=A?false:L.peek()!==o}let p=1024*16,b=typeof TextDecoder<"u"?new TextDecoder:typeof Buffer<"u"?{decode(L){return Buffer.from(L.buffer,L.byteOffset,L.byteLength).toString()}}:{decode(L){let A="";for(let y=0;y<L.length;y++)A+=String.fromCharCode(L[y]);return A}};class x{constructor(){this.pos=0,this.out="",this.buffer=new Uint8Array(p);}write(A){let{buffer:y}=this;y[this.pos++]=A,this.pos===p&&(this.out+=b.decode(y),this.pos=0);}flush(){let{buffer:A,out:y,pos:h}=this;return h>0?y+b.decode(A.subarray(0,h)):y}}class H{constructor(A){this.pos=0,this.buffer=A;}next(){return this.buffer.charCodeAt(this.pos++)}peek(){return this.buffer.charCodeAt(this.pos)}indexOf(A){let{buffer:y,pos:h}=this,S=y.indexOf(A,h);return S===-1?y.length:S}}let M=[];function Y(L){let{length:A}=L,y=new H(L),h=[],S=[],D=0;for(;y.pos<A;y.pos++){D=l(y,D);let B=l(y,0);if(!f(y,A)){let V=S.pop();V[2]=D,V[3]=B;continue}let w=l(y,0),v=l(y,0),$=v&1,N=$?[D,B,0,0,w,l(y,0)]:[D,B,0,0,w],W=M;if(f(y,A)){W=[];do{let V=l(y,0);W.push(V);}while(f(y,A))}N.vars=W,h.push(N),S.push(N);}return h}function m(L){let A=new x;for(let y=0;y<L.length;)y=E(L,y,A,[0]);return A.flush()}function E(L,A,y,h){let S=L[A],{0:D,1:B,2:w,3:v,4:$,vars:N}=S;A>0&&y.write(o),h[0]=u(y,D,h[0]),u(y,B,0),u(y,$,0);let W=S.length===6?1:0;u(y,W,0),S.length===6&&u(y,S[5],0);for(let V of N)u(y,V,0);for(A++;A<L.length;){let V=L[A],{0:oe,1:de}=V;if(oe>w||oe===w&&de>=v)break;A=E(L,A,y,h);}return y.write(o),h[0]=u(y,w,h[0]),u(y,v,0),A}function T(L){let{length:A}=L,y=new H(L),h=[],S=[],D=0,B=0,w=0,v=0,$=0,N=0,W=0,V=0;do{let oe=y.indexOf(";"),de=0;for(;y.pos<oe;y.pos++){if(de=l(y,de),!f(y,oe)){let pe=S.pop();pe[2]=D,pe[3]=de;continue}let I=l(y,0),G=I&1,Q=I&2,Ae=I&4,me=null,Se=M,ie;if(G){let pe=l(y,B);w=l(y,B===pe?w:0),B=pe,ie=[D,de,0,0,pe,w];}else ie=[D,de,0,0];if(ie.isScope=!!Ae,Q){let pe=v,ke=$;v=l(y,v);let Pe=pe===v;$=l(y,Pe?$:0),N=l(y,Pe&&ke===$?N:0),me=[v,$,N];}if(ie.callsite=me,f(y,oe)){Se=[];do{W=D,V=de;let pe=l(y,0),ke;if(pe<-1){ke=[[l(y,0)]];for(let Pe=-1;Pe>pe;Pe--){let ge=W;W=l(y,W),V=l(y,W===ge?V:0);let Te=l(y,0);ke.push([Te,W,V]);}}else ke=[[pe]];Se.push(ke);}while(f(y,oe))}ie.bindings=Se,h.push(ie),S.push(ie);}D++,y.pos=oe+1;}while(y.pos<A);return h}function C(L){if(L.length===0)return "";let A=new x;for(let y=0;y<L.length;)y=R(L,y,A,[0,0,0,0,0,0,0]);return A.flush()}function R(L,A,y,h){let S=L[A],{0:D,1:B,2:w,3:v,isScope:$,callsite:N,bindings:W}=S;h[0]<D?(X(y,h[0],D),h[0]=D,h[1]=0):A>0&&y.write(o),h[1]=u(y,S[1],h[1]);let V=(S.length===6?1:0)|(N?2:0)|($?4:0);if(u(y,V,0),S.length===6){let{4:oe,5:de}=S;oe!==h[2]&&(h[3]=0),h[2]=u(y,oe,h[2]),h[3]=u(y,de,h[3]);}if(N){let{0:oe,1:de,2:I}=S.callsite;oe===h[4]?de!==h[5]&&(h[6]=0):(h[5]=0,h[6]=0),h[4]=u(y,oe,h[4]),h[5]=u(y,de,h[5]),h[6]=u(y,I,h[6]);}if(W)for(let oe of W){oe.length>1&&u(y,-oe.length,0);let de=oe[0][0];u(y,de,0);let I=D,G=B;for(let Q=1;Q<oe.length;Q++){let Ae=oe[Q];I=u(y,Ae[1],I),G=u(y,Ae[2],G),u(y,Ae[0],0);}}for(A++;A<L.length;){let oe=L[A],{0:de,1:I}=oe;if(de>w||de===w&&I>=v)break;A=R(L,A,y,h);}return h[0]<w?(X(y,h[0],w),h[0]=w,h[1]=0):y.write(o),h[1]=u(y,v,h[1]),A}function X(L,A,y){do L.write(i);while(++A<y)}function fe(L){let{length:A}=L,y=new H(L),h=[],S=0,D=0,B=0,w=0,v=0;do{let $=y.indexOf(";"),N=[],W=true,V=0;for(S=0;y.pos<$;){let oe;S=l(y,S),S<V&&(W=false),V=S,f(y,$)?(D=l(y,D),B=l(y,B),w=l(y,w),f(y,$)?(v=l(y,v),oe=[S,D,B,w,v]):oe=[S,D,B,w]):oe=[S],N.push(oe),y.pos++;}W||j(N),h.push(N),y.pos=$+1;}while(y.pos<=A);return h}function j(L){L.sort(le);}function le(L,A){return L[0]-A[0]}function ue(L){let A=new x,y=0,h=0,S=0,D=0;for(let B=0;B<L.length;B++){let w=L[B];if(B>0&&A.write(i),w.length===0)continue;let v=0;for(let $=0;$<w.length;$++){let N=w[$];$>0&&A.write(o),v=u(A,N[0],v),N.length!==1&&(y=u(A,N[1],y),h=u(A,N[2],h),S=u(A,N[3],S),N.length!==4&&(D=u(A,N[4],D)));}}return A.flush()}n.decode=fe,n.decodeGeneratedRanges=T,n.decodeOriginalScopes=Y,n.encode=ue,n.encodeGeneratedRanges=C,n.encodeOriginalScopes=m,Object.defineProperty(n,"__esModule",{value:true});});}),Qu=fg(wg()),ed=/^[a-zA-Z][a-zA-Z\d+\-.]*:/,xg=/^data:application\/json[^,]+base64,/,vg=/(?:\/\/[@#][ \t]+sourceMappingURL=([^\s'"]+?)[ \t]*$)|(?:\/\*[@#][ \t]+sourceMappingURL=([^*]+?)[ \t]*(?:\*\/)[ \t]*$)/,td=typeof WeakRef<"u",Wr=new Map,fs=new Map,Cg=e=>td&&e instanceof WeakRef,Uu=(e,t,n,o)=>{if(n<0||n>=e.length)return null;let i=e[n];if(!i||i.length===0)return null;let s=null;for(let f of i)if(f[0]<=o)s=f;else break;if(!s||s.length<4)return null;let[,r,c,l]=s;if(r===void 0||c===void 0||l===void 0)return null;let u=t[r];return u?{columnNumber:l,fileName:u,lineNumber:c+1}:null},Eg=(e,t,n)=>{if(e.sections){let o=null;for(let r of e.sections)if(t>r.offset.line||t===r.offset.line&&n>=r.offset.column)o=r;else break;if(!o)return null;let i=t-o.offset.line,s=t===o.offset.line?n-o.offset.column:n;return Uu(o.map.mappings,o.map.sources,i,s)}return Uu(e.mappings,e.sources,t-1,n)},Sg=(e,t)=>{let n=t.split(`
-`),o;for(let s=n.length-1;s>=0&&!o;s--){let r=n[s].match(vg);r&&(o=r[1]||r[2]);}if(!o)return null;let i=ed.test(o);if(!(xg.test(o)||i||o.startsWith("/"))){let s=e.split("/");s[s.length-1]=o,o=s.join("/");}return o},Ag=e=>({file:e.file,mappings:(0, Qu.decode)(e.mappings),names:e.names,sourceRoot:e.sourceRoot,sources:e.sources,sourcesContent:e.sourcesContent,version:3}),Tg=e=>{let t=e.sections.map(({map:o,offset:i})=>({map:{...o,mappings:(0, Qu.decode)(o.mappings)},offset:i})),n=new Set;for(let o of t)for(let i of o.map.sources)n.add(i);return {file:e.file,mappings:[],names:[],sections:t,sourceRoot:void 0,sources:Array.from(n),sourcesContent:void 0,version:3}},ju=e=>{if(!e)return  false;let t=e.trim();if(!t)return  false;let n=t.match(ed);if(!n)return  true;let o=n[0].toLowerCase();return o==="http:"||o==="https:"},_g=async(e,t=fetch)=>{if(!ju(e))return null;let n;try{let i=await t(e);if(!i.ok)return null;n=await i.text();}catch{return null}if(!n)return null;let o=Sg(e,n);if(!o||!ju(o))return null;try{let i=await t(o);if(!i.ok)return null;let s=await i.json();return "sections"in s?Tg(s):Ag(s)}catch{return null}},Pg=async(e,t=true,n)=>{if(t&&Wr.has(e)){let s=Wr.get(e);if(s==null)return null;if(Cg(s)){let r=s.deref();if(r)return r;Wr.delete(e);}else return s}if(t&&fs.has(e))return fs.get(e);let o=_g(e,n);t&&fs.set(e,o);let i=await o;return t&&fs.delete(e),t&&(i===null?Wr.set(e,null):Wr.set(e,td?new WeakRef(i):i)),i},kg=async(e,t=true,n)=>await Promise.all(e.map(async o=>{if(!o.fileName)return o;let i=await Pg(o.fileName,t,n);if(!i||typeof o.lineNumber!="number"||typeof o.columnNumber!="number")return o;let s=Eg(i,o.lineNumber,o.columnNumber);return s?{...o,source:s.fileName&&o.source?o.source.replace(o.fileName,s.fileName):o.source,fileName:s.fileName,lineNumber:s.lineNumber,columnNumber:s.columnNumber,isSymbolicated:true}:o})),Qa=e=>e._debugStack instanceof Error&&typeof e._debugStack?.stack=="string",Og=()=>{let e=Wn();for(let t of [...Array.from(mo),...Array.from(e.renderers.values())]){let n=t.currentDispatcherRef;if(n&&typeof n=="object")return "H"in n?n.H:n.current}return null},Wu=e=>{for(let t of mo){let n=t.currentDispatcherRef;n&&typeof n=="object"&&("H"in n?n.H=e:n.current=e);}},On=e=>`
-    in ${e}`,Mg=(e,t)=>{let n=On(e);return t&&(n+=` (at ${t})`),n},qa=false,Za=(e,t)=>{if(!e||qa)return "";let n=Error.prepareStackTrace;Error.prepareStackTrace=void 0,qa=true;let o=Og();Wu(null);let i=console.error,s=console.warn;console.error=()=>{},console.warn=()=>{};try{let l={DetermineComponentFrameRoot(){let b;try{if(t){let x=function(){throw Error()};if(Object.defineProperty(x.prototype,"props",{set:function(){throw Error()}}),typeof Reflect=="object"&&Reflect.construct){try{Reflect.construct(x,[]);}catch(H){b=H;}Reflect.construct(e,[],x);}else {try{x.call();}catch(H){b=H;}e.call(x.prototype);}}else {try{throw Error()}catch(H){b=H;}let x=e();x&&typeof x.catch=="function"&&x.catch(()=>{});}}catch(x){if(x instanceof Error&&b instanceof Error&&typeof x.stack=="string")return [x.stack,b.stack]}return [null,null]}};l.DetermineComponentFrameRoot.displayName="DetermineComponentFrameRoot",Object.getOwnPropertyDescriptor(l.DetermineComponentFrameRoot,"name")?.configurable&&Object.defineProperty(l.DetermineComponentFrameRoot,"name",{value:"DetermineComponentFrameRoot"});let[f,p]=l.DetermineComponentFrameRoot();if(f&&p){let b=f.split(`
-`),x=p.split(`
-`),H=0,M=0;for(;H<b.length&&!b[H].includes("DetermineComponentFrameRoot");)H++;for(;M<x.length&&!x[M].includes("DetermineComponentFrameRoot");)M++;if(H===b.length||M===x.length)for(H=b.length-1,M=x.length-1;H>=1&&M>=0&&b[H]!==x[M];)M--;for(;H>=1&&M>=0;H--,M--)if(b[H]!==x[M]){if(H!==1||M!==1)do if(H--,M--,M<0||b[H]!==x[M]){let Y=`
-${b[H].replace(" at new "," at ")}`,m=Kn(e);return m&&Y.includes("<anonymous>")&&(Y=Y.replace("<anonymous>",m)),Y}while(H>=1&&M>=0);break}}}finally{qa=false,Error.prepareStackTrace=n,Wu(o),console.error=i,console.warn=s;}let r=e?Kn(e):"";return r?On(r):""},Rg=(e,t)=>{let n=e.tag,o="";switch(n){case Ua:o=On("Activity");break;case cs:o=Za(e.type,true);break;case us:o=Za(e.type.render,false);break;case ls:case ds:o=Za(e.type,false);break;case $a:case Va:case Ga:o=On(e.type);break;case Ba:o=On("Lazy");break;case Ha:o=e.child!==t&&t!==null?On("Suspense Fallback"):On("Suspense");break;case za:o=On("SuspenseList");break;case ja:o=On("ViewTransition");break;default:return ""}return o},Ig=e=>{try{let t="",n=e,o=null;do{t+=Rg(n,o);let i=n._debugInfo;if(i&&Array.isArray(i))for(let s=i.length-1;s>=0;s--){let r=i[s];typeof r.name=="string"&&(t+=Mg(r.name,r.env));}o=n,n=n.return;}while(n);return t}catch(t){return t instanceof Error?`
+this.globalThis = this.globalThis || {};
+this.globalThis.__REACT_GRAB_MODULE__ = (function (exports) {
+  "use strict"; /**
+   * @license MIT
+   *
+   * Copyright (c) 2025 Aiden Bai
+   *
+   * This source code is licensed under the MIT license found in the
+   * LICENSE file in the root directory of this source tree.
+   */
+  var op = (e, t) => e === t,
+    nn = Symbol("solid-proxy"),
+    rp = typeof Proxy == "function",
+    Nr = Symbol("solid-track"),
+    zi = { equals: op },
+    bc = Ec,
+    Ft = 1,
+    Mr = 2,
+    yc = { owned: null, cleanups: null, context: null, owner: null },
+    ma = {},
+    $e = null,
+    J = null,
+    Fo = null,
+    Ye = null,
+    ft = null,
+    Ct = null,
+    Ui = 0;
+  function Tn(e, t) {
+    let n = Ye,
+      o = $e,
+      i = e.length === 0,
+      s = t === void 0 ? o : t,
+      r = i
+        ? yc
+        : {
+            owned: null,
+            cleanups: null,
+            context: s ? s.context : null,
+            owner: s,
+          },
+      c = i ? e : () => e(() => Et(() => Gn(r)));
+    (($e = r), (Ye = null));
+    try {
+      return Ot(c, !0);
+    } finally {
+      ((Ye = n), ($e = o));
+    }
+  }
+  function U(e, t) {
+    t = t ? Object.assign({}, zi, t) : zi;
+    let n = {
+        value: e,
+        observers: null,
+        observerSlots: null,
+        comparator: t.equals || void 0,
+      },
+      o = (i) => (typeof i == "function" && (i = i(n.value)), Cc(n, i));
+    return [vc.bind(n), o];
+  }
+  function mc(e, t, n) {
+    let o = Ki(e, t, true, Ft);
+    Ho(o);
+  }
+  function te(e, t, n) {
+    let o = Ki(e, t, false, Ft);
+    Ho(o);
+  }
+  function be(e, t, n) {
+    bc = cp;
+    let o = Ki(e, t, false, Ft);
+    ((o.user = true), Ct ? Ct.push(o) : Ho(o));
+  }
+  function se(e, t, n) {
+    n = n ? Object.assign({}, zi, n) : zi;
+    let o = Ki(e, t, true, 0);
+    return (
+      (o.observers = null),
+      (o.observerSlots = null),
+      (o.comparator = n.equals || void 0),
+      Ho(o),
+      vc.bind(o)
+    );
+  }
+  function ip(e) {
+    return e && typeof e == "object" && "then" in e;
+  }
+  function ba(e, t, n) {
+    let o, i, s;
+    typeof t == "function"
+      ? ((o = e), (i = t), (s = {}))
+      : ((o = true), (i = e), (s = t || {}));
+    let r = null,
+      c = ma,
+      f = false,
+      p = "initialValue" in s,
+      b = typeof o == "function" && se(o),
+      x = new Set(),
+      [H, M] = (s.storage || U)(s.initialValue),
+      [Y, m] = U(void 0),
+      [E, T] = U(void 0, { equals: false }),
+      [C, R] = U(p ? "ready" : "unresolved");
+    function X(L, A, y, h) {
+      return (
+        r === L &&
+          ((r = null),
+          h !== void 0 && (p = true),
+          (L === c || A === c) &&
+            s.onHydrated &&
+            queueMicrotask(() => s.onHydrated(h, { value: A })),
+          (c = ma),
+          fe(A, y)),
+        A
+      );
+    }
+    function fe(L, A) {
+      Ot(() => {
+        (A === void 0 && M(() => L),
+          R(A !== void 0 ? "errored" : p ? "ready" : "unresolved"),
+          m(A));
+        for (let y of x.keys()) y.decrement();
+        x.clear();
+      }, false);
+    }
+    function j() {
+      let L = Rr,
+        A = H(),
+        y = Y();
+      if (y !== void 0 && !r) throw y;
+      return (Ye && !Ye.user && L, A);
+    }
+    function le(L = true) {
+      if (L !== false && f) return;
+      f = false;
+      let A = b ? b() : o;
+      if (A == null || A === false) {
+        X(r, Et(H));
+        return;
+      }
+      let y,
+        h =
+          c !== ma
+            ? c
+            : Et(() => {
+                try {
+                  return i(A, { value: H(), refetching: L });
+                } catch (S) {
+                  y = S;
+                }
+              });
+      if (y !== void 0) {
+        X(r, void 0, Bi(y), A);
+        return;
+      } else if (!ip(h)) return (X(r, h, void 0, A), h);
+      return (
+        (r = h),
+        "v" in h
+          ? (h.s === 1 ? X(r, h.v, void 0, A) : X(r, void 0, Bi(h.v), A), h)
+          : ((f = true),
+            queueMicrotask(() => (f = false)),
+            Ot(() => {
+              (R(p ? "refreshing" : "pending"), T());
+            }, false),
+            h.then(
+              (S) => X(h, S, void 0, A),
+              (S) => X(h, void 0, Bi(S), A),
+            ))
+      );
+    }
+    Object.defineProperties(j, {
+      state: { get: () => C() },
+      error: { get: () => Y() },
+      loading: {
+        get() {
+          let L = C();
+          return L === "pending" || L === "refreshing";
+        },
+      },
+      latest: {
+        get() {
+          if (!p) return j();
+          let L = Y();
+          if (L && !r) throw L;
+          return H();
+        },
+      },
+    });
+    let ue = $e;
+    return (
+      b ? mc(() => ((ue = $e), le(false))) : le(false),
+      [j, { refetch: (L) => wc(ue, () => le(L)), mutate: M }]
+    );
+  }
+  function ji(e) {
+    return Ot(e, false);
+  }
+  function Et(e) {
+    if (Ye === null) return e();
+    let t = Ye;
+    Ye = null;
+    try {
+      return Fo ? Fo.untrack(e) : e();
+    } finally {
+      Ye = t;
+    }
+  }
+  function He(e, t, n) {
+    let o = Array.isArray(e),
+      i,
+      s = n && n.defer;
+    return (r) => {
+      let c;
+      if (o) {
+        c = Array(e.length);
+        for (let u = 0; u < e.length; u++) c[u] = e[u]();
+      } else c = e();
+      if (s) return ((s = false), r);
+      let l = Et(() => t(c, i, r));
+      return ((i = c), l);
+    };
+  }
+  function mt(e) {
+    be(() => Et(e));
+  }
+  function Me(e) {
+    return (
+      $e === null ||
+        ($e.cleanups === null ? ($e.cleanups = [e]) : $e.cleanups.push(e)),
+      e
+    );
+  }
+  function Wi() {
+    return Ye;
+  }
+  function wc(e, t) {
+    let n = $e,
+      o = Ye;
+    (($e = e), (Ye = null));
+    try {
+      return Ot(t, !0);
+    } catch (i) {
+      Xi(i);
+    } finally {
+      (($e = n), (Ye = o));
+    }
+  }
+  var [Cw, pc] = U(false);
+  var Rr;
+  function vc() {
+    let e = J;
+    if (this.sources && this.state)
+      if (this.state === Ft) Ho(this);
+      else {
+        let t = ft;
+        ((ft = null), Ot(() => Vi(this), false), (ft = t));
+      }
+    if (Ye) {
+      let t = this.observers ? this.observers.length : 0;
+      (Ye.sources
+        ? (Ye.sources.push(this), Ye.sourceSlots.push(t))
+        : ((Ye.sources = [this]), (Ye.sourceSlots = [t])),
+        this.observers
+          ? (this.observers.push(Ye),
+            this.observerSlots.push(Ye.sources.length - 1))
+          : ((this.observers = [Ye]),
+            (this.observerSlots = [Ye.sources.length - 1])));
+    }
+    return e && J.sources.has(this) ? this.tValue : this.value;
+  }
+  function Cc(e, t, n) {
+    let o = e.value;
+    if (!e.comparator || !e.comparator(o, t)) {
+      e.value = t;
+      e.observers &&
+        e.observers.length &&
+        Ot(() => {
+          for (let i = 0; i < e.observers.length; i += 1) {
+            let s = e.observers[i],
+              r = J && J.running;
+            (r && J.disposed.has(s)) ||
+              ((r ? !s.tState : !s.state) &&
+                (s.pure ? ft.push(s) : Ct.push(s), s.observers && Sc(s)),
+              r ? (s.tState = Ft) : (s.state = Ft));
+          }
+          if (ft.length > 1e6) throw ((ft = []), new Error());
+        }, false);
+    }
+    return t;
+  }
+  function Ho(e) {
+    if (!e.fn) return;
+    Gn(e);
+    let t = Ui;
+    gc(e, e.value, t);
+  }
+  function gc(e, t, n) {
+    let o,
+      i = $e,
+      s = Ye;
+    Ye = $e = e;
+    try {
+      o = e.fn(t);
+    } catch (r) {
+      return (
+        e.pure &&
+          ((e.state = Ft), e.owned && e.owned.forEach(Gn), (e.owned = null)),
+        (e.updatedAt = n + 1),
+        Xi(r)
+      );
+    } finally {
+      ((Ye = s), ($e = i));
+    }
+    (!e.updatedAt || e.updatedAt <= n) &&
+      (e.updatedAt != null && "observers" in e ? Cc(e, o) : (e.value = o),
+      (e.updatedAt = n));
+  }
+  function Ki(e, t, n, o = Ft, i) {
+    let s = {
+      fn: e,
+      state: o,
+      updatedAt: null,
+      owned: null,
+      sources: null,
+      sourceSlots: null,
+      cleanups: null,
+      value: t,
+      owner: $e,
+      context: $e ? $e.context : null,
+      pure: n,
+    };
+    if (
+      ($e === null ||
+        ($e !== yc && ($e.owned ? $e.owned.push(s) : ($e.owned = [s]))),
+      Fo)
+    );
+    return s;
+  }
+  function Ir(e) {
+    let t = J;
+    if (e.state === 0) return;
+    if (e.state === Mr) return Vi(e);
+    if (e.suspense && Et(e.suspense.inFallback))
+      return e.suspense.effects.push(e);
+    let n = [e];
+    for (; (e = e.owner) && (!e.updatedAt || e.updatedAt < Ui); ) {
+      e.state && n.push(e);
+    }
+    for (let o = n.length - 1; o >= 0; o--) {
+      if (((e = n[o]), t));
+      if (e.state === Ft) Ho(e);
+      else if (e.state === Mr) {
+        let i = ft;
+        ((ft = null), Ot(() => Vi(e, n[0]), false), (ft = i));
+      }
+    }
+  }
+  function Ot(e, t) {
+    if (ft) return e();
+    let n = false;
+    (t || (ft = []), Ct ? (n = true) : (Ct = []), Ui++);
+    try {
+      let o = e();
+      return (ap(n), o);
+    } catch (o) {
+      (n || (Ct = null), (ft = null), Xi(o));
+    }
+  }
+  function ap(e) {
+    if ((ft && (Ec(ft), (ft = null)), e)) return;
+    let n = Ct;
+    ((Ct = null), n.length && Ot(() => bc(n), false));
+  }
+  function Ec(e) {
+    for (let t = 0; t < e.length; t++) Ir(e[t]);
+  }
+  function cp(e) {
+    let t,
+      n = 0;
+    for (t = 0; t < e.length; t++) {
+      let o = e[t];
+      o.user ? (e[n++] = o) : Ir(o);
+    }
+    for (t = 0; t < n; t++) Ir(e[t]);
+  }
+  function Vi(e, t) {
+    e.state = 0;
+    for (let o = 0; o < e.sources.length; o += 1) {
+      let i = e.sources[o];
+      if (i.sources) {
+        let s = i.state;
+        s === Ft
+          ? i !== t && (!i.updatedAt || i.updatedAt < Ui) && Ir(i)
+          : s === Mr && Vi(i, t);
+      }
+    }
+  }
+  function Sc(e) {
+    for (let n = 0; n < e.observers.length; n += 1) {
+      let o = e.observers[n];
+      !o.state &&
+        ((o.state = Mr),
+        o.pure ? ft.push(o) : Ct.push(o),
+        o.observers && Sc(o));
+    }
+  }
+  function Gn(e) {
+    let t;
+    if (e.sources)
+      for (; e.sources.length; ) {
+        let n = e.sources.pop(),
+          o = e.sourceSlots.pop(),
+          i = n.observers;
+        if (i && i.length) {
+          let s = i.pop(),
+            r = n.observerSlots.pop();
+          o < i.length &&
+            ((s.sourceSlots[r] = o), (i[o] = s), (n.observerSlots[o] = r));
+        }
+      }
+    if (e.tOwned) {
+      for (t = e.tOwned.length - 1; t >= 0; t--) Gn(e.tOwned[t]);
+      delete e.tOwned;
+    }
+    if (e.owned) {
+      for (t = e.owned.length - 1; t >= 0; t--) Gn(e.owned[t]);
+      e.owned = null;
+    }
+    if (e.cleanups) {
+      for (t = e.cleanups.length - 1; t >= 0; t--) e.cleanups[t]();
+      e.cleanups = null;
+    }
+    e.state = 0;
+  }
+  function Bi(e) {
+    return e instanceof Error
+      ? e
+      : new Error(typeof e == "string" ? e : "Unknown error", { cause: e });
+  }
+  function Xi(e, t = $e) {
+    let o = Bi(e);
+    throw o;
+  }
+  var ha = Symbol("fallback");
+  function Gi(e) {
+    for (let t = 0; t < e.length; t++) e[t]();
+  }
+  function up(e, t, n = {}) {
+    let o = [],
+      i = [],
+      s = [],
+      r = 0,
+      c = t.length > 1 ? [] : null;
+    return (
+      Me(() => Gi(s)),
+      () => {
+        let l = e() || [],
+          u = l.length,
+          f,
+          p;
+        return (
+          l[Nr],
+          Et(() => {
+            let x, H, M, Y, m, E, T, C, R;
+            if (u === 0)
+              (r !== 0 &&
+                (Gi(s), (s = []), (o = []), (i = []), (r = 0), c && (c = [])),
+                n.fallback &&
+                  ((o = [ha]),
+                  (i[0] = Tn((X) => ((s[0] = X), n.fallback()))),
+                  (r = 1)));
+            else if (r === 0) {
+              for (i = new Array(u), p = 0; p < u; p++)
+                ((o[p] = l[p]), (i[p] = Tn(b)));
+              r = u;
+            } else {
+              for (
+                M = new Array(u),
+                  Y = new Array(u),
+                  c && (m = new Array(u)),
+                  E = 0,
+                  T = Math.min(r, u);
+                E < T && o[E] === l[E];
+                E++
+              );
+              for (
+                T = r - 1, C = u - 1;
+                T >= E && C >= E && o[T] === l[C];
+                T--, C--
+              )
+                ((M[C] = i[T]), (Y[C] = s[T]), c && (m[C] = c[T]));
+              for (x = new Map(), H = new Array(C + 1), p = C; p >= E; p--)
+                ((R = l[p]),
+                  (f = x.get(R)),
+                  (H[p] = f === void 0 ? -1 : f),
+                  x.set(R, p));
+              for (f = E; f <= T; f++)
+                ((R = o[f]),
+                  (p = x.get(R)),
+                  p !== void 0 && p !== -1
+                    ? ((M[p] = i[f]),
+                      (Y[p] = s[f]),
+                      c && (m[p] = c[f]),
+                      (p = H[p]),
+                      x.set(R, p))
+                    : s[f]());
+              for (p = E; p < u; p++)
+                p in M
+                  ? ((i[p] = M[p]),
+                    (s[p] = Y[p]),
+                    c && ((c[p] = m[p]), c[p](p)))
+                  : (i[p] = Tn(b));
+              ((i = i.slice(0, (r = u))), (o = l.slice(0)));
+            }
+            return i;
+          })
+        );
+        function b(x) {
+          if (((s[p] = x), c)) {
+            let [H, M] = U(p);
+            return ((c[p] = M), t(l[p], H));
+          }
+          return t(l[p]);
+        }
+      }
+    );
+  }
+  function dp(e, t, n = {}) {
+    let o = [],
+      i = [],
+      s = [],
+      r = [],
+      c = 0,
+      l;
+    return (
+      Me(() => Gi(s)),
+      () => {
+        let u = e() || [],
+          f = u.length;
+        return (
+          u[Nr],
+          Et(() => {
+            if (f === 0)
+              return (
+                c !== 0 &&
+                  (Gi(s), (s = []), (o = []), (i = []), (c = 0), (r = [])),
+                n.fallback &&
+                  ((o = [ha]),
+                  (i[0] = Tn((b) => ((s[0] = b), n.fallback()))),
+                  (c = 1)),
+                i
+              );
+            for (
+              o[0] === ha && (s[0](), (s = []), (o = []), (i = []), (c = 0)),
+                l = 0;
+              l < f;
+              l++
+            )
+              l < o.length && o[l] !== u[l]
+                ? r[l](() => u[l])
+                : l >= o.length && (i[l] = Tn(p));
+            for (; l < o.length; l++) s[l]();
+            return (
+              (c = r.length = s.length = f),
+              (o = u.slice(0)),
+              (i = i.slice(0, c))
+            );
+          })
+        );
+        function p(b) {
+          s[l] = b;
+          let [x, H] = U(u[l]);
+          return ((r[l] = H), t(x, l));
+        }
+      }
+    );
+  }
+  function O(e, t) {
+    return Et(() => e(t || {}));
+  }
+  function Hi() {
+    return true;
+  }
+  var mp = {
+    get(e, t, n) {
+      return t === nn ? n : e.get(t);
+    },
+    has(e, t) {
+      return t === nn ? true : e.has(t);
+    },
+    set: Hi,
+    deleteProperty: Hi,
+    getOwnPropertyDescriptor(e, t) {
+      return {
+        configurable: true,
+        enumerable: true,
+        get() {
+          return e.get(t);
+        },
+        set: Hi,
+        deleteProperty: Hi,
+      };
+    },
+    ownKeys(e) {
+      return e.keys();
+    },
+  };
+  function pa(e) {
+    return (e = typeof e == "function" ? e() : e) ? e : {};
+  }
+  function pp() {
+    for (let e = 0, t = this.length; e < t; ++e) {
+      let n = this[e]();
+      if (n !== void 0) return n;
+    }
+  }
+  function Bo(...e) {
+    let t = false;
+    for (let r = 0; r < e.length; r++) {
+      let c = e[r];
+      ((t = t || (!!c && nn in c)),
+        (e[r] = typeof c == "function" ? ((t = true), se(c)) : c));
+    }
+    if (rp && t)
+      return new Proxy(
+        {
+          get(r) {
+            for (let c = e.length - 1; c >= 0; c--) {
+              let l = pa(e[c])[r];
+              if (l !== void 0) return l;
+            }
+          },
+          has(r) {
+            for (let c = e.length - 1; c >= 0; c--)
+              if (r in pa(e[c])) return true;
+            return false;
+          },
+          keys() {
+            let r = [];
+            for (let c = 0; c < e.length; c++) r.push(...Object.keys(pa(e[c])));
+            return [...new Set(r)];
+          },
+        },
+        mp,
+      );
+    let n = {},
+      o = Object.create(null);
+    for (let r = e.length - 1; r >= 0; r--) {
+      let c = e[r];
+      if (!c) continue;
+      let l = Object.getOwnPropertyNames(c);
+      for (let u = l.length - 1; u >= 0; u--) {
+        let f = l[u];
+        if (f === "__proto__" || f === "constructor") continue;
+        let p = Object.getOwnPropertyDescriptor(c, f);
+        if (!o[f])
+          o[f] = p.get
+            ? {
+                enumerable: true,
+                configurable: true,
+                get: pp.bind((n[f] = [p.get.bind(c)])),
+              }
+            : p.value !== void 0
+              ? p
+              : void 0;
+        else {
+          let b = n[f];
+          b &&
+            (p.get
+              ? b.push(p.get.bind(c))
+              : p.value !== void 0 && b.push(() => p.value));
+        }
+      }
+    }
+    let i = {},
+      s = Object.keys(o);
+    for (let r = s.length - 1; r >= 0; r--) {
+      let c = s[r],
+        l = o[c];
+      l && l.get
+        ? Object.defineProperty(i, c, l)
+        : (i[c] = l ? l.value : void 0);
+    }
+    return i;
+  }
+  var gp = (e) => `Stale read from <${e}>.`;
+  function on(e) {
+    let t = "fallback" in e && { fallback: () => e.fallback };
+    return se(up(() => e.each, e.children, t || void 0));
+  }
+  function Yi(e) {
+    let t = "fallback" in e && { fallback: () => e.fallback };
+    return se(dp(() => e.each, e.children, t || void 0));
+  }
+  function ye(e) {
+    let t = e.keyed,
+      n = se(() => e.when, void 0, void 0),
+      o = t ? n : se(n, void 0, { equals: (i, s) => !i == !s });
+    return se(
+      () => {
+        let i = o();
+        if (i) {
+          let s = e.children;
+          return typeof s == "function" && s.length > 0
+            ? Et(() =>
+                s(
+                  t
+                    ? i
+                    : () => {
+                        if (!Et(o)) throw gp("Show");
+                        return n();
+                      },
+                ),
+              )
+            : s;
+        }
+        return e.fallback;
+      },
+      void 0,
+      void 0,
+    );
+  }
+  var bp = [
+      "allowfullscreen",
+      "async",
+      "alpha",
+      "autofocus",
+      "autoplay",
+      "checked",
+      "controls",
+      "default",
+      "disabled",
+      "formnovalidate",
+      "hidden",
+      "indeterminate",
+      "inert",
+      "ismap",
+      "loop",
+      "multiple",
+      "muted",
+      "nomodule",
+      "novalidate",
+      "open",
+      "playsinline",
+      "readonly",
+      "required",
+      "reversed",
+      "seamless",
+      "selected",
+      "adauctionheaders",
+      "browsingtopics",
+      "credentialless",
+      "defaultchecked",
+      "defaultmuted",
+      "defaultselected",
+      "defer",
+      "disablepictureinpicture",
+      "disableremoteplayback",
+      "preservespitch",
+      "shadowrootclonable",
+      "shadowrootcustomelementregistry",
+      "shadowrootdelegatesfocus",
+      "shadowrootserializable",
+      "sharedstoragewritable",
+    ],
+    yp = new Set([
+      "className",
+      "value",
+      "readOnly",
+      "noValidate",
+      "formNoValidate",
+      "isMap",
+      "noModule",
+      "playsInline",
+      "adAuctionHeaders",
+      "allowFullscreen",
+      "browsingTopics",
+      "defaultChecked",
+      "defaultMuted",
+      "defaultSelected",
+      "disablePictureInPicture",
+      "disableRemotePlayback",
+      "preservesPitch",
+      "shadowRootClonable",
+      "shadowRootCustomElementRegistry",
+      "shadowRootDelegatesFocus",
+      "shadowRootSerializable",
+      "sharedStorageWritable",
+      ...bp,
+    ]),
+    wp = new Set(["innerHTML", "textContent", "innerText", "children"]),
+    xp = Object.assign(Object.create(null), {
+      className: "class",
+      htmlFor: "for",
+    }),
+    vp = Object.assign(Object.create(null), {
+      class: "className",
+      novalidate: { $: "noValidate", FORM: 1 },
+      formnovalidate: { $: "formNoValidate", BUTTON: 1, INPUT: 1 },
+      ismap: { $: "isMap", IMG: 1 },
+      nomodule: { $: "noModule", SCRIPT: 1 },
+      playsinline: { $: "playsInline", VIDEO: 1 },
+      readonly: { $: "readOnly", INPUT: 1, TEXTAREA: 1 },
+      adauctionheaders: { $: "adAuctionHeaders", IFRAME: 1 },
+      allowfullscreen: { $: "allowFullscreen", IFRAME: 1 },
+      browsingtopics: { $: "browsingTopics", IMG: 1 },
+      defaultchecked: { $: "defaultChecked", INPUT: 1 },
+      defaultmuted: { $: "defaultMuted", AUDIO: 1, VIDEO: 1 },
+      defaultselected: { $: "defaultSelected", OPTION: 1 },
+      disablepictureinpicture: { $: "disablePictureInPicture", VIDEO: 1 },
+      disableremoteplayback: { $: "disableRemotePlayback", AUDIO: 1, VIDEO: 1 },
+      preservespitch: { $: "preservesPitch", AUDIO: 1, VIDEO: 1 },
+      shadowrootclonable: { $: "shadowRootClonable", TEMPLATE: 1 },
+      shadowrootdelegatesfocus: { $: "shadowRootDelegatesFocus", TEMPLATE: 1 },
+      shadowrootserializable: { $: "shadowRootSerializable", TEMPLATE: 1 },
+      sharedstoragewritable: { $: "sharedStorageWritable", IFRAME: 1, IMG: 1 },
+    });
+  function Cp(e, t) {
+    let n = vp[e];
+    return typeof n == "object" ? (n[t] ? n.$ : void 0) : n;
+  }
+  var Ep = new Set([
+    "beforeinput",
+    "click",
+    "dblclick",
+    "contextmenu",
+    "focusin",
+    "focusout",
+    "input",
+    "keydown",
+    "keyup",
+    "mousedown",
+    "mousemove",
+    "mouseout",
+    "mouseover",
+    "mouseup",
+    "pointerdown",
+    "pointermove",
+    "pointerout",
+    "pointerover",
+    "pointerup",
+    "touchend",
+    "touchmove",
+    "touchstart",
+  ]);
+  var Be = (e) => se(() => e());
+  function Ap(e, t, n) {
+    let o = n.length,
+      i = t.length,
+      s = o,
+      r = 0,
+      c = 0,
+      l = t[i - 1].nextSibling,
+      u = null;
+    for (; r < i || c < s; ) {
+      if (t[r] === n[c]) {
+        (r++, c++);
+        continue;
+      }
+      for (; t[i - 1] === n[s - 1]; ) (i--, s--);
+      if (i === r) {
+        let f = s < o ? (c ? n[c - 1].nextSibling : n[s - c]) : l;
+        for (; c < s; ) e.insertBefore(n[c++], f);
+      } else if (s === c)
+        for (; r < i; ) ((!u || !u.has(t[r])) && t[r].remove(), r++);
+      else if (t[r] === n[s - 1] && n[c] === t[i - 1]) {
+        let f = t[--i].nextSibling;
+        (e.insertBefore(n[c++], t[r++].nextSibling),
+          e.insertBefore(n[--s], f),
+          (t[i] = n[s]));
+      } else {
+        if (!u) {
+          u = new Map();
+          let p = c;
+          for (; p < s; ) u.set(n[p], p++);
+        }
+        let f = u.get(t[r]);
+        if (f != null)
+          if (c < f && f < s) {
+            let p = r,
+              b = 1,
+              x;
+            for (
+              ;
+              ++p < i && p < s && !((x = u.get(t[p])) == null || x !== f + b);
+            )
+              b++;
+            if (b > f - c) {
+              let H = t[r];
+              for (; c < f; ) e.insertBefore(n[c++], H);
+            } else e.replaceChild(n[c++], t[r++]);
+          } else r++;
+        else t[r++].remove();
+      }
+    }
+  }
+  var Tc = "_$DX_DELEGATE";
+  function Oc(e, t, n, o = {}) {
+    let i;
+    return (
+      Tn((s) => {
+        ((i = s),
+          t === document ? e() : z(t, e(), t.firstChild ? null : void 0, n));
+      }, o.owner),
+      () => {
+        (i(), (t.textContent = ""));
+      }
+    );
+  }
+  function K(e, t, n, o) {
+    let i,
+      s = () => {
+        let c = document.createElement("template");
+        return ((c.innerHTML = e), c.content.firstChild);
+      },
+      r = () => (i || (i = s())).cloneNode(true);
+    return ((r.cloneNode = r), r);
+  }
+  function it(e, t = window.document) {
+    let n = t[Tc] || (t[Tc] = new Set());
+    for (let o = 0, i = e.length; o < i; o++) {
+      let s = e[o];
+      n.has(s) || (n.add(s), t.addEventListener(s, Mp));
+    }
+  }
+  function ae(e, t, n) {
+    n == null ? e.removeAttribute(t) : e.setAttribute(t, n);
+  }
+  function _p(e, t, n) {
+    n ? e.setAttribute(t, "") : e.removeAttribute(t);
+  }
+  function Re(e, t) {
+    t == null ? e.removeAttribute("class") : (e.className = t);
+  }
+  function Je(e, t, n, o) {
+    if (o)
+      Array.isArray(n)
+        ? ((e[`$$${t}`] = n[0]), (e[`$$${t}Data`] = n[1]))
+        : (e[`$$${t}`] = n);
+    else if (Array.isArray(n)) {
+      let i = n[0];
+      e.addEventListener(t, (n[0] = (s) => i.call(e, n[1], s)));
+    } else e.addEventListener(t, n, typeof n != "function" && n);
+  }
+  function co(e, t, n = {}) {
+    let o = Object.keys(t || {}),
+      i = Object.keys(n),
+      s,
+      r;
+    for (s = 0, r = i.length; s < r; s++) {
+      let c = i[s];
+      !c || c === "undefined" || t[c] || (_c(e, c, false), delete n[c]);
+    }
+    for (s = 0, r = o.length; s < r; s++) {
+      let c = o[s],
+        l = !!t[c];
+      !c ||
+        c === "undefined" ||
+        n[c] === l ||
+        !l ||
+        (_c(e, c, true), (n[c] = l));
+    }
+    return n;
+  }
+  function Pp(e, t, n) {
+    if (!t) return n ? ae(e, "style") : t;
+    let o = e.style;
+    if (typeof t == "string") return (o.cssText = t);
+    (typeof n == "string" && (o.cssText = n = void 0),
+      n || (n = {}),
+      t || (t = {}));
+    let i, s;
+    for (s in n) (t[s] == null && o.removeProperty(s), delete n[s]);
+    for (s in t) ((i = t[s]), i !== n[s] && (o.setProperty(s, i), (n[s] = i)));
+    return n;
+  }
+  function we(e, t, n) {
+    n != null ? e.style.setProperty(t, n) : e.style.removeProperty(t);
+  }
+  function Lr(e, t = {}, n, o) {
+    let i = {};
+    return (
+      te(() => typeof t.ref == "function" && Ke(t.ref, e)),
+      te(() => kp(e, t, n, true, i, true)),
+      i
+    );
+  }
+  function Ke(e, t, n) {
+    return Et(() => e(t, n));
+  }
+  function z(e, t, n, o) {
+    if ((n !== void 0 && !o && (o = []), typeof t != "function"))
+      return Vo(e, t, o, n);
+    te((i) => Vo(e, t(), i, n), o);
+  }
+  function kp(e, t, n, o, i = {}, s = false) {
+    t || (t = {});
+    for (let r in i)
+      if (!(r in t)) {
+        if (r === "children") continue;
+        i[r] = Pc(e, r, null, i[r], n, s, t);
+      }
+    for (let r in t) {
+      if (r === "children") {
+        continue;
+      }
+      let c = t[r];
+      i[r] = Pc(e, r, c, i[r], n, s, t);
+    }
+  }
+  function Op(e) {
+    return e.toLowerCase().replace(/-([a-z])/g, (t, n) => n.toUpperCase());
+  }
+  function _c(e, t, n) {
+    let o = t.trim().split(/\s+/);
+    for (let i = 0, s = o.length; i < s; i++) e.classList.toggle(o[i], n);
+  }
+  function Pc(e, t, n, o, i, s, r) {
+    let c, l, u, f, p;
+    if (t === "style") return Pp(e, n, o);
+    if (t === "classList") return co(e, n, o);
+    if (n === o) return o;
+    if (t === "ref") s || n(e);
+    else if (t.slice(0, 3) === "on:") {
+      let b = t.slice(3);
+      (o && e.removeEventListener(b, o, typeof o != "function" && o),
+        n && e.addEventListener(b, n, typeof n != "function" && n));
+    } else if (t.slice(0, 10) === "oncapture:") {
+      let b = t.slice(10);
+      (o && e.removeEventListener(b, o, true),
+        n && e.addEventListener(b, n, true));
+    } else if (t.slice(0, 2) === "on") {
+      let b = t.slice(2).toLowerCase(),
+        x = Ep.has(b);
+      if (!x && o) {
+        let H = Array.isArray(o) ? o[0] : o;
+        e.removeEventListener(b, H);
+      }
+      (x || n) && (Je(e, b, n, x), x && it([b]));
+    } else if (t.slice(0, 5) === "attr:") ae(e, t.slice(5), n);
+    else if (t.slice(0, 5) === "bool:") _p(e, t.slice(5), n);
+    else if (
+      (p = t.slice(0, 5) === "prop:") ||
+      (u = wp.has(t)) ||
+      (f = Cp(t, e.tagName)) ||
+      (l = yp.has(t)) ||
+      (c = e.nodeName.includes("-") || "is" in r)
+    ) {
+      if (p) ((t = t.slice(5)), (l = true));
+      t === "class" || t === "className"
+        ? Re(e, n)
+        : c && !l && !u
+          ? (e[Op(t)] = n)
+          : (e[f || t] = n);
+    } else {
+      ae(e, xp[t] || t, n);
+    }
+    return n;
+  }
+  function Mp(e) {
+    let t = e.target,
+      n = `$$${e.type}`,
+      o = e.target,
+      i = e.currentTarget,
+      s = (l) =>
+        Object.defineProperty(e, "target", { configurable: true, value: l }),
+      r = () => {
+        let l = t[n];
+        if (l && !t.disabled) {
+          let u = t[`${n}Data`];
+          if ((u !== void 0 ? l.call(t, u, e) : l.call(t, e), e.cancelBubble))
+            return;
+        }
+        return (
+          t.host &&
+            typeof t.host != "string" &&
+            !t.host._$host &&
+            t.contains(e.target) &&
+            s(t.host),
+          true
+        );
+      },
+      c = () => {
+        for (; r() && (t = t._$host || t.parentNode || t.host); );
+      };
+    if (
+      (Object.defineProperty(e, "currentTarget", {
+        configurable: true,
+        get() {
+          return t || document;
+        },
+      }),
+      e.composedPath)
+    ) {
+      let l = e.composedPath();
+      s(l[0]);
+      for (let u = 0; u < l.length - 2 && ((t = l[u]), !!r()); u++) {
+        if (t._$host) {
+          ((t = t._$host), c());
+          break;
+        }
+        if (t.parentNode === i) break;
+      }
+    } else c();
+    s(o);
+  }
+  function Vo(e, t, n, o, i) {
+    for (; typeof n == "function"; ) n = n();
+    if (t === n) return n;
+    let r = typeof t,
+      c = o !== void 0;
+    if (
+      ((e = (c && n[0] && n[0].parentNode) || e),
+      r === "string" || r === "number")
+    ) {
+      if (r === "number" && ((t = t.toString()), t === n)) return n;
+      if (c) {
+        let l = n[0];
+        (l && l.nodeType === 3
+          ? l.data !== t && (l.data = t)
+          : (l = document.createTextNode(t)),
+          (n = zo(e, n, o, l)));
+      } else
+        n !== "" && typeof n == "string"
+          ? (n = e.firstChild.data = t)
+          : (n = e.textContent = t);
+    } else if (t == null || r === "boolean") {
+      n = zo(e, n, o);
+    } else {
+      if (r === "function")
+        return (
+          te(() => {
+            let l = t();
+            for (; typeof l == "function"; ) l = l();
+            n = Vo(e, l, n, o);
+          }),
+          () => n
+        );
+      if (Array.isArray(t)) {
+        let l = [],
+          u = n && Array.isArray(n);
+        if (ya(l, t, n, i))
+          return (te(() => (n = Vo(e, l, n, o, true))), () => n);
+        if (l.length === 0) {
+          if (((n = zo(e, n, o)), c)) return n;
+        } else
+          u
+            ? n.length === 0
+              ? kc(e, l, o)
+              : Ap(e, n, l)
+            : (n && zo(e), kc(e, l));
+        n = l;
+      } else if (t.nodeType) {
+        if (Array.isArray(n)) {
+          if (c) return (n = zo(e, n, o, t));
+          zo(e, n, null, t);
+        } else
+          n == null || n === "" || !e.firstChild
+            ? e.appendChild(t)
+            : e.replaceChild(t, e.firstChild);
+        n = t;
+      }
+    }
+    return n;
+  }
+  function ya(e, t, n, o) {
+    let i = false;
+    for (let s = 0, r = t.length; s < r; s++) {
+      let c = t[s],
+        l = n && n[e.length],
+        u;
+      if (!(c == null || c === true || c === false))
+        if ((u = typeof c) == "object" && c.nodeType) e.push(c);
+        else if (Array.isArray(c)) i = ya(e, c, l) || i;
+        else if (u === "function")
+          if (o) {
+            for (; typeof c == "function"; ) c = c();
+            i =
+              ya(e, Array.isArray(c) ? c : [c], Array.isArray(l) ? l : [l]) ||
+              i;
+          } else (e.push(c), (i = true));
+        else {
+          let f = String(c);
+          l && l.nodeType === 3 && l.data === f
+            ? e.push(l)
+            : e.push(document.createTextNode(f));
+        }
+    }
+    return i;
+  }
+  function kc(e, t, n = null) {
+    for (let o = 0, i = t.length; o < i; o++) e.insertBefore(t[o], n);
+  }
+  function zo(e, t, n, o) {
+    if (n === void 0) return (e.textContent = "");
+    let i = o || document.createTextNode("");
+    if (t.length) {
+      let s = false;
+      for (let r = t.length - 1; r >= 0; r--) {
+        let c = t[r];
+        if (i !== c) {
+          let l = c.parentNode === e;
+          !s && !r
+            ? l
+              ? e.replaceChild(i, c)
+              : e.insertBefore(i, n)
+            : l && c.remove();
+        } else s = true;
+      }
+    } else e.insertBefore(i, n);
+    return [i];
+  }
+  var Mc = `/*! tailwindcss v4.1.17 | MIT License | https://tailwindcss.com */
+@layer properties{@supports (((-webkit-hyphens:none)) and (not (margin-trim:inline))) or ((-moz-orient:inline) and (not (color:rgb(from red r g b)))){*,:before,:after,::backdrop{--tw-translate-x:0;--tw-translate-y:0;--tw-translate-z:0;--tw-scale-x:1;--tw-scale-y:1;--tw-scale-z:1;--tw-rotate-x:initial;--tw-rotate-y:initial;--tw-rotate-z:initial;--tw-skew-x:initial;--tw-skew-y:initial;--tw-border-style:solid;--tw-leading:initial;--tw-font-weight:initial;--tw-ordinal:initial;--tw-slashed-zero:initial;--tw-numeric-figure:initial;--tw-numeric-spacing:initial;--tw-numeric-fraction:initial;--tw-shadow:0 0 #0000;--tw-shadow-color:initial;--tw-shadow-alpha:100%;--tw-inset-shadow:0 0 #0000;--tw-inset-shadow-color:initial;--tw-inset-shadow-alpha:100%;--tw-ring-color:initial;--tw-ring-shadow:0 0 #0000;--tw-inset-ring-color:initial;--tw-inset-ring-shadow:0 0 #0000;--tw-ring-inset:initial;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-offset-shadow:0 0 #0000;--tw-outline-style:solid;--tw-blur:initial;--tw-brightness:initial;--tw-contrast:initial;--tw-grayscale:initial;--tw-hue-rotate:initial;--tw-invert:initial;--tw-opacity:initial;--tw-saturate:initial;--tw-sepia:initial;--tw-drop-shadow:initial;--tw-drop-shadow-color:initial;--tw-drop-shadow-alpha:100%;--tw-drop-shadow-size:initial;--tw-backdrop-blur:initial;--tw-backdrop-brightness:initial;--tw-backdrop-contrast:initial;--tw-backdrop-grayscale:initial;--tw-backdrop-hue-rotate:initial;--tw-backdrop-invert:initial;--tw-backdrop-opacity:initial;--tw-backdrop-saturate:initial;--tw-backdrop-sepia:initial;--tw-duration:initial;--tw-ease:initial;--tw-contain-size:initial;--tw-contain-layout:initial;--tw-contain-paint:initial;--tw-contain-style:initial;--tw-content:""}}}@layer theme{:root,:host{--font-sans:"Geist",ui-sans-serif,system-ui,sans-serif;--font-mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;--color-yellow-500:oklch(79.5% .184 86.047);--color-black:#000;--color-white:#fff;--spacing:4px;--text-sm:14px;--text-sm--line-height:calc(1.25/.875);--font-weight-medium:500;--radius-sm:4px;--ease-out:cubic-bezier(0,0,.2,1);--animate-ping:ping 1s cubic-bezier(0,0,.2,1)infinite;--animate-pulse:pulse 2s cubic-bezier(.4,0,.6,1)infinite;--default-transition-duration:.15s;--default-transition-timing-function:cubic-bezier(.4,0,.2,1);--default-font-family:var(--font-sans);--default-mono-font-family:var(--font-mono);--transition-fast:.1s;--transition-normal:.15s;--transition-slow:.2s}}@layer base{*,:after,:before,::backdrop{box-sizing:border-box;border:0 solid;margin:0;padding:0}::file-selector-button{box-sizing:border-box;border:0 solid;margin:0;padding:0}html,:host{-webkit-text-size-adjust:100%;tab-size:4;line-height:1.5;font-family:var(--default-font-family,ui-sans-serif,system-ui,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji");font-feature-settings:var(--default-font-feature-settings,normal);font-variation-settings:var(--default-font-variation-settings,normal);-webkit-tap-highlight-color:transparent}hr{height:0;color:inherit;border-top-width:1px}abbr:where([title]){-webkit-text-decoration:underline dotted;text-decoration:underline dotted}h1,h2,h3,h4,h5,h6{font-size:inherit;font-weight:inherit}a{color:inherit;-webkit-text-decoration:inherit;-webkit-text-decoration:inherit;-webkit-text-decoration:inherit;text-decoration:inherit}b,strong{font-weight:bolder}code,kbd,samp,pre{font-family:var(--default-mono-font-family,ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace);font-feature-settings:var(--default-mono-font-feature-settings,normal);font-variation-settings:var(--default-mono-font-variation-settings,normal);font-size:1em}small{font-size:80%}sub,sup{vertical-align:baseline;font-size:75%;line-height:0;position:relative}sub{bottom:-.25em}sup{top:-.5em}table{text-indent:0;border-color:inherit;border-collapse:collapse}:-moz-focusring{outline:auto}progress{vertical-align:baseline}summary{display:list-item}ol,ul,menu{list-style:none}img,svg,video,canvas,audio,iframe,embed,object{vertical-align:middle;display:block}img,video{max-width:100%;height:auto}button,input,select,optgroup,textarea{font:inherit;font-feature-settings:inherit;font-variation-settings:inherit;letter-spacing:inherit;color:inherit;opacity:1;background-color:#0000;border-radius:0}::file-selector-button{font:inherit;font-feature-settings:inherit;font-variation-settings:inherit;letter-spacing:inherit;color:inherit;opacity:1;background-color:#0000;border-radius:0}:where(select:is([multiple],[size])) optgroup{font-weight:bolder}:where(select:is([multiple],[size])) optgroup option{padding-inline-start:20px}::file-selector-button{margin-inline-end:4px}::placeholder{opacity:1}@supports (not ((-webkit-appearance:-apple-pay-button))) or (contain-intrinsic-size:1px){::placeholder{color:currentColor}@supports (color:color-mix(in lab, red, red)){::placeholder{color:color-mix(in oklab,currentcolor 50%,transparent)}}}textarea{resize:vertical}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-date-and-time-value{min-height:1lh;text-align:inherit}::-webkit-datetime-edit{display:inline-flex}::-webkit-datetime-edit-fields-wrapper{padding:0}::-webkit-datetime-edit{padding-block:0}::-webkit-datetime-edit-year-field{padding-block:0}::-webkit-datetime-edit-month-field{padding-block:0}::-webkit-datetime-edit-day-field{padding-block:0}::-webkit-datetime-edit-hour-field{padding-block:0}::-webkit-datetime-edit-minute-field{padding-block:0}::-webkit-datetime-edit-second-field{padding-block:0}::-webkit-datetime-edit-millisecond-field{padding-block:0}::-webkit-datetime-edit-meridiem-field{padding-block:0}::-webkit-calendar-picker-indicator{line-height:1}:-moz-ui-invalid{box-shadow:none}button,input:where([type=button],[type=reset],[type=submit]){appearance:button}::file-selector-button{appearance:button}::-webkit-inner-spin-button{height:auto}::-webkit-outer-spin-button{height:auto}[hidden]:where(:not([hidden=until-found])){display:none!important}}@layer components;@layer utilities{.pointer-events-auto{pointer-events:auto}.pointer-events-none{pointer-events:none}.collapse{visibility:collapse}.invisible{visibility:hidden}.visible{visibility:visible}.touch-hitbox{position:relative}.touch-hitbox:before{content:"";width:100%;min-width:44px;height:100%;min-height:44px;display:block;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%)}.absolute{position:absolute}.fixed{position:fixed}.relative{position:relative}.-top-0\\.5{top:calc(var(--spacing)*-.5)}.top-0{top:calc(var(--spacing)*0)}.top-0\\.5{top:calc(var(--spacing)*.5)}.top-1\\/2{top:50%}.top-full{top:100%}.-right-0\\.5{right:calc(var(--spacing)*-.5)}.right-full{right:100%}.bottom-full{bottom:100%}.left-0{left:calc(var(--spacing)*0)}.left-0\\.5{left:calc(var(--spacing)*.5)}.left-1\\.5{left:calc(var(--spacing)*1.5)}.left-1\\/2{left:50%}.left-2\\.5{left:calc(var(--spacing)*2.5)}.left-full{left:100%}.z-1{z-index:1}.z-10{z-index:10}.container{width:100%}@media (min-width:640px){.container{max-width:640px}}@media (min-width:768px){.container{max-width:768px}}@media (min-width:1024px){.container{max-width:1024px}}@media (min-width:1280px){.container{max-width:1280px}}@media (min-width:1536px){.container{max-width:1536px}}.m-0{margin:calc(var(--spacing)*0)}.-mx-2{margin-inline:calc(var(--spacing)*-2)}.mx-0\\.5{margin-inline:calc(var(--spacing)*.5)}.-my-1\\.5{margin-block:calc(var(--spacing)*-1.5)}.my-0\\.5{margin-block:calc(var(--spacing)*.5)}.mt-0\\.5{margin-top:calc(var(--spacing)*.5)}.mt-2\\.5{margin-top:calc(var(--spacing)*2.5)}.mr-0\\.5{margin-right:calc(var(--spacing)*.5)}.mr-1\\.5{margin-right:calc(var(--spacing)*1.5)}.mr-2\\.5{margin-right:calc(var(--spacing)*2.5)}.mb-0\\.5{margin-bottom:calc(var(--spacing)*.5)}.mb-1{margin-bottom:calc(var(--spacing)*1)}.mb-1\\.5{margin-bottom:calc(var(--spacing)*1.5)}.mb-2\\.5{margin-bottom:calc(var(--spacing)*2.5)}.-ml-\\[2px\\]{margin-left:-2px}.ml-0\\.5{margin-left:calc(var(--spacing)*.5)}.ml-1{margin-left:calc(var(--spacing)*1)}.ml-2\\.5{margin-left:calc(var(--spacing)*2.5)}.ml-4{margin-left:calc(var(--spacing)*4)}.ml-auto{margin-left:auto}.line-clamp-5{-webkit-line-clamp:5;-webkit-box-orient:vertical;display:-webkit-box;overflow:hidden}.block{display:block}.contents{display:contents}.flex{display:flex}.grid{display:grid}.hidden{display:none}.inline-block{display:inline-block}.inline-flex{display:inline-flex}.size-1\\.5{width:calc(var(--spacing)*1.5);height:calc(var(--spacing)*1.5)}.size-4{width:calc(var(--spacing)*4);height:calc(var(--spacing)*4)}.size-\\[18px\\]{width:18px;height:18px}.h-0{height:calc(var(--spacing)*0)}.h-1\\.5{height:calc(var(--spacing)*1.5)}.h-2{height:calc(var(--spacing)*2)}.h-2\\.5{height:calc(var(--spacing)*2.5)}.h-3{height:calc(var(--spacing)*3)}.h-4{height:calc(var(--spacing)*4)}.h-\\[17px\\]{height:17px}.h-fit{height:fit-content}.max-h-\\[240px\\]{max-height:240px}.min-h-0{min-height:calc(var(--spacing)*0)}.min-h-4{min-height:calc(var(--spacing)*4)}.w-0{width:calc(var(--spacing)*0)}.w-1\\.5{width:calc(var(--spacing)*1.5)}.w-2{width:calc(var(--spacing)*2)}.w-3\\.5{width:calc(var(--spacing)*3.5)}.w-4{width:calc(var(--spacing)*4)}.w-5{width:calc(var(--spacing)*5)}.w-\\[calc\\(100\\%\\+16px\\)\\]{width:calc(100% + 16px)}.w-auto{width:auto}.w-fit{width:fit-content}.w-full{width:100%}.max-w-\\[280px\\]{max-width:280px}.max-w-full{max-width:100%}.min-w-0{min-width:calc(var(--spacing)*0)}.min-w-\\[100px\\]{min-width:100px}.min-w-\\[150px\\]{min-width:150px}.flex-1{flex:1}.flex-shrink,.shrink{flex-shrink:1}.shrink-0{flex-shrink:0}.flex-grow,.grow{flex-grow:1}.-translate-x-1\\/2{--tw-translate-x:calc(calc(1/2*100%)*-1);translate:var(--tw-translate-x)var(--tw-translate-y)}.-translate-y-1\\/2{--tw-translate-y:calc(calc(1/2*100%)*-1);translate:var(--tw-translate-x)var(--tw-translate-y)}.scale-75{--tw-scale-x:75%;--tw-scale-y:75%;--tw-scale-z:75%;scale:var(--tw-scale-x)var(--tw-scale-y)}.scale-100{--tw-scale-x:100%;--tw-scale-y:100%;--tw-scale-z:100%;scale:var(--tw-scale-x)var(--tw-scale-y)}.-rotate-90{rotate:-90deg}.rotate-0{rotate:none}.rotate-90{rotate:90deg}.rotate-180{rotate:180deg}.interactive-scale{transition-property:transform;transition-duration:var(--transition-normal);transition-timing-function:cubic-bezier(.34,1.56,.64,1)}@media (hover:hover) and (pointer:fine){.interactive-scale:hover{transform:scale(1.05)}}.interactive-scale:active{transform:scale(.97)}.press-scale{transition-property:transform;transition-duration:var(--transition-fast);transition-timing-function:ease-out}.press-scale:active{transform:scale(.97)}.transform{transform:var(--tw-rotate-x,)var(--tw-rotate-y,)var(--tw-rotate-z,)var(--tw-skew-x,)var(--tw-skew-y,)}.animate-ping{animation:var(--animate-ping)}.animate-pulse{animation:var(--animate-pulse)}.cursor-grab{cursor:grab}.cursor-grabbing{cursor:grabbing}.cursor-pointer{cursor:pointer}.resize{resize:both}.resize-none{resize:none}.grid-cols-\\[0fr\\]{grid-template-columns:0fr}.grid-cols-\\[1fr\\]{grid-template-columns:1fr}.grid-rows-\\[0fr\\]{grid-template-rows:0fr}.grid-rows-\\[1fr\\]{grid-template-rows:1fr}.flex-col{flex-direction:column}.flex-wrap{flex-wrap:wrap}.items-center{align-items:center}.items-end{align-items:flex-end}.items-start{align-items:flex-start}.justify-between{justify-content:space-between}.justify-center{justify-content:center}.justify-end{justify-content:flex-end}.gap-0\\.5{gap:calc(var(--spacing)*.5)}.gap-1{gap:calc(var(--spacing)*1)}.gap-1\\.5{gap:calc(var(--spacing)*1.5)}.gap-2{gap:calc(var(--spacing)*2)}.gap-\\[5px\\]{gap:5px}.self-stretch{align-self:stretch}.truncate{text-overflow:ellipsis;white-space:nowrap;overflow:hidden}.overflow-hidden{overflow:hidden}.overflow-visible{overflow:visible}.overflow-y-auto{overflow-y:auto}.rounded-\\[1px\\]{border-radius:1px}.rounded-\\[10px\\]{border-radius:10px}.rounded-full{border-radius:3.40282e38px}.rounded-sm{border-radius:var(--radius-sm)}.rounded-t-\\[10px\\]{border-top-left-radius:10px;border-top-right-radius:10px}.rounded-t-none{border-top-left-radius:0;border-top-right-radius:0}.rounded-l-\\[10px\\]{border-top-left-radius:10px;border-bottom-left-radius:10px}.rounded-l-none{border-top-left-radius:0;border-bottom-left-radius:0}.rounded-r-\\[10px\\]{border-top-right-radius:10px;border-bottom-right-radius:10px}.rounded-r-none{border-top-right-radius:0;border-bottom-right-radius:0}.rounded-b-\\[6px\\]{border-bottom-right-radius:6px;border-bottom-left-radius:6px}.rounded-b-\\[10px\\]{border-bottom-right-radius:10px;border-bottom-left-radius:10px}.rounded-b-none{border-bottom-right-radius:0;border-bottom-left-radius:0}.border{border-style:var(--tw-border-style);border-width:1px}.\\[border-width\\:0\\.5px\\]{border-width:.5px}.\\[border-top-width\\:0\\.5px\\]{border-top-width:.5px}.border-none{--tw-border-style:none;border-style:none}.border-solid{--tw-border-style:solid;border-style:solid}.border-\\[\\#B3B3B3\\]{border-color:#b3b3b3}.border-t-\\[\\#D9D9D9\\]{border-top-color:#d9d9d9}.bg-\\[\\#404040\\]{background-color:#404040}.bg-\\[\\#FEF2F2\\]{background-color:#fef2f2}.bg-black{background-color:var(--color-black)}.bg-black\\/5{background-color:#0000000d}@supports (color:color-mix(in lab, red, red)){.bg-black\\/5{background-color:color-mix(in oklab,var(--color-black)5%,transparent)}}.bg-black\\/25{background-color:#00000040}@supports (color:color-mix(in lab, red, red)){.bg-black\\/25{background-color:color-mix(in oklab,var(--color-black)25%,transparent)}}.bg-transparent{background-color:#0000}.bg-white{background-color:var(--color-white)}.bg-yellow-500{background-color:var(--color-yellow-500)}.p-0{padding:calc(var(--spacing)*0)}.px-0\\.25{padding-inline:calc(var(--spacing)*.25)}.px-1\\.5{padding-inline:calc(var(--spacing)*1.5)}.px-2{padding-inline:calc(var(--spacing)*2)}.px-\\[3px\\]{padding-inline:3px}.py-0\\.5{padding-block:calc(var(--spacing)*.5)}.py-0\\.25{padding-block:calc(var(--spacing)*.25)}.py-1{padding-block:calc(var(--spacing)*1)}.py-1\\.5{padding-block:calc(var(--spacing)*1.5)}.py-2{padding-block:calc(var(--spacing)*2)}.py-px{padding-block:1px}.pt-1\\.5{padding-top:calc(var(--spacing)*1.5)}.pb-1{padding-bottom:calc(var(--spacing)*1)}.text-left{text-align:left}.font-sans{font-family:var(--font-sans)}.text-sm{font-size:var(--text-sm);line-height:var(--tw-leading,var(--text-sm--line-height))}.text-\\[10px\\]{font-size:10px}.text-\\[11px\\]{font-size:11px}.text-\\[12px\\]{font-size:12px}.text-\\[13px\\]{font-size:13px}.leading-3{--tw-leading:calc(var(--spacing)*3);line-height:calc(var(--spacing)*3)}.leading-3\\.5{--tw-leading:calc(var(--spacing)*3.5);line-height:calc(var(--spacing)*3.5)}.leading-4{--tw-leading:calc(var(--spacing)*4);line-height:calc(var(--spacing)*4)}.font-medium{--tw-font-weight:var(--font-weight-medium);font-weight:var(--font-weight-medium)}.wrap-break-word{overflow-wrap:break-word}.text-ellipsis{text-overflow:ellipsis}.whitespace-nowrap{white-space:nowrap}.text-\\[\\#71717a\\]{color:#71717a}.text-\\[\\#B3B3B3\\]{color:#b3b3b3}.text-\\[\\#B91C1C\\]{color:#b91c1c}.text-\\[\\#B91C1C\\]\\/50{color:oklab(50.542% .168942 .0880134/.5)}.text-black{color:var(--color-black)}.text-black\\/25{color:#00000040}@supports (color:color-mix(in lab, red, red)){.text-black\\/25{color:color-mix(in oklab,var(--color-black)25%,transparent)}}.text-black\\/30{color:#0000004d}@supports (color:color-mix(in lab, red, red)){.text-black\\/30{color:color-mix(in oklab,var(--color-black)30%,transparent)}}.text-black\\/40{color:#0006}@supports (color:color-mix(in lab, red, red)){.text-black\\/40{color:color-mix(in oklab,var(--color-black)40%,transparent)}}.text-black\\/50{color:#00000080}@supports (color:color-mix(in lab, red, red)){.text-black\\/50{color:color-mix(in oklab,var(--color-black)50%,transparent)}}.text-black\\/60{color:#0009}@supports (color:color-mix(in lab, red, red)){.text-black\\/60{color:color-mix(in oklab,var(--color-black)60%,transparent)}}.text-black\\/70{color:#000000b3}@supports (color:color-mix(in lab, red, red)){.text-black\\/70{color:color-mix(in oklab,var(--color-black)70%,transparent)}}.text-black\\/80{color:#000c}@supports (color:color-mix(in lab, red, red)){.text-black\\/80{color:color-mix(in oklab,var(--color-black)80%,transparent)}}.text-black\\/85{color:#000000d9}@supports (color:color-mix(in lab, red, red)){.text-black\\/85{color:color-mix(in oklab,var(--color-black)85%,transparent)}}.text-white{color:var(--color-white)}.italic{font-style:italic}.tabular-nums{--tw-numeric-spacing:tabular-nums;font-variant-numeric:var(--tw-ordinal,)var(--tw-slashed-zero,)var(--tw-numeric-figure,)var(--tw-numeric-spacing,)var(--tw-numeric-fraction,)}.antialiased{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}.opacity-0{opacity:0}.opacity-35{opacity:.35}.opacity-40{opacity:.4}.opacity-50{opacity:.5}.opacity-100{opacity:1}.shadow{--tw-shadow:0 1px 3px 0 var(--tw-shadow-color,#0000001a),0 1px 2px -1px var(--tw-shadow-color,#0000001a);box-shadow:var(--tw-inset-shadow),var(--tw-inset-ring-shadow),var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow)}.outline{outline-style:var(--tw-outline-style);outline-width:1px}.blur{--tw-blur:blur(8px);filter:var(--tw-blur,)var(--tw-brightness,)var(--tw-contrast,)var(--tw-grayscale,)var(--tw-hue-rotate,)var(--tw-invert,)var(--tw-saturate,)var(--tw-sepia,)var(--tw-drop-shadow,)}.filter{filter:var(--tw-blur,)var(--tw-brightness,)var(--tw-contrast,)var(--tw-grayscale,)var(--tw-hue-rotate,)var(--tw-invert,)var(--tw-saturate,)var(--tw-sepia,)var(--tw-drop-shadow,)}.filter-\\[drop-shadow\\(0px_1px_2px_\\#51515140\\)\\]{filter:drop-shadow(0 1px 2px #51515140)}.backdrop-filter{-webkit-backdrop-filter:var(--tw-backdrop-blur,)var(--tw-backdrop-brightness,)var(--tw-backdrop-contrast,)var(--tw-backdrop-grayscale,)var(--tw-backdrop-hue-rotate,)var(--tw-backdrop-invert,)var(--tw-backdrop-opacity,)var(--tw-backdrop-saturate,)var(--tw-backdrop-sepia,);backdrop-filter:var(--tw-backdrop-blur,)var(--tw-backdrop-brightness,)var(--tw-backdrop-contrast,)var(--tw-backdrop-grayscale,)var(--tw-backdrop-hue-rotate,)var(--tw-backdrop-invert,)var(--tw-backdrop-opacity,)var(--tw-backdrop-saturate,)var(--tw-backdrop-sepia,)}.transition{transition-property:color,background-color,border-color,outline-color,text-decoration-color,fill,stroke,--tw-gradient-from,--tw-gradient-via,--tw-gradient-to,opacity,box-shadow,transform,translate,scale,rotate,filter,-webkit-backdrop-filter,backdrop-filter,display,content-visibility,overlay,pointer-events;transition-timing-function:var(--tw-ease,var(--default-transition-timing-function));transition-duration:var(--tw-duration,var(--default-transition-duration))}.transition-\\[grid-template-columns\\,opacity\\]{transition-property:grid-template-columns,opacity;transition-timing-function:var(--tw-ease,var(--default-transition-timing-function));transition-duration:var(--tw-duration,var(--default-transition-duration))}.transition-\\[grid-template-rows\\,opacity\\]{transition-property:grid-template-rows,opacity;transition-timing-function:var(--tw-ease,var(--default-transition-timing-function));transition-duration:var(--tw-duration,var(--default-transition-duration))}.transition-\\[opacity\\,transform\\]{transition-property:opacity,transform;transition-timing-function:var(--tw-ease,var(--default-transition-timing-function));transition-duration:var(--tw-duration,var(--default-transition-duration))}.transition-\\[top\\,left\\,width\\,height\\,opacity\\]{transition-property:top,left,width,height,opacity;transition-timing-function:var(--tw-ease,var(--default-transition-timing-function));transition-duration:var(--tw-duration,var(--default-transition-duration))}.transition-\\[transform\\,opacity\\]{transition-property:transform,opacity;transition-timing-function:var(--tw-ease,var(--default-transition-timing-function));transition-duration:var(--tw-duration,var(--default-transition-duration))}.transition-all{transition-property:all;transition-timing-function:var(--tw-ease,var(--default-transition-timing-function));transition-duration:var(--tw-duration,var(--default-transition-duration))}.transition-colors{transition-property:color,background-color,border-color,outline-color,text-decoration-color,fill,stroke,--tw-gradient-from,--tw-gradient-via,--tw-gradient-to;transition-timing-function:var(--tw-ease,var(--default-transition-timing-function));transition-duration:var(--tw-duration,var(--default-transition-duration))}.transition-opacity{transition-property:opacity;transition-timing-function:var(--tw-ease,var(--default-transition-timing-function));transition-duration:var(--tw-duration,var(--default-transition-duration))}.transition-transform{transition-property:transform,translate,scale,rotate;transition-timing-function:var(--tw-ease,var(--default-transition-timing-function));transition-duration:var(--tw-duration,var(--default-transition-duration))}.duration-75{--tw-duration:75ms;transition-duration:75ms}.duration-100{--tw-duration:.1s;transition-duration:.1s}.duration-150{--tw-duration:.15s;transition-duration:.15s}.duration-300{--tw-duration:.3s;transition-duration:.3s}.ease-out{--tw-ease:var(--ease-out);transition-timing-function:var(--ease-out)}.will-change-\\[opacity\\,transform\\]{will-change:opacity,transform}.contain-layout{--tw-contain-layout:layout;contain:var(--tw-contain-size,)var(--tw-contain-layout,)var(--tw-contain-paint,)var(--tw-contain-style,)}.outline-none{--tw-outline-style:none;outline-style:none}.select-none{-webkit-user-select:none;user-select:none}.\\[corner-shape\\:superellipse\\(1\\.25\\)\\]{corner-shape:superellipse(1.25)}.\\[font-synthesis\\:none\\]{font-synthesis:none}.\\[grid-area\\:1\\/1\\]{grid-area:1/1}.\\[scrollbar-color\\:transparent_transparent\\]{scrollbar-color:transparent transparent}.\\[scrollbar-width\\:thin\\]{scrollbar-width:thin}.group-focus-within\\:invisible:is(:where(.group):focus-within *){visibility:hidden}.group-focus-within\\:visible:is(:where(.group):focus-within *){visibility:visible}@media (hover:hover){.group-hover\\:invisible:is(:where(.group):hover *){visibility:hidden}.group-hover\\:visible:is(:where(.group):hover *){visibility:visible}}.before\\:\\!min-h-full:before{content:var(--tw-content);min-height:100%!important}.before\\:\\!min-w-full:before{content:var(--tw-content);min-width:100%!important}@media (hover:hover){.hover\\:bg-\\[\\#F5F5F5\\]:hover{background-color:#f5f5f5}.hover\\:bg-\\[\\#FEE2E2\\]:hover{background-color:#fee2e2}.hover\\:bg-black\\/10:hover{background-color:#0000001a}@supports (color:color-mix(in lab, red, red)){.hover\\:bg-black\\/10:hover{background-color:color-mix(in oklab,var(--color-black)10%,transparent)}}.hover\\:text-\\[\\#B91C1C\\]:hover{color:#b91c1c}.hover\\:text-black:hover{color:var(--color-black)}.hover\\:text-black\\/60:hover{color:#0009}@supports (color:color-mix(in lab, red, red)){.hover\\:text-black\\/60:hover{color:color-mix(in oklab,var(--color-black)60%,transparent)}}.hover\\:opacity-100:hover{opacity:1}.hover\\:\\[scrollbar-color\\:rgba\\(0\\,0\\,0\\,0\\.15\\)_transparent\\]:hover{scrollbar-color:#00000026 transparent}}.disabled\\:cursor-default:disabled{cursor:default}.disabled\\:opacity-40:disabled{opacity:.4}}:host{all:initial;direction:ltr}@keyframes shake{0%,to{transform:translate(0)}15%{transform:translate(-3px)}30%{transform:translate(3px)}45%{transform:translate(-3px)}60%{transform:translate(3px)}75%{transform:translate(-2px)}90%{transform:translate(2px)}}@keyframes pop-in{0%{opacity:0;transform:scale(.9)}70%{opacity:1;transform:scale(1.02)}to{opacity:1;transform:scale(1)}}@keyframes pop-out{0%{opacity:1;transform:scale(1)}to{opacity:0;transform:scale(.95)}}@keyframes slide-in-bottom{0%{opacity:0;transform:translateY(8px)}to{opacity:1;transform:translateY(0)}}@keyframes slide-in-top{0%{opacity:0;transform:translateY(-8px)}to{opacity:1;transform:translateY(0)}}@keyframes slide-in-left{0%{opacity:0;transform:translate(-8px)}to{opacity:1;transform:translate(0)}}@keyframes slide-in-right{0%{opacity:0;transform:translate(8px)}to{opacity:1;transform:translate(0)}}@keyframes success-pop{0%{opacity:0;transform:scale(.9)}60%{opacity:1;transform:scale(1.1)}80%{transform:scale(.95)}to{opacity:1;transform:scale(1)}}@keyframes tooltip-fade-in{0%{opacity:0;transform:scale(.97)}to{opacity:1;transform:scale(1)}}@keyframes icon-loader-spin{0%{opacity:1}50%{opacity:.5}to{opacity:.2}}.icon-loader-bar{animation:.5s linear infinite icon-loader-spin}@keyframes shimmer{0%{background-position:200% 0}to{background-position:-200% 0}}.shimmer-text{color:#0000;background:linear-gradient(90deg,#71717a 0%,#a1a1aa 25%,#71717a 50%,#a1a1aa 75%,#71717a 100%) 0 0/200% 100%;-webkit-background-clip:text;background-clip:text;animation:2.5s linear infinite shimmer}@keyframes clock-flash{0%{transform:scale(1)}25%{transform:scale(1.2)}50%{transform:scale(.92)}75%{transform:scale(1.05)}to{transform:scale(1)}}.animate-clock-flash{will-change:transform;animation:.4s ease-out clock-flash}.animate-shake{will-change:transform;animation:.3s ease-out shake}.animate-pop-in{animation:pop-in var(--transition-normal)ease-out;will-change:transform,opacity}.animate-pop-out{animation:pop-out var(--transition-normal)ease-out forwards;will-change:transform,opacity}.animate-slide-in-bottom{animation:slide-in-bottom var(--transition-slow)ease-out;will-change:transform,opacity}.animate-slide-in-top{animation:slide-in-top var(--transition-slow)ease-out;will-change:transform,opacity}.animate-slide-in-left{animation:slide-in-left var(--transition-slow)ease-out;will-change:transform,opacity}.animate-slide-in-right{animation:slide-in-right var(--transition-slow)ease-out;will-change:transform,opacity}.animate-success-pop{will-change:transform,opacity;animation:.25s ease-out success-pop}.animate-tooltip-fade-in{animation:tooltip-fade-in var(--transition-fast)ease-out;will-change:transform,opacity}@property --tw-translate-x{syntax:"*";inherits:false;initial-value:0}@property --tw-translate-y{syntax:"*";inherits:false;initial-value:0}@property --tw-translate-z{syntax:"*";inherits:false;initial-value:0}@property --tw-scale-x{syntax:"*";inherits:false;initial-value:1}@property --tw-scale-y{syntax:"*";inherits:false;initial-value:1}@property --tw-scale-z{syntax:"*";inherits:false;initial-value:1}@property --tw-rotate-x{syntax:"*";inherits:false}@property --tw-rotate-y{syntax:"*";inherits:false}@property --tw-rotate-z{syntax:"*";inherits:false}@property --tw-skew-x{syntax:"*";inherits:false}@property --tw-skew-y{syntax:"*";inherits:false}@property --tw-border-style{syntax:"*";inherits:false;initial-value:solid}@property --tw-leading{syntax:"*";inherits:false}@property --tw-font-weight{syntax:"*";inherits:false}@property --tw-ordinal{syntax:"*";inherits:false}@property --tw-slashed-zero{syntax:"*";inherits:false}@property --tw-numeric-figure{syntax:"*";inherits:false}@property --tw-numeric-spacing{syntax:"*";inherits:false}@property --tw-numeric-fraction{syntax:"*";inherits:false}@property --tw-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-shadow-color{syntax:"*";inherits:false}@property --tw-shadow-alpha{syntax:"<percentage>";inherits:false;initial-value:100%}@property --tw-inset-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-inset-shadow-color{syntax:"*";inherits:false}@property --tw-inset-shadow-alpha{syntax:"<percentage>";inherits:false;initial-value:100%}@property --tw-ring-color{syntax:"*";inherits:false}@property --tw-ring-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-inset-ring-color{syntax:"*";inherits:false}@property --tw-inset-ring-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-ring-inset{syntax:"*";inherits:false}@property --tw-ring-offset-width{syntax:"<length>";inherits:false;initial-value:0}@property --tw-ring-offset-color{syntax:"*";inherits:false;initial-value:#fff}@property --tw-ring-offset-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-outline-style{syntax:"*";inherits:false;initial-value:solid}@property --tw-blur{syntax:"*";inherits:false}@property --tw-brightness{syntax:"*";inherits:false}@property --tw-contrast{syntax:"*";inherits:false}@property --tw-grayscale{syntax:"*";inherits:false}@property --tw-hue-rotate{syntax:"*";inherits:false}@property --tw-invert{syntax:"*";inherits:false}@property --tw-opacity{syntax:"*";inherits:false}@property --tw-saturate{syntax:"*";inherits:false}@property --tw-sepia{syntax:"*";inherits:false}@property --tw-drop-shadow{syntax:"*";inherits:false}@property --tw-drop-shadow-color{syntax:"*";inherits:false}@property --tw-drop-shadow-alpha{syntax:"<percentage>";inherits:false;initial-value:100%}@property --tw-drop-shadow-size{syntax:"*";inherits:false}@property --tw-backdrop-blur{syntax:"*";inherits:false}@property --tw-backdrop-brightness{syntax:"*";inherits:false}@property --tw-backdrop-contrast{syntax:"*";inherits:false}@property --tw-backdrop-grayscale{syntax:"*";inherits:false}@property --tw-backdrop-hue-rotate{syntax:"*";inherits:false}@property --tw-backdrop-invert{syntax:"*";inherits:false}@property --tw-backdrop-opacity{syntax:"*";inherits:false}@property --tw-backdrop-saturate{syntax:"*";inherits:false}@property --tw-backdrop-sepia{syntax:"*";inherits:false}@property --tw-duration{syntax:"*";inherits:false}@property --tw-ease{syntax:"*";inherits:false}@property --tw-contain-size{syntax:"*";inherits:false}@property --tw-contain-layout{syntax:"*";inherits:false}@property --tw-contain-paint{syntax:"*";inherits:false}@property --tw-contain-style{syntax:"*";inherits:false}@property --tw-content{syntax:"*";inherits:false;initial-value:""}@keyframes ping{75%,to{opacity:0;transform:scale(2)}}@keyframes pulse{50%{opacity:.5}}`;
+  var qi = Symbol("store-raw"),
+    Uo = Symbol("store-node"),
+    _n = Symbol("store-has"),
+    Rc = Symbol("store-self");
+  function Ic(e) {
+    let t = e[nn];
+    if (
+      !t &&
+      (Object.defineProperty(e, nn, { value: (t = new Proxy(e, Lp)) }),
+      !Array.isArray(e))
+    ) {
+      let n = Object.keys(e),
+        o = Object.getOwnPropertyDescriptors(e);
+      for (let i = 0, s = n.length; i < s; i++) {
+        let r = n[i];
+        o[r].get &&
+          Object.defineProperty(e, r, {
+            enumerable: o[r].enumerable,
+            get: o[r].get.bind(t),
+          });
+      }
+    }
+    return t;
+  }
+  function jo(e) {
+    let t;
+    return (
+      e != null &&
+      typeof e == "object" &&
+      (e[nn] ||
+        !(t = Object.getPrototypeOf(e)) ||
+        t === Object.prototype ||
+        Array.isArray(e))
+    );
+  }
+  function Wo(e, t = new Set()) {
+    let n, o, i, s;
+    if ((n = e != null && e[qi])) return n;
+    if (!jo(e) || t.has(e)) return e;
+    if (Array.isArray(e)) {
+      Object.isFrozen(e) ? (e = e.slice(0)) : t.add(e);
+      for (let r = 0, c = e.length; r < c; r++)
+        ((i = e[r]), (o = Wo(i, t)) !== i && (e[r] = o));
+    } else {
+      Object.isFrozen(e) ? (e = Object.assign({}, e)) : t.add(e);
+      let r = Object.keys(e),
+        c = Object.getOwnPropertyDescriptors(e);
+      for (let l = 0, u = r.length; l < u; l++)
+        ((s = r[l]),
+          !c[s].get && ((i = e[s]), (o = Wo(i, t)) !== i && (e[s] = o)));
+    }
+    return e;
+  }
+  function Zi(e, t) {
+    let n = e[t];
+    return (
+      n || Object.defineProperty(e, t, { value: (n = Object.create(null)) }), n
+    );
+  }
+  function Fr(e, t, n) {
+    if (e[t]) return e[t];
+    let [o, i] = U(n, { equals: false, internal: true });
+    return ((o.$ = i), (e[t] = o));
+  }
+  function Ip(e, t) {
+    let n = Reflect.getOwnPropertyDescriptor(e, t);
+    return (
+      !n ||
+        n.get ||
+        !n.configurable ||
+        t === nn ||
+        t === Uo ||
+        (delete n.value, delete n.writable, (n.get = () => e[nn][t])),
+      n
+    );
+  }
+  function Nc(e) {
+    Wi() && Fr(Zi(e, Uo), Rc)();
+  }
+  function Np(e) {
+    return (Nc(e), Reflect.ownKeys(e));
+  }
+  var Lp = {
+    get(e, t, n) {
+      if (t === qi) return e;
+      if (t === nn) return n;
+      if (t === Nr) return (Nc(e), n);
+      let o = Zi(e, Uo),
+        i = o[t],
+        s = i ? i() : e[t];
+      if (t === Uo || t === _n || t === "__proto__") return s;
+      if (!i) {
+        let r = Object.getOwnPropertyDescriptor(e, t);
+        Wi() &&
+          (typeof s != "function" || e.hasOwnProperty(t)) &&
+          !(r && r.get) &&
+          (s = Fr(o, t, s)());
+      }
+      return jo(s) ? Ic(s) : s;
+    },
+    has(e, t) {
+      return t === qi ||
+        t === nn ||
+        t === Nr ||
+        t === Uo ||
+        t === _n ||
+        t === "__proto__"
+        ? true
+        : (Wi() && Fr(Zi(e, _n), t)(), t in e);
+    },
+    set() {
+      return true;
+    },
+    deleteProperty() {
+      return true;
+    },
+    ownKeys: Np,
+    getOwnPropertyDescriptor: Ip,
+  };
+  function Ko(e, t, n, o = false) {
+    if (!o && e[t] === n) return;
+    let i = e[t],
+      s = e.length;
+    n === void 0
+      ? (delete e[t], e[_n] && e[_n][t] && i !== void 0 && e[_n][t].$())
+      : ((e[t] = n), e[_n] && e[_n][t] && i === void 0 && e[_n][t].$());
+    let r = Zi(e, Uo),
+      c;
+    if (
+      ((c = Fr(r, t, i)) && c.$(() => n), Array.isArray(e) && e.length !== s)
+    ) {
+      for (let l = e.length; l < s; l++) (c = r[l]) && c.$();
+      (c = Fr(r, "length", s)) && c.$(e.length);
+    }
+    (c = r[Rc]) && c.$();
+  }
+  function Lc(e, t) {
+    let n = Object.keys(t);
+    for (let o = 0; o < n.length; o += 1) {
+      let i = n[o];
+      Ko(e, i, t[i]);
+    }
+  }
+  function Dp(e, t) {
+    if ((typeof t == "function" && (t = t(e)), (t = Wo(t)), Array.isArray(t))) {
+      if (e === t) return;
+      let n = 0,
+        o = t.length;
+      for (; n < o; n++) {
+        let i = t[n];
+        e[n] !== i && Ko(e, n, i);
+      }
+      Ko(e, "length", o);
+    } else Lc(e, t);
+  }
+  function Dr(e, t, n = []) {
+    let o,
+      i = e;
+    if (t.length > 1) {
+      o = t.shift();
+      let r = typeof o,
+        c = Array.isArray(e);
+      if (Array.isArray(o)) {
+        for (let l = 0; l < o.length; l++) Dr(e, [o[l]].concat(t), n);
+        return;
+      } else if (c && r === "function") {
+        for (let l = 0; l < e.length; l++)
+          o(e[l], l) && Dr(e, [l].concat(t), n);
+        return;
+      } else if (c && r === "object") {
+        let { from: l = 0, to: u = e.length - 1, by: f = 1 } = o;
+        for (let p = l; p <= u; p += f) Dr(e, [p].concat(t), n);
+        return;
+      } else if (t.length > 1) {
+        Dr(e[o], t, [o].concat(n));
+        return;
+      }
+      ((i = e[o]), (n = [o].concat(n)));
+    }
+    let s = t[0];
+    (typeof s == "function" && ((s = s(i, n)), s === i)) ||
+      (o === void 0 && s == null) ||
+      ((s = Wo(s)),
+      o === void 0 || (jo(i) && jo(s) && !Array.isArray(s))
+        ? Lc(i, s)
+        : Ko(e, o, s));
+  }
+  function Qi(...[e, t]) {
+    let n = Wo(e || {}),
+      o = Array.isArray(n),
+      i = Ic(n);
+    function s(...r) {
+      ji(() => {
+        o && r.length === 1 ? Dp(n, r[0]) : Dr(n, r);
+      });
+    }
+    return [i, s];
+  }
+  var Ji = new WeakMap(),
+    Dc = {
+      get(e, t) {
+        if (t === qi) return e;
+        let n = e[t],
+          o;
+        return jo(n) ? Ji.get(n) || (Ji.set(n, (o = new Proxy(n, Dc))), o) : n;
+      },
+      set(e, t, n) {
+        return (Ko(e, t, Wo(n)), true);
+      },
+      deleteProperty(e, t) {
+        return (Ko(e, t, void 0, true), true);
+      },
+    };
+  function Wt(e) {
+    return (t) => {
+      if (jo(t)) {
+        let n;
+        ((n = Ji.get(t)) || Ji.set(t, (n = new Proxy(t, Dc))), e(n));
+      }
+      return t;
+    };
+  }
+  var Fc = "0.1.21";
+  var Xo = "210, 57, 192",
+    $c = `rgba(${Xo}, 1)`,
+    Hc = `rgba(${Xo}, 0.4)`,
+    Bc = `rgba(${Xo}, 0.05)`,
+    es = `rgba(${Xo}, 0.5)`,
+    ts = `rgba(${Xo}, 0.08)`,
+    zc = `rgba(${Xo}, 0.15)`,
+    Vc = 50,
+    Un = 8,
+    Gc = 4,
+    Uc = 0.2,
+    wa = 50,
+    xa = 16,
+    rn = 4,
+    $r = 100,
+    jc = 15,
+    Wc = 3,
+    va = ["id", "class", "aria-label", "data-testid", "role", "name", "title"],
+    Kc = 5e3,
+    Xc = ["Meta", "Control", "Shift", "Alt"],
+    Ca = new Set(["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"]),
+    Hr = "data-react-grab-frozen",
+    Ea = "data-react-grab-ignore",
+    Br = 0.9,
+    Yc = 1e3,
+    qc = 2147483600,
+    Zc = 400,
+    Jc = 100,
+    _e = 16,
+    Sa = 500,
+    Qc = 300,
+    eu = 5,
+    Aa = 150,
+    uo = 14,
+    Ta = 28,
+    Pn = 150,
+    tu = 50,
+    nu = 78,
+    ou = 28,
+    ru = 1500,
+    iu = 0.75,
+    _a = 32,
+    zr = 3,
+    Vr = 20,
+    Pa = 100,
+    $t = 1,
+    ka = 50,
+    su = 50,
+    au = 6,
+    lu = 3,
+    Oa = 2,
+    cu = 16,
+    uu = 100,
+    du = 50,
+    Ma = 0.01,
+    fu = 1e3,
+    mu = 20,
+    pu = 2 * 1024 * 1024,
+    Yo = 100,
+    Gr = 200,
+    jn = 8,
+    qo = 8,
+    mn = 8,
+    fo = 11,
+    gu = 180,
+    hu = 280,
+    bu = 100,
+    ht = "bg-white",
+    Kt = { left: -9999, top: -9999 },
+    Zo = {
+      left: "left center",
+      right: "right center",
+      top: "center top",
+      bottom: "center bottom",
+    },
+    yu =
+      '<svg width="294" height="294" viewBox="0 0 294 294" fill="none" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#clip0_0_3)"><mask id="mask0_0_3" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="0" y="0" width="294" height="294"><path d="M294 0H0V294H294V0Z" fill="white"/></mask><g mask="url(#mask0_0_3)"><path d="M144.599 47.4924C169.712 27.3959 194.548 20.0265 212.132 30.1797C227.847 39.2555 234.881 60.3243 231.926 89.516C231.677 92.0069 231.328 94.5423 230.94 97.1058L228.526 110.14C228.517 110.136 228.505 110.132 228.495 110.127C228.486 110.165 228.479 110.203 228.468 110.24L216.255 105.741C216.256 105.736 216.248 105.728 216.248 105.723C207.915 103.125 199.421 101.075 190.82 99.5888L190.696 99.5588L173.526 97.2648L173.511 97.2631C173.492 97.236 173.467 97.2176 173.447 97.1905C163.862 96.2064 154.233 95.7166 144.599 95.7223C134.943 95.7162 125.295 96.219 115.693 97.2286C110.075 105.033 104.859 113.118 100.063 121.453C95.2426 129.798 90.8624 138.391 86.939 147.193C90.8624 155.996 95.2426 164.588 100.063 172.933C104.866 181.302 110.099 189.417 115.741 197.245C115.749 197.245 115.758 197.246 115.766 197.247L115.752 197.27L115.745 197.283L115.754 197.296L126.501 211.013L126.574 211.089C132.136 217.767 138.126 224.075 144.507 229.974L144.609 230.082L154.572 238.287C154.539 238.319 154.506 238.35 154.472 238.38C154.485 238.392 154.499 238.402 154.513 238.412L143.846 247.482L143.827 247.497C126.56 261.128 109.472 268.745 94.8019 268.745C88.5916 268.837 82.4687 267.272 77.0657 264.208C61.3496 255.132 54.3164 234.062 57.2707 204.871C57.528 202.307 57.8806 199.694 58.2904 197.054C28.3363 185.327 9.52301 167.51 9.52301 147.193C9.52301 129.042 24.2476 112.396 50.9901 100.375C53.3443 99.3163 55.7938 98.3058 58.2904 97.3526C57.8806 94.7023 57.528 92.0803 57.2707 89.516C54.3164 60.3243 61.3496 39.2555 77.0657 30.1797C94.6494 20.0265 119.486 27.3959 144.599 47.4924ZM70.6423 201.315C70.423 202.955 70.2229 204.566 70.0704 206.168C67.6686 229.567 72.5478 246.628 83.3615 252.988L83.5176 253.062C95.0399 259.717 114.015 254.426 134.782 238.38C125.298 229.45 116.594 219.725 108.764 209.314C95.8516 207.742 83.0977 205.066 70.6423 201.315ZM80.3534 163.438C77.34 171.677 74.8666 180.104 72.9484 188.664C81.1787 191.224 89.5657 193.247 98.0572 194.724L98.4618 194.813C95.2115 189.865 92.0191 184.66 88.9311 179.378C85.8433 174.097 83.003 168.768 80.3534 163.438ZM60.759 110.203C59.234 110.839 57.7378 111.475 56.27 112.11C34.7788 121.806 22.3891 134.591 22.3891 147.193C22.3891 160.493 36.4657 174.297 60.7494 184.26C63.7439 171.581 67.8124 159.182 72.9104 147.193C67.822 135.23 63.7566 122.855 60.759 110.203ZM98.4137 99.6404C89.8078 101.145 81.3075 103.206 72.9676 105.809C74.854 114.203 77.2741 122.468 80.2132 130.554L80.3059 130.939C82.9938 125.6 85.8049 120.338 88.8834 115.008C91.9618 109.679 95.1544 104.569 98.4137 99.6404ZM94.9258 38.5215C90.9331 38.4284 86.9866 39.3955 83.4891 41.3243C72.6291 47.6015 67.6975 64.5954 70.0424 87.9446L70.0416 88.2194C70.194 89.8208 70.3941 91.4325 70.6134 93.0624C83.0737 89.3364 95.8263 86.6703 108.736 85.0924C116.57 74.6779 125.28 64.9532 134.773 56.0249C119.877 44.5087 105.895 38.5215 94.9258 38.5215ZM205.737 41.3148C202.268 39.398 198.355 38.4308 194.394 38.5099L194.29 38.512C183.321 38.512 169.34 44.4991 154.444 56.0153C163.93 64.9374 172.634 74.6557 180.462 85.064C193.375 86.6345 206.128 89.3102 218.584 93.0624C218.812 91.4325 219.003 89.8118 219.165 88.2098C221.548 64.7099 216.65 47.6164 205.737 41.3148ZM144.552 64.3097C138.104 70.2614 132.054 76.6306 126.443 83.3765C132.39 82.995 138.426 82.8046 144.552 82.8046C150.727 82.8046 156.778 83.0143 162.707 83.3765C157.08 76.6293 151.015 70.2596 144.552 64.3097Z" fill="white"/><path d="M144.598 47.4924C169.712 27.3959 194.547 20.0265 212.131 30.1797C227.847 39.2555 234.88 60.3243 231.926 89.516C231.677 92.0069 231.327 94.5423 230.941 97.1058L228.526 110.14L228.496 110.127C228.487 110.165 228.478 110.203 228.469 110.24L216.255 105.741L216.249 105.723C207.916 103.125 199.42 101.075 190.82 99.5888L190.696 99.5588L173.525 97.2648L173.511 97.263C173.492 97.236 173.468 97.2176 173.447 97.1905C163.863 96.2064 154.234 95.7166 144.598 95.7223C134.943 95.7162 125.295 96.219 115.693 97.2286C110.075 105.033 104.859 113.118 100.063 121.453C95.2426 129.798 90.8622 138.391 86.939 147.193C90.8622 155.996 95.2426 164.588 100.063 172.933C104.866 181.302 110.099 189.417 115.741 197.245L115.766 197.247L115.752 197.27L115.745 197.283L115.754 197.296L126.501 211.013L126.574 211.089C132.136 217.767 138.126 224.075 144.506 229.974L144.61 230.082L154.572 238.287C154.539 238.319 154.506 238.35 154.473 238.38L154.512 238.412L143.847 247.482L143.827 247.497C126.56 261.13 109.472 268.745 94.8018 268.745C88.5915 268.837 82.4687 267.272 77.0657 264.208C61.3496 255.132 54.3162 234.062 57.2707 204.871C57.528 202.307 57.8806 199.694 58.2904 197.054C28.3362 185.327 9.52298 167.51 9.52298 147.193C9.52298 129.042 24.2476 112.396 50.9901 100.375C53.3443 99.3163 55.7938 98.3058 58.2904 97.3526C57.8806 94.7023 57.528 92.0803 57.2707 89.516C54.3162 60.3243 61.3496 39.2555 77.0657 30.1797C94.6493 20.0265 119.486 27.3959 144.598 47.4924ZM70.6422 201.315C70.423 202.955 70.2229 204.566 70.0704 206.168C67.6686 229.567 72.5478 246.628 83.3615 252.988L83.5175 253.062C95.0399 259.717 114.015 254.426 134.782 238.38C125.298 229.45 116.594 219.725 108.764 209.314C95.8515 207.742 83.0977 205.066 70.6422 201.315ZM80.3534 163.438C77.34 171.677 74.8666 180.104 72.9484 188.664C81.1786 191.224 89.5657 193.247 98.0572 194.724L98.4618 194.813C95.2115 189.865 92.0191 184.66 88.931 179.378C85.8433 174.097 83.003 168.768 80.3534 163.438ZM60.7589 110.203C59.234 110.839 57.7378 111.475 56.2699 112.11C34.7788 121.806 22.3891 134.591 22.3891 147.193C22.3891 160.493 36.4657 174.297 60.7494 184.26C63.7439 171.581 67.8124 159.182 72.9103 147.193C67.822 135.23 63.7566 122.855 60.7589 110.203ZM98.4137 99.6404C89.8078 101.145 81.3075 103.206 72.9676 105.809C74.8539 114.203 77.2741 122.468 80.2132 130.554L80.3059 130.939C82.9938 125.6 85.8049 120.338 88.8834 115.008C91.9618 109.679 95.1544 104.569 98.4137 99.6404ZM94.9258 38.5215C90.9331 38.4284 86.9866 39.3955 83.4891 41.3243C72.629 47.6015 67.6975 64.5954 70.0424 87.9446L70.0415 88.2194C70.194 89.8208 70.3941 91.4325 70.6134 93.0624C83.0737 89.3364 95.8262 86.6703 108.736 85.0924C116.57 74.6779 125.28 64.9532 134.772 56.0249C119.877 44.5087 105.895 38.5215 94.9258 38.5215ZM205.737 41.3148C202.268 39.398 198.355 38.4308 194.394 38.5099L194.291 38.512C183.321 38.512 169.34 44.4991 154.443 56.0153C163.929 64.9374 172.634 74.6557 180.462 85.064C193.374 86.6345 206.129 89.3102 218.584 93.0624C218.813 91.4325 219.003 89.8118 219.166 88.2098C221.548 64.7099 216.65 47.6164 205.737 41.3148ZM144.551 64.3097C138.103 70.2614 132.055 76.6306 126.443 83.3765C132.389 82.995 138.427 82.8046 144.551 82.8046C150.727 82.8046 156.779 83.0143 162.707 83.3765C157.079 76.6293 151.015 70.2596 144.551 64.3097Z" fill="#FF40E0"/></g><mask id="mask1_0_3" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="102" y="84" width="161" height="162"><path d="M235.282 84.827L102.261 112.259L129.693 245.28L262.714 217.848L235.282 84.827Z" fill="white"/></mask><g mask="url(#mask1_0_3)"><path d="M136.863 129.916L213.258 141.224C220.669 142.322 222.495 152.179 215.967 155.856L187.592 171.843L184.135 204.227C183.339 211.678 173.564 213.901 169.624 207.526L129.021 141.831C125.503 136.14 130.245 128.936 136.863 129.916Z" fill="#FF40E0" stroke="#FF40E0" stroke-width="0.817337" stroke-linecap="round" stroke-linejoin="round"/></g></g><defs><clipPath id="clip0_0_3"><rect width="294" height="294" fill="white"/></clipPath></defs></svg>',
+    wu = 1e3,
+    xu = 229,
+    Ra = -9999,
+    Ia = new Set([
+      "display",
+      "position",
+      "top",
+      "right",
+      "bottom",
+      "left",
+      "z-index",
+      "overflow",
+      "overflow-x",
+      "overflow-y",
+      "width",
+      "height",
+      "min-width",
+      "min-height",
+      "max-width",
+      "max-height",
+      "margin-top",
+      "margin-right",
+      "margin-bottom",
+      "margin-left",
+      "padding-top",
+      "padding-right",
+      "padding-bottom",
+      "padding-left",
+      "flex-direction",
+      "flex-wrap",
+      "justify-content",
+      "align-items",
+      "align-self",
+      "align-content",
+      "flex-grow",
+      "flex-shrink",
+      "flex-basis",
+      "order",
+      "gap",
+      "row-gap",
+      "column-gap",
+      "grid-template-columns",
+      "grid-template-rows",
+      "grid-template-areas",
+      "font-family",
+      "font-size",
+      "font-weight",
+      "font-style",
+      "line-height",
+      "letter-spacing",
+      "text-align",
+      "text-decoration-line",
+      "text-decoration-style",
+      "text-transform",
+      "text-overflow",
+      "text-shadow",
+      "white-space",
+      "word-break",
+      "overflow-wrap",
+      "vertical-align",
+      "color",
+      "background-color",
+      "background-image",
+      "background-position",
+      "background-size",
+      "background-repeat",
+      "border-top-width",
+      "border-right-width",
+      "border-bottom-width",
+      "border-left-width",
+      "border-top-style",
+      "border-right-style",
+      "border-bottom-style",
+      "border-left-style",
+      "border-top-color",
+      "border-right-color",
+      "border-bottom-color",
+      "border-left-color",
+      "border-top-left-radius",
+      "border-top-right-radius",
+      "border-bottom-left-radius",
+      "border-bottom-right-radius",
+      "box-shadow",
+      "opacity",
+      "transform",
+      "filter",
+      "backdrop-filter",
+      "object-fit",
+      "object-position",
+    ]);
+  var Fp = (e) =>
+      typeof e == "number" && !Number.isNaN(e) && Number.isFinite(e),
+    $p = (e) => {
+      let t = e.trim();
+      if (!t) return null;
+      let n = parseFloat(t);
+      return Fp(n) ? n : null;
+    },
+    vu = (e, t) => {
+      let n = e.split(",");
+      if (n.length !== t) return null;
+      let o = [];
+      for (let i of n) {
+        let s = $p(i);
+        if (s === null) return null;
+        o.push(s);
+      }
+      return o;
+    },
+    Cu = (e, t, n, o) => e === 1 && t === 0 && n === 0 && o === 1,
+    Hp = (e) =>
+      e[0] === 1 &&
+      e[1] === 0 &&
+      e[2] === 0 &&
+      e[3] === 0 &&
+      e[4] === 0 &&
+      e[5] === 1 &&
+      e[6] === 0 &&
+      e[7] === 0 &&
+      e[8] === 0 &&
+      e[9] === 0 &&
+      e[10] === 1 &&
+      e[11] === 0 &&
+      e[15] === 1,
+    Eu = (e) => {
+      if (!e || e === "none") return "none";
+      if (e.charCodeAt(0) === 109)
+        if (e.charCodeAt(6) === 51) {
+          let n = e.length - 1,
+            o = vu(e.slice(9, n), 16);
+          if (o)
+            return (
+              (o[12] = 0),
+              (o[13] = 0),
+              (o[14] = 0),
+              Hp(o)
+                ? "none"
+                : `matrix3d(${o[0]}, ${o[1]}, ${o[2]}, ${o[3]}, ${o[4]}, ${o[5]}, ${o[6]}, ${o[7]}, ${o[8]}, ${o[9]}, ${o[10]}, ${o[11]}, 0, 0, 0, ${o[15]})`
+            );
+        } else {
+          let n = e.length - 1,
+            o = vu(e.slice(7, n), 6);
+          if (o) {
+            let i = o[0],
+              s = o[1],
+              r = o[2],
+              c = o[3];
+            return Cu(i, s, r, c)
+              ? "none"
+              : `matrix(${i}, ${s}, ${r}, ${c}, 0, 0)`;
+          }
+        }
+      return "none";
+    },
+    Su = (e) =>
+      e.isIdentity
+        ? "none"
+        : e.is2D
+          ? Cu(e.a, e.b, e.c, e.d)
+            ? "none"
+            : `matrix(${e.a}, ${e.b}, ${e.c}, ${e.d}, 0, 0)`
+          : e.m11 === 1 &&
+              e.m12 === 0 &&
+              e.m13 === 0 &&
+              e.m14 === 0 &&
+              e.m21 === 0 &&
+              e.m22 === 1 &&
+              e.m23 === 0 &&
+              e.m24 === 0 &&
+              e.m31 === 0 &&
+              e.m32 === 0 &&
+              e.m33 === 1 &&
+              e.m34 === 0 &&
+              e.m44 === 1
+            ? "none"
+            : `matrix3d(${e.m11}, ${e.m12}, ${e.m13}, ${e.m14}, ${e.m21}, ${e.m22}, ${e.m23}, ${e.m24}, ${e.m31}, ${e.m32}, ${e.m33}, ${e.m34}, 0, 0, 0, ${e.m44})`;
+  var Na = new WeakMap(),
+    Au = () => {
+      Na = new WeakMap();
+    },
+    zp = (e, t) => {
+      let n = t && t !== "none",
+        o = null,
+        i = e.parentElement,
+        s = 0;
+      for (; i && i !== document.documentElement && s < au; ) {
+        let r = window.getComputedStyle(i).transform;
+        if (r && r !== "none")
+          o = o ? new DOMMatrix(r).multiply(o) : new DOMMatrix(r);
+        else if (!n && !o && s >= lu) return "none";
+        ((i = i.parentElement), s++);
+      }
+      return o
+        ? (n && (o = o.multiply(new DOMMatrix(t))), Su(o))
+        : n
+          ? Eu(t)
+          : "none";
+    },
+    ze = (e) => {
+      let t = performance.now(),
+        n = Na.get(e);
+      if (n && t - n.timestamp < 16) return n.bounds;
+      let o = e.getBoundingClientRect(),
+        i = window.getComputedStyle(e),
+        s = zp(e, i.transform),
+        r;
+      if (s !== "none" && e instanceof HTMLElement) {
+        let c = e.offsetWidth,
+          l = e.offsetHeight;
+        if (c > 0 && l > 0) {
+          let u = o.left + o.width * 0.5,
+            f = o.top + o.height * 0.5;
+          r = {
+            borderRadius: i.borderRadius || "0px",
+            height: l,
+            transform: s,
+            width: c,
+            x: u - c * 0.5,
+            y: f - l * 0.5,
+          };
+        } else
+          r = {
+            borderRadius: i.borderRadius || "0px",
+            height: o.height,
+            transform: s,
+            width: o.width,
+            x: o.left,
+            y: o.top,
+          };
+      } else
+        r = {
+          borderRadius: i.borderRadius || "0px",
+          height: o.height,
+          transform: s,
+          width: o.width,
+          x: o.left,
+          y: o.top,
+        };
+      return (Na.set(e, { bounds: r, timestamp: t }), r);
+    };
+  var et = (e) => !!(e?.isConnected ?? e?.ownerDocument?.contains(e));
+  var kn = (e) => ({ x: e.x + e.width / 2, y: e.y + e.height / 2 });
+  var ns = ({ currentPosition: e, previousBounds: t, nextBounds: n }) => {
+    if (!t || !n) return e;
+    let o = kn(t),
+      i = kn(n),
+      s = t.width / 2,
+      r = e.x - o.x,
+      c = s > 0 ? r / s : 0,
+      l = n.width / 2;
+    return { ...e, x: i.x + c * l };
+  };
+  var Vp = (e) => ({
+      current: { state: "idle" },
+      wasActivatedByToggle: false,
+      pendingCommentMode: false,
+      hasAgentProvider: e.hasAgentProvider,
+      keyHoldDuration: e.keyHoldDuration,
+      pointer: { x: -1e3, y: -1e3 },
+      dragStart: { x: -1e3, y: -1e3 },
+      copyStart: { x: -1e3, y: -1e3 },
+      copyOffsetFromCenterX: 0,
+      detectedElement: null,
+      frozenElement: null,
+      frozenElements: [],
+      frozenDragRect: null,
+      lastGrabbedElement: null,
+      lastCopiedElement: null,
+      selectionFilePath: null,
+      selectionLineNumber: null,
+      inputText: "",
+      pendingClickData: null,
+      replySessionId: null,
+      viewportVersion: 0,
+      grabbedBoxes: [],
+      labelInstances: [],
+      agentSessions: new Map(),
+      sessionElements: new Map(),
+      isTouchMode: false,
+      theme: e.theme,
+      activationTimestamp: null,
+      previouslyFocusedElement: null,
+      isAgentConnected: false,
+      supportsUndo: false,
+      supportsFollowUp: false,
+      dismissButtonText: void 0,
+      pendingAbortSessionId: null,
+      contextMenuPosition: null,
+      contextMenuElement: null,
+      contextMenuClickOffset: null,
+      selectedAgent: null,
+    }),
+    Tu = (e) => {
+      let [t, n] = Qi(Vp(e)),
+        o = () => t.current.state === "active",
+        i = () => t.current.state === "holding",
+        s = {
+          startHold: (r) => {
+            (r !== void 0 && n("keyHoldDuration", r),
+              n("current", { state: "holding", startedAt: Date.now() }));
+          },
+          release: () => {
+            t.current.state === "holding" && n("current", { state: "idle" });
+          },
+          activate: () => {
+            (n("current", {
+              state: "active",
+              phase: "hovering",
+              isPromptMode: false,
+              isPendingDismiss: false,
+            }),
+              n("activationTimestamp", Date.now()),
+              n("previouslyFocusedElement", document.activeElement));
+          },
+          deactivate: () => {
+            n(
+              Wt((r) => {
+                ((r.current = { state: "idle" }),
+                  (r.wasActivatedByToggle = false),
+                  (r.pendingCommentMode = false),
+                  (r.inputText = ""),
+                  (r.frozenElement = null),
+                  (r.frozenElements = []),
+                  (r.frozenDragRect = null),
+                  (r.pendingClickData = null),
+                  (r.replySessionId = null),
+                  (r.pendingAbortSessionId = null),
+                  (r.activationTimestamp = null),
+                  (r.previouslyFocusedElement = null),
+                  (r.contextMenuPosition = null),
+                  (r.contextMenuElement = null),
+                  (r.contextMenuClickOffset = null),
+                  (r.selectedAgent = null),
+                  (r.lastCopiedElement = null));
+              }),
+            );
+          },
+          toggle: () => {
+            t.activationTimestamp !== null
+              ? s.deactivate()
+              : (n("wasActivatedByToggle", true), s.activate());
+          },
+          freeze: () => {
+            if (t.current.state === "active") {
+              let r = t.frozenElement ?? t.detectedElement;
+              (r && n("frozenElement", r),
+                n(
+                  "current",
+                  Wt((c) => {
+                    c.state === "active" && (c.phase = "frozen");
+                  }),
+                ));
+            }
+          },
+          unfreeze: () => {
+            t.current.state === "active" &&
+              (n("frozenElement", null),
+              n("frozenElements", []),
+              n("frozenDragRect", null),
+              n(
+                "current",
+                Wt((r) => {
+                  r.state === "active" && (r.phase = "hovering");
+                }),
+              ));
+          },
+          startDrag: (r) => {
+            t.current.state === "active" &&
+              (s.clearFrozenElement(),
+              n("dragStart", {
+                x: r.x + window.scrollX,
+                y: r.y + window.scrollY,
+              }),
+              n(
+                "current",
+                Wt((c) => {
+                  c.state === "active" && (c.phase = "dragging");
+                }),
+              ));
+          },
+          endDrag: () => {
+            t.current.state === "active" &&
+              t.current.phase === "dragging" &&
+              (n("dragStart", { x: -1e3, y: -1e3 }),
+              n(
+                "current",
+                Wt((r) => {
+                  r.state === "active" && (r.phase = "justDragged");
+                }),
+              ));
+          },
+          cancelDrag: () => {
+            t.current.state === "active" &&
+              t.current.phase === "dragging" &&
+              (n("dragStart", { x: -1e3, y: -1e3 }),
+              n(
+                "current",
+                Wt((r) => {
+                  r.state === "active" && (r.phase = "hovering");
+                }),
+              ));
+          },
+          finishJustDragged: () => {
+            t.current.state === "active" &&
+              t.current.phase === "justDragged" &&
+              n(
+                "current",
+                Wt((r) => {
+                  r.state === "active" && (r.phase = "hovering");
+                }),
+              );
+          },
+          startCopy: () => {
+            let r = t.current.state === "active";
+            n("current", {
+              state: "copying",
+              startedAt: Date.now(),
+              wasActive: r,
+            });
+          },
+          completeCopy: (r) => {
+            (n("pendingClickData", null), r && n("lastCopiedElement", r));
+            let c = t.current.state === "copying" ? t.current.wasActive : false;
+            n("current", {
+              state: "justCopied",
+              copiedAt: Date.now(),
+              wasActive: c,
+            });
+          },
+          finishJustCopied: () => {
+            t.current.state === "justCopied" &&
+              (t.current.wasActive && !t.wasActivatedByToggle
+                ? n("current", {
+                    state: "active",
+                    phase: "hovering",
+                    isPromptMode: false,
+                    isPendingDismiss: false,
+                  })
+                : s.deactivate());
+          },
+          enterPromptMode: (r, c) => {
+            let l = ze(c),
+              u = l.x + l.width / 2;
+            (n("copyStart", r),
+              n("copyOffsetFromCenterX", r.x - u),
+              n("pointer", r),
+              n("frozenElement", c),
+              n("wasActivatedByToggle", true),
+              t.current.state !== "active"
+                ? (n("current", {
+                    state: "active",
+                    phase: "frozen",
+                    isPromptMode: true,
+                    isPendingDismiss: false,
+                  }),
+                  n("activationTimestamp", Date.now()),
+                  n("previouslyFocusedElement", document.activeElement))
+                : n(
+                    "current",
+                    Wt((f) => {
+                      f.state === "active" &&
+                        ((f.isPromptMode = true), (f.phase = "frozen"));
+                    }),
+                  ));
+          },
+          exitPromptMode: () => {
+            t.current.state === "active" &&
+              n(
+                "current",
+                Wt((r) => {
+                  r.state === "active" &&
+                    ((r.isPromptMode = false), (r.isPendingDismiss = false));
+                }),
+              );
+          },
+          setInputText: (r) => {
+            n("inputText", r);
+          },
+          clearInputText: () => {
+            n("inputText", "");
+          },
+          setPendingDismiss: (r) => {
+            t.current.state === "active" &&
+              n(
+                "current",
+                Wt((c) => {
+                  c.state === "active" && (c.isPendingDismiss = r);
+                }),
+              );
+          },
+          setPointer: (r) => {
+            n("pointer", r);
+          },
+          setDetectedElement: (r) => {
+            n("detectedElement", r);
+          },
+          setFrozenElement: (r) => {
+            (n("frozenElement", r),
+              n("frozenElements", [r]),
+              n("frozenDragRect", null));
+          },
+          setFrozenElements: (r) => {
+            (n("frozenElements", r),
+              n("frozenElement", r.length > 0 ? r[0] : null),
+              n("frozenDragRect", null));
+          },
+          setFrozenDragRect: (r) => {
+            n("frozenDragRect", r);
+          },
+          clearFrozenElement: () => {
+            (n("frozenElement", null),
+              n("frozenElements", []),
+              n("frozenDragRect", null));
+          },
+          setCopyStart: (r, c) => {
+            let l = ze(c),
+              u = l.x + l.width / 2;
+            (n("copyStart", r), n("copyOffsetFromCenterX", r.x - u));
+          },
+          setLastGrabbed: (r) => {
+            n("lastGrabbedElement", r);
+          },
+          clearLastCopied: () => {
+            n("lastCopiedElement", null);
+          },
+          setWasActivatedByToggle: (r) => {
+            n("wasActivatedByToggle", r);
+          },
+          setPendingCommentMode: (r) => {
+            n("pendingCommentMode", r);
+          },
+          setTouchMode: (r) => {
+            n("isTouchMode", r);
+          },
+          setSelectionSource: (r, c) => {
+            (n("selectionFilePath", r), n("selectionLineNumber", c));
+          },
+          setPendingClickData: (r) => {
+            n("pendingClickData", r);
+          },
+          clearReplySessionId: () => {
+            n("replySessionId", null);
+          },
+          incrementViewportVersion: () => {
+            n("viewportVersion", (r) => r + 1);
+          },
+          addGrabbedBox: (r) => {
+            n("grabbedBoxes", (c) => [...c, r]);
+          },
+          removeGrabbedBox: (r) => {
+            n("grabbedBoxes", (c) => c.filter((l) => l.id !== r));
+          },
+          clearGrabbedBoxes: () => {
+            n("grabbedBoxes", []);
+          },
+          addLabelInstance: (r) => {
+            n("labelInstances", (c) => [...c, r]);
+          },
+          updateLabelInstance: (r, c, l) => {
+            let u = t.labelInstances.findIndex((f) => f.id === r);
+            u !== -1 &&
+              n(
+                "labelInstances",
+                u,
+                Wt((f) => {
+                  ((f.status = c), l !== void 0 && (f.errorMessage = l));
+                }),
+              );
+          },
+          removeLabelInstance: (r) => {
+            n("labelInstances", (c) => c.filter((l) => l.id !== r));
+          },
+          clearLabelInstances: () => {
+            n("labelInstances", []);
+          },
+          setHasAgentProvider: (r) => {
+            n("hasAgentProvider", r);
+          },
+          setAgentCapabilities: (r) => {
+            (n("supportsUndo", r.supportsUndo),
+              n("supportsFollowUp", r.supportsFollowUp),
+              n("dismissButtonText", r.dismissButtonText),
+              n("isAgentConnected", r.isAgentConnected));
+          },
+          setPendingAbortSessionId: (r) => {
+            n("pendingAbortSessionId", r);
+          },
+          updateSessionBounds: () => {
+            let r = t.agentSessions;
+            if (r.size === 0) return;
+            let c = new Map(r),
+              l = false;
+            for (let [u, f] of r) {
+              let p = t.sessionElements.get(u) ?? null;
+              if (et(p)) {
+                let b = ze(p),
+                  x = f.selectionBounds[0],
+                  H = ns({
+                    currentPosition: f.position,
+                    previousBounds: x,
+                    nextBounds: b,
+                  });
+                (c.set(u, { ...f, selectionBounds: [b], position: H }),
+                  (l = true));
+              }
+            }
+            l && n("agentSessions", c);
+          },
+          addAgentSession: (r, c, l) => {
+            let u = new Map(t.agentSessions);
+            (u.set(r, c), n("agentSessions", u));
+            let f = new Map(t.sessionElements);
+            (f.set(r, l), n("sessionElements", f));
+          },
+          updateAgentSessionStatus: (r, c) => {
+            let l = t.agentSessions.get(r);
+            if (!l) return;
+            let u = new Map(t.agentSessions);
+            (u.set(r, { ...l, lastStatus: c }), n("agentSessions", u));
+          },
+          completeAgentSession: (r, c) => {
+            let l = t.agentSessions.get(r);
+            if (!l) return;
+            let u = new Map(t.agentSessions);
+            (u.set(r, {
+              ...l,
+              isStreaming: false,
+              lastStatus: c ?? l.lastStatus,
+            }),
+              n("agentSessions", u));
+          },
+          setAgentSessionError: (r, c) => {
+            let l = t.agentSessions.get(r);
+            if (!l) return;
+            let u = new Map(t.agentSessions);
+            (u.set(r, { ...l, isStreaming: false, error: c }),
+              n("agentSessions", u));
+          },
+          removeAgentSession: (r) => {
+            let c = new Map(t.agentSessions);
+            (c.delete(r), n("agentSessions", c));
+            let l = new Map(t.sessionElements);
+            (l.delete(r), n("sessionElements", l));
+          },
+          showContextMenu: (r, c) => {
+            let l = ze(c),
+              u = l.x + l.width / 2,
+              f = l.y + l.height / 2;
+            (n("contextMenuPosition", r),
+              n("contextMenuElement", c),
+              n("contextMenuClickOffset", { x: r.x - u, y: r.y - f }));
+          },
+          hideContextMenu: () => {
+            (n("contextMenuPosition", null),
+              n("contextMenuElement", null),
+              n("contextMenuClickOffset", null));
+          },
+          updateContextMenuPosition: () => {
+            let r = t.contextMenuElement,
+              c = t.contextMenuClickOffset;
+            if (!r || !c || !et(r)) return;
+            let l = ze(r),
+              u = l.x + l.width / 2,
+              f = l.y + l.height / 2;
+            n("contextMenuPosition", { x: u + c.x, y: f + c.y });
+          },
+          setSelectedAgent: (r) => {
+            n("selectedAgent", r);
+          },
+        };
+      return { store: t, setStore: n, actions: s, isActive: o, isHolding: i };
+    };
+  var pt = (e) => (e.tagName || "").toLowerCase();
+  var Gp = [
+      "input",
+      "textarea",
+      "select",
+      "searchbox",
+      "slider",
+      "spinbutton",
+      "menuitem",
+      "menuitemcheckbox",
+      "menuitemradio",
+      "option",
+      "radio",
+      "textbox",
+      "combobox",
+    ],
+    Up = (e) => {
+      if (e.composed) {
+        let t = e.composedPath()[0];
+        if (t instanceof HTMLElement) return t;
+      } else if (e.target instanceof HTMLElement) return e.target;
+    },
+    St = (e) => {
+      if (document.designMode === "on") return true;
+      let t = Up(e);
+      if (!t) return false;
+      if (t.isContentEditable) return true;
+      let n = pt(t);
+      return Gp.some((o) => o === n || o === t.role);
+    },
+    _u = (e) => {
+      let t = e.target;
+      if (t instanceof HTMLInputElement || t instanceof HTMLTextAreaElement) {
+        let n = t.selectionStart ?? 0;
+        return (t.selectionEnd ?? 0) - n > 0;
+      }
+      return false;
+    },
+    Pu = () => {
+      let e = window.getSelection();
+      return e ? e.toString().length > 0 : false;
+    };
+  var os = "data-react-grab",
+    ku = "react-grab-fonts",
+    Wp = "https://fonts.googleapis.com/css2?family=Geist:wght@500&display=swap",
+    Kp = () => {
+      if (document.getElementById(ku) || !document.head) return;
+      let e = document.createElement("link");
+      ((e.id = ku),
+        (e.rel = "stylesheet"),
+        (e.href = Wp),
+        document.head.appendChild(e));
+    },
+    Ou = (e) => {
+      Kp();
+      let t = document.querySelector(`[${os}]`);
+      if (t) {
+        let r = t.shadowRoot?.querySelector(`[${os}]`);
+        if (r instanceof HTMLDivElement && t.shadowRoot) return r;
+      }
+      let n = document.createElement("div");
+      (n.setAttribute(os, "true"),
+        (n.style.zIndex = String(2147483647)),
+        (n.style.position = "fixed"),
+        (n.style.inset = "0"),
+        (n.style.pointerEvents = "none"));
+      let o = n.attachShadow({ mode: "open" });
+      {
+        let r = document.createElement("style");
+        ((r.textContent = e), o.appendChild(r));
+      }
+      let i = document.createElement("div");
+      (i.setAttribute(os, "true"), o.appendChild(i));
+      let s = document.body ?? document.documentElement;
+      return (
+        s.appendChild(n),
+        setTimeout(() => {
+          s.appendChild(n);
+        }, fu),
+        i
+      );
+    };
+  var La = typeof window < "u",
+    Xp = (e) => 0,
+    Yp = (e) => {},
+    Ve = La
+      ? (
+          Object.getOwnPropertyDescriptor(
+            Window.prototype,
+            "requestAnimationFrame",
+          )?.value ?? window.requestAnimationFrame
+        ).bind(window)
+      : Xp,
+    Ge = La
+      ? (
+          Object.getOwnPropertyDescriptor(
+            Window.prototype,
+            "cancelAnimationFrame",
+          )?.value ?? window.cancelAnimationFrame
+        ).bind(window)
+      : Yp,
+    Mu = () => (La ? new Promise((e) => Ve(() => e())) : Promise.resolve());
+  var Nu = "0.5.30",
+    ss = `bippy-${Nu}`,
+    Ru = Object.defineProperty,
+    qp = Object.prototype.hasOwnProperty,
+    Ur = () => {},
+    Lu = (e) => {
+      try {
+        Function.prototype.toString.call(e).indexOf("^_^") > -1 &&
+          setTimeout(() => {
+            throw Error(
+              "React is running in production mode, but dead code elimination has not been applied. Read how to correctly configure React for production: https://reactjs.org/link/perf-use-production-build",
+            );
+          });
+      } catch {}
+    },
+    as = (e = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__) =>
+      !!(e && "getFiberRoots" in e),
+    Du = false,
+    Iu,
+    jr = (e = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__) =>
+      Du
+        ? true
+        : (e && typeof e.inject == "function" && (Iu = e.inject.toString()),
+          !!Iu?.includes("(injected)")),
+    rs = new Set(),
+    mo = new Set(),
+    Fu = (e) => {
+      let t = new Map(),
+        n = 0,
+        o = {
+          _instrumentationIsActive: false,
+          _instrumentationSource: ss,
+          checkDCE: Lu,
+          hasUnsupportedRendererAttached: false,
+          inject(i) {
+            let s = ++n;
+            return (
+              t.set(s, i),
+              mo.add(i),
+              o._instrumentationIsActive ||
+                ((o._instrumentationIsActive = true), rs.forEach((r) => r())),
+              s
+            );
+          },
+          on: Ur,
+          onCommitFiberRoot: Ur,
+          onCommitFiberUnmount: Ur,
+          onPostCommitFiberRoot: Ur,
+          renderers: t,
+          supportsFiber: true,
+          supportsFlight: true,
+        };
+      try {
+        Ru(globalThis, "__REACT_DEVTOOLS_GLOBAL_HOOK__", {
+          configurable: !0,
+          enumerable: !0,
+          get() {
+            return o;
+          },
+          set(r) {
+            if (r && typeof r == "object") {
+              let c = o.renderers;
+              ((o = r),
+                c.size > 0 &&
+                  (c.forEach((l, u) => {
+                    (mo.add(l), r.renderers.set(u, l));
+                  }),
+                  is(e)));
+            }
+          },
+        });
+        let i = window.hasOwnProperty,
+          s = !1;
+        Ru(window, "hasOwnProperty", {
+          configurable: !0,
+          value: function (...r) {
+            try {
+              if (!s && r[0] === "__REACT_DEVTOOLS_GLOBAL_HOOK__")
+                return (
+                  (globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__ = void 0),
+                  (s = !0),
+                  -0
+                );
+            } catch {}
+            return i.apply(this, r);
+          },
+          writable: !0,
+        });
+      } catch {
+        is(e);
+      }
+      return o;
+    },
+    is = (e) => {
+      try {
+        let t = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+        if (!t) return;
+        if (!t._instrumentationSource) {
+          ((t.checkDCE = Lu),
+            (t.supportsFiber = !0),
+            (t.supportsFlight = !0),
+            (t.hasUnsupportedRendererAttached = !1),
+            (t._instrumentationSource = ss),
+            (t._instrumentationIsActive = !1));
+          let n = as(t);
+          if ((n || (t.on = Ur), t.renderers.size)) {
+            ((t._instrumentationIsActive = !0), rs.forEach((s) => s()));
+            return;
+          }
+          let o = t.inject,
+            i = jr(t);
+          (i &&
+            !n &&
+            ((Du = !0),
+            t.inject({ scheduleRefresh() {} }) &&
+              (t._instrumentationIsActive = !0)),
+            (t.inject = (s) => {
+              let r = o(s);
+              return (
+                mo.add(s),
+                i && t.renderers.set(r, s),
+                (t._instrumentationIsActive = !0),
+                rs.forEach((c) => c()),
+                r
+              );
+            }));
+        }
+        (t.renderers.size || t._instrumentationIsActive || jr()) && e?.();
+      } catch {}
+    },
+    Da = () => qp.call(globalThis, "__REACT_DEVTOOLS_GLOBAL_HOOK__"),
+    Wn = (e) =>
+      Da() ? (is(e), globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__) : Fu(e),
+    $u = () =>
+      !!(
+        typeof window < "u" &&
+        (window.document?.createElement ||
+          window.navigator?.product === "ReactNative")
+      ),
+    Fa = () => {
+      try {
+        $u() && Wn();
+      } catch {}
+    };
+  var ls = 0,
+    cs = 1;
+  var $a = 5;
+  var us = 11,
+    Ha = 13,
+    Hu = 14,
+    ds = 15,
+    Ba = 16;
+  var za = 19;
+  var Va = 26,
+    Ga = 27,
+    Ua = 28,
+    ja = 30;
+  var Jo = (e) => {
+    switch (e.tag) {
+      case cs:
+      case us:
+      case ls:
+      case Hu:
+      case ds:
+        return true;
+      default:
+        return false;
+    }
+  };
+  function Qo(e, t, n = false) {
+    if (!e) return null;
+    let o = t(e);
+    if (o instanceof Promise)
+      return (async () => {
+        if ((await o) === true) return e;
+        let s = n ? e.return : e.child;
+        for (; s; ) {
+          let r = await Ka(s, t, n);
+          if (r) return r;
+          s = n ? null : s.sibling;
+        }
+        return null;
+      })();
+    if (o === true) return e;
+    let i = n ? e.return : e.child;
+    for (; i; ) {
+      let s = Wa(i, t, n);
+      if (s) return s;
+      i = n ? null : i.sibling;
+    }
+    return null;
+  }
+  var Wa = (e, t, n = false) => {
+      if (!e) return null;
+      if (t(e) === true) return e;
+      let o = n ? e.return : e.child;
+      for (; o; ) {
+        let i = Wa(o, t, n);
+        if (i) return i;
+        o = n ? null : o.sibling;
+      }
+      return null;
+    },
+    Ka = async (e, t, n = false) => {
+      if (!e) return null;
+      if ((await t(e)) === true) return e;
+      let o = n ? e.return : e.child;
+      for (; o; ) {
+        let i = await Ka(o, t, n);
+        if (i) return i;
+        o = n ? null : o.sibling;
+      }
+      return null;
+    };
+  var Xa = (e) => {
+      let t = e;
+      return typeof t == "function"
+        ? t
+        : typeof t == "object" && t
+          ? Xa(t.type || t.render)
+          : null;
+    },
+    Kn = (e) => {
+      let t = e;
+      if (typeof t == "string") return t;
+      if (typeof t != "function" && !(typeof t == "object" && t)) return null;
+      let n = t.displayName || t.name || null;
+      if (n) return n;
+      let o = Xa(t);
+      return (o && (o.displayName || o.name)) || null;
+    };
+  var Xn = () => {
+    let e = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+    return !!e?._instrumentationIsActive || as(e) || jr(e);
+  };
+  var po = (e) => {
+      let t = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+      if (t?.renderers)
+        for (let n of t.renderers.values())
+          try {
+            let o = n.findFiberByHostInstance?.(e);
+            if (o) return o;
+          } catch {}
+      if (typeof e == "object" && e) {
+        if ("_reactRootContainer" in e)
+          return e._reactRootContainer?._internalRoot?.current?.child;
+        for (let n in e)
+          if (
+            n.startsWith("__reactContainer$") ||
+            n.startsWith("__reactInternalInstance$") ||
+            n.startsWith("__reactFiber")
+          )
+            return e[n] || null;
+      }
+      return null;
+    },
+    Ya = new Set();
+  var ig = Object.create,
+    Xu = Object.defineProperty,
+    sg = Object.getOwnPropertyDescriptor,
+    ag = Object.getOwnPropertyNames,
+    lg = Object.getPrototypeOf,
+    cg = Object.prototype.hasOwnProperty,
+    ug = (e, t) => () => (t || e((t = { exports: {} }).exports, t), t.exports),
+    dg = (e, t, n, o) => {
+      if ((t && typeof t == "object") || typeof t == "function")
+        for (var i = ag(t), s = 0, r = i.length, c; s < r; s++)
+          ((c = i[s]),
+            !cg.call(e, c) &&
+              c !== n &&
+              Xu(e, c, {
+                get: ((l) => t[l]).bind(null, c),
+                enumerable: !(o = sg(t, c)) || o.enumerable,
+              }));
+      return e;
+    },
+    fg = (e, t, n) => (
+      (n = e == null ? {} : ig(lg(e))),
+      dg(Xu(n, "default", { value: e, enumerable: true }), e)
+    ),
+    Bu = /^[a-zA-Z][a-zA-Z\d+\-.]*:/,
+    mg = [
+      "rsc://",
+      "file:///",
+      "webpack://",
+      "webpack-internal://",
+      "node:",
+      "turbopack://",
+      "metro://",
+      "/app-pages-browser/",
+    ],
+    zu = "about://React/",
+    pg = ["<anonymous>", "eval", ""],
+    Yu = /\.(jsx|tsx|ts|js)$/,
+    gg =
+      /(\.min|bundle|chunk|vendor|vendors|runtime|polyfill|polyfills)\.(js|mjs|cjs)$|(chunk|bundle|vendor|vendors|runtime|polyfill|polyfills|framework|app|main|index)[-_.][A-Za-z0-9_-]{4,}\.(js|mjs|cjs)$|[\da-f]{8,}\.(js|mjs|cjs)$|[-_.][\da-f]{20,}\.(js|mjs|cjs)$|\/dist\/|\/build\/|\/.next\/|\/out\/|\/node_modules\/|\.webpack\.|\.vite\.|\.turbopack\./i,
+    hg = /^\?[\w~.-]+(?:=[^&#]*)?(?:&[\w~.-]+(?:=[^&#]*)?)*$/,
+    qu = "(at Server)",
+    bg = /(^|@)\S+:\d+/,
+    Zu = /^\s*at .*(\S+:\d+|\(native\))/m,
+    yg = /^(eval@)?(\[native code\])?$/;
+  var ms = (e, t) => {
+      {
+        let n = e.split(`
+`),
+          o = [];
+        for (let i of n)
+          if (/^\s*at\s+/.test(i)) {
+            let s = Vu(i, void 0)[0];
+            s && o.push(s);
+          } else if (/^\s*in\s+/.test(i)) {
+            let s = i.replace(/^\s*in\s+/, "").replace(/\s*\(at .*\)$/, "");
+            o.push({ functionName: s, source: i });
+          } else if (i.match(bg)) {
+            let s = Gu(i, void 0)[0];
+            s && o.push(s);
+          }
+        return Ja(o, t);
+      }
+    },
+    Ju = (e) => {
+      if (!e.includes(":")) return [e, void 0, void 0];
+      let t = e.startsWith("(") && /:\d+\)$/.test(e),
+        n = t ? e.slice(1, -1) : e,
+        o = /(.+?)(?::(\d+))?(?::(\d+))?$/,
+        i = o.exec(n);
+      return i ? [i[1], i[2] || void 0, i[3] || void 0] : [n, void 0, void 0];
+    },
+    Ja = (e, t) =>
+      t && t.slice != null
+        ? Array.isArray(t.slice)
+          ? e.slice(t.slice[0], t.slice[1])
+          : e.slice(0, t.slice)
+        : e;
+  var Vu = (e, t) =>
+    Ja(
+      e
+        .split(`
+`)
+        .filter((o) => !!o.match(Zu)),
+      t,
+    ).map((o) => {
+      let i = o;
+      i.includes("(eval ") &&
+        (i = i
+          .replace(/eval code/g, "eval")
+          .replace(/(\(eval at [^()]*)|(,.*$)/g, ""));
+      let s = i
+          .replace(/^\s+/, "")
+          .replace(/\(eval code/g, "(")
+          .replace(/^.*?\s+/, ""),
+        r = s.match(/ (\(.+\)$)/);
+      s = r ? s.replace(r[0], "") : s;
+      let c = Ju(r ? r[1] : s),
+        l = (r && s) || void 0,
+        u = ["eval", "<anonymous>"].includes(c[0]) ? void 0 : c[0];
+      return {
+        functionName: l,
+        fileName: u,
+        lineNumber: c[1] ? +c[1] : void 0,
+        columnNumber: c[2] ? +c[2] : void 0,
+        source: i,
+      };
+    });
+  var Gu = (e, t) =>
+    Ja(
+      e
+        .split(`
+`)
+        .filter((o) => !o.match(yg)),
+      t,
+    ).map((o) => {
+      let i = o;
+      if (
+        (i.includes(" > eval") &&
+          (i = i.replace(
+            / line (\d+)(?: > eval line \d+)* > eval:\d+:\d+/g,
+            ":$1",
+          )),
+        !i.includes("@") && !i.includes(":"))
+      )
+        return { functionName: i };
+      {
+        let s =
+            /(([^\n\r"\u2028\u2029]*".[^\n\r"\u2028\u2029]*"[^\n\r@\u2028\u2029]*(?:@[^\n\r"\u2028\u2029]*"[^\n\r@\u2028\u2029]*)*(?:[\n\r\u2028\u2029][^@]*)?)?[^@]*)@/,
+          r = i.match(s),
+          c = r && r[1] ? r[1] : void 0,
+          l = Ju(i.replace(s, ""));
+        return {
+          functionName: c,
+          fileName: l[0],
+          lineNumber: l[1] ? +l[1] : void 0,
+          columnNumber: l[2] ? +l[2] : void 0,
+          source: i,
+        };
+      }
+    });
+  var wg = ug((e, t) => {
+      (function (n, o) {
+        typeof e == "object" && t !== void 0
+          ? o(e)
+          : typeof define == "function" && define.amd
+            ? define(["exports"], o)
+            : ((n = typeof globalThis < "u" ? globalThis : n || self),
+              o((n.sourcemapCodec = {})));
+      })(void 0, function (n) {
+        let o = 44,
+          i = 59,
+          s =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/",
+          r = new Uint8Array(64),
+          c = new Uint8Array(128);
+        for (let L = 0; L < s.length; L++) {
+          let A = s.charCodeAt(L);
+          ((r[L] = A), (c[A] = L));
+        }
+        function l(L, A) {
+          let y = 0,
+            h = 0,
+            S = 0;
+          do {
+            let B = L.next();
+            ((S = c[B]), (y |= (S & 31) << h), (h += 5));
+          } while (S & 32);
+          let D = y & 1;
+          return ((y >>>= 1), D && (y = -2147483648 | -y), A + y);
+        }
+        function u(L, A, y) {
+          let h = A - y;
+          h = h < 0 ? (-h << 1) | 1 : h << 1;
+          do {
+            let S = h & 31;
+            ((h >>>= 5), h > 0 && (S |= 32), L.write(r[S]));
+          } while (h > 0);
+          return A;
+        }
+        function f(L, A) {
+          return L.pos >= A ? false : L.peek() !== o;
+        }
+        let p = 1024 * 16,
+          b =
+            typeof TextDecoder < "u"
+              ? new TextDecoder()
+              : typeof Buffer < "u"
+                ? {
+                    decode(L) {
+                      return Buffer.from(
+                        L.buffer,
+                        L.byteOffset,
+                        L.byteLength,
+                      ).toString();
+                    },
+                  }
+                : {
+                    decode(L) {
+                      let A = "";
+                      for (let y = 0; y < L.length; y++)
+                        A += String.fromCharCode(L[y]);
+                      return A;
+                    },
+                  };
+        class x {
+          constructor() {
+            ((this.pos = 0),
+              (this.out = ""),
+              (this.buffer = new Uint8Array(p)));
+          }
+          write(A) {
+            let { buffer: y } = this;
+            ((y[this.pos++] = A),
+              this.pos === p && ((this.out += b.decode(y)), (this.pos = 0)));
+          }
+          flush() {
+            let { buffer: A, out: y, pos: h } = this;
+            return h > 0 ? y + b.decode(A.subarray(0, h)) : y;
+          }
+        }
+        class H {
+          constructor(A) {
+            ((this.pos = 0), (this.buffer = A));
+          }
+          next() {
+            return this.buffer.charCodeAt(this.pos++);
+          }
+          peek() {
+            return this.buffer.charCodeAt(this.pos);
+          }
+          indexOf(A) {
+            let { buffer: y, pos: h } = this,
+              S = y.indexOf(A, h);
+            return S === -1 ? y.length : S;
+          }
+        }
+        let M = [];
+        function Y(L) {
+          let { length: A } = L,
+            y = new H(L),
+            h = [],
+            S = [],
+            D = 0;
+          for (; y.pos < A; y.pos++) {
+            D = l(y, D);
+            let B = l(y, 0);
+            if (!f(y, A)) {
+              let V = S.pop();
+              ((V[2] = D), (V[3] = B));
+              continue;
+            }
+            let w = l(y, 0),
+              v = l(y, 0),
+              $ = v & 1,
+              N = $ ? [D, B, 0, 0, w, l(y, 0)] : [D, B, 0, 0, w],
+              W = M;
+            if (f(y, A)) {
+              W = [];
+              do {
+                let V = l(y, 0);
+                W.push(V);
+              } while (f(y, A));
+            }
+            ((N.vars = W), h.push(N), S.push(N));
+          }
+          return h;
+        }
+        function m(L) {
+          let A = new x();
+          for (let y = 0; y < L.length; ) y = E(L, y, A, [0]);
+          return A.flush();
+        }
+        function E(L, A, y, h) {
+          let S = L[A],
+            { 0: D, 1: B, 2: w, 3: v, 4: $, vars: N } = S;
+          (A > 0 && y.write(o), (h[0] = u(y, D, h[0])), u(y, B, 0), u(y, $, 0));
+          let W = S.length === 6 ? 1 : 0;
+          (u(y, W, 0), S.length === 6 && u(y, S[5], 0));
+          for (let V of N) u(y, V, 0);
+          for (A++; A < L.length; ) {
+            let V = L[A],
+              { 0: oe, 1: de } = V;
+            if (oe > w || (oe === w && de >= v)) break;
+            A = E(L, A, y, h);
+          }
+          return (y.write(o), (h[0] = u(y, w, h[0])), u(y, v, 0), A);
+        }
+        function T(L) {
+          let { length: A } = L,
+            y = new H(L),
+            h = [],
+            S = [],
+            D = 0,
+            B = 0,
+            w = 0,
+            v = 0,
+            $ = 0,
+            N = 0,
+            W = 0,
+            V = 0;
+          do {
+            let oe = y.indexOf(";"),
+              de = 0;
+            for (; y.pos < oe; y.pos++) {
+              if (((de = l(y, de)), !f(y, oe))) {
+                let pe = S.pop();
+                ((pe[2] = D), (pe[3] = de));
+                continue;
+              }
+              let I = l(y, 0),
+                G = I & 1,
+                Q = I & 2,
+                Ae = I & 4,
+                me = null,
+                Se = M,
+                ie;
+              if (G) {
+                let pe = l(y, B);
+                ((w = l(y, B === pe ? w : 0)),
+                  (B = pe),
+                  (ie = [D, de, 0, 0, pe, w]));
+              } else ie = [D, de, 0, 0];
+              if (((ie.isScope = !!Ae), Q)) {
+                let pe = v,
+                  ke = $;
+                v = l(y, v);
+                let Pe = pe === v;
+                (($ = l(y, Pe ? $ : 0)),
+                  (N = l(y, Pe && ke === $ ? N : 0)),
+                  (me = [v, $, N]));
+              }
+              if (((ie.callsite = me), f(y, oe))) {
+                Se = [];
+                do {
+                  ((W = D), (V = de));
+                  let pe = l(y, 0),
+                    ke;
+                  if (pe < -1) {
+                    ke = [[l(y, 0)]];
+                    for (let Pe = -1; Pe > pe; Pe--) {
+                      let ge = W;
+                      ((W = l(y, W)), (V = l(y, W === ge ? V : 0)));
+                      let Te = l(y, 0);
+                      ke.push([Te, W, V]);
+                    }
+                  } else ke = [[pe]];
+                  Se.push(ke);
+                } while (f(y, oe));
+              }
+              ((ie.bindings = Se), h.push(ie), S.push(ie));
+            }
+            (D++, (y.pos = oe + 1));
+          } while (y.pos < A);
+          return h;
+        }
+        function C(L) {
+          if (L.length === 0) return "";
+          let A = new x();
+          for (let y = 0; y < L.length; ) y = R(L, y, A, [0, 0, 0, 0, 0, 0, 0]);
+          return A.flush();
+        }
+        function R(L, A, y, h) {
+          let S = L[A],
+            {
+              0: D,
+              1: B,
+              2: w,
+              3: v,
+              isScope: $,
+              callsite: N,
+              bindings: W,
+            } = S;
+          (h[0] < D
+            ? (X(y, h[0], D), (h[0] = D), (h[1] = 0))
+            : A > 0 && y.write(o),
+            (h[1] = u(y, S[1], h[1])));
+          let V = (S.length === 6 ? 1 : 0) | (N ? 2 : 0) | ($ ? 4 : 0);
+          if ((u(y, V, 0), S.length === 6)) {
+            let { 4: oe, 5: de } = S;
+            (oe !== h[2] && (h[3] = 0),
+              (h[2] = u(y, oe, h[2])),
+              (h[3] = u(y, de, h[3])));
+          }
+          if (N) {
+            let { 0: oe, 1: de, 2: I } = S.callsite;
+            (oe === h[4] ? de !== h[5] && (h[6] = 0) : ((h[5] = 0), (h[6] = 0)),
+              (h[4] = u(y, oe, h[4])),
+              (h[5] = u(y, de, h[5])),
+              (h[6] = u(y, I, h[6])));
+          }
+          if (W)
+            for (let oe of W) {
+              oe.length > 1 && u(y, -oe.length, 0);
+              let de = oe[0][0];
+              u(y, de, 0);
+              let I = D,
+                G = B;
+              for (let Q = 1; Q < oe.length; Q++) {
+                let Ae = oe[Q];
+                ((I = u(y, Ae[1], I)), (G = u(y, Ae[2], G)), u(y, Ae[0], 0));
+              }
+            }
+          for (A++; A < L.length; ) {
+            let oe = L[A],
+              { 0: de, 1: I } = oe;
+            if (de > w || (de === w && I >= v)) break;
+            A = R(L, A, y, h);
+          }
+          return (
+            h[0] < w ? (X(y, h[0], w), (h[0] = w), (h[1] = 0)) : y.write(o),
+            (h[1] = u(y, v, h[1])),
+            A
+          );
+        }
+        function X(L, A, y) {
+          do L.write(i);
+          while (++A < y);
+        }
+        function fe(L) {
+          let { length: A } = L,
+            y = new H(L),
+            h = [],
+            S = 0,
+            D = 0,
+            B = 0,
+            w = 0,
+            v = 0;
+          do {
+            let $ = y.indexOf(";"),
+              N = [],
+              W = true,
+              V = 0;
+            for (S = 0; y.pos < $; ) {
+              let oe;
+              ((S = l(y, S)),
+                S < V && (W = false),
+                (V = S),
+                f(y, $)
+                  ? ((D = l(y, D)),
+                    (B = l(y, B)),
+                    (w = l(y, w)),
+                    f(y, $)
+                      ? ((v = l(y, v)), (oe = [S, D, B, w, v]))
+                      : (oe = [S, D, B, w]))
+                  : (oe = [S]),
+                N.push(oe),
+                y.pos++);
+            }
+            (W || j(N), h.push(N), (y.pos = $ + 1));
+          } while (y.pos <= A);
+          return h;
+        }
+        function j(L) {
+          L.sort(le);
+        }
+        function le(L, A) {
+          return L[0] - A[0];
+        }
+        function ue(L) {
+          let A = new x(),
+            y = 0,
+            h = 0,
+            S = 0,
+            D = 0;
+          for (let B = 0; B < L.length; B++) {
+            let w = L[B];
+            if ((B > 0 && A.write(i), w.length === 0)) continue;
+            let v = 0;
+            for (let $ = 0; $ < w.length; $++) {
+              let N = w[$];
+              ($ > 0 && A.write(o),
+                (v = u(A, N[0], v)),
+                N.length !== 1 &&
+                  ((y = u(A, N[1], y)),
+                  (h = u(A, N[2], h)),
+                  (S = u(A, N[3], S)),
+                  N.length !== 4 && (D = u(A, N[4], D))));
+            }
+          }
+          return A.flush();
+        }
+        ((n.decode = fe),
+          (n.decodeGeneratedRanges = T),
+          (n.decodeOriginalScopes = Y),
+          (n.encode = ue),
+          (n.encodeGeneratedRanges = C),
+          (n.encodeOriginalScopes = m),
+          Object.defineProperty(n, "__esModule", { value: true }));
+      });
+    }),
+    Qu = fg(wg()),
+    ed = /^[a-zA-Z][a-zA-Z\d+\-.]*:/,
+    xg = /^data:application\/json[^,]+base64,/,
+    vg =
+      /(?:\/\/[@#][ \t]+sourceMappingURL=([^\s'"]+?)[ \t]*$)|(?:\/\*[@#][ \t]+sourceMappingURL=([^*]+?)[ \t]*(?:\*\/)[ \t]*$)/,
+    td = typeof WeakRef < "u",
+    Wr = new Map(),
+    fs = new Map(),
+    Cg = (e) => td && e instanceof WeakRef,
+    Uu = (e, t, n, o) => {
+      if (n < 0 || n >= e.length) return null;
+      let i = e[n];
+      if (!i || i.length === 0) return null;
+      let s = null;
+      for (let f of i)
+        if (f[0] <= o) s = f;
+        else break;
+      if (!s || s.length < 4) return null;
+      let [, r, c, l] = s;
+      if (r === void 0 || c === void 0 || l === void 0) return null;
+      let u = t[r];
+      return u ? { columnNumber: l, fileName: u, lineNumber: c + 1 } : null;
+    },
+    Eg = (e, t, n) => {
+      if (e.sections) {
+        let o = null;
+        for (let r of e.sections)
+          if (
+            t > r.offset.line ||
+            (t === r.offset.line && n >= r.offset.column)
+          )
+            o = r;
+          else break;
+        if (!o) return null;
+        let i = t - o.offset.line,
+          s = t === o.offset.line ? n - o.offset.column : n;
+        return Uu(o.map.mappings, o.map.sources, i, s);
+      }
+      return Uu(e.mappings, e.sources, t - 1, n);
+    },
+    Sg = (e, t) => {
+      let n = t.split(`
+`),
+        o;
+      for (let s = n.length - 1; s >= 0 && !o; s--) {
+        let r = n[s].match(vg);
+        r && (o = r[1] || r[2]);
+      }
+      if (!o) return null;
+      let i = ed.test(o);
+      if (!(xg.test(o) || i || o.startsWith("/"))) {
+        let s = e.split("/");
+        ((s[s.length - 1] = o), (o = s.join("/")));
+      }
+      return o;
+    },
+    Ag = (e) => ({
+      file: e.file,
+      mappings: (0, Qu.decode)(e.mappings),
+      names: e.names,
+      sourceRoot: e.sourceRoot,
+      sources: e.sources,
+      sourcesContent: e.sourcesContent,
+      version: 3,
+    }),
+    Tg = (e) => {
+      let t = e.sections.map(({ map: o, offset: i }) => ({
+          map: { ...o, mappings: (0, Qu.decode)(o.mappings) },
+          offset: i,
+        })),
+        n = new Set();
+      for (let o of t) for (let i of o.map.sources) n.add(i);
+      return {
+        file: e.file,
+        mappings: [],
+        names: [],
+        sections: t,
+        sourceRoot: void 0,
+        sources: Array.from(n),
+        sourcesContent: void 0,
+        version: 3,
+      };
+    },
+    ju = (e) => {
+      if (!e) return false;
+      let t = e.trim();
+      if (!t) return false;
+      let n = t.match(ed);
+      if (!n) return true;
+      let o = n[0].toLowerCase();
+      return o === "http:" || o === "https:";
+    },
+    _g = async (e, t = fetch) => {
+      if (!ju(e)) return null;
+      let n;
+      try {
+        let i = await t(e);
+        if (!i.ok) return null;
+        n = await i.text();
+      } catch {
+        return null;
+      }
+      if (!n) return null;
+      let o = Sg(e, n);
+      if (!o || !ju(o)) return null;
+      try {
+        let i = await t(o);
+        if (!i.ok) return null;
+        let s = await i.json();
+        return "sections" in s ? Tg(s) : Ag(s);
+      } catch {
+        return null;
+      }
+    },
+    Pg = async (e, t = true, n) => {
+      if (t && Wr.has(e)) {
+        let s = Wr.get(e);
+        if (s == null) return null;
+        if (Cg(s)) {
+          let r = s.deref();
+          if (r) return r;
+          Wr.delete(e);
+        } else return s;
+      }
+      if (t && fs.has(e)) return fs.get(e);
+      let o = _g(e, n);
+      t && fs.set(e, o);
+      let i = await o;
+      return (
+        t && fs.delete(e),
+        t &&
+          (i === null ? Wr.set(e, null) : Wr.set(e, td ? new WeakRef(i) : i)),
+        i
+      );
+    },
+    kg = async (e, t = true, n) =>
+      await Promise.all(
+        e.map(async (o) => {
+          if (!o.fileName) return o;
+          let i = await Pg(o.fileName, t, n);
+          if (
+            !i ||
+            typeof o.lineNumber != "number" ||
+            typeof o.columnNumber != "number"
+          )
+            return o;
+          let s = Eg(i, o.lineNumber, o.columnNumber);
+          return s
+            ? {
+                ...o,
+                source:
+                  s.fileName && o.source
+                    ? o.source.replace(o.fileName, s.fileName)
+                    : o.source,
+                fileName: s.fileName,
+                lineNumber: s.lineNumber,
+                columnNumber: s.columnNumber,
+                isSymbolicated: true,
+              }
+            : o;
+        }),
+      ),
+    Qa = (e) =>
+      e._debugStack instanceof Error && typeof e._debugStack?.stack == "string",
+    Og = () => {
+      let e = Wn();
+      for (let t of [...Array.from(mo), ...Array.from(e.renderers.values())]) {
+        let n = t.currentDispatcherRef;
+        if (n && typeof n == "object") return "H" in n ? n.H : n.current;
+      }
+      return null;
+    },
+    Wu = (e) => {
+      for (let t of mo) {
+        let n = t.currentDispatcherRef;
+        n && typeof n == "object" && ("H" in n ? (n.H = e) : (n.current = e));
+      }
+    },
+    On = (e) => `
+    in ${e}`,
+    Mg = (e, t) => {
+      let n = On(e);
+      return (t && (n += ` (at ${t})`), n);
+    },
+    qa = false,
+    Za = (e, t) => {
+      if (!e || qa) return "";
+      let n = Error.prepareStackTrace;
+      ((Error.prepareStackTrace = void 0), (qa = true));
+      let o = Og();
+      Wu(null);
+      let i = console.error,
+        s = console.warn;
+      ((console.error = () => {}), (console.warn = () => {}));
+      try {
+        let l = {
+          DetermineComponentFrameRoot() {
+            let b;
+            try {
+              if (t) {
+                let x = function () {
+                  throw Error();
+                };
+                if (
+                  (Object.defineProperty(x.prototype, "props", {
+                    set: function () {
+                      throw Error();
+                    },
+                  }),
+                  typeof Reflect == "object" && Reflect.construct)
+                ) {
+                  try {
+                    Reflect.construct(x, []);
+                  } catch (H) {
+                    b = H;
+                  }
+                  Reflect.construct(e, [], x);
+                } else {
+                  try {
+                    x.call();
+                  } catch (H) {
+                    b = H;
+                  }
+                  e.call(x.prototype);
+                }
+              } else {
+                try {
+                  throw Error();
+                } catch (H) {
+                  b = H;
+                }
+                let x = e();
+                x && typeof x.catch == "function" && x.catch(() => {});
+              }
+            } catch (x) {
+              if (
+                x instanceof Error &&
+                b instanceof Error &&
+                typeof x.stack == "string"
+              )
+                return [x.stack, b.stack];
+            }
+            return [null, null];
+          },
+        };
+        ((l.DetermineComponentFrameRoot.displayName =
+          "DetermineComponentFrameRoot"),
+          Object.getOwnPropertyDescriptor(l.DetermineComponentFrameRoot, "name")
+            ?.configurable &&
+            Object.defineProperty(l.DetermineComponentFrameRoot, "name", {
+              value: "DetermineComponentFrameRoot",
+            }));
+        let [f, p] = l.DetermineComponentFrameRoot();
+        if (f && p) {
+          let b = f.split(`
+`),
+            x = p.split(`
+`),
+            H = 0,
+            M = 0;
+          for (
+            ;
+            H < b.length && !b[H].includes("DetermineComponentFrameRoot");
+          )
+            H++;
+          for (
+            ;
+            M < x.length && !x[M].includes("DetermineComponentFrameRoot");
+          )
+            M++;
+          if (H === b.length || M === x.length)
+            for (
+              H = b.length - 1, M = x.length - 1;
+              H >= 1 && M >= 0 && b[H] !== x[M];
+            )
+              M--;
+          for (; H >= 1 && M >= 0; H--, M--)
+            if (b[H] !== x[M]) {
+              if (H !== 1 || M !== 1)
+                do
+                  if ((H--, M--, M < 0 || b[H] !== x[M])) {
+                    let Y = `
+${b[H].replace(" at new ", " at ")}`,
+                      m = Kn(e);
+                    return (
+                      m &&
+                        Y.includes("<anonymous>") &&
+                        (Y = Y.replace("<anonymous>", m)),
+                      Y
+                    );
+                  }
+                while (H >= 1 && M >= 0);
+              break;
+            }
+        }
+      } finally {
+        ((qa = false),
+          (Error.prepareStackTrace = n),
+          Wu(o),
+          (console.error = i),
+          (console.warn = s));
+      }
+      let r = e ? Kn(e) : "";
+      return r ? On(r) : "";
+    },
+    Rg = (e, t) => {
+      let n = e.tag,
+        o = "";
+      switch (n) {
+        case Ua:
+          o = On("Activity");
+          break;
+        case cs:
+          o = Za(e.type, true);
+          break;
+        case us:
+          o = Za(e.type.render, false);
+          break;
+        case ls:
+        case ds:
+          o = Za(e.type, false);
+          break;
+        case $a:
+        case Va:
+        case Ga:
+          o = On(e.type);
+          break;
+        case Ba:
+          o = On("Lazy");
+          break;
+        case Ha:
+          o =
+            e.child !== t && t !== null
+              ? On("Suspense Fallback")
+              : On("Suspense");
+          break;
+        case za:
+          o = On("SuspenseList");
+          break;
+        case ja:
+          o = On("ViewTransition");
+          break;
+        default:
+          return "";
+      }
+      return o;
+    },
+    Ig = (e) => {
+      try {
+        let t = "",
+          n = e,
+          o = null;
+        do {
+          t += Rg(n, o);
+          let i = n._debugInfo;
+          if (i && Array.isArray(i))
+            for (let s = i.length - 1; s >= 0; s--) {
+              let r = i[s];
+              typeof r.name == "string" && (t += Mg(r.name, r.env));
+            }
+          ((o = n), (n = n.return));
+        } while (n);
+        return t;
+      } catch (t) {
+        return t instanceof Error
+          ? `
 Error generating stack: ${t.message}
-${t.stack}`:""}},el=e=>{let t=Error.prepareStackTrace;Error.prepareStackTrace=void 0;let n=e;if(!n)return "";Error.prepareStackTrace=t,n.startsWith(`Error: react-stack-top-frame
-`)&&(n=n.slice(29));let o=n.indexOf(`
-`);if(o!==-1&&(n=n.slice(o+1)),o=Math.max(n.indexOf("react_stack_bottom_frame"),n.indexOf("react-stack-bottom-frame")),o!==-1&&(o=n.lastIndexOf(`
-`,o)),o!==-1)n=n.slice(0,o);else return "";return n},Ng=e=>!!(e.fileName?.startsWith("rsc://")&&e.functionName),Lg=(e,t)=>e.fileName===t.fileName&&e.lineNumber===t.lineNumber&&e.columnNumber===t.columnNumber,Dg=e=>{let t=new Map;for(let n of e)for(let o of n.stackFrames){if(!Ng(o))continue;let i=o.functionName,s=t.get(i)??[];s.some(c=>Lg(c,o))||(s.push(o),t.set(i,s));}return t},Fg=(e,t,n)=>{if(!e.functionName)return {...e,isServer:true};let o=t.get(e.functionName);if(!o||o.length===0)return {...e,isServer:true};let i=n.get(e.functionName)??0,s=o[i%o.length];return n.set(e.functionName,i+1),{...e,isServer:true,fileName:s.fileName,lineNumber:s.lineNumber,columnNumber:s.columnNumber,source:e.source?.replace(qu,`(${s.fileName}:${s.lineNumber}:${s.columnNumber})`)}},$g=e=>{let t=[];return Qo(e,n=>{if(!Qa(n))return;let o=typeof n.type=="string"?n.type:Kn(n.type)||"<anonymous>";t.push({componentName:o,stackFrames:ms(el(n._debugStack?.stack))});},true),t},nd=async(e,t=true,n)=>{let o=$g(e),i=ms(Ig(e)),s=Dg(o),r=new Map,c=i.map(u=>u.source?.includes(qu)??false?Fg(u,s,r):u),l=c.filter((u,f,p)=>{if(f===0)return  true;let b=p[f-1];return u.functionName!==b.functionName});return kg(l,t,n)};var Ku=e=>e.split("/").filter(Boolean).length,Hg=e=>e.split("/").filter(Boolean)[0]??null,Bg=e=>{let t=e.indexOf("/",1);if(t===-1)return e;let n=e.slice(0,t);if(Ku(n)!==1)return e;let o=e.slice(t);if(!Yu.test(o)||Ku(o)<2)return e;let i=Hg(o);return !i||i.startsWith("@")||i.length>4?e:o},go=e=>{if(!e||pg.some(s=>s===e))return "";let t=e,n=t.startsWith("http://")||t.startsWith("https://");if(n)try{t=new URL(t).pathname;}catch{}if(n&&(t=Bg(t)),t.startsWith(zu)){let s=t.slice(zu.length),r=s.indexOf("/"),c=s.indexOf(":");t=r!==-1&&(c===-1||r<c)?s.slice(r+1):s;}let o=true;for(;o;){o=false;for(let s of mg)if(t.startsWith(s)){t=t.slice(s.length),s==="file:///"&&(t=`/${t.replace(/^\/+/,"")}`),o=true;break}}if(Bu.test(t)){let s=t.match(Bu);s&&(t=t.slice(s[0].length));}if(t.startsWith("//")){let s=t.indexOf("/",2);t=s===-1?"":t.slice(s);}let i=t.indexOf("?");if(i!==-1){let s=t.slice(i);hg.test(s)&&(t=t.slice(0,i));}return t},ho=e=>{let t=go(e);return !(!t||!Yu.test(t)||gg.test(t))};var od=e=>e.length>0&&/^[A-Z]/.test(e);Fa();var ps=(e,t)=>e.length>t?`${e.slice(0,t)}...`:e;var zg=new Set(["_","$","motion.","styled.","chakra.","ark.","Primitive.","Slot."]),Vg=new Set(["InnerLayoutRouter","RedirectErrorBoundary","RedirectBoundary","HTTPAccessFallbackErrorBoundary","HTTPAccessFallbackBoundary","LoadingBoundary","ErrorBoundary","InnerScrollAndFocusHandler","ScrollAndFocusHandler","RenderFromTemplateContext","OuterLayoutRouter","body","html","DevRootHTTPAccessFallbackBoundary","AppDevOverlayErrorBoundary","AppDevOverlay","HotReload","Router","ErrorBoundaryHandler","AppRouter","ServerRoot","SegmentStateProvider","RootErrorBoundary","LoadableComponent","MotionDOMComponent"]),Gg=new Set(["Suspense","Fragment","StrictMode","Profiler","SuspenseList"]),tl,tr=e=>(e&&(tl=void 0),tl??=typeof document<"u"&&!!(document.getElementById("__NEXT_DATA__")||document.querySelector("nextjs-portal")),tl),id=e=>{if(Vg.has(e)||Gg.has(e))return  true;for(let t of zg)if(e.startsWith(t))return  true;return  false},er=e=>!(e.length<=1||id(e)||!od(e)||e.startsWith("Primitive.")||e.includes("Provider")&&e.includes("Context")),sd=["about://React/","rsc://React/"],Ug=e=>sd.some(t=>e.startsWith(t)),jg=e=>{for(let t of sd){if(!e.startsWith(t))continue;let n=e.indexOf("/",t.length),o=e.lastIndexOf("?");if(n>-1&&o>-1)return decodeURI(e.slice(n+1,o))}return e},Wg=async e=>{let t=[],n=[];for(let s=0;s<e.length;s++){let r=e[s];!r.isServer||!r.fileName||(t.push(s),n.push({file:jg(r.fileName),methodName:r.functionName??"<unknown>",line1:r.lineNumber??null,column1:r.columnNumber??null,arguments:[]}));}if(n.length===0)return e;let o=new AbortController,i=setTimeout(()=>o.abort(),Kc);try{let s=await fetch("/__nextjs_original-stack-frames",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({frames:n,isServer:!0,isEdgeServer:!1,isAppDirectory:!0}),signal:o.signal});if(!s.ok)return e;let r=await s.json(),c=[...e];for(let l=0;l<t.length;l++){let u=r[l];if(u?.status!=="fulfilled")continue;let f=u.value?.originalStackFrame;if(!f?.file||f.ignored)continue;let p=t[l];c[p]={...e[p],fileName:f.file,lineNumber:f.line1??void 0,columnNumber:f.column1??void 0,isSymbolicated:!0};}return c}catch{return e}finally{clearTimeout(i);}},Kg=e=>{let t=new Map;return Qo(e,n=>{if(!Qa(n))return  false;let o=el(n._debugStack.stack);if(!o)return  false;for(let i of ms(o))!i.functionName||!i.fileName||Ug(i.fileName)&&(t.has(i.functionName)||t.set(i.functionName,{...i,isServer:true}));return  false},true),t},Xg=(e,t)=>{if(!t.some(i=>i.isServer&&!i.fileName&&i.functionName))return t;let o=Kg(e);return o.size===0?t:t.map(i=>{if(!i.isServer||i.fileName||!i.functionName)return i;let s=o.get(i.functionName);return s?{...i,fileName:s.fileName,lineNumber:s.lineNumber,columnNumber:s.columnNumber}:i})},rd=new WeakMap,Yg=async e=>{try{let t=po(e);if(!t)return null;let n=await nd(t);if(tr()){let o=Xg(t,n);return await Wg(o)}return n}catch{return null}},Mn=e=>{if(!Xn())return Promise.resolve([]);let t=rd.get(e);if(t)return t;let n=Yg(e);return rd.set(e,n),n},nr=async e=>{if(!Xn())return null;let t=await Mn(e);if(!t)return null;for(let n of t)if(n.functionName&&er(n.functionName))return n.functionName;return null},nl=e=>{if(!e||e.length===0)return null;for(let t of e)if(t.fileName&&ho(t.fileName))return {filePath:go(t.fileName),lineNumber:t.lineNumber,componentName:t.functionName&&er(t.functionName)?t.functionName:null};return null},ad=e=>!(!e||id(e)||e.startsWith("Primitive.")||e==="SlotClone"||e==="Slot"),Kr=e=>{if(!Xn())return null;let t=po(e);if(!t)return null;let n=t.return;for(;n;){if(Jo(n)){let o=Kn(n.type);if(o&&ad(o))return o}n=n.return;}return null},qg=e=>e?e.some(t=>t.isServer||t.fileName&&ho(t.fileName)):false,Zg=(e,t)=>{if(!Xn())return [];let n=po(e);if(!n)return [];let o=[];return Qo(n,i=>{if(o.length>=t)return  true;if(Jo(i)){let s=Kn(i.type);s&&ad(s)&&o.push(s);}return  false},true),o},Jg=(e,t={})=>{let{maxLines:n=3}=t,o=tr(),i=[];for(let s of e){if(i.length>=n)break;let r=s.fileName&&ho(s.fileName);if(s.isServer&&!r&&(!s.functionName||er(s.functionName))){i.push(`
-  in ${s.functionName||"<anonymous>"} (at Server)`);continue}if(r){let c=`
-  in `,l=s.functionName&&er(s.functionName);l&&(c+=`${s.functionName} (at `),c+=go(s.fileName),o&&s.lineNumber&&s.columnNumber&&(c+=`:${s.lineNumber}:${s.columnNumber}`),l&&(c+=")"),i.push(c);}}return i.join("")},ol=async(e,t={})=>{let n=t.maxLines??3,o=await Mn(e);if(o&&qg(o))return Jg(o,t);let i=Zg(e,n);return i.length>0?i.map(s=>`
-  in ${s}`).join(""):""},gs=async(e,t={})=>{let n=eh(e),o=await ol(e,t);return o?`${n}${o}`:Qg(e)},Qg=e=>{let t=pt(e);if(!(e instanceof HTMLElement)){let s=cd(e,{truncate:false,maxAttrs:va.length});return `<${t}${s} />`}let n=e.innerText?.trim()??e.textContent?.trim()??"",o="";for(let{name:s,value:r}of e.attributes)o+=` ${s}="${r}"`;let i=ps(n,$r);return i.length>0?`<${t}${o}>
+${t.stack}`
+          : "";
+      }
+    },
+    el = (e) => {
+      let t = Error.prepareStackTrace;
+      Error.prepareStackTrace = void 0;
+      let n = e;
+      if (!n) return "";
+      ((Error.prepareStackTrace = t),
+        n.startsWith(`Error: react-stack-top-frame
+`) && (n = n.slice(29)));
+      let o = n.indexOf(`
+`);
+      if (
+        (o !== -1 && (n = n.slice(o + 1)),
+        (o = Math.max(
+          n.indexOf("react_stack_bottom_frame"),
+          n.indexOf("react-stack-bottom-frame"),
+        )),
+        o !== -1 &&
+          (o = n.lastIndexOf(
+            `
+`,
+            o,
+          )),
+        o !== -1)
+      )
+        n = n.slice(0, o);
+      else return "";
+      return n;
+    },
+    Ng = (e) => !!(e.fileName?.startsWith("rsc://") && e.functionName),
+    Lg = (e, t) =>
+      e.fileName === t.fileName &&
+      e.lineNumber === t.lineNumber &&
+      e.columnNumber === t.columnNumber,
+    Dg = (e) => {
+      let t = new Map();
+      for (let n of e)
+        for (let o of n.stackFrames) {
+          if (!Ng(o)) continue;
+          let i = o.functionName,
+            s = t.get(i) ?? [];
+          s.some((c) => Lg(c, o)) || (s.push(o), t.set(i, s));
+        }
+      return t;
+    },
+    Fg = (e, t, n) => {
+      if (!e.functionName) return { ...e, isServer: true };
+      let o = t.get(e.functionName);
+      if (!o || o.length === 0) return { ...e, isServer: true };
+      let i = n.get(e.functionName) ?? 0,
+        s = o[i % o.length];
+      return (
+        n.set(e.functionName, i + 1),
+        {
+          ...e,
+          isServer: true,
+          fileName: s.fileName,
+          lineNumber: s.lineNumber,
+          columnNumber: s.columnNumber,
+          source: e.source?.replace(
+            qu,
+            `(${s.fileName}:${s.lineNumber}:${s.columnNumber})`,
+          ),
+        }
+      );
+    },
+    $g = (e) => {
+      let t = [];
+      return (
+        Qo(
+          e,
+          (n) => {
+            if (!Qa(n)) return;
+            let o =
+              typeof n.type == "string" ? n.type : Kn(n.type) || "<anonymous>";
+            t.push({
+              componentName: o,
+              stackFrames: ms(el(n._debugStack?.stack)),
+            });
+          },
+          true,
+        ),
+        t
+      );
+    },
+    nd = async (e, t = true, n) => {
+      let o = $g(e),
+        i = ms(Ig(e)),
+        s = Dg(o),
+        r = new Map(),
+        c = i.map((u) => ((u.source?.includes(qu) ?? false) ? Fg(u, s, r) : u)),
+        l = c.filter((u, f, p) => {
+          if (f === 0) return true;
+          let b = p[f - 1];
+          return u.functionName !== b.functionName;
+        });
+      return kg(l, t, n);
+    };
+  var Ku = (e) => e.split("/").filter(Boolean).length,
+    Hg = (e) => e.split("/").filter(Boolean)[0] ?? null,
+    Bg = (e) => {
+      let t = e.indexOf("/", 1);
+      if (t === -1) return e;
+      let n = e.slice(0, t);
+      if (Ku(n) !== 1) return e;
+      let o = e.slice(t);
+      if (!Yu.test(o) || Ku(o) < 2) return e;
+      let i = Hg(o);
+      return !i || i.startsWith("@") || i.length > 4 ? e : o;
+    },
+    go = (e) => {
+      if (!e || pg.some((s) => s === e)) return "";
+      let t = e,
+        n = t.startsWith("http://") || t.startsWith("https://");
+      if (n)
+        try {
+          t = new URL(t).pathname;
+        } catch {}
+      if ((n && (t = Bg(t)), t.startsWith(zu))) {
+        let s = t.slice(zu.length),
+          r = s.indexOf("/"),
+          c = s.indexOf(":");
+        t = r !== -1 && (c === -1 || r < c) ? s.slice(r + 1) : s;
+      }
+      let o = true;
+      for (; o; ) {
+        o = false;
+        for (let s of mg)
+          if (t.startsWith(s)) {
+            ((t = t.slice(s.length)),
+              s === "file:///" && (t = `/${t.replace(/^\/+/, "")}`),
+              (o = true));
+            break;
+          }
+      }
+      if (Bu.test(t)) {
+        let s = t.match(Bu);
+        s && (t = t.slice(s[0].length));
+      }
+      if (t.startsWith("//")) {
+        let s = t.indexOf("/", 2);
+        t = s === -1 ? "" : t.slice(s);
+      }
+      let i = t.indexOf("?");
+      if (i !== -1) {
+        let s = t.slice(i);
+        hg.test(s) && (t = t.slice(0, i));
+      }
+      return t;
+    },
+    ho = (e) => {
+      let t = go(e);
+      return !(!t || !Yu.test(t) || gg.test(t));
+    };
+  var od = (e) => e.length > 0 && /^[A-Z]/.test(e);
+  Fa();
+  var ps = (e, t) => (e.length > t ? `${e.slice(0, t)}...` : e);
+  var zg = new Set([
+      "_",
+      "$",
+      "motion.",
+      "styled.",
+      "chakra.",
+      "ark.",
+      "Primitive.",
+      "Slot.",
+    ]),
+    Vg = new Set([
+      "InnerLayoutRouter",
+      "RedirectErrorBoundary",
+      "RedirectBoundary",
+      "HTTPAccessFallbackErrorBoundary",
+      "HTTPAccessFallbackBoundary",
+      "LoadingBoundary",
+      "ErrorBoundary",
+      "InnerScrollAndFocusHandler",
+      "ScrollAndFocusHandler",
+      "RenderFromTemplateContext",
+      "OuterLayoutRouter",
+      "body",
+      "html",
+      "DevRootHTTPAccessFallbackBoundary",
+      "AppDevOverlayErrorBoundary",
+      "AppDevOverlay",
+      "HotReload",
+      "Router",
+      "ErrorBoundaryHandler",
+      "AppRouter",
+      "ServerRoot",
+      "SegmentStateProvider",
+      "RootErrorBoundary",
+      "LoadableComponent",
+      "MotionDOMComponent",
+    ]),
+    Gg = new Set([
+      "Suspense",
+      "Fragment",
+      "StrictMode",
+      "Profiler",
+      "SuspenseList",
+    ]),
+    tl,
+    tr = (e) => (
+      e && (tl = void 0),
+      (tl ??=
+        typeof document < "u" &&
+        !!(
+          document.getElementById("__NEXT_DATA__") ||
+          document.querySelector("nextjs-portal")
+        )),
+      tl
+    ),
+    id = (e) => {
+      if (Vg.has(e) || Gg.has(e)) return true;
+      for (let t of zg) if (e.startsWith(t)) return true;
+      return false;
+    },
+    er = (e) =>
+      !(
+        e.length <= 1 ||
+        id(e) ||
+        !od(e) ||
+        e.startsWith("Primitive.") ||
+        (e.includes("Provider") && e.includes("Context"))
+      ),
+    sd = ["about://React/", "rsc://React/"],
+    Ug = (e) => sd.some((t) => e.startsWith(t)),
+    jg = (e) => {
+      for (let t of sd) {
+        if (!e.startsWith(t)) continue;
+        let n = e.indexOf("/", t.length),
+          o = e.lastIndexOf("?");
+        if (n > -1 && o > -1) return decodeURI(e.slice(n + 1, o));
+      }
+      return e;
+    },
+    Wg = async (e) => {
+      let t = [],
+        n = [];
+      for (let s = 0; s < e.length; s++) {
+        let r = e[s];
+        !r.isServer ||
+          !r.fileName ||
+          (t.push(s),
+          n.push({
+            file: jg(r.fileName),
+            methodName: r.functionName ?? "<unknown>",
+            line1: r.lineNumber ?? null,
+            column1: r.columnNumber ?? null,
+            arguments: [],
+          }));
+      }
+      if (n.length === 0) return e;
+      let o = new AbortController(),
+        i = setTimeout(() => o.abort(), Kc);
+      try {
+        let s = await fetch("/__nextjs_original-stack-frames", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            frames: n,
+            isServer: !0,
+            isEdgeServer: !1,
+            isAppDirectory: !0,
+          }),
+          signal: o.signal,
+        });
+        if (!s.ok) return e;
+        let r = await s.json(),
+          c = [...e];
+        for (let l = 0; l < t.length; l++) {
+          let u = r[l];
+          if (u?.status !== "fulfilled") continue;
+          let f = u.value?.originalStackFrame;
+          if (!f?.file || f.ignored) continue;
+          let p = t[l];
+          c[p] = {
+            ...e[p],
+            fileName: f.file,
+            lineNumber: f.line1 ?? void 0,
+            columnNumber: f.column1 ?? void 0,
+            isSymbolicated: !0,
+          };
+        }
+        return c;
+      } catch {
+        return e;
+      } finally {
+        clearTimeout(i);
+      }
+    },
+    Kg = (e) => {
+      let t = new Map();
+      return (
+        Qo(
+          e,
+          (n) => {
+            if (!Qa(n)) return false;
+            let o = el(n._debugStack.stack);
+            if (!o) return false;
+            for (let i of ms(o))
+              !i.functionName ||
+                !i.fileName ||
+                (Ug(i.fileName) &&
+                  (t.has(i.functionName) ||
+                    t.set(i.functionName, { ...i, isServer: true })));
+            return false;
+          },
+          true,
+        ),
+        t
+      );
+    },
+    Xg = (e, t) => {
+      if (!t.some((i) => i.isServer && !i.fileName && i.functionName)) return t;
+      let o = Kg(e);
+      return o.size === 0
+        ? t
+        : t.map((i) => {
+            if (!i.isServer || i.fileName || !i.functionName) return i;
+            let s = o.get(i.functionName);
+            return s
+              ? {
+                  ...i,
+                  fileName: s.fileName,
+                  lineNumber: s.lineNumber,
+                  columnNumber: s.columnNumber,
+                }
+              : i;
+          });
+    },
+    rd = new WeakMap(),
+    Yg = async (e) => {
+      try {
+        let t = po(e);
+        if (!t) return null;
+        let n = await nd(t);
+        if (tr()) {
+          let o = Xg(t, n);
+          return await Wg(o);
+        }
+        return n;
+      } catch {
+        return null;
+      }
+    },
+    Mn = (e) => {
+      if (!Xn()) return Promise.resolve([]);
+      let t = rd.get(e);
+      if (t) return t;
+      let n = Yg(e);
+      return (rd.set(e, n), n);
+    },
+    nr = async (e) => {
+      if (!Xn()) return null;
+      let t = await Mn(e);
+      if (!t) return null;
+      for (let n of t)
+        if (n.functionName && er(n.functionName)) return n.functionName;
+      return null;
+    },
+    nl = (e) => {
+      if (!e || e.length === 0) return null;
+      for (let t of e)
+        if (t.fileName && ho(t.fileName))
+          return {
+            filePath: go(t.fileName),
+            lineNumber: t.lineNumber,
+            componentName:
+              t.functionName && er(t.functionName) ? t.functionName : null,
+          };
+      return null;
+    },
+    ad = (e) =>
+      !(
+        !e ||
+        id(e) ||
+        e.startsWith("Primitive.") ||
+        e === "SlotClone" ||
+        e === "Slot"
+      ),
+    Kr = (e) => {
+      if (!Xn()) return null;
+      let t = po(e);
+      if (!t) return null;
+      let n = t.return;
+      for (; n; ) {
+        if (Jo(n)) {
+          let o = Kn(n.type);
+          if (o && ad(o)) return o;
+        }
+        n = n.return;
+      }
+      return null;
+    },
+    qg = (e) =>
+      e ? e.some((t) => t.isServer || (t.fileName && ho(t.fileName))) : false,
+    Zg = (e, t) => {
+      if (!Xn()) return [];
+      let n = po(e);
+      if (!n) return [];
+      let o = [];
+      return (
+        Qo(
+          n,
+          (i) => {
+            if (o.length >= t) return true;
+            if (Jo(i)) {
+              let s = Kn(i.type);
+              s && ad(s) && o.push(s);
+            }
+            return false;
+          },
+          true,
+        ),
+        o
+      );
+    },
+    Jg = (e, t = {}) => {
+      let { maxLines: n = 3 } = t,
+        o = tr(),
+        i = [];
+      for (let s of e) {
+        if (i.length >= n) break;
+        let r = s.fileName && ho(s.fileName);
+        if (s.isServer && !r && (!s.functionName || er(s.functionName))) {
+          i.push(`
+  in ${s.functionName || "<anonymous>"} (at Server)`);
+          continue;
+        }
+        if (r) {
+          let c = `
+  in `,
+            l = s.functionName && er(s.functionName);
+          (l && (c += `${s.functionName} (at `),
+            (c += go(s.fileName)),
+            o &&
+              s.lineNumber &&
+              s.columnNumber &&
+              (c += `:${s.lineNumber}:${s.columnNumber}`),
+            l && (c += ")"),
+            i.push(c));
+        }
+      }
+      return i.join("");
+    },
+    ol = async (e, t = {}) => {
+      let n = t.maxLines ?? 3,
+        o = await Mn(e);
+      if (o && qg(o)) return Jg(o, t);
+      let i = Zg(e, n);
+      return i.length > 0
+        ? i
+            .map(
+              (s) => `
+  in ${s}`,
+            )
+            .join("")
+        : "";
+    },
+    gs = async (e, t = {}) => {
+      let n = eh(e),
+        o = await ol(e, t);
+      return o ? `${n}${o}` : Qg(e);
+    },
+    Qg = (e) => {
+      let t = pt(e);
+      if (!(e instanceof HTMLElement)) {
+        let s = cd(e, { truncate: false, maxAttrs: va.length });
+        return `<${t}${s} />`;
+      }
+      let n = e.innerText?.trim() ?? e.textContent?.trim() ?? "",
+        o = "";
+      for (let { name: s, value: r } of e.attributes) o += ` ${s}="${r}"`;
+      let i = ps(n, $r);
+      return i.length > 0
+        ? `<${t}${o}>
   ${i}
-</${t}>`:`<${t}${o} />`},ld=e=>ps(e,jc),cd=(e,t={})=>{let{truncate:n=true,maxAttrs:o=Wc}=t,i=[];for(let s of va){if(i.length>=o)break;let r=e.getAttribute(s);if(r){let c=n?ld(r):r;i.push(`${s}="${c}"`);}}return i.length>0?` ${i.join(" ")}`:""},eh=e=>{let t=pt(e);if(!(e instanceof HTMLElement)){let b=cd(e);return `<${t}${b} />`}let n=e.innerText?.trim()??e.textContent?.trim()??"",o="";for(let{name:b,value:x}of e.attributes)o+=` ${b}="${ld(x)}"`;let i=[],s=[],r=false,c=Array.from(e.childNodes);for(let b of c)b.nodeType!==Node.COMMENT_NODE&&(b.nodeType===Node.TEXT_NODE?b.textContent&&b.textContent.trim().length>0&&(r=true):b instanceof Element&&(r?s.push(b):i.push(b)));let l=b=>b.length===0?"":b.length<=2?b.map(x=>`<${pt(x)} ...>`).join(`
-  `):`(${b.length} elements)`,u="",f=l(i);f&&(u+=`
-  ${f}`),n.length>0&&(u+=`
-  ${ps(n,$r)}`);let p=l(s);return p&&(u+=`
-  ${p}`),u.length>0?`<${t}${o}>${u}
-</${t}>`:`<${t}${o} />`};var th="https://react-grab.com",ud=(e,t)=>{let n=t?`&line=${t}`:"";return `${th}/open-file?url=${encodeURIComponent(e)}${n}`};var nh=async(e,t)=>{let n=tr(),o=new URLSearchParams({file:e}),i=n?"line1":"line",s=n?"column1":"column";return t&&o.set(i,String(t)),o.set(s,"1"),(await fetch(`${n?"/__nextjs_launch-editor":"/__open-in-editor"}?${o}`)).ok},or=async(e,t,n)=>{if(await nh(e,t).catch(()=>false))return;let i=ud(e,t),s=n?n(i,e,t):i;window.open(s,"_blank","noopener,noreferrer");};var rr=(e,t,n)=>e+(t-e)*n;var rh=K("<canvas data-react-grab-overlay-canvas style=position:fixed;top:0;left:0;pointer-events:none>"),Yn={drag:{borderColor:Hc,fillColor:Bc,lerpFactor:.7},selection:{borderColor:es,fillColor:ts,lerpFactor:.95},grabbed:{borderColor:es,fillColor:ts,lerpFactor:.95},processing:{borderColor:es,fillColor:ts,lerpFactor:.95}},md=e=>{let t,n=null,o=0,i=0,s=1,r=null,c={crosshair:{canvas:null,context:null},drag:{canvas:null,context:null},selection:{canvas:null,context:null},grabbed:{canvas:null,context:null},processing:{canvas:null,context:null}},l={x:0,y:0},u=[],f=null,p=[],b=[],x=(h,S,D)=>{let B=new OffscreenCanvas(h*D,S*D),w=B.getContext("2d");return w&&w.scale(D,D),{canvas:B,context:w}},H=()=>{if(t){s=Math.max(window.devicePixelRatio||1,2),o=window.innerWidth,i=window.innerHeight,t.width=o*s,t.height=i*s,t.style.width=`${o}px`,t.style.height=`${i}px`,n=t.getContext("2d"),n&&n.scale(s,s);for(let h of Object.keys(c))c[h]=x(o,i,s);}},M=h=>{if(!h)return 0;let S=h.match(/^(\d+(?:\.\d+)?)/);return S?parseFloat(S[1]):0},Y=(h,S,D)=>({id:h,current:{x:S.x,y:S.y,width:S.width,height:S.height},target:{x:S.x,y:S.y,width:S.width,height:S.height},borderRadius:M(S.borderRadius),opacity:D?.opacity??1,targetOpacity:D?.targetOpacity??D?.opacity??1,createdAt:D?.createdAt,isInitialized:true}),m=(h,S,D)=>{h.target={x:S.x,y:S.y,width:S.width,height:S.height},h.borderRadius=M(S.borderRadius),D!==void 0&&(h.targetOpacity=D);},E=h=>h.boundsMultiple??[h.bounds],T=(h,S,D,B,w,v,$,N,W=1)=>{if(B<=0||w<=0)return;let V=Math.min(B/2,w/2),oe=Math.min(v,V);h.globalAlpha=W,h.beginPath(),oe>0?h.roundRect(S,D,B,w,oe):h.rect(S,D,B,w),h.fillStyle=$,h.fill(),h.strokeStyle=N,h.lineWidth=1,h.stroke(),h.globalAlpha=1;},C=()=>{let h=c.crosshair;if(!h.context)return;let S=h.context;S.clearRect(0,0,o,i),e.crosshairVisible&&(S.strokeStyle=$c,S.lineWidth=1,S.beginPath(),S.moveTo(l.x,0),S.lineTo(l.x,i),S.moveTo(0,l.y),S.lineTo(o,l.y),S.stroke());},R=()=>{let h=c.drag;if(!h.context)return;let S=h.context;if(S.clearRect(0,0,o,i),!e.dragVisible||!f)return;let D=Yn.drag;T(S,f.current.x,f.current.y,f.current.width,f.current.height,f.borderRadius,D.fillColor,D.borderColor);},X=()=>{let h=c.selection;if(!h.context)return;let S=h.context;if(S.clearRect(0,0,o,i),!e.selectionVisible)return;let D=Yn.selection;for(let B of u){let w=e.selectionIsFading?0:B.opacity;T(S,B.current.x,B.current.y,B.current.width,B.current.height,B.borderRadius,D.fillColor,D.borderColor,w);}},fe=()=>{let h=c.grabbed;if(!h.context)return;let S=h.context;S.clearRect(0,0,o,i);let D=Yn.grabbed;for(let B of p)T(S,B.current.x,B.current.y,B.current.width,B.current.height,B.borderRadius,D.fillColor,D.borderColor,B.opacity);},j=()=>{let h=c.processing;if(!h.context)return;let S=h.context;S.clearRect(0,0,o,i);let D=Yn.processing;for(let B of b)T(S,B.current.x,B.current.y,B.current.width,B.current.height,B.borderRadius,D.fillColor,D.borderColor,B.opacity);},le=()=>{if(!n||!t)return;n.setTransform(1,0,0,1,0,0),n.clearRect(0,0,t.width,t.height),n.setTransform(s,0,0,s,0,0),C(),R(),X(),fe(),j();let h=["crosshair","drag","selection","grabbed","processing"];for(let S of h){let D=c[S];D.canvas&&n.drawImage(D.canvas,0,0,o,i);}},ue=(h,S,D)=>{let B=rr(h.current.x,h.target.x,S),w=rr(h.current.y,h.target.y,S),v=rr(h.current.width,h.target.width,S),$=rr(h.current.height,h.target.height,S),N=Math.abs(B-h.target.x)<.5&&Math.abs(w-h.target.y)<.5&&Math.abs(v-h.target.width)<.5&&Math.abs($-h.target.height)<.5;h.current.x=N?h.target.x:B,h.current.y=N?h.target.y:w,h.current.width=N?h.target.width:v,h.current.height=N?h.target.height:$;let W=true;if(D?.interpolateOpacity){let V=rr(h.opacity,h.targetOpacity,S);W=Math.abs(V-h.targetOpacity)<.01,h.opacity=W?h.targetOpacity:V;}return !N||!W},L=()=>{let h=false;f?.isInitialized&&ue(f,Yn.drag.lerpFactor)&&(h=true);for(let D of u)D.isInitialized&&ue(D,Yn.selection.lerpFactor)&&(h=true);let S=Date.now();p=p.filter(D=>{let B=D.id.startsWith("label-");if(D.isInitialized&&ue(D,Yn.grabbed.lerpFactor,{interpolateOpacity:B})&&(h=true),D.createdAt){let w=S-D.createdAt,v=1600;if(w>=v)return  false;if(w>1500){let $=(w-1500)/100;D.opacity=1-$,h=true;}return  true}return B?!(Math.abs(D.opacity-D.targetOpacity)<.01&&D.targetOpacity===0):D.opacity>0});for(let D of b)D.isInitialized&&ue(D,Yn.processing.lerpFactor)&&(h=true);le(),h?r=Ve(L):r=null;},A=()=>{r===null&&(r=Ve(L));},y=()=>{H(),A();};return be(He(()=>[e.mouseX,e.mouseY],([h,S])=>{let D=h??0,B=S??0;l.x=D,l.y=B,A();})),be(He(()=>e.crosshairVisible,()=>{A();})),be(He(()=>[e.selectionVisible,e.selectionBounds,e.selectionBoundsMultiple,e.selectionIsFading,e.selectionShouldSnap],([h,S,D,,B])=>{if(!h||!S&&(!D||D.length===0)){u=[],A();return}u=(D&&D.length>0?D:S?[S]:[]).map((v,$)=>{let N=`selection-${$}`,W=u.find(V=>V.id===N);return W?(m(W,v),B&&(W.current={...W.target}),W):Y(N,v)}),A();})),be(He(()=>[e.dragVisible,e.dragBounds],([h,S])=>{if(!h||!S){f=null,A();return}f?m(f,S):f=Y("drag",S),A();})),be(He(()=>e.grabbedBoxes,h=>{let S=h??[],D=new Set(S.map(w=>w.id)),B=new Set(p.map(w=>w.id));for(let w of S)B.has(w.id)||p.push(Y(w.id,w.bounds,{createdAt:w.createdAt}));for(let w of p){let v=S.find($=>$.id===w.id);v&&m(w,v.bounds);}p=p.filter(w=>w.id.startsWith("label-")?true:D.has(w.id)),A();})),be(He(()=>e.agentSessions,h=>{if(!h||h.size===0){b=[],A();return}let S=[];for(let[D,B]of h)for(let w=0;w<B.selectionBounds.length;w++){let v=B.selectionBounds[w],$=`processing-${D}-${w}`,N=b.find(W=>W.id===$);N?(m(N,v),S.push(N)):S.push(Y($,v));}b=S,A();})),be(He(()=>e.labelInstances,h=>{let S=h??[];for(let B of S){let w=E(B),v=B.status==="fading"?0:1;for(let $=0;$<w.length;$++){let N=w[$],W=`label-${B.id}-${$}`,V=p.find(oe=>oe.id===W);V?m(V,N,v):p.push(Y(W,N,{opacity:1,targetOpacity:v}));}}let D=new Set;for(let B of S){let w=E(B);for(let v=0;v<w.length;v++)D.add(`label-${B.id}-${v}`);}p=p.filter(B=>B.id.startsWith("label-")?D.has(B.id):true),A();})),mt(()=>{H(),A(),window.addEventListener("resize",y);let h=null,S=()=>{Math.max(window.devicePixelRatio||1,2)!==s&&(y(),D());},D=()=>{h&&h.removeEventListener("change",S),h=window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`),h.addEventListener("change",S);};D(),Me(()=>{window.removeEventListener("resize",y),h&&h.removeEventListener("change",S),r!==null&&Ge(r);});}),(()=>{var h=rh(),S=t;return typeof S=="function"?Ke(S,h):t=h,te(D=>we(h,"z-index",String(2147483645))),h})()};var bs=e=>{if(e<=0)return Un;let t=e*Uc;return Math.max(Gc,Math.min(Un,t))};function pd(e){var t,n,o="";if(typeof e=="string"||typeof e=="number")o+=e;else if(typeof e=="object")if(Array.isArray(e)){var i=e.length;for(t=0;t<i;t++)e[t]&&(n=pd(e[t]))&&(o&&(o+=" "),o+=n);}else for(n in e)e[n]&&(o&&(o+=" "),o+=n);return o}function gd(){for(var e,t,n=0,o="",i=arguments.length;n<i;n++)(e=arguments[n])&&(t=pd(e))&&(o&&(o+=" "),o+=t);return o}var ll="-",ih=e=>{let t=ah(e),{conflictingClassGroups:n,conflictingClassGroupModifiers:o}=e;return {getClassGroupId:r=>{let c=r.split(ll);return c[0]===""&&c.length!==1&&c.shift(),yd(c,t)||sh(r)},getConflictingClassGroupIds:(r,c)=>{let l=n[r]||[];return c&&o[r]?[...l,...o[r]]:l}}},yd=(e,t)=>{if(e.length===0)return t.classGroupId;let n=e[0],o=t.nextPart.get(n),i=o?yd(e.slice(1),o):void 0;if(i)return i;if(t.validators.length===0)return;let s=e.join(ll);return t.validators.find(({validator:r})=>r(s))?.classGroupId},hd=/^\[(.+)\]$/,sh=e=>{if(hd.test(e)){let t=hd.exec(e)[1],n=t?.substring(0,t.indexOf(":"));if(n)return "arbitrary.."+n}},ah=e=>{let{theme:t,prefix:n}=e,o={nextPart:new Map,validators:[]};return ch(Object.entries(e.classGroups),n).forEach(([s,r])=>{al(r,o,s,t);}),o},al=(e,t,n,o)=>{e.forEach(i=>{if(typeof i=="string"){let s=i===""?t:bd(t,i);s.classGroupId=n;return}if(typeof i=="function"){if(lh(i)){al(i(o),t,n,o);return}t.validators.push({validator:i,classGroupId:n});return}Object.entries(i).forEach(([s,r])=>{al(r,bd(t,s),n,o);});});},bd=(e,t)=>{let n=e;return t.split(ll).forEach(o=>{n.nextPart.has(o)||n.nextPart.set(o,{nextPart:new Map,validators:[]}),n=n.nextPart.get(o);}),n},lh=e=>e.isThemeGetter,ch=(e,t)=>t?e.map(([n,o])=>{let i=o.map(s=>typeof s=="string"?t+s:typeof s=="object"?Object.fromEntries(Object.entries(s).map(([r,c])=>[t+r,c])):s);return [n,i]}):e,uh=e=>{if(e<1)return {get:()=>{},set:()=>{}};let t=0,n=new Map,o=new Map,i=(s,r)=>{n.set(s,r),t++,t>e&&(t=0,o=n,n=new Map);};return {get(s){let r=n.get(s);if(r!==void 0)return r;if((r=o.get(s))!==void 0)return i(s,r),r},set(s,r){n.has(s)?n.set(s,r):i(s,r);}}},wd="!",dh=e=>{let{separator:t,experimentalParseClassName:n}=e,o=t.length===1,i=t[0],s=t.length,r=c=>{let l=[],u=0,f=0,p;for(let Y=0;Y<c.length;Y++){let m=c[Y];if(u===0){if(m===i&&(o||c.slice(Y,Y+s)===t)){l.push(c.slice(f,Y)),f=Y+s;continue}if(m==="/"){p=Y;continue}}m==="["?u++:m==="]"&&u--;}let b=l.length===0?c:c.substring(f),x=b.startsWith(wd),H=x?b.substring(1):b,M=p&&p>f?p-f:void 0;return {modifiers:l,hasImportantModifier:x,baseClassName:H,maybePostfixModifierPosition:M}};return n?c=>n({className:c,parseClassName:r}):r},fh=e=>{if(e.length<=1)return e;let t=[],n=[];return e.forEach(o=>{o[0]==="["?(t.push(...n.sort(),o),n=[]):n.push(o);}),t.push(...n.sort()),t},mh=e=>({cache:uh(e.cacheSize),parseClassName:dh(e),...ih(e)}),ph=/\s+/,gh=(e,t)=>{let{parseClassName:n,getClassGroupId:o,getConflictingClassGroupIds:i}=t,s=[],r=e.trim().split(ph),c="";for(let l=r.length-1;l>=0;l-=1){let u=r[l],{modifiers:f,hasImportantModifier:p,baseClassName:b,maybePostfixModifierPosition:x}=n(u),H=!!x,M=o(H?b.substring(0,x):b);if(!M){if(!H){c=u+(c.length>0?" "+c:c);continue}if(M=o(b),!M){c=u+(c.length>0?" "+c:c);continue}H=false;}let Y=fh(f).join(":"),m=p?Y+wd:Y,E=m+M;if(s.includes(E))continue;s.push(E);let T=i(M,H);for(let C=0;C<T.length;++C){let R=T[C];s.push(m+R);}c=u+(c.length>0?" "+c:c);}return c};function hh(){let e=0,t,n,o="";for(;e<arguments.length;)(t=arguments[e++])&&(n=xd(t))&&(o&&(o+=" "),o+=n);return o}var xd=e=>{if(typeof e=="string")return e;let t,n="";for(let o=0;o<e.length;o++)e[o]&&(t=xd(e[o]))&&(n&&(n+=" "),n+=t);return n};function bh(e,...t){let n,o,i,s=r;function r(l){let u=t.reduce((f,p)=>p(f),e());return n=mh(u),o=n.cache.get,i=n.cache.set,s=c,c(l)}function c(l){let u=o(l);if(u)return u;let f=gh(l,n);return i(l,f),f}return function(){return s(hh.apply(null,arguments))}}var ot=e=>{let t=n=>n[e]||[];return t.isThemeGetter=true,t},vd=/^\[(?:([a-z-]+):)?(.+)\]$/i,yh=/^\d+\/\d+$/,wh=new Set(["px","full","screen"]),xh=/^(\d+(\.\d+)?)?(xs|sm|md|lg|xl)$/,vh=/\d+(%|px|r?em|[sdl]?v([hwib]|min|max)|pt|pc|in|cm|mm|cap|ch|ex|r?lh|cq(w|h|i|b|min|max))|\b(calc|min|max|clamp)\(.+\)|^0$/,Ch=/^(rgba?|hsla?|hwb|(ok)?(lab|lch))\(.+\)$/,Eh=/^(inset_)?-?((\d+)?\.?(\d+)[a-z]+|0)_-?((\d+)?\.?(\d+)[a-z]+|0)/,Sh=/^(url|image|image-set|cross-fade|element|(repeating-)?(linear|radial|conic)-gradient)\(.+\)$/,Rn=e=>ir(e)||wh.has(e)||yh.test(e),qn=e=>sr(e,"length",Rh),ir=e=>!!e&&!Number.isNaN(Number(e)),sl=e=>sr(e,"number",ir),Xr=e=>!!e&&Number.isInteger(Number(e)),Ah=e=>e.endsWith("%")&&ir(e.slice(0,-1)),Ie=e=>vd.test(e),Zn=e=>xh.test(e),Th=new Set(["length","size","percentage"]),_h=e=>sr(e,Th,Cd),Ph=e=>sr(e,"position",Cd),kh=new Set(["image","url"]),Oh=e=>sr(e,kh,Nh),Mh=e=>sr(e,"",Ih),Yr=()=>true,sr=(e,t,n)=>{let o=vd.exec(e);return o?o[1]?typeof t=="string"?o[1]===t:t.has(o[1]):n(o[2]):false},Rh=e=>vh.test(e)&&!Ch.test(e),Cd=()=>false,Ih=e=>Eh.test(e),Nh=e=>Sh.test(e);var Lh=()=>{let e=ot("colors"),t=ot("spacing"),n=ot("blur"),o=ot("brightness"),i=ot("borderColor"),s=ot("borderRadius"),r=ot("borderSpacing"),c=ot("borderWidth"),l=ot("contrast"),u=ot("grayscale"),f=ot("hueRotate"),p=ot("invert"),b=ot("gap"),x=ot("gradientColorStops"),H=ot("gradientColorStopPositions"),M=ot("inset"),Y=ot("margin"),m=ot("opacity"),E=ot("padding"),T=ot("saturate"),C=ot("scale"),R=ot("sepia"),X=ot("skew"),fe=ot("space"),j=ot("translate"),le=()=>["auto","contain","none"],ue=()=>["auto","hidden","clip","visible","scroll"],L=()=>["auto",Ie,t],A=()=>[Ie,t],y=()=>["",Rn,qn],h=()=>["auto",ir,Ie],S=()=>["bottom","center","left","left-bottom","left-top","right","right-bottom","right-top","top"],D=()=>["solid","dashed","dotted","double","none"],B=()=>["normal","multiply","screen","overlay","darken","lighten","color-dodge","color-burn","hard-light","soft-light","difference","exclusion","hue","saturation","color","luminosity"],w=()=>["start","end","center","between","around","evenly","stretch"],v=()=>["","0",Ie],$=()=>["auto","avoid","all","avoid-page","page","left","right","column"],N=()=>[ir,Ie];return {cacheSize:500,separator:":",theme:{colors:[Yr],spacing:[Rn,qn],blur:["none","",Zn,Ie],brightness:N(),borderColor:[e],borderRadius:["none","","full",Zn,Ie],borderSpacing:A(),borderWidth:y(),contrast:N(),grayscale:v(),hueRotate:N(),invert:v(),gap:A(),gradientColorStops:[e],gradientColorStopPositions:[Ah,qn],inset:L(),margin:L(),opacity:N(),padding:A(),saturate:N(),scale:N(),sepia:v(),skew:N(),space:A(),translate:A()},classGroups:{aspect:[{aspect:["auto","square","video",Ie]}],container:["container"],columns:[{columns:[Zn]}],"break-after":[{"break-after":$()}],"break-before":[{"break-before":$()}],"break-inside":[{"break-inside":["auto","avoid","avoid-page","avoid-column"]}],"box-decoration":[{"box-decoration":["slice","clone"]}],box:[{box:["border","content"]}],display:["block","inline-block","inline","flex","inline-flex","table","inline-table","table-caption","table-cell","table-column","table-column-group","table-footer-group","table-header-group","table-row-group","table-row","flow-root","grid","inline-grid","contents","list-item","hidden"],float:[{float:["right","left","none","start","end"]}],clear:[{clear:["left","right","both","none","start","end"]}],isolation:["isolate","isolation-auto"],"object-fit":[{object:["contain","cover","fill","none","scale-down"]}],"object-position":[{object:[...S(),Ie]}],overflow:[{overflow:ue()}],"overflow-x":[{"overflow-x":ue()}],"overflow-y":[{"overflow-y":ue()}],overscroll:[{overscroll:le()}],"overscroll-x":[{"overscroll-x":le()}],"overscroll-y":[{"overscroll-y":le()}],position:["static","fixed","absolute","relative","sticky"],inset:[{inset:[M]}],"inset-x":[{"inset-x":[M]}],"inset-y":[{"inset-y":[M]}],start:[{start:[M]}],end:[{end:[M]}],top:[{top:[M]}],right:[{right:[M]}],bottom:[{bottom:[M]}],left:[{left:[M]}],visibility:["visible","invisible","collapse"],z:[{z:["auto",Xr,Ie]}],basis:[{basis:L()}],"flex-direction":[{flex:["row","row-reverse","col","col-reverse"]}],"flex-wrap":[{flex:["wrap","wrap-reverse","nowrap"]}],flex:[{flex:["1","auto","initial","none",Ie]}],grow:[{grow:v()}],shrink:[{shrink:v()}],order:[{order:["first","last","none",Xr,Ie]}],"grid-cols":[{"grid-cols":[Yr]}],"col-start-end":[{col:["auto",{span:["full",Xr,Ie]},Ie]}],"col-start":[{"col-start":h()}],"col-end":[{"col-end":h()}],"grid-rows":[{"grid-rows":[Yr]}],"row-start-end":[{row:["auto",{span:[Xr,Ie]},Ie]}],"row-start":[{"row-start":h()}],"row-end":[{"row-end":h()}],"grid-flow":[{"grid-flow":["row","col","dense","row-dense","col-dense"]}],"auto-cols":[{"auto-cols":["auto","min","max","fr",Ie]}],"auto-rows":[{"auto-rows":["auto","min","max","fr",Ie]}],gap:[{gap:[b]}],"gap-x":[{"gap-x":[b]}],"gap-y":[{"gap-y":[b]}],"justify-content":[{justify:["normal",...w()]}],"justify-items":[{"justify-items":["start","end","center","stretch"]}],"justify-self":[{"justify-self":["auto","start","end","center","stretch"]}],"align-content":[{content:["normal",...w(),"baseline"]}],"align-items":[{items:["start","end","center","baseline","stretch"]}],"align-self":[{self:["auto","start","end","center","stretch","baseline"]}],"place-content":[{"place-content":[...w(),"baseline"]}],"place-items":[{"place-items":["start","end","center","baseline","stretch"]}],"place-self":[{"place-self":["auto","start","end","center","stretch"]}],p:[{p:[E]}],px:[{px:[E]}],py:[{py:[E]}],ps:[{ps:[E]}],pe:[{pe:[E]}],pt:[{pt:[E]}],pr:[{pr:[E]}],pb:[{pb:[E]}],pl:[{pl:[E]}],m:[{m:[Y]}],mx:[{mx:[Y]}],my:[{my:[Y]}],ms:[{ms:[Y]}],me:[{me:[Y]}],mt:[{mt:[Y]}],mr:[{mr:[Y]}],mb:[{mb:[Y]}],ml:[{ml:[Y]}],"space-x":[{"space-x":[fe]}],"space-x-reverse":["space-x-reverse"],"space-y":[{"space-y":[fe]}],"space-y-reverse":["space-y-reverse"],w:[{w:["auto","min","max","fit","svw","lvw","dvw",Ie,t]}],"min-w":[{"min-w":[Ie,t,"min","max","fit"]}],"max-w":[{"max-w":[Ie,t,"none","full","min","max","fit","prose",{screen:[Zn]},Zn]}],h:[{h:[Ie,t,"auto","min","max","fit","svh","lvh","dvh"]}],"min-h":[{"min-h":[Ie,t,"min","max","fit","svh","lvh","dvh"]}],"max-h":[{"max-h":[Ie,t,"min","max","fit","svh","lvh","dvh"]}],size:[{size:[Ie,t,"auto","min","max","fit"]}],"font-size":[{text:["base",Zn,qn]}],"font-smoothing":["antialiased","subpixel-antialiased"],"font-style":["italic","not-italic"],"font-weight":[{font:["thin","extralight","light","normal","medium","semibold","bold","extrabold","black",sl]}],"font-family":[{font:[Yr]}],"fvn-normal":["normal-nums"],"fvn-ordinal":["ordinal"],"fvn-slashed-zero":["slashed-zero"],"fvn-figure":["lining-nums","oldstyle-nums"],"fvn-spacing":["proportional-nums","tabular-nums"],"fvn-fraction":["diagonal-fractions","stacked-fractions"],tracking:[{tracking:["tighter","tight","normal","wide","wider","widest",Ie]}],"line-clamp":[{"line-clamp":["none",ir,sl]}],leading:[{leading:["none","tight","snug","normal","relaxed","loose",Rn,Ie]}],"list-image":[{"list-image":["none",Ie]}],"list-style-type":[{list:["none","disc","decimal",Ie]}],"list-style-position":[{list:["inside","outside"]}],"placeholder-color":[{placeholder:[e]}],"placeholder-opacity":[{"placeholder-opacity":[m]}],"text-alignment":[{text:["left","center","right","justify","start","end"]}],"text-color":[{text:[e]}],"text-opacity":[{"text-opacity":[m]}],"text-decoration":["underline","overline","line-through","no-underline"],"text-decoration-style":[{decoration:[...D(),"wavy"]}],"text-decoration-thickness":[{decoration:["auto","from-font",Rn,qn]}],"underline-offset":[{"underline-offset":["auto",Rn,Ie]}],"text-decoration-color":[{decoration:[e]}],"text-transform":["uppercase","lowercase","capitalize","normal-case"],"text-overflow":["truncate","text-ellipsis","text-clip"],"text-wrap":[{text:["wrap","nowrap","balance","pretty"]}],indent:[{indent:A()}],"vertical-align":[{align:["baseline","top","middle","bottom","text-top","text-bottom","sub","super",Ie]}],whitespace:[{whitespace:["normal","nowrap","pre","pre-line","pre-wrap","break-spaces"]}],break:[{break:["normal","words","all","keep"]}],hyphens:[{hyphens:["none","manual","auto"]}],content:[{content:["none",Ie]}],"bg-attachment":[{bg:["fixed","local","scroll"]}],"bg-clip":[{"bg-clip":["border","padding","content","text"]}],"bg-opacity":[{"bg-opacity":[m]}],"bg-origin":[{"bg-origin":["border","padding","content"]}],"bg-position":[{bg:[...S(),Ph]}],"bg-repeat":[{bg:["no-repeat",{repeat:["","x","y","round","space"]}]}],"bg-size":[{bg:["auto","cover","contain",_h]}],"bg-image":[{bg:["none",{"gradient-to":["t","tr","r","br","b","bl","l","tl"]},Oh]}],"bg-color":[{bg:[e]}],"gradient-from-pos":[{from:[H]}],"gradient-via-pos":[{via:[H]}],"gradient-to-pos":[{to:[H]}],"gradient-from":[{from:[x]}],"gradient-via":[{via:[x]}],"gradient-to":[{to:[x]}],rounded:[{rounded:[s]}],"rounded-s":[{"rounded-s":[s]}],"rounded-e":[{"rounded-e":[s]}],"rounded-t":[{"rounded-t":[s]}],"rounded-r":[{"rounded-r":[s]}],"rounded-b":[{"rounded-b":[s]}],"rounded-l":[{"rounded-l":[s]}],"rounded-ss":[{"rounded-ss":[s]}],"rounded-se":[{"rounded-se":[s]}],"rounded-ee":[{"rounded-ee":[s]}],"rounded-es":[{"rounded-es":[s]}],"rounded-tl":[{"rounded-tl":[s]}],"rounded-tr":[{"rounded-tr":[s]}],"rounded-br":[{"rounded-br":[s]}],"rounded-bl":[{"rounded-bl":[s]}],"border-w":[{border:[c]}],"border-w-x":[{"border-x":[c]}],"border-w-y":[{"border-y":[c]}],"border-w-s":[{"border-s":[c]}],"border-w-e":[{"border-e":[c]}],"border-w-t":[{"border-t":[c]}],"border-w-r":[{"border-r":[c]}],"border-w-b":[{"border-b":[c]}],"border-w-l":[{"border-l":[c]}],"border-opacity":[{"border-opacity":[m]}],"border-style":[{border:[...D(),"hidden"]}],"divide-x":[{"divide-x":[c]}],"divide-x-reverse":["divide-x-reverse"],"divide-y":[{"divide-y":[c]}],"divide-y-reverse":["divide-y-reverse"],"divide-opacity":[{"divide-opacity":[m]}],"divide-style":[{divide:D()}],"border-color":[{border:[i]}],"border-color-x":[{"border-x":[i]}],"border-color-y":[{"border-y":[i]}],"border-color-s":[{"border-s":[i]}],"border-color-e":[{"border-e":[i]}],"border-color-t":[{"border-t":[i]}],"border-color-r":[{"border-r":[i]}],"border-color-b":[{"border-b":[i]}],"border-color-l":[{"border-l":[i]}],"divide-color":[{divide:[i]}],"outline-style":[{outline:["",...D()]}],"outline-offset":[{"outline-offset":[Rn,Ie]}],"outline-w":[{outline:[Rn,qn]}],"outline-color":[{outline:[e]}],"ring-w":[{ring:y()}],"ring-w-inset":["ring-inset"],"ring-color":[{ring:[e]}],"ring-opacity":[{"ring-opacity":[m]}],"ring-offset-w":[{"ring-offset":[Rn,qn]}],"ring-offset-color":[{"ring-offset":[e]}],shadow:[{shadow:["","inner","none",Zn,Mh]}],"shadow-color":[{shadow:[Yr]}],opacity:[{opacity:[m]}],"mix-blend":[{"mix-blend":[...B(),"plus-lighter","plus-darker"]}],"bg-blend":[{"bg-blend":B()}],filter:[{filter:["","none"]}],blur:[{blur:[n]}],brightness:[{brightness:[o]}],contrast:[{contrast:[l]}],"drop-shadow":[{"drop-shadow":["","none",Zn,Ie]}],grayscale:[{grayscale:[u]}],"hue-rotate":[{"hue-rotate":[f]}],invert:[{invert:[p]}],saturate:[{saturate:[T]}],sepia:[{sepia:[R]}],"backdrop-filter":[{"backdrop-filter":["","none"]}],"backdrop-blur":[{"backdrop-blur":[n]}],"backdrop-brightness":[{"backdrop-brightness":[o]}],"backdrop-contrast":[{"backdrop-contrast":[l]}],"backdrop-grayscale":[{"backdrop-grayscale":[u]}],"backdrop-hue-rotate":[{"backdrop-hue-rotate":[f]}],"backdrop-invert":[{"backdrop-invert":[p]}],"backdrop-opacity":[{"backdrop-opacity":[m]}],"backdrop-saturate":[{"backdrop-saturate":[T]}],"backdrop-sepia":[{"backdrop-sepia":[R]}],"border-collapse":[{border:["collapse","separate"]}],"border-spacing":[{"border-spacing":[r]}],"border-spacing-x":[{"border-spacing-x":[r]}],"border-spacing-y":[{"border-spacing-y":[r]}],"table-layout":[{table:["auto","fixed"]}],caption:[{caption:["top","bottom"]}],transition:[{transition:["none","all","","colors","opacity","shadow","transform",Ie]}],duration:[{duration:N()}],ease:[{ease:["linear","in","out","in-out",Ie]}],delay:[{delay:N()}],animate:[{animate:["none","spin","ping","pulse","bounce",Ie]}],transform:[{transform:["","gpu","none"]}],scale:[{scale:[C]}],"scale-x":[{"scale-x":[C]}],"scale-y":[{"scale-y":[C]}],rotate:[{rotate:[Xr,Ie]}],"translate-x":[{"translate-x":[j]}],"translate-y":[{"translate-y":[j]}],"skew-x":[{"skew-x":[X]}],"skew-y":[{"skew-y":[X]}],"transform-origin":[{origin:["center","top","top-right","right","bottom-right","bottom","bottom-left","left","top-left",Ie]}],accent:[{accent:["auto",e]}],appearance:[{appearance:["none","auto"]}],cursor:[{cursor:["auto","default","pointer","wait","text","move","help","not-allowed","none","context-menu","progress","cell","crosshair","vertical-text","alias","copy","no-drop","grab","grabbing","all-scroll","col-resize","row-resize","n-resize","e-resize","s-resize","w-resize","ne-resize","nw-resize","se-resize","sw-resize","ew-resize","ns-resize","nesw-resize","nwse-resize","zoom-in","zoom-out",Ie]}],"caret-color":[{caret:[e]}],"pointer-events":[{"pointer-events":["none","auto"]}],resize:[{resize:["none","y","x",""]}],"scroll-behavior":[{scroll:["auto","smooth"]}],"scroll-m":[{"scroll-m":A()}],"scroll-mx":[{"scroll-mx":A()}],"scroll-my":[{"scroll-my":A()}],"scroll-ms":[{"scroll-ms":A()}],"scroll-me":[{"scroll-me":A()}],"scroll-mt":[{"scroll-mt":A()}],"scroll-mr":[{"scroll-mr":A()}],"scroll-mb":[{"scroll-mb":A()}],"scroll-ml":[{"scroll-ml":A()}],"scroll-p":[{"scroll-p":A()}],"scroll-px":[{"scroll-px":A()}],"scroll-py":[{"scroll-py":A()}],"scroll-ps":[{"scroll-ps":A()}],"scroll-pe":[{"scroll-pe":A()}],"scroll-pt":[{"scroll-pt":A()}],"scroll-pr":[{"scroll-pr":A()}],"scroll-pb":[{"scroll-pb":A()}],"scroll-pl":[{"scroll-pl":A()}],"snap-align":[{snap:["start","end","center","align-none"]}],"snap-stop":[{snap:["normal","always"]}],"snap-type":[{snap:["none","x","y","both"]}],"snap-strictness":[{snap:["mandatory","proximity"]}],touch:[{touch:["auto","none","manipulation"]}],"touch-x":[{"touch-pan":["x","left","right"]}],"touch-y":[{"touch-pan":["y","up","down"]}],"touch-pz":["touch-pinch-zoom"],select:[{select:["none","text","all","auto"]}],"will-change":[{"will-change":["auto","scroll","contents","transform",Ie]}],fill:[{fill:[e,"none"]}],"stroke-w":[{stroke:[Rn,qn,sl]}],stroke:[{stroke:[e,"none"]}],sr:["sr-only","not-sr-only"],"forced-color-adjust":[{"forced-color-adjust":["auto","none"]}]},conflictingClassGroups:{overflow:["overflow-x","overflow-y"],overscroll:["overscroll-x","overscroll-y"],inset:["inset-x","inset-y","start","end","top","right","bottom","left"],"inset-x":["right","left"],"inset-y":["top","bottom"],flex:["basis","grow","shrink"],gap:["gap-x","gap-y"],p:["px","py","ps","pe","pt","pr","pb","pl"],px:["pr","pl"],py:["pt","pb"],m:["mx","my","ms","me","mt","mr","mb","ml"],mx:["mr","ml"],my:["mt","mb"],size:["w","h"],"font-size":["leading"],"fvn-normal":["fvn-ordinal","fvn-slashed-zero","fvn-figure","fvn-spacing","fvn-fraction"],"fvn-ordinal":["fvn-normal"],"fvn-slashed-zero":["fvn-normal"],"fvn-figure":["fvn-normal"],"fvn-spacing":["fvn-normal"],"fvn-fraction":["fvn-normal"],"line-clamp":["display","overflow"],rounded:["rounded-s","rounded-e","rounded-t","rounded-r","rounded-b","rounded-l","rounded-ss","rounded-se","rounded-ee","rounded-es","rounded-tl","rounded-tr","rounded-br","rounded-bl"],"rounded-s":["rounded-ss","rounded-es"],"rounded-e":["rounded-se","rounded-ee"],"rounded-t":["rounded-tl","rounded-tr"],"rounded-r":["rounded-tr","rounded-br"],"rounded-b":["rounded-br","rounded-bl"],"rounded-l":["rounded-tl","rounded-bl"],"border-spacing":["border-spacing-x","border-spacing-y"],"border-w":["border-w-s","border-w-e","border-w-t","border-w-r","border-w-b","border-w-l"],"border-w-x":["border-w-r","border-w-l"],"border-w-y":["border-w-t","border-w-b"],"border-color":["border-color-s","border-color-e","border-color-t","border-color-r","border-color-b","border-color-l"],"border-color-x":["border-color-r","border-color-l"],"border-color-y":["border-color-t","border-color-b"],"scroll-m":["scroll-mx","scroll-my","scroll-ms","scroll-me","scroll-mt","scroll-mr","scroll-mb","scroll-ml"],"scroll-mx":["scroll-mr","scroll-ml"],"scroll-my":["scroll-mt","scroll-mb"],"scroll-p":["scroll-px","scroll-py","scroll-ps","scroll-pe","scroll-pt","scroll-pr","scroll-pb","scroll-pl"],"scroll-px":["scroll-pr","scroll-pl"],"scroll-py":["scroll-pt","scroll-pb"],touch:["touch-x","touch-y","touch-pz"],"touch-x":["touch"],"touch-y":["touch"],"touch-pz":["touch"]},conflictingClassGroupModifiers:{"font-size":["leading"]}}};var Ed=bh(Lh);var Ee=(...e)=>Ed(gd(e));var ys=e=>e.elementsCount&&e.elementsCount>1?{tagName:`${e.elementsCount} elements`,componentName:void 0}:{tagName:e.tagName||e.componentName||"element",componentName:e.tagName?e.componentName:void 0};var cl=null,In=()=>(cl===null&&(cl=typeof navigator<"u"&&/Mac|iPhone|iPad/.test(navigator.platform)),cl);var Jn=e=>e==="Enter"?"\u21B5":In()?`\u2318${e}`:`Ctrl+${e.replace("\u21E7","Shift+")}`;var Dh=K('<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 12 12"fill=none style=transform:rotate(180deg)><path d="M5 3V1L1 4.5L5 8V6C8 6 10 7 11 10C11 7 9 4 5 3Z"fill=currentColor>'),ws=e=>{let t=()=>e.size??12;return (()=>{var n=Dh();return te(o=>{var i=t(),s=t(),r=e.class;return i!==o.e&&ae(n,"width",o.e=i),s!==o.t&&ae(n,"height",o.t=s),r!==o.a&&ae(n,"class",o.a=r),o},{e:void 0,t:void 0,a:void 0}),n})()};var Fh=K('<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 12 12"fill=none><path d="M6 1L6 11M6 1L2 5M6 1L10 5"stroke=currentColor stroke-width=1.5 stroke-linecap=round stroke-linejoin=round>'),xs=e=>{let t=()=>e.size??12;return (()=>{var n=Fh();return te(o=>{var i=t(),s=t(),r=e.class;return i!==o.e&&ae(n,"width",o.e=i),s!==o.t&&ae(n,"height",o.t=s),r!==o.a&&ae(n,"class",o.a=r),o},{e:void 0,t:void 0,a:void 0}),n})()};var $h=K('<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 24 24"fill=none stroke=currentColor stroke-width=2 stroke-linecap=round stroke-linejoin=round><path class=icon-loader-bar d="M12 2v4"style=animation-delay:0ms></path><path class=icon-loader-bar d="M15 6.8l2-3.5"style=animation-delay:-42ms></path><path class=icon-loader-bar d="M17.2 9l3.5-2"style=animation-delay:-83ms></path><path class=icon-loader-bar d="M18 12h4"style=animation-delay:-125ms></path><path class=icon-loader-bar d="M17.2 15l3.5 2"style=animation-delay:-167ms></path><path class=icon-loader-bar d="M15 17.2l2 3.5"style=animation-delay:-208ms></path><path class=icon-loader-bar d="M12 18v4"style=animation-delay:-250ms></path><path class=icon-loader-bar d="M9 17.2l-2 3.5"style=animation-delay:-292ms></path><path class=icon-loader-bar d="M6.8 15l-3.5 2"style=animation-delay:-333ms></path><path class=icon-loader-bar d="M2 12h4"style=animation-delay:-375ms></path><path class=icon-loader-bar d="M6.8 9l-3.5-2"style=animation-delay:-417ms></path><path class=icon-loader-bar d="M9 6.8l-2-3.5"style=animation-delay:-458ms>'),Sd=e=>{let t=()=>e.size??16;return (()=>{var n=$h(),o=n.firstChild,i=o.nextSibling,s=i.nextSibling,r=s.nextSibling,c=r.nextSibling,l=c.nextSibling,u=l.nextSibling,f=u.nextSibling,p=f.nextSibling,b=p.nextSibling,x=b.nextSibling;x.nextSibling;return te(M=>{var Y=t(),m=t(),E=e.class;return Y!==M.e&&ae(n,"width",M.e=Y),m!==M.t&&ae(n,"height",M.t=m),E!==M.a&&ae(n,"class",M.a=E),M},{e:void 0,t:void 0,a:void 0}),n})()};var Hh=K('<div data-react-grab-arrow class="absolute w-0 h-0 z-10">'),vs=e=>{let t=()=>e.color??"white",n=()=>e.position==="bottom",o=()=>bs(e.labelWidth??0);return (()=>{var i=Hh();return te(s=>{var r=`calc(${e.leftPercent}% + ${e.leftOffsetPx}px)`,c=n()?"0":void 0,l=n()?void 0:"0",u=n()?"translateX(-50%) translateY(-100%)":"translateX(-50%) translateY(100%)",f=`${o()}px solid transparent`,p=`${o()}px solid transparent`,b=n()?`${o()}px solid ${t()}`:void 0,x=n()?void 0:`${o()}px solid ${t()}`;return r!==s.e&&we(i,"left",s.e=r),c!==s.t&&we(i,"top",s.t=c),l!==s.a&&we(i,"bottom",s.a=l),u!==s.o&&we(i,"transform",s.o=u),f!==s.i&&we(i,"border-left",s.i=f),p!==s.n&&we(i,"border-right",s.n=p),b!==s.s&&we(i,"border-bottom",s.s=b),x!==s.h&&we(i,"border-top",s.h=x),s},{e:void 0,t:void 0,a:void 0,o:void 0,i:void 0,n:void 0,s:void 0,h:void 0}),i})()};var Bh=K('<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 24 24"fill=none stroke=currentColor stroke-linecap=round stroke-linejoin=round stroke-width=2><path d="M12 6H6a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-6"></path><path d="M11 13l9-9"></path><path d="M15 4h5v5">'),Ad=e=>{let t=()=>e.size??12;return (()=>{var n=Bh();return te(o=>{var i=t(),s=t(),r=e.class;return i!==o.e&&ae(n,"width",o.e=i),s!==o.t&&ae(n,"height",o.t=s),r!==o.a&&ae(n,"class",o.a=r),o},{e:void 0,t:void 0,a:void 0}),n})()};var Td=K("<span class=text-black>"),zh=K("<span class=text-black/50>."),Vh=K('<div><span class="text-[13px] leading-4 h-fit font-medium overflow-hidden text-ellipsis whitespace-nowrap min-w-0">'),qr=e=>{let[t,n]=U(false),o=()=>{n(true),e.onHoverChange?.(true);},i=()=>{n(false),e.onHoverChange?.(false);};return (()=>{var s=Vh(),r=s.firstChild;return Je(s,"click",e.onClick,true),s.addEventListener("mouseleave",i),s.addEventListener("mouseenter",o),z(r,O(ye,{get when(){return e.componentName},get children(){return [(()=>{var c=Td();return z(c,()=>e.componentName),c})(),(()=>{var c=zh();c.firstChild;return z(c,()=>e.tagName,null),c})()]}}),null),z(r,O(ye,{get when(){return !e.componentName},get children(){var c=Td();return z(c,()=>e.tagName),c}}),null),z(s,O(ye,{get when(){return e.isClickable||e.forceShowIcon},get children(){return O(Ad,{size:10,get class(){return Ee("text-black transition-all duration-100 shrink-0",t()||e.forceShowIcon?"opacity-100 scale-100":"opacity-0 scale-75 -ml-[2px] w-0")}})}}),null),te(()=>Re(s,Ee("contain-layout flex items-center gap-1 max-w-[280px] overflow-hidden",e.shrink&&"shrink-0",e.isClickable&&"cursor-pointer"))),s})()};it(["click"]);var Gh=K('<div class="[font-synthesis:none] contain-layout shrink-0 flex flex-col items-start px-2 py-1.5 w-auto h-fit self-stretch [border-top-width:0.5px] border-t-solid border-t-[#D9D9D9] antialiased rounded-t-none rounded-b-[6px]">'),Mt=e=>(()=>{var t=Gh();return z(t,()=>e.children),t})();var Cs=null,Tt={claim:e=>{Cs=e;},release:e=>{Cs===e&&(Cs=null);},isActive:e=>Cs===e};var Uh=K('<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 22 19"fill=none><path d="M6.76263 18.6626C7.48251 18.6626 7.95474 18.1682 7.95474 17.4895C7.95474 17.1207 7.80474 16.8576 7.58683 16.6361L5.3018 14.4137L2.84621 12.3589L2.44374 13.0037L5.92137 13.1622H17.9232C20.4842 13.1622 21.593 12.021 21.593 9.47237V3.66983C21.593 1.10875 20.4842 0 17.9232 0H12.5414C11.8179 0 11.3018 0.545895 11.3018 1.21695C11.3018 1.888 11.8179 2.43389 12.5414 2.43389H17.8424C18.7937 2.43389 19.1897 2.83653 19.1897 3.78784V9.35747C19.1897 10.3257 18.7937 10.7314 17.8424 10.7314H5.92137L2.44374 10.8832L2.84621 11.5281L5.3018 9.47993L7.58683 7.2606C7.80474 7.03914 7.95474 6.7693 7.95474 6.40049C7.95474 5.72854 7.48251 5.22747 6.76263 5.22747C6.46129 5.22747 6.12975 5.36905 5.89231 5.6096L0.376815 11.0425C0.134921 11.2777 0 11.6141 0 11.9452C0 12.2728 0.134921 12.6158 0.376815 12.848L5.89231 18.2871C6.12975 18.5276 6.46129 18.6626 6.76263 18.6626Z"fill=currentColor>'),Es=e=>{let t=()=>e.size??12;return (()=>{var n=Uh();return te(o=>{var i=t(),s=t()*19/22,r=e.class;return i!==o.e&&ae(n,"width",o.e=i),s!==o.t&&ae(n,"height",o.t=s),r!==o.a&&ae(n,"class",o.a=r),o},{e:void 0,t:void 0,a:void 0}),n})()};var jh=K('<div class="contain-layout shrink-0 flex items-center justify-end gap-[5px] w-full h-fit"><button data-react-grab-discard-no class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-white [border-width:0.5px] border-solid border-[#B3B3B3] cursor-pointer transition-all hover:bg-[#F5F5F5] press-scale h-[17px]"><span class="text-black text-[13px] leading-3.5 font-sans font-medium">No</span></button><button data-react-grab-discard-yes class="contain-layout shrink-0 flex items-center justify-center gap-0.5 px-[3px] py-px rounded-sm bg-[#FEF2F2] cursor-pointer transition-all hover:bg-[#FEE2E2] press-scale h-[17px]"><span class="text-[#B91C1C] text-[13px] leading-3.5 font-sans font-medium">Yes'),Wh=K('<div data-react-grab-discard-prompt class="contain-layout shrink-0 flex flex-col justify-center items-end w-fit h-fit"><div class="contain-layout shrink-0 flex items-center gap-1 pt-1.5 pb-1 px-2 w-full h-fit"><span class="text-black text-[13px] leading-4 shrink-0 font-sans font-medium w-fit h-fit">'),Zr=e=>{let t=Symbol(),n=i=>{if(!Tt.isActive(t)||St(i))return;let s=i.code==="Enter",r=i.code==="Escape";(s||r)&&(i.preventDefault(),i.stopPropagation(),r&&e.cancelOnEscape?e.onCancel?.():e.onConfirm?.());},o=()=>{Tt.claim(t);};return mt(()=>{Tt.claim(t),window.addEventListener("keydown",n,{capture:true});}),Me(()=>{Tt.release(t),window.removeEventListener("keydown",n,{capture:true});}),(()=>{var i=Wh(),s=i.firstChild,r=s.firstChild;return i.$$click=o,i.$$pointerdown=o,z(r,()=>e.label??"Discard?"),z(i,O(Mt,{get children(){var c=jh(),l=c.firstChild,u=l.nextSibling;u.firstChild;return Je(l,"click",e.onCancel,true),Je(u,"click",e.onConfirm,true),z(u,O(Es,{size:10,class:"text-[#B91C1C]/50"}),null),c}}),null),i})()};it(["pointerdown","click"]);var Kh=K('<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 24 24"fill=none><path d="M17.65 6.35C16.2 4.9 14.21 4 12 4C7.58 4 4.01 7.58 4.01 12C4.01 16.42 7.58 20 12 20C15.73 20 18.84 17.45 19.73 14H17.65C16.83 16.33 14.61 18 12 18C8.69 18 6 15.31 6 12C6 8.69 8.69 6 12 6C13.66 6 15.14 6.69 16.22 7.78L13 11H20V4L17.65 6.35Z"fill=currentColor>'),_d=e=>{let t=()=>e.size??12;return (()=>{var n=Kh();return te(o=>{var i=t(),s=t(),r=e.class;return i!==o.e&&ae(n,"width",o.e=i),s!==o.t&&ae(n,"height",o.t=s),r!==o.a&&ae(n,"class",o.a=r),o},{e:void 0,t:void 0,a:void 0}),n})()};var Xh=K('<div class="contain-layout shrink-0 flex items-center justify-end gap-[5px] w-full h-fit"><button data-react-grab-retry class="contain-layout shrink-0 flex items-center justify-center gap-1 px-[3px] py-px rounded-sm bg-white [border-width:0.5px] border-solid border-[#B3B3B3] cursor-pointer transition-all hover:bg-[#F5F5F5] press-scale h-[17px]"><span class="text-black text-[13px] leading-3.5 font-sans font-medium">Retry</span></button><button data-react-grab-error-ok class="contain-layout shrink-0 flex items-center justify-center gap-1 px-[3px] py-px rounded-sm bg-white [border-width:0.5px] border-solid border-[#B3B3B3] cursor-pointer transition-all hover:bg-[#F5F5F5] press-scale h-[17px]"><span class="text-black text-[13px] leading-3.5 font-sans font-medium">Ok'),Yh=K('<div data-react-grab-error class="contain-layout shrink-0 flex flex-col justify-center items-end w-fit h-fit max-w-[280px]"><div class="contain-layout shrink-0 flex items-start gap-1 px-2 w-full h-fit"><span class="text-[#B91C1C] text-[13px] leading-4 font-sans font-medium overflow-hidden line-clamp-5">'),Pd=e=>{let t=Symbol(),n=s=>{if(!Tt.isActive(t)||St(s))return;let r=s.code==="Enter",c=s.code==="Escape";r?(s.preventDefault(),s.stopPropagation(),e.onRetry?.()):c&&(s.preventDefault(),s.stopPropagation(),e.onAcknowledge?.());},o=()=>{Tt.claim(t);};mt(()=>{Tt.claim(t),window.addEventListener("keydown",n,{capture:true});}),Me(()=>{Tt.release(t),window.removeEventListener("keydown",n,{capture:true});});let i=()=>!!(e.onRetry||e.onAcknowledge);return (()=>{var s=Yh(),r=s.firstChild,c=r.firstChild;return s.$$click=o,s.$$pointerdown=o,z(c,()=>e.error),z(s,O(ye,{get when(){return i()},get children(){return O(Mt,{get children(){var l=Xh(),u=l.firstChild;u.firstChild;var p=u.nextSibling;return Je(u,"click",e.onRetry,true),z(u,O(_d,{size:10,class:"text-black/50"}),null),Je(p,"click",e.onAcknowledge,true),l}})}}),null),te(l=>{var u={"pt-1.5 pb-1":i(),"py-1.5":!i()},f=e.error;return l.e=co(r,u,l.e),f!==l.t&&ae(c,"title",l.t=f),l},{e:void 0,t:void 0}),s})()};it(["pointerdown","click"]);var qh=K('<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 24 24"fill=currentColor><circle cx=5 cy=12 r=2></circle><circle cx=12 cy=12 r=2></circle><circle cx=19 cy=12 r=2>'),Ss=e=>{let t=()=>e.size??12;return (()=>{var n=qh();return te(o=>{var i=t(),s=t(),r=e.class;return i!==o.e&&ae(n,"width",o.e=i),s!==o.t&&ae(n,"height",o.t=s),r!==o.a&&ae(n,"class",o.a=r),o},{e:void 0,t:void 0,a:void 0}),n})()};var Zh=K('<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 21 21"fill=none><g clip-path=url(#clip0_icon_check)><path d="M20.1767 10.0875C20.1767 15.6478 15.6576 20.175 10.0875 20.175C4.52715 20.175 0 15.6478 0 10.0875C0 4.51914 4.52715 0 10.0875 0C15.6576 0 20.1767 4.51914 20.1767 10.0875ZM13.0051 6.23867L8.96699 12.7041L7.08476 10.3143C6.83358 9.99199 6.59941 9.88828 6.28984 9.88828C5.79414 9.88828 5.39961 10.2918 5.39961 10.7893C5.39961 11.0367 5.48925 11.2621 5.66386 11.4855L8.05703 14.3967C8.33027 14.7508 8.63183 14.9103 8.99902 14.9103C9.36445 14.9103 9.68105 14.7312 9.90546 14.3896L14.4742 7.27206C14.6107 7.04765 14.7289 6.80898 14.7289 6.58359C14.7289 6.07187 14.281 5.72968 13.7934 5.72968C13.4937 5.72968 13.217 5.90527 13.0051 6.23867Z"fill=currentColor></path></g><defs><clipPath id=clip0_icon_check><rect width=20.5381 height=20.1848 fill=white>'),Jr=e=>{let t=()=>e.size??21;return (()=>{var n=Zh();return te(o=>{var i=t(),s=t()*20.1848/20.5381,r=e.class;return i!==o.e&&ae(n,"width",o.e=i),s!==o.t&&ae(n,"height",o.t=s),r!==o.a&&ae(n,"class",o.a=r),o},{e:void 0,t:void 0,a:void 0}),n})()};var Jh=K('<button data-react-grab-ignore-events data-react-grab-more-options class="flex items-center justify-center size-[18px] rounded-sm cursor-pointer bg-transparent hover:bg-black/10 text-black/30 hover:text-black border-none outline-none p-0 shrink-0 press-scale">'),Qh=K('<button data-react-grab-undo class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[#FEF2F2] cursor-pointer transition-all hover:bg-[#FEE2E2] press-scale h-[17px]"><span class="text-[#B91C1C] text-[13px] leading-3.5 font-sans font-medium">Undo'),eb=K('<button data-react-grab-dismiss class="contain-layout shrink-0 flex items-center justify-center gap-1 px-[3px] py-px rounded-sm bg-white [border-width:0.5px] border-solid border-[#B3B3B3] cursor-pointer transition-all hover:bg-[#F5F5F5] press-scale h-[17px]"><span class="text-black text-[13px] leading-3.5 font-sans font-medium">'),tb=K('<div class="contain-layout shrink-0 flex items-center justify-between gap-2 pt-1.5 pb-1 px-2 w-full h-fit"><span class="text-black text-[13px] leading-4 font-sans font-medium h-fit tabular-nums overflow-hidden text-ellipsis whitespace-nowrap min-w-0"></span><div class="contain-layout shrink-0 flex items-center gap-2 h-fit">'),nb=K('<div class="contain-layout shrink-0 flex items-center gap-0.5 py-1.5 px-2 w-full h-fit"><span class="text-black text-[13px] leading-4 font-sans font-medium h-fit tabular-nums overflow-hidden text-ellipsis whitespace-nowrap min-w-0">'),ob=K('<div class="flex items-center gap-1 w-full mb-1 overflow-hidden"><span class="text-black/40 text-[11px] leading-3 font-medium truncate italic">'),rb=K('<div class="shrink-0 flex justify-between items-end w-full min-h-4"><textarea data-react-grab-ignore-events data-react-grab-followup-input class="text-black text-[13px] leading-4 font-medium bg-transparent border-none outline-none resize-none flex-1 p-0 m-0 wrap-break-word overflow-y-auto"placeholder=follow-up rows=1 style=field-sizing:content;min-height:16px;max-height:95px;scrollbar-width:none></textarea><button data-react-grab-followup-submit>'),ib=K("<div data-react-grab-completion>"),kd=e=>(()=>{var t=Jh();return Je(t,"click",n=>{n.stopImmediatePropagation(),e.onClick();}),Je(t,"pointerdown",n=>{n.stopImmediatePropagation();}),z(t,O(Ss,{size:14})),t})(),Od=e=>{let t=Symbol(),n,o,i,[s,r]=U(false),[c,l]=U(false),[u,f]=U(e.statusText),[p,b]=U(""),x=()=>{o!==void 0&&window.clearTimeout(o),i!==void 0&&window.clearTimeout(i),l(true),e.onFadingChange?.(true),e.onShowContextMenu?.();},H=()=>{s()||(r(true),f("Copied"),e.onCopyStateChange?.(),o=window.setTimeout(()=>{l(true),e.onFadingChange?.(true),i=window.setTimeout(()=>{e.onDismiss?.();},100);},1400));},M=()=>{let T=p().trim();T&&e.onFollowUpSubmit&&e.onFollowUpSubmit(T);},Y=T=>{if(T.isComposing||T.keyCode===229)return;let C=T.code==="KeyZ"&&(T.metaKey||T.ctrlKey),R=T.code==="Enter"&&!T.shiftKey,X=T.code==="Escape";C||T.stopImmediatePropagation(),R?(T.preventDefault(),p().trim()?M():H()):X&&(T.preventDefault(),e.onDismiss?.());},m=T=>{if(!Tt.isActive(t))return;let C=T.code==="KeyZ"&&(T.metaKey||T.ctrlKey)&&!T.shiftKey,R=T.code==="Enter",X=T.code==="Escape";if(C&&e.supportsUndo&&e.onUndo){T.preventDefault(),T.stopPropagation(),e.onUndo();return}St(T)||(R?(T.preventDefault(),T.stopPropagation(),H()):X&&(T.preventDefault(),T.stopPropagation(),e.onDismiss?.()));},E=()=>{Tt.claim(t);};return be(()=>{s()||f(e.statusText);}),mt(()=>{Tt.claim(t),window.addEventListener("keydown",m,{capture:true}),e.supportsFollowUp&&e.onFollowUpSubmit&&n&&n.focus();}),Me(()=>{Tt.release(t),window.removeEventListener("keydown",m,{capture:true}),o!==void 0&&window.clearTimeout(o),i!==void 0&&window.clearTimeout(i);}),(()=>{var T=ib();return T.$$click=E,T.$$pointerdown=E,z(T,O(ye,{get when(){return Be(()=>!s())()&&(e.onDismiss||e.onUndo)},get children(){var C=tb(),R=C.firstChild,X=R.nextSibling;return z(R,u),z(X,O(ye,{get when(){return Be(()=>!!e.onShowContextMenu)()&&!e.supportsFollowUp},get children(){return O(kd,{onClick:x})}}),null),z(X,O(ye,{get when(){return Be(()=>!!e.supportsUndo)()&&e.onUndo},get children(){var fe=Qh();return fe.$$click=()=>e.onUndo?.(),fe}}),null),z(X,O(ye,{get when(){return e.onDismiss},get children(){var fe=eb(),j=fe.firstChild;return fe.$$click=H,z(j,()=>e.dismissButtonText??"Keep"),z(fe,O(ye,{get when(){return !s()},get children(){return O(Es,{size:10,class:"text-black/50"})}}),null),te(()=>fe.disabled=s()),fe}}),null),C}}),null),z(T,O(ye,{get when(){return s()||!e.onDismiss&&!e.onUndo},get children(){var C=nb(),R=C.firstChild;return z(C,O(Jr,{size:14,class:"text-black/85 shrink-0 animate-success-pop"}),R),z(R,u),z(C,O(ye,{get when(){return Be(()=>!!e.onShowContextMenu)()&&!e.supportsFollowUp},get children(){return O(kd,{onClick:x})}}),null),C}}),null),z(T,O(ye,{get when(){return Be(()=>!!(!s()&&e.supportsFollowUp))()&&e.onFollowUpSubmit},get children(){return O(Mt,{get children(){return [O(ye,{get when(){return e.previousPrompt},get children(){var C=ob(),R=C.firstChild;return z(C,O(ws,{size:10,class:"text-black/30 shrink-0"}),R),z(R,()=>e.previousPrompt),C}}),(()=>{var C=rb(),R=C.firstChild,X=R.nextSibling;R.$$keydown=Y,R.$$input=j=>b(j.target.value);var fe=n;return typeof fe=="function"?Ke(fe,R):n=R,X.$$click=M,z(X,O(xs,{size:10,class:"text-white"})),te(j=>{var le=e.previousPrompt?"14px":"0",ue=Ee("contain-layout shrink-0 flex items-center justify-center size-4 rounded-full bg-black cursor-pointer ml-1 interactive-scale",!p().trim()&&"opacity-35");return le!==j.e&&we(C,"padding-left",j.e=le),ue!==j.t&&Re(X,j.t=ue),j},{e:void 0,t:void 0}),te(()=>R.value=p()),C})()]}})}}),null),te(C=>{var R=Ee("contain-layout shrink-0 flex flex-col justify-center items-end rounded-[10px] antialiased w-fit h-fit max-w-[280px] transition-opacity duration-100 ease-out [font-synthesis:none] [corner-shape:superellipse(1.25)]",ht),X=c()?0:1;return R!==C.e&&Re(T,C.e=R),X!==C.t&&we(T,"opacity",C.t=X),C},{e:void 0,t:void 0}),T})()};it(["pointerdown","click","input","keydown"]);var sb="0",ab="1",lb=({hiddenOpacity:e=sb,visibleOpacity:t=ab}={})=>{let n,o,i=()=>{o&&(o.style.opacity=e);};return {containerRef:l=>{n=l;},followerRef:l=>{o=l;},followElement:l=>{if(!o||!n)return;if(!l){i();return}let u=n.getBoundingClientRect(),f=l.getBoundingClientRect(),p=f.top-u.top+n.scrollTop,b=f.left-u.left+n.scrollLeft;o.style.opacity=t,o.style.top=`${p}px`,o.style.left=`${b}px`,o.style.width=`${f.width}px`,o.style.height=`${f.height}px`;},hideFollower:i}},Qn=()=>{let{containerRef:e,followerRef:t,followElement:n,hideFollower:o}=lb();return {containerRef:e,highlightRef:t,updateHighlight:n,clearHighlight:o}};var cb=K('<div class="relative flex flex-col w-[calc(100%+16px)] -mx-2 -my-1.5"><div class="pointer-events-none absolute bg-black/5 opacity-0 transition-[top,left,width,height,opacity] duration-75 ease-out">'),ub=K("<span class=text-black/40>."),db=K('<button data-react-grab-ignore-events class="relative z-1 contain-layout flex items-center w-full px-2 py-1 cursor-pointer text-left border-none bg-transparent"><span class="text-[13px] leading-4 h-fit font-medium overflow-hidden text-ellipsis whitespace-nowrap min-w-0 transition-colors">'),Md=e=>{let{containerRef:t,highlightRef:n,updateHighlight:o,clearHighlight:i}=Qn(),s=[];return be(()=>{let r=s[e.activeIndex];r&&o(r);}),O(Mt,{get children(){var r=cb(),c=r.firstChild;return Ke(t,r),Ke(n,c),z(r,O(on,{get each(){return e.items},children:(l,u)=>(()=>{var f=db(),p=f.firstChild;return f.$$click=b=>{b.stopPropagation(),e.onSelect(u());},f.addEventListener("pointerleave",()=>{let b=s[e.activeIndex];b?o(b):i();}),f.addEventListener("pointerenter",b=>{o(b.currentTarget),e.onSelect(u());}),f.$$pointerdown=b=>b.stopPropagation(),Ke(b=>{s[u()]=b;},f),z(p,O(ye,{get when(){return l.componentName},get children(){return [Be(()=>l.componentName),ub()]}}),null),z(p,()=>l.tagName,null),te(b=>{var x=l.tagName,H=u()===e.activeIndex,M=u()!==e.activeIndex;return x!==b.e&&ae(f,"data-react-grab-arrow-nav-item",b.e=x),H!==b.t&&p.classList.toggle("text-black",b.t=H),M!==b.a&&p.classList.toggle("text-black/30",b.a=M),b},{e:void 0,t:void 0,a:void 0}),f})()}),null),r}})};it(["pointerdown","click"]);var fb=K('<button data-react-grab-ignore-events data-react-grab-abort class="contain-layout shrink-0 flex items-center justify-center size-4 rounded-full bg-black cursor-pointer ml-1 interactive-scale"><div class="size-1.5 bg-white rounded-[1px]">'),mb=K('<div class="shrink-0 flex justify-between items-end w-full min-h-4"><textarea data-react-grab-ignore-events class="text-black text-[13px] leading-4 font-medium bg-transparent border-none outline-none resize-none flex-1 p-0 m-0 opacity-50 wrap-break-word overflow-y-auto"placeholder="Add context"rows=1 disabled style=field-sizing:content;min-height:16px;max-height:95px;scrollbar-width:none>'),pb=K('<div class="contain-layout shrink-0 flex flex-col justify-center items-start w-fit h-fit max-w-[280px]"><div class="contain-layout shrink-0 flex items-center gap-1 py-1.5 px-2 w-full h-fit"><span class="shimmer-text text-[13px] leading-4 font-sans font-medium h-fit tabular-nums overflow-hidden text-ellipsis whitespace-nowrap">'),gb=K('<div class="flex flex-col w-[calc(100%+16px)] -mx-2 -my-1.5">'),hb=K('<div class="contain-layout shrink-0 flex flex-col items-start w-fit h-fit"><div class="contain-layout shrink-0 flex items-center gap-1 w-fit h-fit px-2">'),bb=K('<div class="flex items-center gap-1 w-full mb-1 overflow-hidden"><span class="text-black/40 text-[11px] leading-3 font-medium truncate italic">'),yb=K('<button data-react-grab-submit class="contain-layout shrink-0 flex items-center justify-center size-4 rounded-full bg-black cursor-pointer ml-1 interactive-scale">'),wb=K('<div class="shrink-0 flex justify-between items-end w-full min-h-4"><textarea data-react-grab-ignore-events data-react-grab-input class="text-black text-[13px] leading-4 font-medium bg-transparent border-none outline-none resize-none flex-1 p-0 m-0 wrap-break-word overflow-y-auto"placeholder="Add context"rows=1 style=field-sizing:content;min-height:16px;max-height:95px;scrollbar-width:none>'),xb=K('<div class="contain-layout shrink-0 flex flex-col justify-center items-start w-fit h-fit min-w-[150px] max-w-[280px]"><div class="contain-layout shrink-0 flex items-center gap-1 pt-1.5 pb-1 w-fit h-fit px-2 max-w-full">'),vb=K("<div data-react-grab-ignore-events data-react-grab-selection-label style=z-index:2147483647><div>"),Cb=K('<span class="text-[11px] font-sans text-black/50 ml-4">'),Eb=K('<div class="contain-layout flex items-center justify-between w-full px-2 py-1 transition-colors"><span class="text-[13px] leading-4 font-sans font-medium text-black">'),Rd={left:Ra,top:Ra,arrowLeftPercent:wa,arrowLeftOffset:0,edgeOffsetX:0},Ts=e=>{let t,n,o,i=false,s=null,r=null,[c,l]=U(0),[u,f]=U(0),[p,b]=U(0),[x,H]=U("bottom"),[M,Y]=U(0),[m,E]=U(false),[T,C]=U(false),R=()=>e.status!=="copying"&&e.status!=="copied"&&e.status!=="fading"&&e.status!=="error",X=()=>e.status==="copied"||e.status==="fading",fe=()=>!!(e.isPromptMode||X()&&(e.onDismiss||e.onShowContextMenu)||e.status==="copying"&&e.onAbort||e.status==="error"&&(e.onAcknowledgeError||e.onRetry)||e.arrowNavigationState?.isVisible),j,le=I=>{i=I;},ue=()=>{Y(I=>I+1);},L=I=>{if(St(I))return;let G=I.code==="Enter"&&!e.isPromptMode&&R(),Q=I.code==="KeyC"&&I.ctrlKey&&e.status==="copying"&&e.onAbort;G?(I.preventDefault(),I.stopImmediatePropagation(),e.onToggleExpand?.()):Q&&(I.preventDefault(),I.stopImmediatePropagation(),e.onAbort?.());};mt(()=>{if(j=new ResizeObserver(I=>{for(let G of I){let Q=G.target.getBoundingClientRect();G.target===t&&!i?(l(Q.width),f(Q.height)):G.target===n&&b(Q.width);}}),t){let I=t.getBoundingClientRect();l(I.width),f(I.height),j.observe(t);}n&&(b(n.getBoundingClientRect().width),j.observe(n)),window.addEventListener("scroll",ue,true),window.addEventListener("resize",ue),window.addEventListener("keydown",L,{capture:true});}),Me(()=>{j?.disconnect(),window.removeEventListener("scroll",ue,true),window.removeEventListener("resize",ue),window.removeEventListener("keydown",L,{capture:true});}),be(()=>{let I=`${e.tagName??""}:${e.componentName??""}`;I!==r&&(r=I,s=null);}),be(()=>{if(e.isPromptMode&&o&&e.onSubmit){let I=setTimeout(()=>{o?.focus();},0);Me(()=>{clearTimeout(I);});}});let A=se(()=>{M();let I=e.selectionBounds,G=c(),Q=u(),Ae=G>0&&Q>0,me=I&&I.width>0&&I.height>0;if(!Ae||!me)return {position:s??Rd,computedArrowPosition:null};let Se=window.innerWidth,ie=window.innerHeight;if(!(I.x+I.width>0&&I.x<Se&&I.y+I.height>0&&I.y<ie))return {position:Rd,computedArrowPosition:null};let ke=I.x+I.width/2,Pe=e.mouseX??ke,ge=I.y+I.height,Te=I.y,rt=e.hideArrow?0:bs(p()),ct=Pe,Ue=0,wt=ge+rt+rn;if(G>0){let sn=ct-G/2,Pt=ct+G/2;Pt>Se-8&&(Ue=Se-8-Pt),sn+Ue<8&&(Ue=8-sn);}let bn=Q+rt+rn,Ht=wt+Q<=ie-8;Ht||(wt=Te-bn),wt<8&&(wt=8);let Bt=wa,Rt=G/2,yn=Rt-Ue,xt=Math.min(xa,Rt),Dn=Math.max(G-xa,Rt),It=Math.max(xt,Math.min(Dn,yn))-Rt;return {position:{left:ct,top:wt,arrowLeftPercent:Bt,arrowLeftOffset:It,edgeOffsetX:Ue},computedArrowPosition:Ht?"bottom":"top"}});be(()=>{let I=A();I.computedArrowPosition!==null&&(s=I.position,E(true),H(I.computedArrowPosition));});let y=I=>{if(I.isComposing||I.keyCode===xu)return;I.stopImmediatePropagation();let G=I.code==="Enter"&&!I.shiftKey,Q=I.code==="Escape";G?(I.preventDefault(),e.onSubmit?.()):Q&&(I.preventDefault(),e.onConfirmDismiss?.());},h=I=>{let G=I.target;G instanceof HTMLTextAreaElement&&e.onInputChange?.(G.value);},S=()=>ys({tagName:e.tagName,componentName:e.componentName,elementsCount:e.elementsCount}),D=()=>S().tagName,B=()=>S().componentName,w=()=>e.actionCycleState?.items??[],v=()=>e.actionCycleState?.activeIndex??0,$=()=>!!e.actionCycleState?.isVisible,N=()=>!!e.arrowNavigationState?.isVisible,W=I=>{I.stopImmediatePropagation(),e.filePath&&e.onOpen&&e.onOpen();},V=()=>!!(e.filePath&&e.onOpen),oe=I=>{I.stopImmediatePropagation(),R()&&e.isPromptMode&&!e.isPendingDismiss&&e.onSubmit&&o&&o.focus();},de=()=>m()&&(X()||e.status==="error");return O(ye,{get when(){return Be(()=>e.visible!==false)()&&(e.selectionBounds||de())},get children(){var I=vb(),G=I.firstChild;I.addEventListener("mouseleave",()=>e.onHoverChange?.(false)),I.addEventListener("mouseenter",()=>e.onHoverChange?.(true)),I.$$click=me=>{me.stopImmediatePropagation();},I.$$pointerdown=oe;var Q=t;typeof Q=="function"?Ke(Q,I):t=I,z(I,O(ye,{get when(){return !e.hideArrow},get children(){return O(vs,{get position(){return x()},get leftPercent(){return A().position.arrowLeftPercent},get leftOffsetPx(){return A().position.arrowLeftOffset},get labelWidth(){return p()}})}}),G),z(I,O(ye,{get when(){return Be(()=>!!X())()&&!e.error},get children(){return O(Od,{get statusText(){return Be(()=>!!e.hasAgent)()?e.statusText??"Completed":"Copied"},get supportsUndo(){return e.supportsUndo},get supportsFollowUp(){return e.supportsFollowUp},get dismissButtonText(){return e.dismissButtonText},get previousPrompt(){return e.previousPrompt},get onDismiss(){return e.onDismiss},get onUndo(){return e.onUndo},get onFollowUpSubmit(){return e.onFollowUpSubmit},onFadingChange:C,get onShowContextMenu(){return e.onShowContextMenu}})}}),G);var Ae=n;return typeof Ae=="function"?Ke(Ae,G):n=G,z(G,O(ye,{get when(){return Be(()=>e.status==="copying")()&&!e.isPendingAbort},get children(){var me=pb(),Se=me.firstChild,ie=Se.firstChild;return z(Se,O(Sd,{size:13,class:"text-[#71717a] shrink-0"}),ie),z(ie,()=>e.statusText??"Grabbing\u2026"),z(me,O(ye,{get when(){return Be(()=>!!e.hasAgent)()&&e.inputValue},get children(){return O(Mt,{get children(){var pe=mb(),ke=pe.firstChild,Pe=o;return typeof Pe=="function"?Ke(Pe,ke):o=ke,z(pe,O(ye,{get when(){return e.onAbort},get children(){var ge=fb();return ge.$$click=Te=>{Te.stopPropagation(),e.onAbort?.();},ge.$$pointerdown=Te=>Te.stopPropagation(),ge}}),null),te(()=>ke.value=e.inputValue??""),pe}})}}),null),te(()=>me.classList.toggle("min-w-[150px]",!!(e.hasAgent&&e.inputValue))),me}}),null),z(G,O(ye,{get when(){return Be(()=>e.status==="copying")()&&e.isPendingAbort},get children(){return O(Zr,{get onConfirm(){return e.onConfirmAbort},get onCancel(){return e.onCancelAbort}})}}),null),z(G,O(ye,{get when(){return Be(()=>!!R())()&&!e.isPromptMode},get children(){var me=hb(),Se=me.firstChild;return z(Se,O(qr,{get tagName(){return D()},get componentName(){return B()},get isClickable(){return V()},onClick:W,onHoverChange:le,shrink:true,get forceShowIcon(){return Be(()=>!!N())()?V():!!e.isContextMenuOpen}})),z(me,O(ye,{get when(){return e.arrowNavigationState?.isVisible},get children(){return O(Md,{get items(){return e.arrowNavigationState.items},get activeIndex(){return e.arrowNavigationState.activeIndex},onSelect:ie=>e.onArrowNavigationSelect?.(ie)})}}),null),z(me,O(ye,{get when(){return Be(()=>!N())()&&$()},get children(){return O(Mt,{get children(){var ie=gb();return z(ie,O(on,{get each(){return w()},children:(pe,ke)=>(()=>{var Pe=Eb(),ge=Pe.firstChild;return z(ge,()=>pe.label),z(Pe,O(ye,{get when(){return pe.shortcut},get children(){var Te=Cb();return z(Te,()=>Jn(pe.shortcut)),Te}}),null),te(Te=>{var rt=pe.label.toLowerCase(),ct=ke()===v(),Ue=ke()===w().length-1;return rt!==Te.e&&ae(Pe,"data-react-grab-action-cycle-item",Te.e=rt),ct!==Te.t&&Pe.classList.toggle("bg-black/5",Te.t=ct),Ue!==Te.a&&Pe.classList.toggle("rounded-b-[6px]",Te.a=Ue),Te},{e:void 0,t:void 0,a:void 0}),Pe})()})),ie}})}}),null),te(ie=>{var pe=!!N(),ke={"py-1.5":!N(),"pt-1.5 pb-1":N()};return pe!==ie.e&&me.classList.toggle("min-w-[100px]",ie.e=pe),ie.t=co(Se,ke,ie.t),ie},{e:void 0,t:void 0}),me}}),null),z(G,O(ye,{get when(){return Be(()=>!!(R()&&e.isPromptMode))()&&!e.isPendingDismiss},get children(){var me=xb(),Se=me.firstChild;return z(Se,O(qr,{get tagName(){return D()},get componentName(){return B()},get isClickable(){return V()},onClick:W,onHoverChange:le,forceShowIcon:true})),z(me,O(Mt,{get children(){return [O(ye,{get when(){return e.replyToPrompt},get children(){var ie=bb(),pe=ie.firstChild;return z(ie,O(ws,{size:10,class:"text-black/30 shrink-0"}),pe),z(pe,()=>e.replyToPrompt),ie}}),(()=>{var ie=wb(),pe=ie.firstChild;pe.$$keydown=y,pe.$$input=h;var ke=o;return typeof ke=="function"?Ke(ke,pe):o=pe,z(ie,O(ye,{get when(){return e.onSubmit},get children(){var Pe=yb();return Pe.$$click=()=>e.onSubmit?.(),z(Pe,O(xs,{size:10,class:"text-white"})),Pe}}),null),te(Pe=>{var ge=e.replyToPrompt?"14px":"0",Te=!e.onSubmit;return ge!==Pe.e&&we(ie,"padding-left",Pe.e=ge),Te!==Pe.t&&(pe.readOnly=Pe.t=Te),Pe},{e:void 0,t:void 0}),te(()=>pe.value=e.inputValue??""),ie})()]}}),null),me}}),null),z(G,O(ye,{get when(){return e.isPendingDismiss},get children(){return O(Zr,{get onConfirm(){return e.onConfirmDismiss},get onCancel(){return e.onCancelDismiss}})}}),null),z(G,O(ye,{get when(){return e.error},get children(){return O(Pd,{get error(){return e.error},get onAcknowledge(){return e.onAcknowledgeError},get onRetry(){return e.onRetry}})}}),null),te(me=>{var Se=Ee("fixed font-sans text-[13px] antialiased filter-[drop-shadow(0px_1px_2px_#51515140)] select-none transition-opacity duration-100 ease-out"),ie=`${A().position.top}px`,pe=`${A().position.left}px`,ke=`translateX(calc(-50% + ${A().position.edgeOffsetX}px))`,Pe=fe()?"auto":"none",ge=e.status==="fading"||T()?0:1,Te=Ee("contain-layout flex items-center gap-[5px] rounded-[10px] antialiased w-fit h-fit p-0 [font-synthesis:none] [corner-shape:superellipse(1.25)]",ht),rt=X()&&!e.error?"none":void 0;return Se!==me.e&&Re(I,me.e=Se),ie!==me.t&&we(I,"top",me.t=ie),pe!==me.a&&we(I,"left",me.a=pe),ke!==me.o&&we(I,"transform",me.o=ke),Pe!==me.i&&we(I,"pointer-events",me.i=Pe),ge!==me.n&&we(I,"opacity",me.n=ge),Te!==me.s&&Re(G,me.s=Te),rt!==me.h&&we(G,"display",me.h=rt),me},{e:void 0,t:void 0,a:void 0,o:void 0,i:void 0,n:void 0,s:void 0,h:void 0}),I}})};it(["pointerdown","click","input","keydown"]);var Id="react-grab-toolbar-state",yo=()=>{try{let e=localStorage.getItem(Id);if(!e)return null;let t=JSON.parse(e);return {edge:t.edge??"bottom",ratio:t.ratio??.5,collapsed:t.collapsed??!1,enabled:t.enabled??!0}}catch(e){console.warn("[react-grab] Failed to load toolbar state from localStorage:",e);}return null},Qr=e=>{try{localStorage.setItem(Id,JSON.stringify(e));}catch(t){console.warn("[react-grab] Failed to save toolbar state to localStorage:",t);}};var Sb=K('<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 18 18"fill=currentColor><path opacity=0.4 d="M7.65631 10.9565C7.31061 10.0014 7.54012 8.96635 8.25592 8.25195C8.74522 7.76615 9.38771 7.49951 10.0694 7.49951C10.3682 7.49951 10.6641 7.55171 10.9483 7.65381L16.0001 9.49902V4.75C16.0001 3.2334 14.7667 2 13.2501 2H4.75012C3.23352 2 2.00012 3.2334 2.00012 4.75V13.25C2.00012 14.7666 3.23352 16 4.75012 16H9.49962L7.65631 10.9565Z"></path><path d="M17.296 11.5694L10.4415 9.06545C10.0431 8.92235 9.61441 9.01658 9.31551 9.31338C9.01671 9.61168 8.92101 10.0429 9.06551 10.4413L11.5704 17.2948C11.7247 17.7191 12.128 18.0004 12.5772 18.0004C12.585 18.0004 12.5918 17.9999 12.5987 17.9999C13.0577 17.9906 13.4591 17.6913 13.5987 17.2543L14.4854 14.4857L17.2559 13.5985C17.6914 13.4589 17.9903 13.057 18 12.599C18.0097 12.141 17.7267 11.7276 17.296 11.5694Z">'),Nd=e=>{let t=()=>e.size??14;return (()=>{var n=Sb();return te(o=>{var i=t(),s=t(),r=e.class;return i!==o.e&&ae(n,"width",o.e=i),s!==o.t&&ae(n,"height",o.t=s),r!==o.a&&ae(n,"class",o.a=r),o},{e:void 0,t:void 0,a:void 0}),n})()};var Ab=K('<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 24 24"fill=none stroke=currentColor stroke-width=2.5 stroke-linecap=round stroke-linejoin=round><path d="m18 15-6-6-6 6">'),Ld=e=>{let t=()=>e.size??12;return (()=>{var n=Ab();return te(o=>{var i=t(),s=t(),r=e.class;return i!==o.e&&ae(n,"width",o.e=i),s!==o.t&&ae(n,"height",o.t=s),r!==o.a&&ae(n,"class",o.a=r),o},{e:void 0,t:void 0,a:void 0}),n})()};var Tb=K('<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 24 24"fill=currentColor><path fill-rule=evenodd clip-rule=evenodd d="M12 1.25C6.06294 1.25 1.25 6.06294 1.25 12C1.25 17.9371 6.06294 22.75 12 22.75C17.9371 22.75 22.75 17.9371 22.75 12C22.75 6.06294 17.9371 1.25 12 1.25ZM13 8C13 7.44772 12.5523 7 12 7C11.4477 7 11 7.44772 11 8V12C11 12.2652 11.1054 12.5196 11.2929 12.7071L13.2929 14.7071C13.6834 15.0976 14.3166 15.0976 14.7071 14.7071C15.0976 14.3166 15.0976 13.6834 14.7071 13.2929L13 11.5858V8Z">'),Dd=e=>{let t=()=>e.size??14;return (()=>{var n=Tb();return te(o=>{var i=t(),s=t(),r=e.class;return i!==o.e&&ae(n,"width",o.e=i),s!==o.t&&ae(n,"height",o.t=s),r!==o.a&&ae(n,"class",o.a=r),o},{e:void 0,t:void 0,a:void 0}),n})()};var _b=K('<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 24 24"fill=currentColor><path d="M16.0549 8.25C17.4225 8.24998 18.5248 8.24996 19.3918 8.36652C20.2919 8.48754 21.0497 8.74643 21.6517 9.34835C22.2536 9.95027 22.5125 10.7081 22.6335 11.6083C22.75 12.4752 22.75 13.5775 22.75 14.9451V14.9451V16.0549V16.0549C22.75 17.4225 22.75 18.5248 22.6335 19.3918C22.5125 20.2919 22.2536 21.0497 21.6517 21.6517C21.0497 22.2536 20.2919 22.5125 19.3918 22.6335C18.5248 22.75 17.4225 22.75 16.0549 22.75H16.0549H14.9451H14.9451C13.5775 22.75 12.4752 22.75 11.6082 22.6335C10.7081 22.5125 9.95027 22.2536 9.34835 21.6516C8.74643 21.0497 8.48754 20.2919 8.36652 19.3918C8.24996 18.5248 8.24998 17.4225 8.25 16.0549V16.0549V14.9451V14.9451C8.24998 13.5775 8.24996 12.4752 8.36652 11.6082C8.48754 10.7081 8.74643 9.95027 9.34835 9.34835C9.95027 8.74643 10.7081 8.48754 11.6083 8.36652C12.4752 8.24996 13.5775 8.24998 14.9451 8.25H14.9451H16.0549H16.0549Z"></path><path d="M6.75 14.8569C6.74991 13.5627 6.74983 12.3758 6.8799 11.4084C7.0232 10.3425 7.36034 9.21504 8.28769 8.28769C9.21504 7.36034 10.3425 7.0232 11.4084 6.8799C12.3758 6.74983 13.5627 6.74991 14.8569 6.75L17.0931 6.75C17.3891 6.75 17.5371 6.75 17.6261 6.65419C17.7151 6.55838 17.7045 6.4142 17.6833 6.12584C17.6648 5.87546 17.6412 5.63892 17.6111 5.41544C17.4818 4.45589 17.2232 3.6585 16.6718 2.98663C16.4744 2.74612 16.2539 2.52558 16.0134 2.3282C15.3044 1.74638 14.4557 1.49055 13.4248 1.36868C12.4205 1.24998 11.1512 1.24999 9.54893 1.25H9.45109C7.84883 1.24999 6.57947 1.24998 5.57525 1.36868C4.54428 1.49054 3.69558 1.74638 2.98663 2.3282C2.74612 2.52558 2.52558 2.74612 2.3282 2.98663C1.74638 3.69558 1.49055 4.54428 1.36868 5.57525C1.24998 6.57947 1.24999 7.84882 1.25 9.45108V9.54891C1.24999 11.1512 1.24998 12.4205 1.36868 13.4247C1.49054 14.4557 1.74638 15.3044 2.3282 16.0134C2.52558 16.2539 2.74612 16.4744 2.98663 16.6718C3.6585 17.2232 4.45589 17.4818 5.41544 17.6111C5.63892 17.6412 5.87546 17.6648 6.12584 17.6833C6.4142 17.7045 6.55838 17.7151 6.65419 17.6261C6.75 17.5371 6.75 17.3891 6.75 17.0931V14.8569Z">'),ei=e=>{let t=()=>e.size??14;return (()=>{var n=_b();return te(o=>{var i=t(),s=t(),r=e.class;return i!==o.e&&ae(n,"width",o.e=i),s!==o.t&&ae(n,"height",o.t=s),r!==o.a&&ae(n,"class",o.a=r),o},{e:void 0,t:void 0,a:void 0}),n})()};var ul=(e,t,n)=>(e.x-n.x)*(t.y-n.y)-(t.x-n.x)*(e.y-n.y),Pb=(e,t,n,o)=>{let i=ul(e,t,n),s=ul(e,n,o),r=ul(e,o,t),c=i<0||s<0||r<0,l=i>0||s>0||r>0;return !c||!l},dl=(e,t)=>e.x>=t.x&&e.x<=t.x+t.width&&e.y>=t.y&&e.y<=t.y+t.height,kb=(e,t)=>{let n=t.y+t.height,o=t.x+t.width;return e.y<=t.y?[{x:t.x,y:n},{x:o,y:n}]:e.y>=n?[{x:t.x,y:t.y},{x:o,y:t.y}]:e.x<=t.x?[{x:o,y:t.y},{x:o,y:n}]:[{x:t.x,y:t.y},{x:t.x,y:n}]},_s=()=>{let e=null,t=()=>{e?.(),e=null;};return {start:(o,i,s)=>{t();let r=i[0];if(!r||dl(o,r))return;let[c,l]=kb(o,r),u=p=>i.some(b=>dl(p,b)),f=p=>{let b={x:p.clientX,y:p.clientY};if(u(b)){dl(b,r)&&t();return}Pb(b,o,c,l)||(t(),s());};window.addEventListener("mousemove",f),e=()=>{window.removeEventListener("mousemove",f);};},stop:t}};var yt=false,fl=(e,t,n)=>{let o=e.get(t);if(o)return o;let i=n();return e.set(t,i),i},Fd=new WeakMap,$d=new WeakMap,Ob=new WeakMap,pl=new Set,gl=[],Ps=[],ks=new WeakMap,Os=new WeakMap,Hd=new WeakSet,Bd=Ya,Mb=e=>{let t=e;for(;t.return;)t=t.return;return t.stateNode??null},zd=()=>{if(Bd.size>0)return Bd;let e=new Set,t=n=>{let o=po(n);if(o){let i=Mb(o);i&&e.add(i);return}for(let i of Array.from(n.children))if(t(i),e.size>0)return};return t(document.body),e},Rb=(e,t)=>{if(!e)return t;if(!t)return e;if(!e.next||!t.next)return t;let n=e.next,o=t.next,i=e===n,s=t===o;return i&&s?(e.next=t,t.next=e):i?(e.next=o,t.next=e):s?(t.next=n,e.next=t):(e.next=o,t.next=n),t},Ib=e=>{if(!e||ks.has(e))return;let t={originalPendingDescriptor:Object.getOwnPropertyDescriptor(e,"pending"),pendingValueAtPause:e.pending,bufferedPending:null};typeof e.getSnapshot=="function"&&(t.originalGetSnapshot=e.getSnapshot,t.snapshotValueAtPause=e.getSnapshot(),e.getSnapshot=()=>yt?t.snapshotValueAtPause:t.originalGetSnapshot());let n=t.pendingValueAtPause;Object.defineProperty(e,"pending",{configurable:true,enumerable:true,get:()=>yt?t.bufferedPending:n,set:o=>{yt&&(t.bufferedPending=o),n=o;}}),ks.set(e,t);},Nb=e=>{let t=ks.get(e);if(!t)return;t.originalGetSnapshot&&(e.getSnapshot=t.originalGetSnapshot);let n=Rb(t.pendingValueAtPause??null,t.bufferedPending??null);t.originalPendingDescriptor?Object.defineProperty(e,"pending",t.originalPendingDescriptor):delete e.pending,e.pending=n,ks.delete(e);},Lb=e=>{if(Os.has(e))return;let t={originalDescriptor:Object.getOwnPropertyDescriptor(e,"memoizedValue"),frozenValue:e.memoizedValue};Object.defineProperty(e,"memoizedValue",{configurable:true,enumerable:true,get(){return yt?t.frozenValue:t.originalDescriptor?.get?t.originalDescriptor.get.call(this):this._memoizedValue},set(n){if(yt){t.pendingValue=n,t.didReceivePendingValue=true;return}t.originalDescriptor?.set?t.originalDescriptor.set.call(this,n):this._memoizedValue=n;}}),t.originalDescriptor?.get||(e._memoizedValue=t.frozenValue),Os.set(e,t);},Db=e=>{let t=Os.get(e);t&&(t.originalDescriptor?Object.defineProperty(e,"memoizedValue",t.originalDescriptor):delete e.memoizedValue,t.didReceivePendingValue&&(e.memoizedValue=t.pendingValue),Os.delete(e));},Vd=(e,t)=>{let n=e.memoizedState;for(;n;)n.queue&&typeof n.queue=="object"&&t(n.queue),n=n.next;},Gd=(e,t)=>{let n=e.dependencies?.firstContext;for(;n&&typeof n=="object"&&"memoizedValue"in n;)t(n),n=n.next;},Ms=(e,t)=>{e&&(Jo(e)&&t(e),Ms(e.child,t),Ms(e.sibling,t));},Fb=e=>{Vd(e,Ib),Gd(e,Lb);},$b=e=>{Vd(e,Nb),Gd(e,Db);},Hb=e=>{if(Fd.has(e))return;let t=e,n={useState:t.useState,useReducer:t.useReducer,useTransition:t.useTransition,useSyncExternalStore:t.useSyncExternalStore};Fd.set(e,n),t.useState=(...o)=>{let i=n.useState.apply(e,o);if(!yt||!Array.isArray(i)||typeof i[1]!="function")return i;let[s,r]=i,c=fl($d,r,()=>(...l)=>{yt?Ps.push(()=>r(...l)):r(...l);});return [s,c]},t.useReducer=(...o)=>{let i=n.useReducer.apply(e,o);if(!yt||!Array.isArray(i)||typeof i[1]!="function")return i;let[s,r]=i,c=fl($d,r,()=>(...l)=>{yt?Ps.push(()=>r(...l)):r(...l);});return [s,c]},t.useTransition=(...o)=>{let i=n.useTransition.apply(e,o);if(!yt||!Array.isArray(i)||typeof i[1]!="function")return i;let[s,r]=i,c=fl(Ob,r,()=>l=>{yt?gl.push(()=>r(l)):r(l);});return [s,c]},t.useSyncExternalStore=(o,i,s)=>{if(!yt)return n.useSyncExternalStore(o,i,s);let r=c=>o(()=>{yt?pl.add(c):c();});return n.useSyncExternalStore(r,i,s)};},Bb=e=>{let t=e.currentDispatcherRef;if(!t||typeof t!="object")return;let n="H"in t?"H":"current",o=t[n];Object.defineProperty(t,n,{configurable:true,enumerable:true,get:()=>(o&&typeof o=="object"&&Hb(o),o),set:i=>{o=i;}});},zb=e=>{queueMicrotask(()=>{try{for(let t of Wn().renderers.values())if(typeof t.scheduleUpdate=="function"){for(let n of e)if(n.current)try{t.scheduleUpdate(n.current);}catch{}}}catch{}});},ml=e=>{for(let t of e)try{t();}catch{}},Vb=()=>{for(let e of Wn().renderers.values())Hd.has(e)||(Bb(e),Hd.add(e));},Rs=()=>{if(yt)return ()=>{};Vb(),yt=true;let e=zd();for(let t of e)Ms(t.current,Fb);return ()=>{if(yt)try{let t=zd();for(let s of t)Ms(s.current,$b);let n=Array.from(pl),o=gl.slice(),i=Ps.slice();yt=!1,ml(n),ml(o),ml(i),zb(t);}finally{pl.clear(),gl.length=0,Ps.length=0;}}};var ti=(e,t)=>{let n=document.createElement("style");return n.setAttribute(e,""),n.textContent=t,document.head.appendChild(n),n};var wo=false,Nn=new Map,Ud=-1,jd=new WeakSet,ni=new Map,lr=new Map,Gb=e=>jd.has(e)?true:!wo||!("gsapVersions"in window)||!(new Error().stack??"").includes("_tick")?false:(jd.add(e),true);typeof window<"u"&&(window.requestAnimationFrame=e=>{if(!Gb(e))return Ve(e);if(wo){let n=Ud--;return Nn.set(n,e),n}let t=Ve(n=>{if(wo){let o=Ud--;Nn.set(o,e),ni.set(t,o);return}e(n);});return t},window.cancelAnimationFrame=e=>{if(Nn.has(e)){Nn.delete(e);return}let t=lr.get(e);if(t!==void 0){Ge(t.nativeId),lr.delete(e);return}let n=ni.get(e);if(n!==void 0){Nn.delete(n),ni.delete(e);return}Ge(e);});var Wd=()=>{if(!wo){wo=true,Nn.clear(),ni.clear();for(let[e,{nativeId:t,callback:n}]of lr)Ge(t),Nn.set(e,n);lr.clear();}},Kd=()=>{if(wo){wo=false;for(let[e,t]of Nn.entries()){let n=Ve(o=>{lr.delete(e),t(o);});lr.set(e,{nativeId:n,callback:t});}Nn.clear(),ni.clear();}};var Ub=`
+</${t}>`
+        : `<${t}${o} />`;
+    },
+    ld = (e) => ps(e, jc),
+    cd = (e, t = {}) => {
+      let { truncate: n = true, maxAttrs: o = Wc } = t,
+        i = [];
+      for (let s of va) {
+        if (i.length >= o) break;
+        let r = e.getAttribute(s);
+        if (r) {
+          let c = n ? ld(r) : r;
+          i.push(`${s}="${c}"`);
+        }
+      }
+      return i.length > 0 ? ` ${i.join(" ")}` : "";
+    },
+    eh = (e) => {
+      let t = pt(e);
+      if (!(e instanceof HTMLElement)) {
+        let b = cd(e);
+        return `<${t}${b} />`;
+      }
+      let n = e.innerText?.trim() ?? e.textContent?.trim() ?? "",
+        o = "";
+      for (let { name: b, value: x } of e.attributes) o += ` ${b}="${ld(x)}"`;
+      let i = [],
+        s = [],
+        r = false,
+        c = Array.from(e.childNodes);
+      for (let b of c)
+        b.nodeType !== Node.COMMENT_NODE &&
+          (b.nodeType === Node.TEXT_NODE
+            ? b.textContent && b.textContent.trim().length > 0 && (r = true)
+            : b instanceof Element && (r ? s.push(b) : i.push(b)));
+      let l = (b) =>
+          b.length === 0
+            ? ""
+            : b.length <= 2
+              ? b.map((x) => `<${pt(x)} ...>`).join(`
+  `)
+              : `(${b.length} elements)`,
+        u = "",
+        f = l(i);
+      (f &&
+        (u += `
+  ${f}`),
+        n.length > 0 &&
+          (u += `
+  ${ps(n, $r)}`));
+      let p = l(s);
+      return (
+        p &&
+          (u += `
+  ${p}`),
+        u.length > 0
+          ? `<${t}${o}>${u}
+</${t}>`
+          : `<${t}${o} />`
+      );
+    };
+  var th = "https://react-grab.com",
+    ud = (e, t) => {
+      let n = t ? `&line=${t}` : "";
+      return `${th}/open-file?url=${encodeURIComponent(e)}${n}`;
+    };
+  var nh = async (e, t) => {
+      let n = tr(),
+        o = new URLSearchParams({ file: e }),
+        i = n ? "line1" : "line",
+        s = n ? "column1" : "column";
+      return (
+        t && o.set(i, String(t)),
+        o.set(s, "1"),
+        (
+          await fetch(
+            `${n ? "/__nextjs_launch-editor" : "/__open-in-editor"}?${o}`,
+          )
+        ).ok
+      );
+    },
+    or = async (e, t, n) => {
+      if (await nh(e, t).catch(() => false)) return;
+      let i = ud(e, t),
+        s = n ? n(i, e, t) : i;
+      window.open(s, "_blank", "noopener,noreferrer");
+    };
+  var rr = (e, t, n) => e + (t - e) * n;
+  var rh = K(
+      "<canvas data-react-grab-overlay-canvas style=position:fixed;top:0;left:0;pointer-events:none>",
+    ),
+    Yn = {
+      drag: { borderColor: Hc, fillColor: Bc, lerpFactor: 0.7 },
+      selection: { borderColor: es, fillColor: ts, lerpFactor: 0.95 },
+      grabbed: { borderColor: es, fillColor: ts, lerpFactor: 0.95 },
+      processing: { borderColor: es, fillColor: ts, lerpFactor: 0.95 },
+    },
+    md = (e) => {
+      let t,
+        n = null,
+        o = 0,
+        i = 0,
+        s = 1,
+        r = null,
+        c = {
+          crosshair: { canvas: null, context: null },
+          drag: { canvas: null, context: null },
+          selection: { canvas: null, context: null },
+          grabbed: { canvas: null, context: null },
+          processing: { canvas: null, context: null },
+        },
+        l = { x: 0, y: 0 },
+        u = [],
+        f = null,
+        p = [],
+        b = [],
+        x = (h, S, D) => {
+          let B = new OffscreenCanvas(h * D, S * D),
+            w = B.getContext("2d");
+          return (w && w.scale(D, D), { canvas: B, context: w });
+        },
+        H = () => {
+          if (t) {
+            ((s = Math.max(window.devicePixelRatio || 1, 2)),
+              (o = window.innerWidth),
+              (i = window.innerHeight),
+              (t.width = o * s),
+              (t.height = i * s),
+              (t.style.width = `${o}px`),
+              (t.style.height = `${i}px`),
+              (n = t.getContext("2d")),
+              n && n.scale(s, s));
+            for (let h of Object.keys(c)) c[h] = x(o, i, s);
+          }
+        },
+        M = (h) => {
+          if (!h) return 0;
+          let S = h.match(/^(\d+(?:\.\d+)?)/);
+          return S ? parseFloat(S[1]) : 0;
+        },
+        Y = (h, S, D) => ({
+          id: h,
+          current: { x: S.x, y: S.y, width: S.width, height: S.height },
+          target: { x: S.x, y: S.y, width: S.width, height: S.height },
+          borderRadius: M(S.borderRadius),
+          opacity: D?.opacity ?? 1,
+          targetOpacity: D?.targetOpacity ?? D?.opacity ?? 1,
+          createdAt: D?.createdAt,
+          isInitialized: true,
+        }),
+        m = (h, S, D) => {
+          ((h.target = { x: S.x, y: S.y, width: S.width, height: S.height }),
+            (h.borderRadius = M(S.borderRadius)),
+            D !== void 0 && (h.targetOpacity = D));
+        },
+        E = (h) => h.boundsMultiple ?? [h.bounds],
+        T = (h, S, D, B, w, v, $, N, W = 1) => {
+          if (B <= 0 || w <= 0) return;
+          let V = Math.min(B / 2, w / 2),
+            oe = Math.min(v, V);
+          ((h.globalAlpha = W),
+            h.beginPath(),
+            oe > 0 ? h.roundRect(S, D, B, w, oe) : h.rect(S, D, B, w),
+            (h.fillStyle = $),
+            h.fill(),
+            (h.strokeStyle = N),
+            (h.lineWidth = 1),
+            h.stroke(),
+            (h.globalAlpha = 1));
+        },
+        C = () => {
+          let h = c.crosshair;
+          if (!h.context) return;
+          let S = h.context;
+          (S.clearRect(0, 0, o, i),
+            e.crosshairVisible &&
+              ((S.strokeStyle = $c),
+              (S.lineWidth = 1),
+              S.beginPath(),
+              S.moveTo(l.x, 0),
+              S.lineTo(l.x, i),
+              S.moveTo(0, l.y),
+              S.lineTo(o, l.y),
+              S.stroke()));
+        },
+        R = () => {
+          let h = c.drag;
+          if (!h.context) return;
+          let S = h.context;
+          if ((S.clearRect(0, 0, o, i), !e.dragVisible || !f)) return;
+          let D = Yn.drag;
+          T(
+            S,
+            f.current.x,
+            f.current.y,
+            f.current.width,
+            f.current.height,
+            f.borderRadius,
+            D.fillColor,
+            D.borderColor,
+          );
+        },
+        X = () => {
+          let h = c.selection;
+          if (!h.context) return;
+          let S = h.context;
+          if ((S.clearRect(0, 0, o, i), !e.selectionVisible)) return;
+          let D = Yn.selection;
+          for (let B of u) {
+            let w = e.selectionIsFading ? 0 : B.opacity;
+            T(
+              S,
+              B.current.x,
+              B.current.y,
+              B.current.width,
+              B.current.height,
+              B.borderRadius,
+              D.fillColor,
+              D.borderColor,
+              w,
+            );
+          }
+        },
+        fe = () => {
+          let h = c.grabbed;
+          if (!h.context) return;
+          let S = h.context;
+          S.clearRect(0, 0, o, i);
+          let D = Yn.grabbed;
+          for (let B of p)
+            T(
+              S,
+              B.current.x,
+              B.current.y,
+              B.current.width,
+              B.current.height,
+              B.borderRadius,
+              D.fillColor,
+              D.borderColor,
+              B.opacity,
+            );
+        },
+        j = () => {
+          let h = c.processing;
+          if (!h.context) return;
+          let S = h.context;
+          S.clearRect(0, 0, o, i);
+          let D = Yn.processing;
+          for (let B of b)
+            T(
+              S,
+              B.current.x,
+              B.current.y,
+              B.current.width,
+              B.current.height,
+              B.borderRadius,
+              D.fillColor,
+              D.borderColor,
+              B.opacity,
+            );
+        },
+        le = () => {
+          if (!n || !t) return;
+          (n.setTransform(1, 0, 0, 1, 0, 0),
+            n.clearRect(0, 0, t.width, t.height),
+            n.setTransform(s, 0, 0, s, 0, 0),
+            C(),
+            R(),
+            X(),
+            fe(),
+            j());
+          let h = ["crosshair", "drag", "selection", "grabbed", "processing"];
+          for (let S of h) {
+            let D = c[S];
+            D.canvas && n.drawImage(D.canvas, 0, 0, o, i);
+          }
+        },
+        ue = (h, S, D) => {
+          let B = rr(h.current.x, h.target.x, S),
+            w = rr(h.current.y, h.target.y, S),
+            v = rr(h.current.width, h.target.width, S),
+            $ = rr(h.current.height, h.target.height, S),
+            N =
+              Math.abs(B - h.target.x) < 0.5 &&
+              Math.abs(w - h.target.y) < 0.5 &&
+              Math.abs(v - h.target.width) < 0.5 &&
+              Math.abs($ - h.target.height) < 0.5;
+          ((h.current.x = N ? h.target.x : B),
+            (h.current.y = N ? h.target.y : w),
+            (h.current.width = N ? h.target.width : v),
+            (h.current.height = N ? h.target.height : $));
+          let W = true;
+          if (D?.interpolateOpacity) {
+            let V = rr(h.opacity, h.targetOpacity, S);
+            ((W = Math.abs(V - h.targetOpacity) < 0.01),
+              (h.opacity = W ? h.targetOpacity : V));
+          }
+          return !N || !W;
+        },
+        L = () => {
+          let h = false;
+          f?.isInitialized && ue(f, Yn.drag.lerpFactor) && (h = true);
+          for (let D of u)
+            D.isInitialized && ue(D, Yn.selection.lerpFactor) && (h = true);
+          let S = Date.now();
+          p = p.filter((D) => {
+            let B = D.id.startsWith("label-");
+            if (
+              (D.isInitialized &&
+                ue(D, Yn.grabbed.lerpFactor, { interpolateOpacity: B }) &&
+                (h = true),
+              D.createdAt)
+            ) {
+              let w = S - D.createdAt,
+                v = 1600;
+              if (w >= v) return false;
+              if (w > 1500) {
+                let $ = (w - 1500) / 100;
+                ((D.opacity = 1 - $), (h = true));
+              }
+              return true;
+            }
+            return B
+              ? !(
+                  Math.abs(D.opacity - D.targetOpacity) < 0.01 &&
+                  D.targetOpacity === 0
+                )
+              : D.opacity > 0;
+          });
+          for (let D of b)
+            D.isInitialized && ue(D, Yn.processing.lerpFactor) && (h = true);
+          (le(), h ? (r = Ve(L)) : (r = null));
+        },
+        A = () => {
+          r === null && (r = Ve(L));
+        },
+        y = () => {
+          (H(), A());
+        };
+      return (
+        be(
+          He(
+            () => [e.mouseX, e.mouseY],
+            ([h, S]) => {
+              let D = h ?? 0,
+                B = S ?? 0;
+              ((l.x = D), (l.y = B), A());
+            },
+          ),
+        ),
+        be(
+          He(
+            () => e.crosshairVisible,
+            () => {
+              A();
+            },
+          ),
+        ),
+        be(
+          He(
+            () => [
+              e.selectionVisible,
+              e.selectionBounds,
+              e.selectionBoundsMultiple,
+              e.selectionIsFading,
+              e.selectionShouldSnap,
+            ],
+            ([h, S, D, , B]) => {
+              if (!h || (!S && (!D || D.length === 0))) {
+                ((u = []), A());
+                return;
+              }
+              ((u = (D && D.length > 0 ? D : S ? [S] : []).map((v, $) => {
+                let N = `selection-${$}`,
+                  W = u.find((V) => V.id === N);
+                return W
+                  ? (m(W, v), B && (W.current = { ...W.target }), W)
+                  : Y(N, v);
+              })),
+                A());
+            },
+          ),
+        ),
+        be(
+          He(
+            () => [e.dragVisible, e.dragBounds],
+            ([h, S]) => {
+              if (!h || !S) {
+                ((f = null), A());
+                return;
+              }
+              (f ? m(f, S) : (f = Y("drag", S)), A());
+            },
+          ),
+        ),
+        be(
+          He(
+            () => e.grabbedBoxes,
+            (h) => {
+              let S = h ?? [],
+                D = new Set(S.map((w) => w.id)),
+                B = new Set(p.map((w) => w.id));
+              for (let w of S)
+                B.has(w.id) ||
+                  p.push(Y(w.id, w.bounds, { createdAt: w.createdAt }));
+              for (let w of p) {
+                let v = S.find(($) => $.id === w.id);
+                v && m(w, v.bounds);
+              }
+              ((p = p.filter((w) =>
+                w.id.startsWith("label-") ? true : D.has(w.id),
+              )),
+                A());
+            },
+          ),
+        ),
+        be(
+          He(
+            () => e.agentSessions,
+            (h) => {
+              if (!h || h.size === 0) {
+                ((b = []), A());
+                return;
+              }
+              let S = [];
+              for (let [D, B] of h)
+                for (let w = 0; w < B.selectionBounds.length; w++) {
+                  let v = B.selectionBounds[w],
+                    $ = `processing-${D}-${w}`,
+                    N = b.find((W) => W.id === $);
+                  N ? (m(N, v), S.push(N)) : S.push(Y($, v));
+                }
+              ((b = S), A());
+            },
+          ),
+        ),
+        be(
+          He(
+            () => e.labelInstances,
+            (h) => {
+              let S = h ?? [];
+              for (let B of S) {
+                let w = E(B),
+                  v = B.status === "fading" ? 0 : 1;
+                for (let $ = 0; $ < w.length; $++) {
+                  let N = w[$],
+                    W = `label-${B.id}-${$}`,
+                    V = p.find((oe) => oe.id === W);
+                  V
+                    ? m(V, N, v)
+                    : p.push(Y(W, N, { opacity: 1, targetOpacity: v }));
+                }
+              }
+              let D = new Set();
+              for (let B of S) {
+                let w = E(B);
+                for (let v = 0; v < w.length; v++) D.add(`label-${B.id}-${v}`);
+              }
+              ((p = p.filter((B) =>
+                B.id.startsWith("label-") ? D.has(B.id) : true,
+              )),
+                A());
+            },
+          ),
+        ),
+        mt(() => {
+          (H(), A(), window.addEventListener("resize", y));
+          let h = null,
+            S = () => {
+              Math.max(window.devicePixelRatio || 1, 2) !== s && (y(), D());
+            },
+            D = () => {
+              (h && h.removeEventListener("change", S),
+                (h = window.matchMedia(
+                  `(resolution: ${window.devicePixelRatio}dppx)`,
+                )),
+                h.addEventListener("change", S));
+            };
+          (D(),
+            Me(() => {
+              (window.removeEventListener("resize", y),
+                h && h.removeEventListener("change", S),
+                r !== null && Ge(r));
+            }));
+        }),
+        (() => {
+          var h = rh(),
+            S = t;
+          return (
+            typeof S == "function" ? Ke(S, h) : (t = h),
+            te((D) => we(h, "z-index", String(2147483645))),
+            h
+          );
+        })()
+      );
+    };
+  var bs = (e) => {
+    if (e <= 0) return Un;
+    let t = e * Uc;
+    return Math.max(Gc, Math.min(Un, t));
+  };
+  function pd(e) {
+    var t,
+      n,
+      o = "";
+    if (typeof e == "string" || typeof e == "number") o += e;
+    else if (typeof e == "object")
+      if (Array.isArray(e)) {
+        var i = e.length;
+        for (t = 0; t < i; t++)
+          e[t] && (n = pd(e[t])) && (o && (o += " "), (o += n));
+      } else for (n in e) e[n] && (o && (o += " "), (o += n));
+    return o;
+  }
+  function gd() {
+    for (var e, t, n = 0, o = "", i = arguments.length; n < i; n++)
+      (e = arguments[n]) && (t = pd(e)) && (o && (o += " "), (o += t));
+    return o;
+  }
+  var ll = "-",
+    ih = (e) => {
+      let t = ah(e),
+        { conflictingClassGroups: n, conflictingClassGroupModifiers: o } = e;
+      return {
+        getClassGroupId: (r) => {
+          let c = r.split(ll);
+          return (
+            c[0] === "" && c.length !== 1 && c.shift(), yd(c, t) || sh(r)
+          );
+        },
+        getConflictingClassGroupIds: (r, c) => {
+          let l = n[r] || [];
+          return c && o[r] ? [...l, ...o[r]] : l;
+        },
+      };
+    },
+    yd = (e, t) => {
+      if (e.length === 0) return t.classGroupId;
+      let n = e[0],
+        o = t.nextPart.get(n),
+        i = o ? yd(e.slice(1), o) : void 0;
+      if (i) return i;
+      if (t.validators.length === 0) return;
+      let s = e.join(ll);
+      return t.validators.find(({ validator: r }) => r(s))?.classGroupId;
+    },
+    hd = /^\[(.+)\]$/,
+    sh = (e) => {
+      if (hd.test(e)) {
+        let t = hd.exec(e)[1],
+          n = t?.substring(0, t.indexOf(":"));
+        if (n) return "arbitrary.." + n;
+      }
+    },
+    ah = (e) => {
+      let { theme: t, prefix: n } = e,
+        o = { nextPart: new Map(), validators: [] };
+      return (
+        ch(Object.entries(e.classGroups), n).forEach(([s, r]) => {
+          al(r, o, s, t);
+        }),
+        o
+      );
+    },
+    al = (e, t, n, o) => {
+      e.forEach((i) => {
+        if (typeof i == "string") {
+          let s = i === "" ? t : bd(t, i);
+          s.classGroupId = n;
+          return;
+        }
+        if (typeof i == "function") {
+          if (lh(i)) {
+            al(i(o), t, n, o);
+            return;
+          }
+          t.validators.push({ validator: i, classGroupId: n });
+          return;
+        }
+        Object.entries(i).forEach(([s, r]) => {
+          al(r, bd(t, s), n, o);
+        });
+      });
+    },
+    bd = (e, t) => {
+      let n = e;
+      return (
+        t.split(ll).forEach((o) => {
+          (n.nextPart.has(o) ||
+            n.nextPart.set(o, { nextPart: new Map(), validators: [] }),
+            (n = n.nextPart.get(o)));
+        }),
+        n
+      );
+    },
+    lh = (e) => e.isThemeGetter,
+    ch = (e, t) =>
+      t
+        ? e.map(([n, o]) => {
+            let i = o.map((s) =>
+              typeof s == "string"
+                ? t + s
+                : typeof s == "object"
+                  ? Object.fromEntries(
+                      Object.entries(s).map(([r, c]) => [t + r, c]),
+                    )
+                  : s,
+            );
+            return [n, i];
+          })
+        : e,
+    uh = (e) => {
+      if (e < 1) return { get: () => {}, set: () => {} };
+      let t = 0,
+        n = new Map(),
+        o = new Map(),
+        i = (s, r) => {
+          (n.set(s, r), t++, t > e && ((t = 0), (o = n), (n = new Map())));
+        };
+      return {
+        get(s) {
+          let r = n.get(s);
+          if (r !== void 0) return r;
+          if ((r = o.get(s)) !== void 0) return (i(s, r), r);
+        },
+        set(s, r) {
+          n.has(s) ? n.set(s, r) : i(s, r);
+        },
+      };
+    },
+    wd = "!",
+    dh = (e) => {
+      let { separator: t, experimentalParseClassName: n } = e,
+        o = t.length === 1,
+        i = t[0],
+        s = t.length,
+        r = (c) => {
+          let l = [],
+            u = 0,
+            f = 0,
+            p;
+          for (let Y = 0; Y < c.length; Y++) {
+            let m = c[Y];
+            if (u === 0) {
+              if (m === i && (o || c.slice(Y, Y + s) === t)) {
+                (l.push(c.slice(f, Y)), (f = Y + s));
+                continue;
+              }
+              if (m === "/") {
+                p = Y;
+                continue;
+              }
+            }
+            m === "[" ? u++ : m === "]" && u--;
+          }
+          let b = l.length === 0 ? c : c.substring(f),
+            x = b.startsWith(wd),
+            H = x ? b.substring(1) : b,
+            M = p && p > f ? p - f : void 0;
+          return {
+            modifiers: l,
+            hasImportantModifier: x,
+            baseClassName: H,
+            maybePostfixModifierPosition: M,
+          };
+        };
+      return n ? (c) => n({ className: c, parseClassName: r }) : r;
+    },
+    fh = (e) => {
+      if (e.length <= 1) return e;
+      let t = [],
+        n = [];
+      return (
+        e.forEach((o) => {
+          o[0] === "[" ? (t.push(...n.sort(), o), (n = [])) : n.push(o);
+        }),
+        t.push(...n.sort()),
+        t
+      );
+    },
+    mh = (e) => ({ cache: uh(e.cacheSize), parseClassName: dh(e), ...ih(e) }),
+    ph = /\s+/,
+    gh = (e, t) => {
+      let {
+          parseClassName: n,
+          getClassGroupId: o,
+          getConflictingClassGroupIds: i,
+        } = t,
+        s = [],
+        r = e.trim().split(ph),
+        c = "";
+      for (let l = r.length - 1; l >= 0; l -= 1) {
+        let u = r[l],
+          {
+            modifiers: f,
+            hasImportantModifier: p,
+            baseClassName: b,
+            maybePostfixModifierPosition: x,
+          } = n(u),
+          H = !!x,
+          M = o(H ? b.substring(0, x) : b);
+        if (!M) {
+          if (!H) {
+            c = u + (c.length > 0 ? " " + c : c);
+            continue;
+          }
+          if (((M = o(b)), !M)) {
+            c = u + (c.length > 0 ? " " + c : c);
+            continue;
+          }
+          H = false;
+        }
+        let Y = fh(f).join(":"),
+          m = p ? Y + wd : Y,
+          E = m + M;
+        if (s.includes(E)) continue;
+        s.push(E);
+        let T = i(M, H);
+        for (let C = 0; C < T.length; ++C) {
+          let R = T[C];
+          s.push(m + R);
+        }
+        c = u + (c.length > 0 ? " " + c : c);
+      }
+      return c;
+    };
+  function hh() {
+    let e = 0,
+      t,
+      n,
+      o = "";
+    for (; e < arguments.length; )
+      (t = arguments[e++]) && (n = xd(t)) && (o && (o += " "), (o += n));
+    return o;
+  }
+  var xd = (e) => {
+    if (typeof e == "string") return e;
+    let t,
+      n = "";
+    for (let o = 0; o < e.length; o++)
+      e[o] && (t = xd(e[o])) && (n && (n += " "), (n += t));
+    return n;
+  };
+  function bh(e, ...t) {
+    let n,
+      o,
+      i,
+      s = r;
+    function r(l) {
+      let u = t.reduce((f, p) => p(f), e());
+      return ((n = mh(u)), (o = n.cache.get), (i = n.cache.set), (s = c), c(l));
+    }
+    function c(l) {
+      let u = o(l);
+      if (u) return u;
+      let f = gh(l, n);
+      return (i(l, f), f);
+    }
+    return function () {
+      return s(hh.apply(null, arguments));
+    };
+  }
+  var ot = (e) => {
+      let t = (n) => n[e] || [];
+      return ((t.isThemeGetter = true), t);
+    },
+    vd = /^\[(?:([a-z-]+):)?(.+)\]$/i,
+    yh = /^\d+\/\d+$/,
+    wh = new Set(["px", "full", "screen"]),
+    xh = /^(\d+(\.\d+)?)?(xs|sm|md|lg|xl)$/,
+    vh =
+      /\d+(%|px|r?em|[sdl]?v([hwib]|min|max)|pt|pc|in|cm|mm|cap|ch|ex|r?lh|cq(w|h|i|b|min|max))|\b(calc|min|max|clamp)\(.+\)|^0$/,
+    Ch = /^(rgba?|hsla?|hwb|(ok)?(lab|lch))\(.+\)$/,
+    Eh = /^(inset_)?-?((\d+)?\.?(\d+)[a-z]+|0)_-?((\d+)?\.?(\d+)[a-z]+|0)/,
+    Sh =
+      /^(url|image|image-set|cross-fade|element|(repeating-)?(linear|radial|conic)-gradient)\(.+\)$/,
+    Rn = (e) => ir(e) || wh.has(e) || yh.test(e),
+    qn = (e) => sr(e, "length", Rh),
+    ir = (e) => !!e && !Number.isNaN(Number(e)),
+    sl = (e) => sr(e, "number", ir),
+    Xr = (e) => !!e && Number.isInteger(Number(e)),
+    Ah = (e) => e.endsWith("%") && ir(e.slice(0, -1)),
+    Ie = (e) => vd.test(e),
+    Zn = (e) => xh.test(e),
+    Th = new Set(["length", "size", "percentage"]),
+    _h = (e) => sr(e, Th, Cd),
+    Ph = (e) => sr(e, "position", Cd),
+    kh = new Set(["image", "url"]),
+    Oh = (e) => sr(e, kh, Nh),
+    Mh = (e) => sr(e, "", Ih),
+    Yr = () => true,
+    sr = (e, t, n) => {
+      let o = vd.exec(e);
+      return o
+        ? o[1]
+          ? typeof t == "string"
+            ? o[1] === t
+            : t.has(o[1])
+          : n(o[2])
+        : false;
+    },
+    Rh = (e) => vh.test(e) && !Ch.test(e),
+    Cd = () => false,
+    Ih = (e) => Eh.test(e),
+    Nh = (e) => Sh.test(e);
+  var Lh = () => {
+    let e = ot("colors"),
+      t = ot("spacing"),
+      n = ot("blur"),
+      o = ot("brightness"),
+      i = ot("borderColor"),
+      s = ot("borderRadius"),
+      r = ot("borderSpacing"),
+      c = ot("borderWidth"),
+      l = ot("contrast"),
+      u = ot("grayscale"),
+      f = ot("hueRotate"),
+      p = ot("invert"),
+      b = ot("gap"),
+      x = ot("gradientColorStops"),
+      H = ot("gradientColorStopPositions"),
+      M = ot("inset"),
+      Y = ot("margin"),
+      m = ot("opacity"),
+      E = ot("padding"),
+      T = ot("saturate"),
+      C = ot("scale"),
+      R = ot("sepia"),
+      X = ot("skew"),
+      fe = ot("space"),
+      j = ot("translate"),
+      le = () => ["auto", "contain", "none"],
+      ue = () => ["auto", "hidden", "clip", "visible", "scroll"],
+      L = () => ["auto", Ie, t],
+      A = () => [Ie, t],
+      y = () => ["", Rn, qn],
+      h = () => ["auto", ir, Ie],
+      S = () => [
+        "bottom",
+        "center",
+        "left",
+        "left-bottom",
+        "left-top",
+        "right",
+        "right-bottom",
+        "right-top",
+        "top",
+      ],
+      D = () => ["solid", "dashed", "dotted", "double", "none"],
+      B = () => [
+        "normal",
+        "multiply",
+        "screen",
+        "overlay",
+        "darken",
+        "lighten",
+        "color-dodge",
+        "color-burn",
+        "hard-light",
+        "soft-light",
+        "difference",
+        "exclusion",
+        "hue",
+        "saturation",
+        "color",
+        "luminosity",
+      ],
+      w = () => [
+        "start",
+        "end",
+        "center",
+        "between",
+        "around",
+        "evenly",
+        "stretch",
+      ],
+      v = () => ["", "0", Ie],
+      $ = () => [
+        "auto",
+        "avoid",
+        "all",
+        "avoid-page",
+        "page",
+        "left",
+        "right",
+        "column",
+      ],
+      N = () => [ir, Ie];
+    return {
+      cacheSize: 500,
+      separator: ":",
+      theme: {
+        colors: [Yr],
+        spacing: [Rn, qn],
+        blur: ["none", "", Zn, Ie],
+        brightness: N(),
+        borderColor: [e],
+        borderRadius: ["none", "", "full", Zn, Ie],
+        borderSpacing: A(),
+        borderWidth: y(),
+        contrast: N(),
+        grayscale: v(),
+        hueRotate: N(),
+        invert: v(),
+        gap: A(),
+        gradientColorStops: [e],
+        gradientColorStopPositions: [Ah, qn],
+        inset: L(),
+        margin: L(),
+        opacity: N(),
+        padding: A(),
+        saturate: N(),
+        scale: N(),
+        sepia: v(),
+        skew: N(),
+        space: A(),
+        translate: A(),
+      },
+      classGroups: {
+        aspect: [{ aspect: ["auto", "square", "video", Ie] }],
+        container: ["container"],
+        columns: [{ columns: [Zn] }],
+        "break-after": [{ "break-after": $() }],
+        "break-before": [{ "break-before": $() }],
+        "break-inside": [
+          { "break-inside": ["auto", "avoid", "avoid-page", "avoid-column"] },
+        ],
+        "box-decoration": [{ "box-decoration": ["slice", "clone"] }],
+        box: [{ box: ["border", "content"] }],
+        display: [
+          "block",
+          "inline-block",
+          "inline",
+          "flex",
+          "inline-flex",
+          "table",
+          "inline-table",
+          "table-caption",
+          "table-cell",
+          "table-column",
+          "table-column-group",
+          "table-footer-group",
+          "table-header-group",
+          "table-row-group",
+          "table-row",
+          "flow-root",
+          "grid",
+          "inline-grid",
+          "contents",
+          "list-item",
+          "hidden",
+        ],
+        float: [{ float: ["right", "left", "none", "start", "end"] }],
+        clear: [{ clear: ["left", "right", "both", "none", "start", "end"] }],
+        isolation: ["isolate", "isolation-auto"],
+        "object-fit": [
+          { object: ["contain", "cover", "fill", "none", "scale-down"] },
+        ],
+        "object-position": [{ object: [...S(), Ie] }],
+        overflow: [{ overflow: ue() }],
+        "overflow-x": [{ "overflow-x": ue() }],
+        "overflow-y": [{ "overflow-y": ue() }],
+        overscroll: [{ overscroll: le() }],
+        "overscroll-x": [{ "overscroll-x": le() }],
+        "overscroll-y": [{ "overscroll-y": le() }],
+        position: ["static", "fixed", "absolute", "relative", "sticky"],
+        inset: [{ inset: [M] }],
+        "inset-x": [{ "inset-x": [M] }],
+        "inset-y": [{ "inset-y": [M] }],
+        start: [{ start: [M] }],
+        end: [{ end: [M] }],
+        top: [{ top: [M] }],
+        right: [{ right: [M] }],
+        bottom: [{ bottom: [M] }],
+        left: [{ left: [M] }],
+        visibility: ["visible", "invisible", "collapse"],
+        z: [{ z: ["auto", Xr, Ie] }],
+        basis: [{ basis: L() }],
+        "flex-direction": [
+          { flex: ["row", "row-reverse", "col", "col-reverse"] },
+        ],
+        "flex-wrap": [{ flex: ["wrap", "wrap-reverse", "nowrap"] }],
+        flex: [{ flex: ["1", "auto", "initial", "none", Ie] }],
+        grow: [{ grow: v() }],
+        shrink: [{ shrink: v() }],
+        order: [{ order: ["first", "last", "none", Xr, Ie] }],
+        "grid-cols": [{ "grid-cols": [Yr] }],
+        "col-start-end": [{ col: ["auto", { span: ["full", Xr, Ie] }, Ie] }],
+        "col-start": [{ "col-start": h() }],
+        "col-end": [{ "col-end": h() }],
+        "grid-rows": [{ "grid-rows": [Yr] }],
+        "row-start-end": [{ row: ["auto", { span: [Xr, Ie] }, Ie] }],
+        "row-start": [{ "row-start": h() }],
+        "row-end": [{ "row-end": h() }],
+        "grid-flow": [
+          { "grid-flow": ["row", "col", "dense", "row-dense", "col-dense"] },
+        ],
+        "auto-cols": [{ "auto-cols": ["auto", "min", "max", "fr", Ie] }],
+        "auto-rows": [{ "auto-rows": ["auto", "min", "max", "fr", Ie] }],
+        gap: [{ gap: [b] }],
+        "gap-x": [{ "gap-x": [b] }],
+        "gap-y": [{ "gap-y": [b] }],
+        "justify-content": [{ justify: ["normal", ...w()] }],
+        "justify-items": [
+          { "justify-items": ["start", "end", "center", "stretch"] },
+        ],
+        "justify-self": [
+          { "justify-self": ["auto", "start", "end", "center", "stretch"] },
+        ],
+        "align-content": [{ content: ["normal", ...w(), "baseline"] }],
+        "align-items": [
+          { items: ["start", "end", "center", "baseline", "stretch"] },
+        ],
+        "align-self": [
+          { self: ["auto", "start", "end", "center", "stretch", "baseline"] },
+        ],
+        "place-content": [{ "place-content": [...w(), "baseline"] }],
+        "place-items": [
+          { "place-items": ["start", "end", "center", "baseline", "stretch"] },
+        ],
+        "place-self": [
+          { "place-self": ["auto", "start", "end", "center", "stretch"] },
+        ],
+        p: [{ p: [E] }],
+        px: [{ px: [E] }],
+        py: [{ py: [E] }],
+        ps: [{ ps: [E] }],
+        pe: [{ pe: [E] }],
+        pt: [{ pt: [E] }],
+        pr: [{ pr: [E] }],
+        pb: [{ pb: [E] }],
+        pl: [{ pl: [E] }],
+        m: [{ m: [Y] }],
+        mx: [{ mx: [Y] }],
+        my: [{ my: [Y] }],
+        ms: [{ ms: [Y] }],
+        me: [{ me: [Y] }],
+        mt: [{ mt: [Y] }],
+        mr: [{ mr: [Y] }],
+        mb: [{ mb: [Y] }],
+        ml: [{ ml: [Y] }],
+        "space-x": [{ "space-x": [fe] }],
+        "space-x-reverse": ["space-x-reverse"],
+        "space-y": [{ "space-y": [fe] }],
+        "space-y-reverse": ["space-y-reverse"],
+        w: [{ w: ["auto", "min", "max", "fit", "svw", "lvw", "dvw", Ie, t] }],
+        "min-w": [{ "min-w": [Ie, t, "min", "max", "fit"] }],
+        "max-w": [
+          {
+            "max-w": [
+              Ie,
+              t,
+              "none",
+              "full",
+              "min",
+              "max",
+              "fit",
+              "prose",
+              { screen: [Zn] },
+              Zn,
+            ],
+          },
+        ],
+        h: [{ h: [Ie, t, "auto", "min", "max", "fit", "svh", "lvh", "dvh"] }],
+        "min-h": [
+          { "min-h": [Ie, t, "min", "max", "fit", "svh", "lvh", "dvh"] },
+        ],
+        "max-h": [
+          { "max-h": [Ie, t, "min", "max", "fit", "svh", "lvh", "dvh"] },
+        ],
+        size: [{ size: [Ie, t, "auto", "min", "max", "fit"] }],
+        "font-size": [{ text: ["base", Zn, qn] }],
+        "font-smoothing": ["antialiased", "subpixel-antialiased"],
+        "font-style": ["italic", "not-italic"],
+        "font-weight": [
+          {
+            font: [
+              "thin",
+              "extralight",
+              "light",
+              "normal",
+              "medium",
+              "semibold",
+              "bold",
+              "extrabold",
+              "black",
+              sl,
+            ],
+          },
+        ],
+        "font-family": [{ font: [Yr] }],
+        "fvn-normal": ["normal-nums"],
+        "fvn-ordinal": ["ordinal"],
+        "fvn-slashed-zero": ["slashed-zero"],
+        "fvn-figure": ["lining-nums", "oldstyle-nums"],
+        "fvn-spacing": ["proportional-nums", "tabular-nums"],
+        "fvn-fraction": ["diagonal-fractions", "stacked-fractions"],
+        tracking: [
+          {
+            tracking: [
+              "tighter",
+              "tight",
+              "normal",
+              "wide",
+              "wider",
+              "widest",
+              Ie,
+            ],
+          },
+        ],
+        "line-clamp": [{ "line-clamp": ["none", ir, sl] }],
+        leading: [
+          {
+            leading: [
+              "none",
+              "tight",
+              "snug",
+              "normal",
+              "relaxed",
+              "loose",
+              Rn,
+              Ie,
+            ],
+          },
+        ],
+        "list-image": [{ "list-image": ["none", Ie] }],
+        "list-style-type": [{ list: ["none", "disc", "decimal", Ie] }],
+        "list-style-position": [{ list: ["inside", "outside"] }],
+        "placeholder-color": [{ placeholder: [e] }],
+        "placeholder-opacity": [{ "placeholder-opacity": [m] }],
+        "text-alignment": [
+          { text: ["left", "center", "right", "justify", "start", "end"] },
+        ],
+        "text-color": [{ text: [e] }],
+        "text-opacity": [{ "text-opacity": [m] }],
+        "text-decoration": [
+          "underline",
+          "overline",
+          "line-through",
+          "no-underline",
+        ],
+        "text-decoration-style": [{ decoration: [...D(), "wavy"] }],
+        "text-decoration-thickness": [
+          { decoration: ["auto", "from-font", Rn, qn] },
+        ],
+        "underline-offset": [{ "underline-offset": ["auto", Rn, Ie] }],
+        "text-decoration-color": [{ decoration: [e] }],
+        "text-transform": [
+          "uppercase",
+          "lowercase",
+          "capitalize",
+          "normal-case",
+        ],
+        "text-overflow": ["truncate", "text-ellipsis", "text-clip"],
+        "text-wrap": [{ text: ["wrap", "nowrap", "balance", "pretty"] }],
+        indent: [{ indent: A() }],
+        "vertical-align": [
+          {
+            align: [
+              "baseline",
+              "top",
+              "middle",
+              "bottom",
+              "text-top",
+              "text-bottom",
+              "sub",
+              "super",
+              Ie,
+            ],
+          },
+        ],
+        whitespace: [
+          {
+            whitespace: [
+              "normal",
+              "nowrap",
+              "pre",
+              "pre-line",
+              "pre-wrap",
+              "break-spaces",
+            ],
+          },
+        ],
+        break: [{ break: ["normal", "words", "all", "keep"] }],
+        hyphens: [{ hyphens: ["none", "manual", "auto"] }],
+        content: [{ content: ["none", Ie] }],
+        "bg-attachment": [{ bg: ["fixed", "local", "scroll"] }],
+        "bg-clip": [{ "bg-clip": ["border", "padding", "content", "text"] }],
+        "bg-opacity": [{ "bg-opacity": [m] }],
+        "bg-origin": [{ "bg-origin": ["border", "padding", "content"] }],
+        "bg-position": [{ bg: [...S(), Ph] }],
+        "bg-repeat": [
+          { bg: ["no-repeat", { repeat: ["", "x", "y", "round", "space"] }] },
+        ],
+        "bg-size": [{ bg: ["auto", "cover", "contain", _h] }],
+        "bg-image": [
+          {
+            bg: [
+              "none",
+              { "gradient-to": ["t", "tr", "r", "br", "b", "bl", "l", "tl"] },
+              Oh,
+            ],
+          },
+        ],
+        "bg-color": [{ bg: [e] }],
+        "gradient-from-pos": [{ from: [H] }],
+        "gradient-via-pos": [{ via: [H] }],
+        "gradient-to-pos": [{ to: [H] }],
+        "gradient-from": [{ from: [x] }],
+        "gradient-via": [{ via: [x] }],
+        "gradient-to": [{ to: [x] }],
+        rounded: [{ rounded: [s] }],
+        "rounded-s": [{ "rounded-s": [s] }],
+        "rounded-e": [{ "rounded-e": [s] }],
+        "rounded-t": [{ "rounded-t": [s] }],
+        "rounded-r": [{ "rounded-r": [s] }],
+        "rounded-b": [{ "rounded-b": [s] }],
+        "rounded-l": [{ "rounded-l": [s] }],
+        "rounded-ss": [{ "rounded-ss": [s] }],
+        "rounded-se": [{ "rounded-se": [s] }],
+        "rounded-ee": [{ "rounded-ee": [s] }],
+        "rounded-es": [{ "rounded-es": [s] }],
+        "rounded-tl": [{ "rounded-tl": [s] }],
+        "rounded-tr": [{ "rounded-tr": [s] }],
+        "rounded-br": [{ "rounded-br": [s] }],
+        "rounded-bl": [{ "rounded-bl": [s] }],
+        "border-w": [{ border: [c] }],
+        "border-w-x": [{ "border-x": [c] }],
+        "border-w-y": [{ "border-y": [c] }],
+        "border-w-s": [{ "border-s": [c] }],
+        "border-w-e": [{ "border-e": [c] }],
+        "border-w-t": [{ "border-t": [c] }],
+        "border-w-r": [{ "border-r": [c] }],
+        "border-w-b": [{ "border-b": [c] }],
+        "border-w-l": [{ "border-l": [c] }],
+        "border-opacity": [{ "border-opacity": [m] }],
+        "border-style": [{ border: [...D(), "hidden"] }],
+        "divide-x": [{ "divide-x": [c] }],
+        "divide-x-reverse": ["divide-x-reverse"],
+        "divide-y": [{ "divide-y": [c] }],
+        "divide-y-reverse": ["divide-y-reverse"],
+        "divide-opacity": [{ "divide-opacity": [m] }],
+        "divide-style": [{ divide: D() }],
+        "border-color": [{ border: [i] }],
+        "border-color-x": [{ "border-x": [i] }],
+        "border-color-y": [{ "border-y": [i] }],
+        "border-color-s": [{ "border-s": [i] }],
+        "border-color-e": [{ "border-e": [i] }],
+        "border-color-t": [{ "border-t": [i] }],
+        "border-color-r": [{ "border-r": [i] }],
+        "border-color-b": [{ "border-b": [i] }],
+        "border-color-l": [{ "border-l": [i] }],
+        "divide-color": [{ divide: [i] }],
+        "outline-style": [{ outline: ["", ...D()] }],
+        "outline-offset": [{ "outline-offset": [Rn, Ie] }],
+        "outline-w": [{ outline: [Rn, qn] }],
+        "outline-color": [{ outline: [e] }],
+        "ring-w": [{ ring: y() }],
+        "ring-w-inset": ["ring-inset"],
+        "ring-color": [{ ring: [e] }],
+        "ring-opacity": [{ "ring-opacity": [m] }],
+        "ring-offset-w": [{ "ring-offset": [Rn, qn] }],
+        "ring-offset-color": [{ "ring-offset": [e] }],
+        shadow: [{ shadow: ["", "inner", "none", Zn, Mh] }],
+        "shadow-color": [{ shadow: [Yr] }],
+        opacity: [{ opacity: [m] }],
+        "mix-blend": [{ "mix-blend": [...B(), "plus-lighter", "plus-darker"] }],
+        "bg-blend": [{ "bg-blend": B() }],
+        filter: [{ filter: ["", "none"] }],
+        blur: [{ blur: [n] }],
+        brightness: [{ brightness: [o] }],
+        contrast: [{ contrast: [l] }],
+        "drop-shadow": [{ "drop-shadow": ["", "none", Zn, Ie] }],
+        grayscale: [{ grayscale: [u] }],
+        "hue-rotate": [{ "hue-rotate": [f] }],
+        invert: [{ invert: [p] }],
+        saturate: [{ saturate: [T] }],
+        sepia: [{ sepia: [R] }],
+        "backdrop-filter": [{ "backdrop-filter": ["", "none"] }],
+        "backdrop-blur": [{ "backdrop-blur": [n] }],
+        "backdrop-brightness": [{ "backdrop-brightness": [o] }],
+        "backdrop-contrast": [{ "backdrop-contrast": [l] }],
+        "backdrop-grayscale": [{ "backdrop-grayscale": [u] }],
+        "backdrop-hue-rotate": [{ "backdrop-hue-rotate": [f] }],
+        "backdrop-invert": [{ "backdrop-invert": [p] }],
+        "backdrop-opacity": [{ "backdrop-opacity": [m] }],
+        "backdrop-saturate": [{ "backdrop-saturate": [T] }],
+        "backdrop-sepia": [{ "backdrop-sepia": [R] }],
+        "border-collapse": [{ border: ["collapse", "separate"] }],
+        "border-spacing": [{ "border-spacing": [r] }],
+        "border-spacing-x": [{ "border-spacing-x": [r] }],
+        "border-spacing-y": [{ "border-spacing-y": [r] }],
+        "table-layout": [{ table: ["auto", "fixed"] }],
+        caption: [{ caption: ["top", "bottom"] }],
+        transition: [
+          {
+            transition: [
+              "none",
+              "all",
+              "",
+              "colors",
+              "opacity",
+              "shadow",
+              "transform",
+              Ie,
+            ],
+          },
+        ],
+        duration: [{ duration: N() }],
+        ease: [{ ease: ["linear", "in", "out", "in-out", Ie] }],
+        delay: [{ delay: N() }],
+        animate: [{ animate: ["none", "spin", "ping", "pulse", "bounce", Ie] }],
+        transform: [{ transform: ["", "gpu", "none"] }],
+        scale: [{ scale: [C] }],
+        "scale-x": [{ "scale-x": [C] }],
+        "scale-y": [{ "scale-y": [C] }],
+        rotate: [{ rotate: [Xr, Ie] }],
+        "translate-x": [{ "translate-x": [j] }],
+        "translate-y": [{ "translate-y": [j] }],
+        "skew-x": [{ "skew-x": [X] }],
+        "skew-y": [{ "skew-y": [X] }],
+        "transform-origin": [
+          {
+            origin: [
+              "center",
+              "top",
+              "top-right",
+              "right",
+              "bottom-right",
+              "bottom",
+              "bottom-left",
+              "left",
+              "top-left",
+              Ie,
+            ],
+          },
+        ],
+        accent: [{ accent: ["auto", e] }],
+        appearance: [{ appearance: ["none", "auto"] }],
+        cursor: [
+          {
+            cursor: [
+              "auto",
+              "default",
+              "pointer",
+              "wait",
+              "text",
+              "move",
+              "help",
+              "not-allowed",
+              "none",
+              "context-menu",
+              "progress",
+              "cell",
+              "crosshair",
+              "vertical-text",
+              "alias",
+              "copy",
+              "no-drop",
+              "grab",
+              "grabbing",
+              "all-scroll",
+              "col-resize",
+              "row-resize",
+              "n-resize",
+              "e-resize",
+              "s-resize",
+              "w-resize",
+              "ne-resize",
+              "nw-resize",
+              "se-resize",
+              "sw-resize",
+              "ew-resize",
+              "ns-resize",
+              "nesw-resize",
+              "nwse-resize",
+              "zoom-in",
+              "zoom-out",
+              Ie,
+            ],
+          },
+        ],
+        "caret-color": [{ caret: [e] }],
+        "pointer-events": [{ "pointer-events": ["none", "auto"] }],
+        resize: [{ resize: ["none", "y", "x", ""] }],
+        "scroll-behavior": [{ scroll: ["auto", "smooth"] }],
+        "scroll-m": [{ "scroll-m": A() }],
+        "scroll-mx": [{ "scroll-mx": A() }],
+        "scroll-my": [{ "scroll-my": A() }],
+        "scroll-ms": [{ "scroll-ms": A() }],
+        "scroll-me": [{ "scroll-me": A() }],
+        "scroll-mt": [{ "scroll-mt": A() }],
+        "scroll-mr": [{ "scroll-mr": A() }],
+        "scroll-mb": [{ "scroll-mb": A() }],
+        "scroll-ml": [{ "scroll-ml": A() }],
+        "scroll-p": [{ "scroll-p": A() }],
+        "scroll-px": [{ "scroll-px": A() }],
+        "scroll-py": [{ "scroll-py": A() }],
+        "scroll-ps": [{ "scroll-ps": A() }],
+        "scroll-pe": [{ "scroll-pe": A() }],
+        "scroll-pt": [{ "scroll-pt": A() }],
+        "scroll-pr": [{ "scroll-pr": A() }],
+        "scroll-pb": [{ "scroll-pb": A() }],
+        "scroll-pl": [{ "scroll-pl": A() }],
+        "snap-align": [{ snap: ["start", "end", "center", "align-none"] }],
+        "snap-stop": [{ snap: ["normal", "always"] }],
+        "snap-type": [{ snap: ["none", "x", "y", "both"] }],
+        "snap-strictness": [{ snap: ["mandatory", "proximity"] }],
+        touch: [{ touch: ["auto", "none", "manipulation"] }],
+        "touch-x": [{ "touch-pan": ["x", "left", "right"] }],
+        "touch-y": [{ "touch-pan": ["y", "up", "down"] }],
+        "touch-pz": ["touch-pinch-zoom"],
+        select: [{ select: ["none", "text", "all", "auto"] }],
+        "will-change": [
+          { "will-change": ["auto", "scroll", "contents", "transform", Ie] },
+        ],
+        fill: [{ fill: [e, "none"] }],
+        "stroke-w": [{ stroke: [Rn, qn, sl] }],
+        stroke: [{ stroke: [e, "none"] }],
+        sr: ["sr-only", "not-sr-only"],
+        "forced-color-adjust": [{ "forced-color-adjust": ["auto", "none"] }],
+      },
+      conflictingClassGroups: {
+        overflow: ["overflow-x", "overflow-y"],
+        overscroll: ["overscroll-x", "overscroll-y"],
+        inset: [
+          "inset-x",
+          "inset-y",
+          "start",
+          "end",
+          "top",
+          "right",
+          "bottom",
+          "left",
+        ],
+        "inset-x": ["right", "left"],
+        "inset-y": ["top", "bottom"],
+        flex: ["basis", "grow", "shrink"],
+        gap: ["gap-x", "gap-y"],
+        p: ["px", "py", "ps", "pe", "pt", "pr", "pb", "pl"],
+        px: ["pr", "pl"],
+        py: ["pt", "pb"],
+        m: ["mx", "my", "ms", "me", "mt", "mr", "mb", "ml"],
+        mx: ["mr", "ml"],
+        my: ["mt", "mb"],
+        size: ["w", "h"],
+        "font-size": ["leading"],
+        "fvn-normal": [
+          "fvn-ordinal",
+          "fvn-slashed-zero",
+          "fvn-figure",
+          "fvn-spacing",
+          "fvn-fraction",
+        ],
+        "fvn-ordinal": ["fvn-normal"],
+        "fvn-slashed-zero": ["fvn-normal"],
+        "fvn-figure": ["fvn-normal"],
+        "fvn-spacing": ["fvn-normal"],
+        "fvn-fraction": ["fvn-normal"],
+        "line-clamp": ["display", "overflow"],
+        rounded: [
+          "rounded-s",
+          "rounded-e",
+          "rounded-t",
+          "rounded-r",
+          "rounded-b",
+          "rounded-l",
+          "rounded-ss",
+          "rounded-se",
+          "rounded-ee",
+          "rounded-es",
+          "rounded-tl",
+          "rounded-tr",
+          "rounded-br",
+          "rounded-bl",
+        ],
+        "rounded-s": ["rounded-ss", "rounded-es"],
+        "rounded-e": ["rounded-se", "rounded-ee"],
+        "rounded-t": ["rounded-tl", "rounded-tr"],
+        "rounded-r": ["rounded-tr", "rounded-br"],
+        "rounded-b": ["rounded-br", "rounded-bl"],
+        "rounded-l": ["rounded-tl", "rounded-bl"],
+        "border-spacing": ["border-spacing-x", "border-spacing-y"],
+        "border-w": [
+          "border-w-s",
+          "border-w-e",
+          "border-w-t",
+          "border-w-r",
+          "border-w-b",
+          "border-w-l",
+        ],
+        "border-w-x": ["border-w-r", "border-w-l"],
+        "border-w-y": ["border-w-t", "border-w-b"],
+        "border-color": [
+          "border-color-s",
+          "border-color-e",
+          "border-color-t",
+          "border-color-r",
+          "border-color-b",
+          "border-color-l",
+        ],
+        "border-color-x": ["border-color-r", "border-color-l"],
+        "border-color-y": ["border-color-t", "border-color-b"],
+        "scroll-m": [
+          "scroll-mx",
+          "scroll-my",
+          "scroll-ms",
+          "scroll-me",
+          "scroll-mt",
+          "scroll-mr",
+          "scroll-mb",
+          "scroll-ml",
+        ],
+        "scroll-mx": ["scroll-mr", "scroll-ml"],
+        "scroll-my": ["scroll-mt", "scroll-mb"],
+        "scroll-p": [
+          "scroll-px",
+          "scroll-py",
+          "scroll-ps",
+          "scroll-pe",
+          "scroll-pt",
+          "scroll-pr",
+          "scroll-pb",
+          "scroll-pl",
+        ],
+        "scroll-px": ["scroll-pr", "scroll-pl"],
+        "scroll-py": ["scroll-pt", "scroll-pb"],
+        touch: ["touch-x", "touch-y", "touch-pz"],
+        "touch-x": ["touch"],
+        "touch-y": ["touch"],
+        "touch-pz": ["touch"],
+      },
+      conflictingClassGroupModifiers: { "font-size": ["leading"] },
+    };
+  };
+  var Ed = bh(Lh);
+  var Ee = (...e) => Ed(gd(e));
+  var ys = (e) =>
+    e.elementsCount && e.elementsCount > 1
+      ? { tagName: `${e.elementsCount} elements`, componentName: void 0 }
+      : {
+          tagName: e.tagName || e.componentName || "element",
+          componentName: e.tagName ? e.componentName : void 0,
+        };
+  var cl = null,
+    In = () => (
+      cl === null &&
+        (cl =
+          typeof navigator < "u" && /Mac|iPhone|iPad/.test(navigator.platform)),
+      cl
+    );
+  var Jn = (e) =>
+    e === "Enter"
+      ? "\u21B5"
+      : In()
+        ? `\u2318${e}`
+        : `Ctrl+${e.replace("\u21E7", "Shift+")}`;
+  var Dh = K(
+      '<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 12 12"fill=none style=transform:rotate(180deg)><path d="M5 3V1L1 4.5L5 8V6C8 6 10 7 11 10C11 7 9 4 5 3Z"fill=currentColor>',
+    ),
+    ws = (e) => {
+      let t = () => e.size ?? 12;
+      return (() => {
+        var n = Dh();
+        return (
+          te(
+            (o) => {
+              var i = t(),
+                s = t(),
+                r = e.class;
+              return (
+                i !== o.e && ae(n, "width", (o.e = i)),
+                s !== o.t && ae(n, "height", (o.t = s)),
+                r !== o.a && ae(n, "class", (o.a = r)),
+                o
+              );
+            },
+            { e: void 0, t: void 0, a: void 0 },
+          ),
+          n
+        );
+      })();
+    };
+  var Fh = K(
+      '<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 12 12"fill=none><path d="M6 1L6 11M6 1L2 5M6 1L10 5"stroke=currentColor stroke-width=1.5 stroke-linecap=round stroke-linejoin=round>',
+    ),
+    xs = (e) => {
+      let t = () => e.size ?? 12;
+      return (() => {
+        var n = Fh();
+        return (
+          te(
+            (o) => {
+              var i = t(),
+                s = t(),
+                r = e.class;
+              return (
+                i !== o.e && ae(n, "width", (o.e = i)),
+                s !== o.t && ae(n, "height", (o.t = s)),
+                r !== o.a && ae(n, "class", (o.a = r)),
+                o
+              );
+            },
+            { e: void 0, t: void 0, a: void 0 },
+          ),
+          n
+        );
+      })();
+    };
+  var $h = K(
+      '<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 24 24"fill=none stroke=currentColor stroke-width=2 stroke-linecap=round stroke-linejoin=round><path class=icon-loader-bar d="M12 2v4"style=animation-delay:0ms></path><path class=icon-loader-bar d="M15 6.8l2-3.5"style=animation-delay:-42ms></path><path class=icon-loader-bar d="M17.2 9l3.5-2"style=animation-delay:-83ms></path><path class=icon-loader-bar d="M18 12h4"style=animation-delay:-125ms></path><path class=icon-loader-bar d="M17.2 15l3.5 2"style=animation-delay:-167ms></path><path class=icon-loader-bar d="M15 17.2l2 3.5"style=animation-delay:-208ms></path><path class=icon-loader-bar d="M12 18v4"style=animation-delay:-250ms></path><path class=icon-loader-bar d="M9 17.2l-2 3.5"style=animation-delay:-292ms></path><path class=icon-loader-bar d="M6.8 15l-3.5 2"style=animation-delay:-333ms></path><path class=icon-loader-bar d="M2 12h4"style=animation-delay:-375ms></path><path class=icon-loader-bar d="M6.8 9l-3.5-2"style=animation-delay:-417ms></path><path class=icon-loader-bar d="M9 6.8l-2-3.5"style=animation-delay:-458ms>',
+    ),
+    Sd = (e) => {
+      let t = () => e.size ?? 16;
+      return (() => {
+        var n = $h(),
+          o = n.firstChild,
+          i = o.nextSibling,
+          s = i.nextSibling,
+          r = s.nextSibling,
+          c = r.nextSibling,
+          l = c.nextSibling,
+          u = l.nextSibling,
+          f = u.nextSibling,
+          p = f.nextSibling,
+          b = p.nextSibling,
+          x = b.nextSibling;
+        x.nextSibling;
+        return (
+          te(
+            (M) => {
+              var Y = t(),
+                m = t(),
+                E = e.class;
+              return (
+                Y !== M.e && ae(n, "width", (M.e = Y)),
+                m !== M.t && ae(n, "height", (M.t = m)),
+                E !== M.a && ae(n, "class", (M.a = E)),
+                M
+              );
+            },
+            { e: void 0, t: void 0, a: void 0 },
+          ),
+          n
+        );
+      })();
+    };
+  var Hh = K('<div data-react-grab-arrow class="absolute w-0 h-0 z-10">'),
+    vs = (e) => {
+      let t = () => e.color ?? "white",
+        n = () => e.position === "bottom",
+        o = () => bs(e.labelWidth ?? 0);
+      return (() => {
+        var i = Hh();
+        return (
+          te(
+            (s) => {
+              var r = `calc(${e.leftPercent}% + ${e.leftOffsetPx}px)`,
+                c = n() ? "0" : void 0,
+                l = n() ? void 0 : "0",
+                u = n()
+                  ? "translateX(-50%) translateY(-100%)"
+                  : "translateX(-50%) translateY(100%)",
+                f = `${o()}px solid transparent`,
+                p = `${o()}px solid transparent`,
+                b = n() ? `${o()}px solid ${t()}` : void 0,
+                x = n() ? void 0 : `${o()}px solid ${t()}`;
+              return (
+                r !== s.e && we(i, "left", (s.e = r)),
+                c !== s.t && we(i, "top", (s.t = c)),
+                l !== s.a && we(i, "bottom", (s.a = l)),
+                u !== s.o && we(i, "transform", (s.o = u)),
+                f !== s.i && we(i, "border-left", (s.i = f)),
+                p !== s.n && we(i, "border-right", (s.n = p)),
+                b !== s.s && we(i, "border-bottom", (s.s = b)),
+                x !== s.h && we(i, "border-top", (s.h = x)),
+                s
+              );
+            },
+            {
+              e: void 0,
+              t: void 0,
+              a: void 0,
+              o: void 0,
+              i: void 0,
+              n: void 0,
+              s: void 0,
+              h: void 0,
+            },
+          ),
+          i
+        );
+      })();
+    };
+  var Bh = K(
+      '<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 24 24"fill=none stroke=currentColor stroke-linecap=round stroke-linejoin=round stroke-width=2><path d="M12 6H6a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-6"></path><path d="M11 13l9-9"></path><path d="M15 4h5v5">',
+    ),
+    Ad = (e) => {
+      let t = () => e.size ?? 12;
+      return (() => {
+        var n = Bh();
+        return (
+          te(
+            (o) => {
+              var i = t(),
+                s = t(),
+                r = e.class;
+              return (
+                i !== o.e && ae(n, "width", (o.e = i)),
+                s !== o.t && ae(n, "height", (o.t = s)),
+                r !== o.a && ae(n, "class", (o.a = r)),
+                o
+              );
+            },
+            { e: void 0, t: void 0, a: void 0 },
+          ),
+          n
+        );
+      })();
+    };
+  var Td = K("<span class=text-black>"),
+    zh = K("<span class=text-black/50>."),
+    Vh = K(
+      '<div><span class="text-[13px] leading-4 h-fit font-medium overflow-hidden text-ellipsis whitespace-nowrap min-w-0">',
+    ),
+    qr = (e) => {
+      let [t, n] = U(false),
+        o = () => {
+          (n(true), e.onHoverChange?.(true));
+        },
+        i = () => {
+          (n(false), e.onHoverChange?.(false));
+        };
+      return (() => {
+        var s = Vh(),
+          r = s.firstChild;
+        return (
+          Je(s, "click", e.onClick, true),
+          s.addEventListener("mouseleave", i),
+          s.addEventListener("mouseenter", o),
+          z(
+            r,
+            O(ye, {
+              get when() {
+                return e.componentName;
+              },
+              get children() {
+                return [
+                  (() => {
+                    var c = Td();
+                    return (z(c, () => e.componentName), c);
+                  })(),
+                  (() => {
+                    var c = zh();
+                    c.firstChild;
+                    return (z(c, () => e.tagName, null), c);
+                  })(),
+                ];
+              },
+            }),
+            null,
+          ),
+          z(
+            r,
+            O(ye, {
+              get when() {
+                return !e.componentName;
+              },
+              get children() {
+                var c = Td();
+                return (z(c, () => e.tagName), c);
+              },
+            }),
+            null,
+          ),
+          z(
+            s,
+            O(ye, {
+              get when() {
+                return e.isClickable || e.forceShowIcon;
+              },
+              get children() {
+                return O(Ad, {
+                  size: 10,
+                  get class() {
+                    return Ee(
+                      "text-black transition-all duration-100 shrink-0",
+                      t() || e.forceShowIcon
+                        ? "opacity-100 scale-100"
+                        : "opacity-0 scale-75 -ml-[2px] w-0",
+                    );
+                  },
+                });
+              },
+            }),
+            null,
+          ),
+          te(() =>
+            Re(
+              s,
+              Ee(
+                "contain-layout flex items-center gap-1 max-w-[280px] overflow-hidden",
+                e.shrink && "shrink-0",
+                e.isClickable && "cursor-pointer",
+              ),
+            ),
+          ),
+          s
+        );
+      })();
+    };
+  it(["click"]);
+  var Gh = K(
+      '<div class="[font-synthesis:none] contain-layout shrink-0 flex flex-col items-start px-2 py-1.5 w-auto h-fit self-stretch [border-top-width:0.5px] border-t-solid border-t-[#D9D9D9] antialiased rounded-t-none rounded-b-[6px]">',
+    ),
+    Mt = (e) =>
+      (() => {
+        var t = Gh();
+        return (z(t, () => e.children), t);
+      })();
+  var Cs = null,
+    Tt = {
+      claim: (e) => {
+        Cs = e;
+      },
+      release: (e) => {
+        Cs === e && (Cs = null);
+      },
+      isActive: (e) => Cs === e,
+    };
+  var Uh = K(
+      '<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 22 19"fill=none><path d="M6.76263 18.6626C7.48251 18.6626 7.95474 18.1682 7.95474 17.4895C7.95474 17.1207 7.80474 16.8576 7.58683 16.6361L5.3018 14.4137L2.84621 12.3589L2.44374 13.0037L5.92137 13.1622H17.9232C20.4842 13.1622 21.593 12.021 21.593 9.47237V3.66983C21.593 1.10875 20.4842 0 17.9232 0H12.5414C11.8179 0 11.3018 0.545895 11.3018 1.21695C11.3018 1.888 11.8179 2.43389 12.5414 2.43389H17.8424C18.7937 2.43389 19.1897 2.83653 19.1897 3.78784V9.35747C19.1897 10.3257 18.7937 10.7314 17.8424 10.7314H5.92137L2.44374 10.8832L2.84621 11.5281L5.3018 9.47993L7.58683 7.2606C7.80474 7.03914 7.95474 6.7693 7.95474 6.40049C7.95474 5.72854 7.48251 5.22747 6.76263 5.22747C6.46129 5.22747 6.12975 5.36905 5.89231 5.6096L0.376815 11.0425C0.134921 11.2777 0 11.6141 0 11.9452C0 12.2728 0.134921 12.6158 0.376815 12.848L5.89231 18.2871C6.12975 18.5276 6.46129 18.6626 6.76263 18.6626Z"fill=currentColor>',
+    ),
+    Es = (e) => {
+      let t = () => e.size ?? 12;
+      return (() => {
+        var n = Uh();
+        return (
+          te(
+            (o) => {
+              var i = t(),
+                s = (t() * 19) / 22,
+                r = e.class;
+              return (
+                i !== o.e && ae(n, "width", (o.e = i)),
+                s !== o.t && ae(n, "height", (o.t = s)),
+                r !== o.a && ae(n, "class", (o.a = r)),
+                o
+              );
+            },
+            { e: void 0, t: void 0, a: void 0 },
+          ),
+          n
+        );
+      })();
+    };
+  var jh = K(
+      '<div class="contain-layout shrink-0 flex items-center justify-end gap-[5px] w-full h-fit"><button data-react-grab-discard-no class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-white [border-width:0.5px] border-solid border-[#B3B3B3] cursor-pointer transition-all hover:bg-[#F5F5F5] press-scale h-[17px]"><span class="text-black text-[13px] leading-3.5 font-sans font-medium">No</span></button><button data-react-grab-discard-yes class="contain-layout shrink-0 flex items-center justify-center gap-0.5 px-[3px] py-px rounded-sm bg-[#FEF2F2] cursor-pointer transition-all hover:bg-[#FEE2E2] press-scale h-[17px]"><span class="text-[#B91C1C] text-[13px] leading-3.5 font-sans font-medium">Yes',
+    ),
+    Wh = K(
+      '<div data-react-grab-discard-prompt class="contain-layout shrink-0 flex flex-col justify-center items-end w-fit h-fit"><div class="contain-layout shrink-0 flex items-center gap-1 pt-1.5 pb-1 px-2 w-full h-fit"><span class="text-black text-[13px] leading-4 shrink-0 font-sans font-medium w-fit h-fit">',
+    ),
+    Zr = (e) => {
+      let t = Symbol(),
+        n = (i) => {
+          if (!Tt.isActive(t) || St(i)) return;
+          let s = i.code === "Enter",
+            r = i.code === "Escape";
+          (s || r) &&
+            (i.preventDefault(),
+            i.stopPropagation(),
+            r && e.cancelOnEscape ? e.onCancel?.() : e.onConfirm?.());
+        },
+        o = () => {
+          Tt.claim(t);
+        };
+      return (
+        mt(() => {
+          (Tt.claim(t),
+            window.addEventListener("keydown", n, { capture: true }));
+        }),
+        Me(() => {
+          (Tt.release(t),
+            window.removeEventListener("keydown", n, { capture: true }));
+        }),
+        (() => {
+          var i = Wh(),
+            s = i.firstChild,
+            r = s.firstChild;
+          return (
+            (i.$$click = o),
+            (i.$$pointerdown = o),
+            z(r, () => e.label ?? "Discard?"),
+            z(
+              i,
+              O(Mt, {
+                get children() {
+                  var c = jh(),
+                    l = c.firstChild,
+                    u = l.nextSibling;
+                  u.firstChild;
+                  return (
+                    Je(l, "click", e.onCancel, true),
+                    Je(u, "click", e.onConfirm, true),
+                    z(u, O(Es, { size: 10, class: "text-[#B91C1C]/50" }), null),
+                    c
+                  );
+                },
+              }),
+              null,
+            ),
+            i
+          );
+        })()
+      );
+    };
+  it(["pointerdown", "click"]);
+  var Kh = K(
+      '<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 24 24"fill=none><path d="M17.65 6.35C16.2 4.9 14.21 4 12 4C7.58 4 4.01 7.58 4.01 12C4.01 16.42 7.58 20 12 20C15.73 20 18.84 17.45 19.73 14H17.65C16.83 16.33 14.61 18 12 18C8.69 18 6 15.31 6 12C6 8.69 8.69 6 12 6C13.66 6 15.14 6.69 16.22 7.78L13 11H20V4L17.65 6.35Z"fill=currentColor>',
+    ),
+    _d = (e) => {
+      let t = () => e.size ?? 12;
+      return (() => {
+        var n = Kh();
+        return (
+          te(
+            (o) => {
+              var i = t(),
+                s = t(),
+                r = e.class;
+              return (
+                i !== o.e && ae(n, "width", (o.e = i)),
+                s !== o.t && ae(n, "height", (o.t = s)),
+                r !== o.a && ae(n, "class", (o.a = r)),
+                o
+              );
+            },
+            { e: void 0, t: void 0, a: void 0 },
+          ),
+          n
+        );
+      })();
+    };
+  var Xh = K(
+      '<div class="contain-layout shrink-0 flex items-center justify-end gap-[5px] w-full h-fit"><button data-react-grab-retry class="contain-layout shrink-0 flex items-center justify-center gap-1 px-[3px] py-px rounded-sm bg-white [border-width:0.5px] border-solid border-[#B3B3B3] cursor-pointer transition-all hover:bg-[#F5F5F5] press-scale h-[17px]"><span class="text-black text-[13px] leading-3.5 font-sans font-medium">Retry</span></button><button data-react-grab-error-ok class="contain-layout shrink-0 flex items-center justify-center gap-1 px-[3px] py-px rounded-sm bg-white [border-width:0.5px] border-solid border-[#B3B3B3] cursor-pointer transition-all hover:bg-[#F5F5F5] press-scale h-[17px]"><span class="text-black text-[13px] leading-3.5 font-sans font-medium">Ok',
+    ),
+    Yh = K(
+      '<div data-react-grab-error class="contain-layout shrink-0 flex flex-col justify-center items-end w-fit h-fit max-w-[280px]"><div class="contain-layout shrink-0 flex items-start gap-1 px-2 w-full h-fit"><span class="text-[#B91C1C] text-[13px] leading-4 font-sans font-medium overflow-hidden line-clamp-5">',
+    ),
+    Pd = (e) => {
+      let t = Symbol(),
+        n = (s) => {
+          if (!Tt.isActive(t) || St(s)) return;
+          let r = s.code === "Enter",
+            c = s.code === "Escape";
+          r
+            ? (s.preventDefault(), s.stopPropagation(), e.onRetry?.())
+            : c &&
+              (s.preventDefault(), s.stopPropagation(), e.onAcknowledge?.());
+        },
+        o = () => {
+          Tt.claim(t);
+        };
+      (mt(() => {
+        (Tt.claim(t), window.addEventListener("keydown", n, { capture: true }));
+      }),
+        Me(() => {
+          (Tt.release(t),
+            window.removeEventListener("keydown", n, { capture: true }));
+        }));
+      let i = () => !!(e.onRetry || e.onAcknowledge);
+      return (() => {
+        var s = Yh(),
+          r = s.firstChild,
+          c = r.firstChild;
+        return (
+          (s.$$click = o),
+          (s.$$pointerdown = o),
+          z(c, () => e.error),
+          z(
+            s,
+            O(ye, {
+              get when() {
+                return i();
+              },
+              get children() {
+                return O(Mt, {
+                  get children() {
+                    var l = Xh(),
+                      u = l.firstChild;
+                    u.firstChild;
+                    var p = u.nextSibling;
+                    return (
+                      Je(u, "click", e.onRetry, true),
+                      z(u, O(_d, { size: 10, class: "text-black/50" }), null),
+                      Je(p, "click", e.onAcknowledge, true),
+                      l
+                    );
+                  },
+                });
+              },
+            }),
+            null,
+          ),
+          te(
+            (l) => {
+              var u = { "pt-1.5 pb-1": i(), "py-1.5": !i() },
+                f = e.error;
+              return (
+                (l.e = co(r, u, l.e)), f !== l.t && ae(c, "title", (l.t = f)), l
+              );
+            },
+            { e: void 0, t: void 0 },
+          ),
+          s
+        );
+      })();
+    };
+  it(["pointerdown", "click"]);
+  var qh = K(
+      '<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 24 24"fill=currentColor><circle cx=5 cy=12 r=2></circle><circle cx=12 cy=12 r=2></circle><circle cx=19 cy=12 r=2>',
+    ),
+    Ss = (e) => {
+      let t = () => e.size ?? 12;
+      return (() => {
+        var n = qh();
+        return (
+          te(
+            (o) => {
+              var i = t(),
+                s = t(),
+                r = e.class;
+              return (
+                i !== o.e && ae(n, "width", (o.e = i)),
+                s !== o.t && ae(n, "height", (o.t = s)),
+                r !== o.a && ae(n, "class", (o.a = r)),
+                o
+              );
+            },
+            { e: void 0, t: void 0, a: void 0 },
+          ),
+          n
+        );
+      })();
+    };
+  var Zh = K(
+      '<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 21 21"fill=none><g clip-path=url(#clip0_icon_check)><path d="M20.1767 10.0875C20.1767 15.6478 15.6576 20.175 10.0875 20.175C4.52715 20.175 0 15.6478 0 10.0875C0 4.51914 4.52715 0 10.0875 0C15.6576 0 20.1767 4.51914 20.1767 10.0875ZM13.0051 6.23867L8.96699 12.7041L7.08476 10.3143C6.83358 9.99199 6.59941 9.88828 6.28984 9.88828C5.79414 9.88828 5.39961 10.2918 5.39961 10.7893C5.39961 11.0367 5.48925 11.2621 5.66386 11.4855L8.05703 14.3967C8.33027 14.7508 8.63183 14.9103 8.99902 14.9103C9.36445 14.9103 9.68105 14.7312 9.90546 14.3896L14.4742 7.27206C14.6107 7.04765 14.7289 6.80898 14.7289 6.58359C14.7289 6.07187 14.281 5.72968 13.7934 5.72968C13.4937 5.72968 13.217 5.90527 13.0051 6.23867Z"fill=currentColor></path></g><defs><clipPath id=clip0_icon_check><rect width=20.5381 height=20.1848 fill=white>',
+    ),
+    Jr = (e) => {
+      let t = () => e.size ?? 21;
+      return (() => {
+        var n = Zh();
+        return (
+          te(
+            (o) => {
+              var i = t(),
+                s = (t() * 20.1848) / 20.5381,
+                r = e.class;
+              return (
+                i !== o.e && ae(n, "width", (o.e = i)),
+                s !== o.t && ae(n, "height", (o.t = s)),
+                r !== o.a && ae(n, "class", (o.a = r)),
+                o
+              );
+            },
+            { e: void 0, t: void 0, a: void 0 },
+          ),
+          n
+        );
+      })();
+    };
+  var Jh = K(
+      '<button data-react-grab-ignore-events data-react-grab-more-options class="flex items-center justify-center size-[18px] rounded-sm cursor-pointer bg-transparent hover:bg-black/10 text-black/30 hover:text-black border-none outline-none p-0 shrink-0 press-scale">',
+    ),
+    Qh = K(
+      '<button data-react-grab-undo class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[#FEF2F2] cursor-pointer transition-all hover:bg-[#FEE2E2] press-scale h-[17px]"><span class="text-[#B91C1C] text-[13px] leading-3.5 font-sans font-medium">Undo',
+    ),
+    eb = K(
+      '<button data-react-grab-dismiss class="contain-layout shrink-0 flex items-center justify-center gap-1 px-[3px] py-px rounded-sm bg-white [border-width:0.5px] border-solid border-[#B3B3B3] cursor-pointer transition-all hover:bg-[#F5F5F5] press-scale h-[17px]"><span class="text-black text-[13px] leading-3.5 font-sans font-medium">',
+    ),
+    tb = K(
+      '<div class="contain-layout shrink-0 flex items-center justify-between gap-2 pt-1.5 pb-1 px-2 w-full h-fit"><span class="text-black text-[13px] leading-4 font-sans font-medium h-fit tabular-nums overflow-hidden text-ellipsis whitespace-nowrap min-w-0"></span><div class="contain-layout shrink-0 flex items-center gap-2 h-fit">',
+    ),
+    nb = K(
+      '<div class="contain-layout shrink-0 flex items-center gap-0.5 py-1.5 px-2 w-full h-fit"><span class="text-black text-[13px] leading-4 font-sans font-medium h-fit tabular-nums overflow-hidden text-ellipsis whitespace-nowrap min-w-0">',
+    ),
+    ob = K(
+      '<div class="flex items-center gap-1 w-full mb-1 overflow-hidden"><span class="text-black/40 text-[11px] leading-3 font-medium truncate italic">',
+    ),
+    rb = K(
+      '<div class="shrink-0 flex justify-between items-end w-full min-h-4"><textarea data-react-grab-ignore-events data-react-grab-followup-input class="text-black text-[13px] leading-4 font-medium bg-transparent border-none outline-none resize-none flex-1 p-0 m-0 wrap-break-word overflow-y-auto"placeholder=follow-up rows=1 style=field-sizing:content;min-height:16px;max-height:95px;scrollbar-width:none></textarea><button data-react-grab-followup-submit>',
+    ),
+    ib = K("<div data-react-grab-completion>"),
+    kd = (e) =>
+      (() => {
+        var t = Jh();
+        return (
+          Je(t, "click", (n) => {
+            (n.stopImmediatePropagation(), e.onClick());
+          }),
+          Je(t, "pointerdown", (n) => {
+            n.stopImmediatePropagation();
+          }),
+          z(t, O(Ss, { size: 14 })),
+          t
+        );
+      })(),
+    Od = (e) => {
+      let t = Symbol(),
+        n,
+        o,
+        i,
+        [s, r] = U(false),
+        [c, l] = U(false),
+        [u, f] = U(e.statusText),
+        [p, b] = U(""),
+        x = () => {
+          (o !== void 0 && window.clearTimeout(o),
+            i !== void 0 && window.clearTimeout(i),
+            l(true),
+            e.onFadingChange?.(true),
+            e.onShowContextMenu?.());
+        },
+        H = () => {
+          s() ||
+            (r(true),
+            f("Copied"),
+            e.onCopyStateChange?.(),
+            (o = window.setTimeout(() => {
+              (l(true),
+                e.onFadingChange?.(true),
+                (i = window.setTimeout(() => {
+                  e.onDismiss?.();
+                }, 100)));
+            }, 1400)));
+        },
+        M = () => {
+          let T = p().trim();
+          T && e.onFollowUpSubmit && e.onFollowUpSubmit(T);
+        },
+        Y = (T) => {
+          if (T.isComposing || T.keyCode === 229) return;
+          let C = T.code === "KeyZ" && (T.metaKey || T.ctrlKey),
+            R = T.code === "Enter" && !T.shiftKey,
+            X = T.code === "Escape";
+          (C || T.stopImmediatePropagation(),
+            R
+              ? (T.preventDefault(), p().trim() ? M() : H())
+              : X && (T.preventDefault(), e.onDismiss?.()));
+        },
+        m = (T) => {
+          if (!Tt.isActive(t)) return;
+          let C = T.code === "KeyZ" && (T.metaKey || T.ctrlKey) && !T.shiftKey,
+            R = T.code === "Enter",
+            X = T.code === "Escape";
+          if (C && e.supportsUndo && e.onUndo) {
+            (T.preventDefault(), T.stopPropagation(), e.onUndo());
+            return;
+          }
+          St(T) ||
+            (R
+              ? (T.preventDefault(), T.stopPropagation(), H())
+              : X &&
+                (T.preventDefault(), T.stopPropagation(), e.onDismiss?.()));
+        },
+        E = () => {
+          Tt.claim(t);
+        };
+      return (
+        be(() => {
+          s() || f(e.statusText);
+        }),
+        mt(() => {
+          (Tt.claim(t),
+            window.addEventListener("keydown", m, { capture: true }),
+            e.supportsFollowUp && e.onFollowUpSubmit && n && n.focus());
+        }),
+        Me(() => {
+          (Tt.release(t),
+            window.removeEventListener("keydown", m, { capture: true }),
+            o !== void 0 && window.clearTimeout(o),
+            i !== void 0 && window.clearTimeout(i));
+        }),
+        (() => {
+          var T = ib();
+          return (
+            (T.$$click = E),
+            (T.$$pointerdown = E),
+            z(
+              T,
+              O(ye, {
+                get when() {
+                  return Be(() => !s())() && (e.onDismiss || e.onUndo);
+                },
+                get children() {
+                  var C = tb(),
+                    R = C.firstChild,
+                    X = R.nextSibling;
+                  return (
+                    z(R, u),
+                    z(
+                      X,
+                      O(ye, {
+                        get when() {
+                          return (
+                            Be(() => !!e.onShowContextMenu)() &&
+                            !e.supportsFollowUp
+                          );
+                        },
+                        get children() {
+                          return O(kd, { onClick: x });
+                        },
+                      }),
+                      null,
+                    ),
+                    z(
+                      X,
+                      O(ye, {
+                        get when() {
+                          return Be(() => !!e.supportsUndo)() && e.onUndo;
+                        },
+                        get children() {
+                          var fe = Qh();
+                          return ((fe.$$click = () => e.onUndo?.()), fe);
+                        },
+                      }),
+                      null,
+                    ),
+                    z(
+                      X,
+                      O(ye, {
+                        get when() {
+                          return e.onDismiss;
+                        },
+                        get children() {
+                          var fe = eb(),
+                            j = fe.firstChild;
+                          return (
+                            (fe.$$click = H),
+                            z(j, () => e.dismissButtonText ?? "Keep"),
+                            z(
+                              fe,
+                              O(ye, {
+                                get when() {
+                                  return !s();
+                                },
+                                get children() {
+                                  return O(Es, {
+                                    size: 10,
+                                    class: "text-black/50",
+                                  });
+                                },
+                              }),
+                              null,
+                            ),
+                            te(() => (fe.disabled = s())),
+                            fe
+                          );
+                        },
+                      }),
+                      null,
+                    ),
+                    C
+                  );
+                },
+              }),
+              null,
+            ),
+            z(
+              T,
+              O(ye, {
+                get when() {
+                  return s() || (!e.onDismiss && !e.onUndo);
+                },
+                get children() {
+                  var C = nb(),
+                    R = C.firstChild;
+                  return (
+                    z(
+                      C,
+                      O(Jr, {
+                        size: 14,
+                        class: "text-black/85 shrink-0 animate-success-pop",
+                      }),
+                      R,
+                    ),
+                    z(R, u),
+                    z(
+                      C,
+                      O(ye, {
+                        get when() {
+                          return (
+                            Be(() => !!e.onShowContextMenu)() &&
+                            !e.supportsFollowUp
+                          );
+                        },
+                        get children() {
+                          return O(kd, { onClick: x });
+                        },
+                      }),
+                      null,
+                    ),
+                    C
+                  );
+                },
+              }),
+              null,
+            ),
+            z(
+              T,
+              O(ye, {
+                get when() {
+                  return (
+                    Be(() => !!(!s() && e.supportsFollowUp))() &&
+                    e.onFollowUpSubmit
+                  );
+                },
+                get children() {
+                  return O(Mt, {
+                    get children() {
+                      return [
+                        O(ye, {
+                          get when() {
+                            return e.previousPrompt;
+                          },
+                          get children() {
+                            var C = ob(),
+                              R = C.firstChild;
+                            return (
+                              z(
+                                C,
+                                O(ws, {
+                                  size: 10,
+                                  class: "text-black/30 shrink-0",
+                                }),
+                                R,
+                              ),
+                              z(R, () => e.previousPrompt),
+                              C
+                            );
+                          },
+                        }),
+                        (() => {
+                          var C = rb(),
+                            R = C.firstChild,
+                            X = R.nextSibling;
+                          ((R.$$keydown = Y),
+                            (R.$$input = (j) => b(j.target.value)));
+                          var fe = n;
+                          return (
+                            typeof fe == "function" ? Ke(fe, R) : (n = R),
+                            (X.$$click = M),
+                            z(X, O(xs, { size: 10, class: "text-white" })),
+                            te(
+                              (j) => {
+                                var le = e.previousPrompt ? "14px" : "0",
+                                  ue = Ee(
+                                    "contain-layout shrink-0 flex items-center justify-center size-4 rounded-full bg-black cursor-pointer ml-1 interactive-scale",
+                                    !p().trim() && "opacity-35",
+                                  );
+                                return (
+                                  le !== j.e &&
+                                    we(C, "padding-left", (j.e = le)),
+                                  ue !== j.t && Re(X, (j.t = ue)),
+                                  j
+                                );
+                              },
+                              { e: void 0, t: void 0 },
+                            ),
+                            te(() => (R.value = p())),
+                            C
+                          );
+                        })(),
+                      ];
+                    },
+                  });
+                },
+              }),
+              null,
+            ),
+            te(
+              (C) => {
+                var R = Ee(
+                    "contain-layout shrink-0 flex flex-col justify-center items-end rounded-[10px] antialiased w-fit h-fit max-w-[280px] transition-opacity duration-100 ease-out [font-synthesis:none] [corner-shape:superellipse(1.25)]",
+                    ht,
+                  ),
+                  X = c() ? 0 : 1;
+                return (
+                  R !== C.e && Re(T, (C.e = R)),
+                  X !== C.t && we(T, "opacity", (C.t = X)),
+                  C
+                );
+              },
+              { e: void 0, t: void 0 },
+            ),
+            T
+          );
+        })()
+      );
+    };
+  it(["pointerdown", "click", "input", "keydown"]);
+  var sb = "0",
+    ab = "1",
+    lb = ({ hiddenOpacity: e = sb, visibleOpacity: t = ab } = {}) => {
+      let n,
+        o,
+        i = () => {
+          o && (o.style.opacity = e);
+        };
+      return {
+        containerRef: (l) => {
+          n = l;
+        },
+        followerRef: (l) => {
+          o = l;
+        },
+        followElement: (l) => {
+          if (!o || !n) return;
+          if (!l) {
+            i();
+            return;
+          }
+          let u = n.getBoundingClientRect(),
+            f = l.getBoundingClientRect(),
+            p = f.top - u.top + n.scrollTop,
+            b = f.left - u.left + n.scrollLeft;
+          ((o.style.opacity = t),
+            (o.style.top = `${p}px`),
+            (o.style.left = `${b}px`),
+            (o.style.width = `${f.width}px`),
+            (o.style.height = `${f.height}px`));
+        },
+        hideFollower: i,
+      };
+    },
+    Qn = () => {
+      let {
+        containerRef: e,
+        followerRef: t,
+        followElement: n,
+        hideFollower: o,
+      } = lb();
+      return {
+        containerRef: e,
+        highlightRef: t,
+        updateHighlight: n,
+        clearHighlight: o,
+      };
+    };
+  var cb = K(
+      '<div class="relative flex flex-col w-[calc(100%+16px)] -mx-2 -my-1.5"><div class="pointer-events-none absolute bg-black/5 opacity-0 transition-[top,left,width,height,opacity] duration-75 ease-out">',
+    ),
+    ub = K("<span class=text-black/40>."),
+    db = K(
+      '<button data-react-grab-ignore-events class="relative z-1 contain-layout flex items-center w-full px-2 py-1 cursor-pointer text-left border-none bg-transparent"><span class="text-[13px] leading-4 h-fit font-medium overflow-hidden text-ellipsis whitespace-nowrap min-w-0 transition-colors">',
+    ),
+    Md = (e) => {
+      let {
+          containerRef: t,
+          highlightRef: n,
+          updateHighlight: o,
+          clearHighlight: i,
+        } = Qn(),
+        s = [];
+      return (
+        be(() => {
+          let r = s[e.activeIndex];
+          r && o(r);
+        }),
+        O(Mt, {
+          get children() {
+            var r = cb(),
+              c = r.firstChild;
+            return (
+              Ke(t, r),
+              Ke(n, c),
+              z(
+                r,
+                O(on, {
+                  get each() {
+                    return e.items;
+                  },
+                  children: (l, u) =>
+                    (() => {
+                      var f = db(),
+                        p = f.firstChild;
+                      return (
+                        (f.$$click = (b) => {
+                          (b.stopPropagation(), e.onSelect(u()));
+                        }),
+                        f.addEventListener("pointerleave", () => {
+                          let b = s[e.activeIndex];
+                          b ? o(b) : i();
+                        }),
+                        f.addEventListener("pointerenter", (b) => {
+                          (o(b.currentTarget), e.onSelect(u()));
+                        }),
+                        (f.$$pointerdown = (b) => b.stopPropagation()),
+                        Ke((b) => {
+                          s[u()] = b;
+                        }, f),
+                        z(
+                          p,
+                          O(ye, {
+                            get when() {
+                              return l.componentName;
+                            },
+                            get children() {
+                              return [Be(() => l.componentName), ub()];
+                            },
+                          }),
+                          null,
+                        ),
+                        z(p, () => l.tagName, null),
+                        te(
+                          (b) => {
+                            var x = l.tagName,
+                              H = u() === e.activeIndex,
+                              M = u() !== e.activeIndex;
+                            return (
+                              x !== b.e &&
+                                ae(
+                                  f,
+                                  "data-react-grab-arrow-nav-item",
+                                  (b.e = x),
+                                ),
+                              H !== b.t &&
+                                p.classList.toggle("text-black", (b.t = H)),
+                              M !== b.a &&
+                                p.classList.toggle("text-black/30", (b.a = M)),
+                              b
+                            );
+                          },
+                          { e: void 0, t: void 0, a: void 0 },
+                        ),
+                        f
+                      );
+                    })(),
+                }),
+                null,
+              ),
+              r
+            );
+          },
+        })
+      );
+    };
+  it(["pointerdown", "click"]);
+  var fb = K(
+      '<button data-react-grab-ignore-events data-react-grab-abort class="contain-layout shrink-0 flex items-center justify-center size-4 rounded-full bg-black cursor-pointer ml-1 interactive-scale"><div class="size-1.5 bg-white rounded-[1px]">',
+    ),
+    mb = K(
+      '<div class="shrink-0 flex justify-between items-end w-full min-h-4"><textarea data-react-grab-ignore-events class="text-black text-[13px] leading-4 font-medium bg-transparent border-none outline-none resize-none flex-1 p-0 m-0 opacity-50 wrap-break-word overflow-y-auto"placeholder="Add context"rows=1 disabled style=field-sizing:content;min-height:16px;max-height:95px;scrollbar-width:none>',
+    ),
+    pb = K(
+      '<div class="contain-layout shrink-0 flex flex-col justify-center items-start w-fit h-fit max-w-[280px]"><div class="contain-layout shrink-0 flex items-center gap-1 py-1.5 px-2 w-full h-fit"><span class="shimmer-text text-[13px] leading-4 font-sans font-medium h-fit tabular-nums overflow-hidden text-ellipsis whitespace-nowrap">',
+    ),
+    gb = K('<div class="flex flex-col w-[calc(100%+16px)] -mx-2 -my-1.5">'),
+    hb = K(
+      '<div class="contain-layout shrink-0 flex flex-col items-start w-fit h-fit"><div class="contain-layout shrink-0 flex items-center gap-1 w-fit h-fit px-2">',
+    ),
+    bb = K(
+      '<div class="flex items-center gap-1 w-full mb-1 overflow-hidden"><span class="text-black/40 text-[11px] leading-3 font-medium truncate italic">',
+    ),
+    yb = K(
+      '<button data-react-grab-submit class="contain-layout shrink-0 flex items-center justify-center size-4 rounded-full bg-black cursor-pointer ml-1 interactive-scale">',
+    ),
+    wb = K(
+      '<div class="shrink-0 flex justify-between items-end w-full min-h-4"><textarea data-react-grab-ignore-events data-react-grab-input class="text-black text-[13px] leading-4 font-medium bg-transparent border-none outline-none resize-none flex-1 p-0 m-0 wrap-break-word overflow-y-auto"placeholder="Add context"rows=1 style=field-sizing:content;min-height:16px;max-height:95px;scrollbar-width:none>',
+    ),
+    xb = K(
+      '<div class="contain-layout shrink-0 flex flex-col justify-center items-start w-fit h-fit min-w-[150px] max-w-[280px]"><div class="contain-layout shrink-0 flex items-center gap-1 pt-1.5 pb-1 w-fit h-fit px-2 max-w-full">',
+    ),
+    vb = K(
+      "<div data-react-grab-ignore-events data-react-grab-selection-label style=z-index:2147483647><div>",
+    ),
+    Cb = K('<span class="text-[11px] font-sans text-black/50 ml-4">'),
+    Eb = K(
+      '<div class="contain-layout flex items-center justify-between w-full px-2 py-1 transition-colors"><span class="text-[13px] leading-4 font-sans font-medium text-black">',
+    ),
+    Rd = {
+      left: Ra,
+      top: Ra,
+      arrowLeftPercent: wa,
+      arrowLeftOffset: 0,
+      edgeOffsetX: 0,
+    },
+    Ts = (e) => {
+      let t,
+        n,
+        o,
+        i = false,
+        s = null,
+        r = null,
+        [c, l] = U(0),
+        [u, f] = U(0),
+        [p, b] = U(0),
+        [x, H] = U("bottom"),
+        [M, Y] = U(0),
+        [m, E] = U(false),
+        [T, C] = U(false),
+        R = () =>
+          e.status !== "copying" &&
+          e.status !== "copied" &&
+          e.status !== "fading" &&
+          e.status !== "error",
+        X = () => e.status === "copied" || e.status === "fading",
+        fe = () =>
+          !!(
+            e.isPromptMode ||
+            (X() && (e.onDismiss || e.onShowContextMenu)) ||
+            (e.status === "copying" && e.onAbort) ||
+            (e.status === "error" && (e.onAcknowledgeError || e.onRetry)) ||
+            e.arrowNavigationState?.isVisible
+          ),
+        j,
+        le = (I) => {
+          i = I;
+        },
+        ue = () => {
+          Y((I) => I + 1);
+        },
+        L = (I) => {
+          if (St(I)) return;
+          let G = I.code === "Enter" && !e.isPromptMode && R(),
+            Q =
+              I.code === "KeyC" &&
+              I.ctrlKey &&
+              e.status === "copying" &&
+              e.onAbort;
+          G
+            ? (I.preventDefault(),
+              I.stopImmediatePropagation(),
+              e.onToggleExpand?.())
+            : Q &&
+              (I.preventDefault(), I.stopImmediatePropagation(), e.onAbort?.());
+        };
+      (mt(() => {
+        if (
+          ((j = new ResizeObserver((I) => {
+            for (let G of I) {
+              let Q = G.target.getBoundingClientRect();
+              G.target === t && !i
+                ? (l(Q.width), f(Q.height))
+                : G.target === n && b(Q.width);
+            }
+          })),
+          t)
+        ) {
+          let I = t.getBoundingClientRect();
+          (l(I.width), f(I.height), j.observe(t));
+        }
+        (n && (b(n.getBoundingClientRect().width), j.observe(n)),
+          window.addEventListener("scroll", ue, true),
+          window.addEventListener("resize", ue),
+          window.addEventListener("keydown", L, { capture: true }));
+      }),
+        Me(() => {
+          (j?.disconnect(),
+            window.removeEventListener("scroll", ue, true),
+            window.removeEventListener("resize", ue),
+            window.removeEventListener("keydown", L, { capture: true }));
+        }),
+        be(() => {
+          let I = `${e.tagName ?? ""}:${e.componentName ?? ""}`;
+          I !== r && ((r = I), (s = null));
+        }),
+        be(() => {
+          if (e.isPromptMode && o && e.onSubmit) {
+            let I = setTimeout(() => {
+              o?.focus();
+            }, 0);
+            Me(() => {
+              clearTimeout(I);
+            });
+          }
+        }));
+      let A = se(() => {
+        M();
+        let I = e.selectionBounds,
+          G = c(),
+          Q = u(),
+          Ae = G > 0 && Q > 0,
+          me = I && I.width > 0 && I.height > 0;
+        if (!Ae || !me)
+          return { position: s ?? Rd, computedArrowPosition: null };
+        let Se = window.innerWidth,
+          ie = window.innerHeight;
+        if (!(I.x + I.width > 0 && I.x < Se && I.y + I.height > 0 && I.y < ie))
+          return { position: Rd, computedArrowPosition: null };
+        let ke = I.x + I.width / 2,
+          Pe = e.mouseX ?? ke,
+          ge = I.y + I.height,
+          Te = I.y,
+          rt = e.hideArrow ? 0 : bs(p()),
+          ct = Pe,
+          Ue = 0,
+          wt = ge + rt + rn;
+        if (G > 0) {
+          let sn = ct - G / 2,
+            Pt = ct + G / 2;
+          (Pt > Se - 8 && (Ue = Se - 8 - Pt), sn + Ue < 8 && (Ue = 8 - sn));
+        }
+        let bn = Q + rt + rn,
+          Ht = wt + Q <= ie - 8;
+        (Ht || (wt = Te - bn), wt < 8 && (wt = 8));
+        let Bt = wa,
+          Rt = G / 2,
+          yn = Rt - Ue,
+          xt = Math.min(xa, Rt),
+          Dn = Math.max(G - xa, Rt),
+          It = Math.max(xt, Math.min(Dn, yn)) - Rt;
+        return {
+          position: {
+            left: ct,
+            top: wt,
+            arrowLeftPercent: Bt,
+            arrowLeftOffset: It,
+            edgeOffsetX: Ue,
+          },
+          computedArrowPosition: Ht ? "bottom" : "top",
+        };
+      });
+      be(() => {
+        let I = A();
+        I.computedArrowPosition !== null &&
+          ((s = I.position), E(true), H(I.computedArrowPosition));
+      });
+      let y = (I) => {
+          if (I.isComposing || I.keyCode === xu) return;
+          I.stopImmediatePropagation();
+          let G = I.code === "Enter" && !I.shiftKey,
+            Q = I.code === "Escape";
+          G
+            ? (I.preventDefault(), e.onSubmit?.())
+            : Q && (I.preventDefault(), e.onConfirmDismiss?.());
+        },
+        h = (I) => {
+          let G = I.target;
+          G instanceof HTMLTextAreaElement && e.onInputChange?.(G.value);
+        },
+        S = () =>
+          ys({
+            tagName: e.tagName,
+            componentName: e.componentName,
+            elementsCount: e.elementsCount,
+          }),
+        D = () => S().tagName,
+        B = () => S().componentName,
+        w = () => e.actionCycleState?.items ?? [],
+        v = () => e.actionCycleState?.activeIndex ?? 0,
+        $ = () => !!e.actionCycleState?.isVisible,
+        N = () => !!e.arrowNavigationState?.isVisible,
+        W = (I) => {
+          (I.stopImmediatePropagation(), e.filePath && e.onOpen && e.onOpen());
+        },
+        V = () => !!(e.filePath && e.onOpen),
+        oe = (I) => {
+          (I.stopImmediatePropagation(),
+            R() &&
+              e.isPromptMode &&
+              !e.isPendingDismiss &&
+              e.onSubmit &&
+              o &&
+              o.focus());
+        },
+        de = () => m() && (X() || e.status === "error");
+      return O(ye, {
+        get when() {
+          return Be(() => e.visible !== false)() && (e.selectionBounds || de());
+        },
+        get children() {
+          var I = vb(),
+            G = I.firstChild;
+          (I.addEventListener("mouseleave", () => e.onHoverChange?.(false)),
+            I.addEventListener("mouseenter", () => e.onHoverChange?.(true)),
+            (I.$$click = (me) => {
+              me.stopImmediatePropagation();
+            }),
+            (I.$$pointerdown = oe));
+          var Q = t;
+          (typeof Q == "function" ? Ke(Q, I) : (t = I),
+            z(
+              I,
+              O(ye, {
+                get when() {
+                  return !e.hideArrow;
+                },
+                get children() {
+                  return O(vs, {
+                    get position() {
+                      return x();
+                    },
+                    get leftPercent() {
+                      return A().position.arrowLeftPercent;
+                    },
+                    get leftOffsetPx() {
+                      return A().position.arrowLeftOffset;
+                    },
+                    get labelWidth() {
+                      return p();
+                    },
+                  });
+                },
+              }),
+              G,
+            ),
+            z(
+              I,
+              O(ye, {
+                get when() {
+                  return Be(() => !!X())() && !e.error;
+                },
+                get children() {
+                  return O(Od, {
+                    get statusText() {
+                      return Be(() => !!e.hasAgent)()
+                        ? (e.statusText ?? "Completed")
+                        : "Copied";
+                    },
+                    get supportsUndo() {
+                      return e.supportsUndo;
+                    },
+                    get supportsFollowUp() {
+                      return e.supportsFollowUp;
+                    },
+                    get dismissButtonText() {
+                      return e.dismissButtonText;
+                    },
+                    get previousPrompt() {
+                      return e.previousPrompt;
+                    },
+                    get onDismiss() {
+                      return e.onDismiss;
+                    },
+                    get onUndo() {
+                      return e.onUndo;
+                    },
+                    get onFollowUpSubmit() {
+                      return e.onFollowUpSubmit;
+                    },
+                    onFadingChange: C,
+                    get onShowContextMenu() {
+                      return e.onShowContextMenu;
+                    },
+                  });
+                },
+              }),
+              G,
+            ));
+          var Ae = n;
+          return (
+            typeof Ae == "function" ? Ke(Ae, G) : (n = G),
+            z(
+              G,
+              O(ye, {
+                get when() {
+                  return (
+                    Be(() => e.status === "copying")() && !e.isPendingAbort
+                  );
+                },
+                get children() {
+                  var me = pb(),
+                    Se = me.firstChild,
+                    ie = Se.firstChild;
+                  return (
+                    z(
+                      Se,
+                      O(Sd, { size: 13, class: "text-[#71717a] shrink-0" }),
+                      ie,
+                    ),
+                    z(ie, () => e.statusText ?? "Grabbing\u2026"),
+                    z(
+                      me,
+                      O(ye, {
+                        get when() {
+                          return Be(() => !!e.hasAgent)() && e.inputValue;
+                        },
+                        get children() {
+                          return O(Mt, {
+                            get children() {
+                              var pe = mb(),
+                                ke = pe.firstChild,
+                                Pe = o;
+                              return (
+                                typeof Pe == "function" ? Ke(Pe, ke) : (o = ke),
+                                z(
+                                  pe,
+                                  O(ye, {
+                                    get when() {
+                                      return e.onAbort;
+                                    },
+                                    get children() {
+                                      var ge = fb();
+                                      return (
+                                        (ge.$$click = (Te) => {
+                                          (Te.stopPropagation(), e.onAbort?.());
+                                        }),
+                                        (ge.$$pointerdown = (Te) =>
+                                          Te.stopPropagation()),
+                                        ge
+                                      );
+                                    },
+                                  }),
+                                  null,
+                                ),
+                                te(() => (ke.value = e.inputValue ?? "")),
+                                pe
+                              );
+                            },
+                          });
+                        },
+                      }),
+                      null,
+                    ),
+                    te(() =>
+                      me.classList.toggle(
+                        "min-w-[150px]",
+                        !!(e.hasAgent && e.inputValue),
+                      ),
+                    ),
+                    me
+                  );
+                },
+              }),
+              null,
+            ),
+            z(
+              G,
+              O(ye, {
+                get when() {
+                  return Be(() => e.status === "copying")() && e.isPendingAbort;
+                },
+                get children() {
+                  return O(Zr, {
+                    get onConfirm() {
+                      return e.onConfirmAbort;
+                    },
+                    get onCancel() {
+                      return e.onCancelAbort;
+                    },
+                  });
+                },
+              }),
+              null,
+            ),
+            z(
+              G,
+              O(ye, {
+                get when() {
+                  return Be(() => !!R())() && !e.isPromptMode;
+                },
+                get children() {
+                  var me = hb(),
+                    Se = me.firstChild;
+                  return (
+                    z(
+                      Se,
+                      O(qr, {
+                        get tagName() {
+                          return D();
+                        },
+                        get componentName() {
+                          return B();
+                        },
+                        get isClickable() {
+                          return V();
+                        },
+                        onClick: W,
+                        onHoverChange: le,
+                        shrink: true,
+                        get forceShowIcon() {
+                          return Be(() => !!N())()
+                            ? V()
+                            : !!e.isContextMenuOpen;
+                        },
+                      }),
+                    ),
+                    z(
+                      me,
+                      O(ye, {
+                        get when() {
+                          return e.arrowNavigationState?.isVisible;
+                        },
+                        get children() {
+                          return O(Md, {
+                            get items() {
+                              return e.arrowNavigationState.items;
+                            },
+                            get activeIndex() {
+                              return e.arrowNavigationState.activeIndex;
+                            },
+                            onSelect: (ie) => e.onArrowNavigationSelect?.(ie),
+                          });
+                        },
+                      }),
+                      null,
+                    ),
+                    z(
+                      me,
+                      O(ye, {
+                        get when() {
+                          return Be(() => !N())() && $();
+                        },
+                        get children() {
+                          return O(Mt, {
+                            get children() {
+                              var ie = gb();
+                              return (
+                                z(
+                                  ie,
+                                  O(on, {
+                                    get each() {
+                                      return w();
+                                    },
+                                    children: (pe, ke) =>
+                                      (() => {
+                                        var Pe = Eb(),
+                                          ge = Pe.firstChild;
+                                        return (
+                                          z(ge, () => pe.label),
+                                          z(
+                                            Pe,
+                                            O(ye, {
+                                              get when() {
+                                                return pe.shortcut;
+                                              },
+                                              get children() {
+                                                var Te = Cb();
+                                                return (
+                                                  z(Te, () => Jn(pe.shortcut)),
+                                                  Te
+                                                );
+                                              },
+                                            }),
+                                            null,
+                                          ),
+                                          te(
+                                            (Te) => {
+                                              var rt = pe.label.toLowerCase(),
+                                                ct = ke() === v(),
+                                                Ue = ke() === w().length - 1;
+                                              return (
+                                                rt !== Te.e &&
+                                                  ae(
+                                                    Pe,
+                                                    "data-react-grab-action-cycle-item",
+                                                    (Te.e = rt),
+                                                  ),
+                                                ct !== Te.t &&
+                                                  Pe.classList.toggle(
+                                                    "bg-black/5",
+                                                    (Te.t = ct),
+                                                  ),
+                                                Ue !== Te.a &&
+                                                  Pe.classList.toggle(
+                                                    "rounded-b-[6px]",
+                                                    (Te.a = Ue),
+                                                  ),
+                                                Te
+                                              );
+                                            },
+                                            { e: void 0, t: void 0, a: void 0 },
+                                          ),
+                                          Pe
+                                        );
+                                      })(),
+                                  }),
+                                ),
+                                ie
+                              );
+                            },
+                          });
+                        },
+                      }),
+                      null,
+                    ),
+                    te(
+                      (ie) => {
+                        var pe = !!N(),
+                          ke = { "py-1.5": !N(), "pt-1.5 pb-1": N() };
+                        return (
+                          pe !== ie.e &&
+                            me.classList.toggle("min-w-[100px]", (ie.e = pe)),
+                          (ie.t = co(Se, ke, ie.t)),
+                          ie
+                        );
+                      },
+                      { e: void 0, t: void 0 },
+                    ),
+                    me
+                  );
+                },
+              }),
+              null,
+            ),
+            z(
+              G,
+              O(ye, {
+                get when() {
+                  return (
+                    Be(() => !!(R() && e.isPromptMode))() && !e.isPendingDismiss
+                  );
+                },
+                get children() {
+                  var me = xb(),
+                    Se = me.firstChild;
+                  return (
+                    z(
+                      Se,
+                      O(qr, {
+                        get tagName() {
+                          return D();
+                        },
+                        get componentName() {
+                          return B();
+                        },
+                        get isClickable() {
+                          return V();
+                        },
+                        onClick: W,
+                        onHoverChange: le,
+                        forceShowIcon: true,
+                      }),
+                    ),
+                    z(
+                      me,
+                      O(Mt, {
+                        get children() {
+                          return [
+                            O(ye, {
+                              get when() {
+                                return e.replyToPrompt;
+                              },
+                              get children() {
+                                var ie = bb(),
+                                  pe = ie.firstChild;
+                                return (
+                                  z(
+                                    ie,
+                                    O(ws, {
+                                      size: 10,
+                                      class: "text-black/30 shrink-0",
+                                    }),
+                                    pe,
+                                  ),
+                                  z(pe, () => e.replyToPrompt),
+                                  ie
+                                );
+                              },
+                            }),
+                            (() => {
+                              var ie = wb(),
+                                pe = ie.firstChild;
+                              ((pe.$$keydown = y), (pe.$$input = h));
+                              var ke = o;
+                              return (
+                                typeof ke == "function" ? Ke(ke, pe) : (o = pe),
+                                z(
+                                  ie,
+                                  O(ye, {
+                                    get when() {
+                                      return e.onSubmit;
+                                    },
+                                    get children() {
+                                      var Pe = yb();
+                                      return (
+                                        (Pe.$$click = () => e.onSubmit?.()),
+                                        z(
+                                          Pe,
+                                          O(xs, {
+                                            size: 10,
+                                            class: "text-white",
+                                          }),
+                                        ),
+                                        Pe
+                                      );
+                                    },
+                                  }),
+                                  null,
+                                ),
+                                te(
+                                  (Pe) => {
+                                    var ge = e.replyToPrompt ? "14px" : "0",
+                                      Te = !e.onSubmit;
+                                    return (
+                                      ge !== Pe.e &&
+                                        we(ie, "padding-left", (Pe.e = ge)),
+                                      Te !== Pe.t && (pe.readOnly = Pe.t = Te),
+                                      Pe
+                                    );
+                                  },
+                                  { e: void 0, t: void 0 },
+                                ),
+                                te(() => (pe.value = e.inputValue ?? "")),
+                                ie
+                              );
+                            })(),
+                          ];
+                        },
+                      }),
+                      null,
+                    ),
+                    me
+                  );
+                },
+              }),
+              null,
+            ),
+            z(
+              G,
+              O(ye, {
+                get when() {
+                  return e.isPendingDismiss;
+                },
+                get children() {
+                  return O(Zr, {
+                    get onConfirm() {
+                      return e.onConfirmDismiss;
+                    },
+                    get onCancel() {
+                      return e.onCancelDismiss;
+                    },
+                  });
+                },
+              }),
+              null,
+            ),
+            z(
+              G,
+              O(ye, {
+                get when() {
+                  return e.error;
+                },
+                get children() {
+                  return O(Pd, {
+                    get error() {
+                      return e.error;
+                    },
+                    get onAcknowledge() {
+                      return e.onAcknowledgeError;
+                    },
+                    get onRetry() {
+                      return e.onRetry;
+                    },
+                  });
+                },
+              }),
+              null,
+            ),
+            te(
+              (me) => {
+                var Se = Ee(
+                    "fixed font-sans text-[13px] antialiased filter-[drop-shadow(0px_1px_2px_#51515140)] select-none transition-opacity duration-100 ease-out",
+                  ),
+                  ie = `${A().position.top}px`,
+                  pe = `${A().position.left}px`,
+                  ke = `translateX(calc(-50% + ${A().position.edgeOffsetX}px))`,
+                  Pe = fe() ? "auto" : "none",
+                  ge = e.status === "fading" || T() ? 0 : 1,
+                  Te = Ee(
+                    "contain-layout flex items-center gap-[5px] rounded-[10px] antialiased w-fit h-fit p-0 [font-synthesis:none] [corner-shape:superellipse(1.25)]",
+                    ht,
+                  ),
+                  rt = X() && !e.error ? "none" : void 0;
+                return (
+                  Se !== me.e && Re(I, (me.e = Se)),
+                  ie !== me.t && we(I, "top", (me.t = ie)),
+                  pe !== me.a && we(I, "left", (me.a = pe)),
+                  ke !== me.o && we(I, "transform", (me.o = ke)),
+                  Pe !== me.i && we(I, "pointer-events", (me.i = Pe)),
+                  ge !== me.n && we(I, "opacity", (me.n = ge)),
+                  Te !== me.s && Re(G, (me.s = Te)),
+                  rt !== me.h && we(G, "display", (me.h = rt)),
+                  me
+                );
+              },
+              {
+                e: void 0,
+                t: void 0,
+                a: void 0,
+                o: void 0,
+                i: void 0,
+                n: void 0,
+                s: void 0,
+                h: void 0,
+              },
+            ),
+            I
+          );
+        },
+      });
+    };
+  it(["pointerdown", "click", "input", "keydown"]);
+  var Id = "react-grab-toolbar-state",
+    yo = () => {
+      try {
+        let e = localStorage.getItem(Id);
+        if (!e) return null;
+        let t = JSON.parse(e);
+        return {
+          edge: t.edge ?? "bottom",
+          ratio: t.ratio ?? 0.5,
+          collapsed: t.collapsed ?? !1,
+          enabled: t.enabled ?? !0,
+        };
+      } catch (e) {
+        console.warn(
+          "[react-grab] Failed to load toolbar state from localStorage:",
+          e,
+        );
+      }
+      return null;
+    },
+    Qr = (e) => {
+      try {
+        localStorage.setItem(Id, JSON.stringify(e));
+      } catch (t) {
+        console.warn(
+          "[react-grab] Failed to save toolbar state to localStorage:",
+          t,
+        );
+      }
+    };
+  var Sb = K(
+      '<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 18 18"fill=currentColor><path opacity=0.4 d="M7.65631 10.9565C7.31061 10.0014 7.54012 8.96635 8.25592 8.25195C8.74522 7.76615 9.38771 7.49951 10.0694 7.49951C10.3682 7.49951 10.6641 7.55171 10.9483 7.65381L16.0001 9.49902V4.75C16.0001 3.2334 14.7667 2 13.2501 2H4.75012C3.23352 2 2.00012 3.2334 2.00012 4.75V13.25C2.00012 14.7666 3.23352 16 4.75012 16H9.49962L7.65631 10.9565Z"></path><path d="M17.296 11.5694L10.4415 9.06545C10.0431 8.92235 9.61441 9.01658 9.31551 9.31338C9.01671 9.61168 8.92101 10.0429 9.06551 10.4413L11.5704 17.2948C11.7247 17.7191 12.128 18.0004 12.5772 18.0004C12.585 18.0004 12.5918 17.9999 12.5987 17.9999C13.0577 17.9906 13.4591 17.6913 13.5987 17.2543L14.4854 14.4857L17.2559 13.5985C17.6914 13.4589 17.9903 13.057 18 12.599C18.0097 12.141 17.7267 11.7276 17.296 11.5694Z">',
+    ),
+    Nd = (e) => {
+      let t = () => e.size ?? 14;
+      return (() => {
+        var n = Sb();
+        return (
+          te(
+            (o) => {
+              var i = t(),
+                s = t(),
+                r = e.class;
+              return (
+                i !== o.e && ae(n, "width", (o.e = i)),
+                s !== o.t && ae(n, "height", (o.t = s)),
+                r !== o.a && ae(n, "class", (o.a = r)),
+                o
+              );
+            },
+            { e: void 0, t: void 0, a: void 0 },
+          ),
+          n
+        );
+      })();
+    };
+  var Ab = K(
+      '<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 24 24"fill=none stroke=currentColor stroke-width=2.5 stroke-linecap=round stroke-linejoin=round><path d="m18 15-6-6-6 6">',
+    ),
+    Ld = (e) => {
+      let t = () => e.size ?? 12;
+      return (() => {
+        var n = Ab();
+        return (
+          te(
+            (o) => {
+              var i = t(),
+                s = t(),
+                r = e.class;
+              return (
+                i !== o.e && ae(n, "width", (o.e = i)),
+                s !== o.t && ae(n, "height", (o.t = s)),
+                r !== o.a && ae(n, "class", (o.a = r)),
+                o
+              );
+            },
+            { e: void 0, t: void 0, a: void 0 },
+          ),
+          n
+        );
+      })();
+    };
+  var Tb = K(
+      '<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 24 24"fill=currentColor><path fill-rule=evenodd clip-rule=evenodd d="M12 1.25C6.06294 1.25 1.25 6.06294 1.25 12C1.25 17.9371 6.06294 22.75 12 22.75C17.9371 22.75 22.75 17.9371 22.75 12C22.75 6.06294 17.9371 1.25 12 1.25ZM13 8C13 7.44772 12.5523 7 12 7C11.4477 7 11 7.44772 11 8V12C11 12.2652 11.1054 12.5196 11.2929 12.7071L13.2929 14.7071C13.6834 15.0976 14.3166 15.0976 14.7071 14.7071C15.0976 14.3166 15.0976 13.6834 14.7071 13.2929L13 11.5858V8Z">',
+    ),
+    Dd = (e) => {
+      let t = () => e.size ?? 14;
+      return (() => {
+        var n = Tb();
+        return (
+          te(
+            (o) => {
+              var i = t(),
+                s = t(),
+                r = e.class;
+              return (
+                i !== o.e && ae(n, "width", (o.e = i)),
+                s !== o.t && ae(n, "height", (o.t = s)),
+                r !== o.a && ae(n, "class", (o.a = r)),
+                o
+              );
+            },
+            { e: void 0, t: void 0, a: void 0 },
+          ),
+          n
+        );
+      })();
+    };
+  var _b = K(
+      '<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 24 24"fill=currentColor><path d="M16.0549 8.25C17.4225 8.24998 18.5248 8.24996 19.3918 8.36652C20.2919 8.48754 21.0497 8.74643 21.6517 9.34835C22.2536 9.95027 22.5125 10.7081 22.6335 11.6083C22.75 12.4752 22.75 13.5775 22.75 14.9451V14.9451V16.0549V16.0549C22.75 17.4225 22.75 18.5248 22.6335 19.3918C22.5125 20.2919 22.2536 21.0497 21.6517 21.6517C21.0497 22.2536 20.2919 22.5125 19.3918 22.6335C18.5248 22.75 17.4225 22.75 16.0549 22.75H16.0549H14.9451H14.9451C13.5775 22.75 12.4752 22.75 11.6082 22.6335C10.7081 22.5125 9.95027 22.2536 9.34835 21.6516C8.74643 21.0497 8.48754 20.2919 8.36652 19.3918C8.24996 18.5248 8.24998 17.4225 8.25 16.0549V16.0549V14.9451V14.9451C8.24998 13.5775 8.24996 12.4752 8.36652 11.6082C8.48754 10.7081 8.74643 9.95027 9.34835 9.34835C9.95027 8.74643 10.7081 8.48754 11.6083 8.36652C12.4752 8.24996 13.5775 8.24998 14.9451 8.25H14.9451H16.0549H16.0549Z"></path><path d="M6.75 14.8569C6.74991 13.5627 6.74983 12.3758 6.8799 11.4084C7.0232 10.3425 7.36034 9.21504 8.28769 8.28769C9.21504 7.36034 10.3425 7.0232 11.4084 6.8799C12.3758 6.74983 13.5627 6.74991 14.8569 6.75L17.0931 6.75C17.3891 6.75 17.5371 6.75 17.6261 6.65419C17.7151 6.55838 17.7045 6.4142 17.6833 6.12584C17.6648 5.87546 17.6412 5.63892 17.6111 5.41544C17.4818 4.45589 17.2232 3.6585 16.6718 2.98663C16.4744 2.74612 16.2539 2.52558 16.0134 2.3282C15.3044 1.74638 14.4557 1.49055 13.4248 1.36868C12.4205 1.24998 11.1512 1.24999 9.54893 1.25H9.45109C7.84883 1.24999 6.57947 1.24998 5.57525 1.36868C4.54428 1.49054 3.69558 1.74638 2.98663 2.3282C2.74612 2.52558 2.52558 2.74612 2.3282 2.98663C1.74638 3.69558 1.49055 4.54428 1.36868 5.57525C1.24998 6.57947 1.24999 7.84882 1.25 9.45108V9.54891C1.24999 11.1512 1.24998 12.4205 1.36868 13.4247C1.49054 14.4557 1.74638 15.3044 2.3282 16.0134C2.52558 16.2539 2.74612 16.4744 2.98663 16.6718C3.6585 17.2232 4.45589 17.4818 5.41544 17.6111C5.63892 17.6412 5.87546 17.6648 6.12584 17.6833C6.4142 17.7045 6.55838 17.7151 6.65419 17.6261C6.75 17.5371 6.75 17.3891 6.75 17.0931V14.8569Z">',
+    ),
+    ei = (e) => {
+      let t = () => e.size ?? 14;
+      return (() => {
+        var n = _b();
+        return (
+          te(
+            (o) => {
+              var i = t(),
+                s = t(),
+                r = e.class;
+              return (
+                i !== o.e && ae(n, "width", (o.e = i)),
+                s !== o.t && ae(n, "height", (o.t = s)),
+                r !== o.a && ae(n, "class", (o.a = r)),
+                o
+              );
+            },
+            { e: void 0, t: void 0, a: void 0 },
+          ),
+          n
+        );
+      })();
+    };
+  var ul = (e, t, n) => (e.x - n.x) * (t.y - n.y) - (t.x - n.x) * (e.y - n.y),
+    Pb = (e, t, n, o) => {
+      let i = ul(e, t, n),
+        s = ul(e, n, o),
+        r = ul(e, o, t),
+        c = i < 0 || s < 0 || r < 0,
+        l = i > 0 || s > 0 || r > 0;
+      return !c || !l;
+    },
+    dl = (e, t) =>
+      e.x >= t.x && e.x <= t.x + t.width && e.y >= t.y && e.y <= t.y + t.height,
+    kb = (e, t) => {
+      let n = t.y + t.height,
+        o = t.x + t.width;
+      return e.y <= t.y
+        ? [
+            { x: t.x, y: n },
+            { x: o, y: n },
+          ]
+        : e.y >= n
+          ? [
+              { x: t.x, y: t.y },
+              { x: o, y: t.y },
+            ]
+          : e.x <= t.x
+            ? [
+                { x: o, y: t.y },
+                { x: o, y: n },
+              ]
+            : [
+                { x: t.x, y: t.y },
+                { x: t.x, y: n },
+              ];
+    },
+    _s = () => {
+      let e = null,
+        t = () => {
+          (e?.(), (e = null));
+        };
+      return {
+        start: (o, i, s) => {
+          t();
+          let r = i[0];
+          if (!r || dl(o, r)) return;
+          let [c, l] = kb(o, r),
+            u = (p) => i.some((b) => dl(p, b)),
+            f = (p) => {
+              let b = { x: p.clientX, y: p.clientY };
+              if (u(b)) {
+                dl(b, r) && t();
+                return;
+              }
+              Pb(b, o, c, l) || (t(), s());
+            };
+          (window.addEventListener("mousemove", f),
+            (e = () => {
+              window.removeEventListener("mousemove", f);
+            }));
+        },
+        stop: t,
+      };
+    };
+  var yt = false,
+    fl = (e, t, n) => {
+      let o = e.get(t);
+      if (o) return o;
+      let i = n();
+      return (e.set(t, i), i);
+    },
+    Fd = new WeakMap(),
+    $d = new WeakMap(),
+    Ob = new WeakMap(),
+    pl = new Set(),
+    gl = [],
+    Ps = [],
+    ks = new WeakMap(),
+    Os = new WeakMap(),
+    Hd = new WeakSet(),
+    Bd = Ya,
+    Mb = (e) => {
+      let t = e;
+      for (; t.return; ) t = t.return;
+      return t.stateNode ?? null;
+    },
+    zd = () => {
+      if (Bd.size > 0) return Bd;
+      let e = new Set(),
+        t = (n) => {
+          let o = po(n);
+          if (o) {
+            let i = Mb(o);
+            i && e.add(i);
+            return;
+          }
+          for (let i of Array.from(n.children)) if ((t(i), e.size > 0)) return;
+        };
+      return (t(document.body), e);
+    },
+    Rb = (e, t) => {
+      if (!e) return t;
+      if (!t) return e;
+      if (!e.next || !t.next) return t;
+      let n = e.next,
+        o = t.next,
+        i = e === n,
+        s = t === o;
+      return (
+        i && s
+          ? ((e.next = t), (t.next = e))
+          : i
+            ? ((e.next = o), (t.next = e))
+            : s
+              ? ((t.next = n), (e.next = t))
+              : ((e.next = o), (t.next = n)),
+        t
+      );
+    },
+    Ib = (e) => {
+      if (!e || ks.has(e)) return;
+      let t = {
+        originalPendingDescriptor: Object.getOwnPropertyDescriptor(
+          e,
+          "pending",
+        ),
+        pendingValueAtPause: e.pending,
+        bufferedPending: null,
+      };
+      typeof e.getSnapshot == "function" &&
+        ((t.originalGetSnapshot = e.getSnapshot),
+        (t.snapshotValueAtPause = e.getSnapshot()),
+        (e.getSnapshot = () =>
+          yt ? t.snapshotValueAtPause : t.originalGetSnapshot()));
+      let n = t.pendingValueAtPause;
+      (Object.defineProperty(e, "pending", {
+        configurable: true,
+        enumerable: true,
+        get: () => (yt ? t.bufferedPending : n),
+        set: (o) => {
+          (yt && (t.bufferedPending = o), (n = o));
+        },
+      }),
+        ks.set(e, t));
+    },
+    Nb = (e) => {
+      let t = ks.get(e);
+      if (!t) return;
+      t.originalGetSnapshot && (e.getSnapshot = t.originalGetSnapshot);
+      let n = Rb(t.pendingValueAtPause ?? null, t.bufferedPending ?? null);
+      (t.originalPendingDescriptor
+        ? Object.defineProperty(e, "pending", t.originalPendingDescriptor)
+        : delete e.pending,
+        (e.pending = n),
+        ks.delete(e));
+    },
+    Lb = (e) => {
+      if (Os.has(e)) return;
+      let t = {
+        originalDescriptor: Object.getOwnPropertyDescriptor(e, "memoizedValue"),
+        frozenValue: e.memoizedValue,
+      };
+      (Object.defineProperty(e, "memoizedValue", {
+        configurable: true,
+        enumerable: true,
+        get() {
+          return yt
+            ? t.frozenValue
+            : t.originalDescriptor?.get
+              ? t.originalDescriptor.get.call(this)
+              : this._memoizedValue;
+        },
+        set(n) {
+          if (yt) {
+            ((t.pendingValue = n), (t.didReceivePendingValue = true));
+            return;
+          }
+          t.originalDescriptor?.set
+            ? t.originalDescriptor.set.call(this, n)
+            : (this._memoizedValue = n);
+        },
+      }),
+        t.originalDescriptor?.get || (e._memoizedValue = t.frozenValue),
+        Os.set(e, t));
+    },
+    Db = (e) => {
+      let t = Os.get(e);
+      t &&
+        (t.originalDescriptor
+          ? Object.defineProperty(e, "memoizedValue", t.originalDescriptor)
+          : delete e.memoizedValue,
+        t.didReceivePendingValue && (e.memoizedValue = t.pendingValue),
+        Os.delete(e));
+    },
+    Vd = (e, t) => {
+      let n = e.memoizedState;
+      for (; n; )
+        (n.queue && typeof n.queue == "object" && t(n.queue), (n = n.next));
+    },
+    Gd = (e, t) => {
+      let n = e.dependencies?.firstContext;
+      for (; n && typeof n == "object" && "memoizedValue" in n; )
+        (t(n), (n = n.next));
+    },
+    Ms = (e, t) => {
+      e && (Jo(e) && t(e), Ms(e.child, t), Ms(e.sibling, t));
+    },
+    Fb = (e) => {
+      (Vd(e, Ib), Gd(e, Lb));
+    },
+    $b = (e) => {
+      (Vd(e, Nb), Gd(e, Db));
+    },
+    Hb = (e) => {
+      if (Fd.has(e)) return;
+      let t = e,
+        n = {
+          useState: t.useState,
+          useReducer: t.useReducer,
+          useTransition: t.useTransition,
+          useSyncExternalStore: t.useSyncExternalStore,
+        };
+      (Fd.set(e, n),
+        (t.useState = (...o) => {
+          let i = n.useState.apply(e, o);
+          if (!yt || !Array.isArray(i) || typeof i[1] != "function") return i;
+          let [s, r] = i,
+            c = fl($d, r, () => (...l) => {
+              yt ? Ps.push(() => r(...l)) : r(...l);
+            });
+          return [s, c];
+        }),
+        (t.useReducer = (...o) => {
+          let i = n.useReducer.apply(e, o);
+          if (!yt || !Array.isArray(i) || typeof i[1] != "function") return i;
+          let [s, r] = i,
+            c = fl($d, r, () => (...l) => {
+              yt ? Ps.push(() => r(...l)) : r(...l);
+            });
+          return [s, c];
+        }),
+        (t.useTransition = (...o) => {
+          let i = n.useTransition.apply(e, o);
+          if (!yt || !Array.isArray(i) || typeof i[1] != "function") return i;
+          let [s, r] = i,
+            c = fl(Ob, r, () => (l) => {
+              yt ? gl.push(() => r(l)) : r(l);
+            });
+          return [s, c];
+        }),
+        (t.useSyncExternalStore = (o, i, s) => {
+          if (!yt) return n.useSyncExternalStore(o, i, s);
+          let r = (c) =>
+            o(() => {
+              yt ? pl.add(c) : c();
+            });
+          return n.useSyncExternalStore(r, i, s);
+        }));
+    },
+    Bb = (e) => {
+      let t = e.currentDispatcherRef;
+      if (!t || typeof t != "object") return;
+      let n = "H" in t ? "H" : "current",
+        o = t[n];
+      Object.defineProperty(t, n, {
+        configurable: true,
+        enumerable: true,
+        get: () => (o && typeof o == "object" && Hb(o), o),
+        set: (i) => {
+          o = i;
+        },
+      });
+    },
+    zb = (e) => {
+      queueMicrotask(() => {
+        try {
+          for (let t of Wn().renderers.values())
+            if (typeof t.scheduleUpdate == "function") {
+              for (let n of e)
+                if (n.current)
+                  try {
+                    t.scheduleUpdate(n.current);
+                  } catch {}
+            }
+        } catch {}
+      });
+    },
+    ml = (e) => {
+      for (let t of e)
+        try {
+          t();
+        } catch {}
+    },
+    Vb = () => {
+      for (let e of Wn().renderers.values()) Hd.has(e) || (Bb(e), Hd.add(e));
+    },
+    Rs = () => {
+      if (yt) return () => {};
+      (Vb(), (yt = true));
+      let e = zd();
+      for (let t of e) Ms(t.current, Fb);
+      return () => {
+        if (yt)
+          try {
+            let t = zd();
+            for (let s of t) Ms(s.current, $b);
+            let n = Array.from(pl),
+              o = gl.slice(),
+              i = Ps.slice();
+            ((yt = !1), ml(n), ml(o), ml(i), zb(t));
+          } finally {
+            (pl.clear(), (gl.length = 0), (Ps.length = 0));
+          }
+      };
+    };
+  var ti = (e, t) => {
+    let n = document.createElement("style");
+    return (
+      n.setAttribute(e, ""),
+      (n.textContent = t),
+      document.head.appendChild(n),
+      n
+    );
+  };
+  var wo = false,
+    Nn = new Map(),
+    Ud = -1,
+    jd = new WeakSet(),
+    ni = new Map(),
+    lr = new Map(),
+    Gb = (e) =>
+      jd.has(e)
+        ? true
+        : !wo ||
+            !("gsapVersions" in window) ||
+            !(new Error().stack ?? "").includes("_tick")
+          ? false
+          : (jd.add(e), true);
+  typeof window < "u" &&
+    ((window.requestAnimationFrame = (e) => {
+      if (!Gb(e)) return Ve(e);
+      if (wo) {
+        let n = Ud--;
+        return (Nn.set(n, e), n);
+      }
+      let t = Ve((n) => {
+        if (wo) {
+          let o = Ud--;
+          (Nn.set(o, e), ni.set(t, o));
+          return;
+        }
+        e(n);
+      });
+      return t;
+    }),
+    (window.cancelAnimationFrame = (e) => {
+      if (Nn.has(e)) {
+        Nn.delete(e);
+        return;
+      }
+      let t = lr.get(e);
+      if (t !== void 0) {
+        (Ge(t.nativeId), lr.delete(e));
+        return;
+      }
+      let n = ni.get(e);
+      if (n !== void 0) {
+        (Nn.delete(n), ni.delete(e));
+        return;
+      }
+      Ge(e);
+    }));
+  var Wd = () => {
+      if (!wo) {
+        ((wo = true), Nn.clear(), ni.clear());
+        for (let [e, { nativeId: t, callback: n }] of lr) (Ge(t), Nn.set(e, n));
+        lr.clear();
+      }
+    },
+    Kd = () => {
+      if (wo) {
+        wo = false;
+        for (let [e, t] of Nn.entries()) {
+          let n = Ve((o) => {
+            (lr.delete(e), t(o));
+          });
+          lr.set(e, { nativeId: n, callback: t });
+        }
+        (Nn.clear(), ni.clear());
+      }
+    };
+  var Ub = `
 [${Hr}],
 [${Hr}] * {
   animation-play-state: paused !important;
   transition: none !important;
 }
-`,jb=`
+`,
+    jb = `
 *, *::before, *::after {
   animation-play-state: paused !important;
   transition: none !important;
 }
-`,Yd="svg",Xd=null,xo=[],oi=[],hl=[],cr=null,Is=[],ri=new Map,ii=[],Wb=()=>{Xd||(Xd=ti("data-react-grab-frozen-styles",Ub));},Kb=(e,t)=>e.length===t.length&&e.every((n,o)=>n===t[o]),qd=e=>{let t=new Set;for(let n of e){n instanceof SVGSVGElement?t.add(n):n instanceof SVGElement&&n.ownerSVGElement&&t.add(n.ownerSVGElement);for(let o of n.querySelectorAll(Yd))o instanceof SVGSVGElement&&t.add(o);}return [...t]},Zd=(e,t)=>{let n=Reflect.get(e,t);typeof n=="function"&&n.call(e);},Jd=e=>{for(let t of e){let n=ri.get(t)??0;n===0&&Zd(t,"pauseAnimations"),ri.set(t,n+1);}},Qd=e=>{for(let t of e){let n=ri.get(t);if(n){if(n===1){ri.delete(t),Zd(t,"unpauseAnimations");continue}ri.set(t,n-1);}}},Xb=e=>{let t=[];for(let n of e)for(let o of n.getAnimations({subtree:true}))o.playState==="running"&&t.push(o);return t},ef=e=>{for(let t of e)try{t.finish();}catch{}},ur=e=>{if(e.length!==0&&!Kb(e,hl)){bl(),hl=[...e],Wb(),xo=e,oi=qd(xo),Jd(oi);for(let t of xo)t.setAttribute(Hr,"");ii=Xb(xo);for(let t of ii)t.pause();}},bl=()=>{if(!(xo.length===0&&oi.length===0&&ii.length===0)){for(let e of xo)e.removeAttribute(Hr);Qd(oi),ef(ii),xo=[],oi=[],ii=[],hl=[];}},tf=e=>e.length===0?(bl(),()=>{}):(ur(e),bl),Ns=()=>{cr||(cr=ti("data-react-grab-global-freeze",jb),Is=qd(Array.from(document.querySelectorAll(Yd))),Jd(Is),Wd());},si=()=>{if(!cr)return;cr.textContent=`
+`,
+    Yd = "svg",
+    Xd = null,
+    xo = [],
+    oi = [],
+    hl = [],
+    cr = null,
+    Is = [],
+    ri = new Map(),
+    ii = [],
+    Wb = () => {
+      Xd || (Xd = ti("data-react-grab-frozen-styles", Ub));
+    },
+    Kb = (e, t) => e.length === t.length && e.every((n, o) => n === t[o]),
+    qd = (e) => {
+      let t = new Set();
+      for (let n of e) {
+        n instanceof SVGSVGElement
+          ? t.add(n)
+          : n instanceof SVGElement &&
+            n.ownerSVGElement &&
+            t.add(n.ownerSVGElement);
+        for (let o of n.querySelectorAll(Yd))
+          o instanceof SVGSVGElement && t.add(o);
+      }
+      return [...t];
+    },
+    Zd = (e, t) => {
+      let n = Reflect.get(e, t);
+      typeof n == "function" && n.call(e);
+    },
+    Jd = (e) => {
+      for (let t of e) {
+        let n = ri.get(t) ?? 0;
+        (n === 0 && Zd(t, "pauseAnimations"), ri.set(t, n + 1));
+      }
+    },
+    Qd = (e) => {
+      for (let t of e) {
+        let n = ri.get(t);
+        if (n) {
+          if (n === 1) {
+            (ri.delete(t), Zd(t, "unpauseAnimations"));
+            continue;
+          }
+          ri.set(t, n - 1);
+        }
+      }
+    },
+    Xb = (e) => {
+      let t = [];
+      for (let n of e)
+        for (let o of n.getAnimations({ subtree: true }))
+          o.playState === "running" && t.push(o);
+      return t;
+    },
+    ef = (e) => {
+      for (let t of e)
+        try {
+          t.finish();
+        } catch {}
+    },
+    ur = (e) => {
+      if (e.length !== 0 && !Kb(e, hl)) {
+        (bl(), (hl = [...e]), Wb(), (xo = e), (oi = qd(xo)), Jd(oi));
+        for (let t of xo) t.setAttribute(Hr, "");
+        ii = Xb(xo);
+        for (let t of ii) t.pause();
+      }
+    },
+    bl = () => {
+      if (!(xo.length === 0 && oi.length === 0 && ii.length === 0)) {
+        for (let e of xo) e.removeAttribute(Hr);
+        (Qd(oi), ef(ii), (xo = []), (oi = []), (ii = []), (hl = []));
+      }
+    },
+    tf = (e) => (e.length === 0 ? (bl(), () => {}) : (ur(e), bl)),
+    Ns = () => {
+      cr ||
+        ((cr = ti("data-react-grab-global-freeze", jb)),
+        (Is = qd(Array.from(document.querySelectorAll(Yd)))),
+        Jd(Is),
+        Wd());
+    },
+    si = () => {
+      if (!cr) return;
+      cr.textContent = `
 *, *::before, *::after {
   transition: none !important;
 }
-`;let e=[];for(let t of document.getAnimations()){if(t.effect instanceof KeyframeEffect){let n=t.effect.target;if(n instanceof Element&&n.getRootNode()instanceof ShadowRoot)continue}e.push(t);}ef(e),cr.remove(),cr=null,Qd(Is),Is=[],Kd();};var nf=(e,t=window.getComputedStyle(e))=>t.display!=="none"&&t.visibility!=="hidden"&&t.opacity!=="0";var vo=e=>{let t=pt(e);return t==="html"||t==="body"};var Yb=e=>{if(e.hasAttribute("data-react-grab"))return  true;let t=e.getRootNode();return t instanceof ShadowRoot&&t.host.hasAttribute("data-react-grab")},qb=e=>e.hasAttribute(Ea)||e.closest(`[${Ea}]`)!==null,Zb=e=>{let t=parseInt(e.zIndex,10);return e.pointerEvents==="none"&&e.position==="fixed"&&!isNaN(t)&&t>=qc},Jb=(e,t)=>{let n=t.position;if(n!=="fixed"&&n!=="absolute")return  false;let o=e.getBoundingClientRect();if(!(o.width/window.innerWidth>=Br&&o.height/window.innerHeight>=Br))return  false;let s=t.backgroundColor;if(s==="transparent"||s==="rgba(0, 0, 0, 0)"||parseFloat(t.opacity)<.1)return  true;let c=parseInt(t.zIndex,10);return !isNaN(c)&&c>Yc},Ls=new WeakMap,of=()=>{Ls=new WeakMap;},gn=e=>{if(vo(e)||Yb(e)||qb(e))return  false;let t=performance.now(),n=Ls.get(e);if(n&&t-n.timestamp<du)return n.isVisible;let o=window.getComputedStyle(e);return nf(e,o)?e.clientWidth/window.innerWidth>=Br&&e.clientHeight/window.innerHeight>=Br&&(Zb(o)||Jb(e,o))?false:(Ls.set(e,{isVisible:true,timestamp:t}),true):(Ls.set(e,{isVisible:false,timestamp:t}),false)};var Co=null,Eo=null,rf=()=>{Eo!==null&&clearTimeout(Eo),Eo=setTimeout(()=>{Eo=null,li();},uu);},yl=()=>{Eo!==null&&(clearTimeout(Eo),Eo=null);},Qb=(e,t,n,o)=>{let i=Math.abs(e-n),s=Math.abs(t-o);return i<=Oa&&s<=Oa},Ds=(e,t)=>{yl(),ai();let n=document.elementsFromPoint(e,t);return rf(),n},dr=(e,t)=>{let n=performance.now();if(Co){let s=Qb(e,t,Co.clientX,Co.clientY),r=n-Co.timestamp<cu;if(s||r)return Co.element}yl(),ai();let o=null,i=document.elementFromPoint(e,t);if(i&&gn(i))o=i;else {let s=document.elementsFromPoint(e,t);for(let r of s)if(r!==i&&gn(r)){o=r;break}}return rf(),Co={clientX:e,clientY:t,element:o,timestamp:n},o},Fs=()=>{yl(),li(),Co=null;};var ey="html { pointer-events: none !important; }",cf=["mouseenter","mouseleave","mouseover","mouseout","pointerenter","pointerleave","pointerover","pointerout"],uf=["focus","blur","focusin","focusout"],df=["background-color","color","border-color","box-shadow","transform","opacity","outline","filter","scale","visibility"],ff=["background-color","color","border-color","box-shadow","outline","outline-offset","outline-width","outline-color","outline-style","filter","opacity","ring-color","ring-width"],mf=new Map,wl=new Map,eo=null,pf=e=>{e.stopImmediatePropagation();},gf=e=>{e.preventDefault(),e.stopImmediatePropagation();},ty=(e,t)=>{let n=new Map;for(let o of t){let i=e.style.getPropertyValue(o);i&&n.set(o,i);}return n},sf=(e,t,n)=>{let o=[];for(let i of document.querySelectorAll(e)){if(!(i instanceof HTMLElement)||n?.has(i))continue;let s=getComputedStyle(i),r=i.style.cssText,c=ty(i,t);for(let l of t){let u=s.getPropertyValue(l);u&&(r+=`${l}: ${u} !important; `);}o.push({element:i,frozenStyles:r,originalPropertyValues:c});}return o},af=(e,t)=>{for(let{element:n,frozenStyles:o,originalPropertyValues:i}of e)t.set(n,i),n.style.cssText=o;},lf=(e,t)=>{for(let[n,o]of e)for(let i of t){let s=o.get(i);s?n.style.setProperty(i,s):n.style.removeProperty(i);}e.clear();},ai=()=>{eo&&(eo.disabled=true);},li=()=>{eo&&(eo.disabled=false);},$s=()=>{if(eo)return;for(let n of cf)document.addEventListener(n,pf,true);for(let n of uf)document.addEventListener(n,gf,true);let e=sf(":hover",df),t=sf(":focus, :focus-visible",ff,wl);af(e,mf),af(t,wl),eo=ti("data-react-grab-frozen-pseudo",ey);},ci=()=>{Fs();for(let e of cf)document.removeEventListener(e,pf,true);for(let e of uf)document.removeEventListener(e,gf,true);lf(mf,df),lf(wl,ff),eo?.remove(),eo=null;};var ny=K("<div style=z-index:2147483647>"),xl=0,oy=()=>Date.now()-xl<Jc,Ln=e=>{let[t,n]=U(false),[o,i]=U(true),s;return be(He(()=>e.visible,r=>{s!==void 0&&(clearTimeout(s),s=void 0),r?oy()?(i(false),n(true)):(i(true),s=setTimeout(()=>{n(true);},Zc)):(t()&&(xl=Date.now()),n(false));})),Me(()=>{s!==void 0&&clearTimeout(s),t()&&(xl=Date.now());}),O(ye,{get when(){return t()},get children(){var r=ny();return z(r,()=>e.children),te(()=>Re(r,Ee("absolute whitespace-nowrap px-1.5 py-0.5 rounded-[10px] text-[10px] text-black/60 pointer-events-none [corner-shape:superellipse(1.25)]",ht,e.position==="left"||e.position==="right"?"top-1/2 -translate-y-1/2":"left-1/2 -translate-x-1/2",e.position==="top"&&"bottom-full mb-2.5",e.position==="bottom"&&"top-full mt-2.5",e.position==="left"&&"right-full mr-2.5",e.position==="right"&&"left-full ml-2.5",o()&&"animate-tooltip-fade-in"))),r}})};var hf=(e,t,n)=>{if(t)return e?"grid-rows-[1fr] opacity-100":"grid-cols-[1fr] opacity-100";let o=e?"grid-rows-[0fr] opacity-0":"grid-cols-[0fr] opacity-0";return n?`${o} ${n}`:o},bf=e=>e?"mb-1.5":"mr-1.5",yf=e=>e?"min-h-0":"min-w-0",wf=e=>e?"before:!min-h-full":"before:!min-w-full";var ry=K('<span data-react-grab-unread-indicator class="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-[#404040]">'),iy=K("<div style=z-index:2147483647>Enable to continue"),sy=K('<div data-react-grab-ignore-events data-react-grab-toolbar style=z-index:2147483647><div><div><div><div><div><div><button data-react-grab-ignore-events data-react-grab-toolbar-toggle></button></div></div><div><div><button data-react-grab-ignore-events data-react-grab-toolbar-history aria-haspopup=menu><span class="inline-flex relative"></span></button></div></div><div><div><button data-react-grab-ignore-events data-react-grab-toolbar-copy-all aria-label="Copy all history items"></button></div></div><div><div><button data-react-grab-ignore-events data-react-grab-toolbar-menu aria-haspopup=menu></button></div></div></div><div class="relative shrink-0 overflow-visible"><button data-react-grab-ignore-events data-react-grab-toolbar-enabled><div><div></div></div></button></div></div></div><button data-react-grab-ignore-events data-react-grab-toolbar-collapse class="contain-layout shrink-0 flex items-center justify-center cursor-pointer interactive-scale">'),xf=e=>{let t,n,o=null,i=0,s=0,r=_s(),c=k=>{if(!t)return null;let ee=t.getRootNode().querySelector(k);if(!ee)return null;let ne=ee.getBoundingClientRect();return {x:ne.x-mn,y:ne.y-mn,width:ne.width+mn*2,height:ne.height+mn*2}},l=(...k)=>{let q=[];for(let ee of k){let ne=c(ee);ne&&q.push(ne);}return q.length>0?q:null},u=yo(),[f,p]=U(false),[b,x]=U(false),[H,M]=U(false),[Y,m]=U(false),[E,T]=U(false),[C,R]=U(u?.edge??"bottom"),[X,fe]=U(u?.ratio??.5),[j,le]=U({x:0,y:0}),[ue,L]=U({x:0,y:0}),[A,y]=U({x:0,y:0}),[h,S]=U(false),[D,B]=U(false),[w,v]=U(false),[$,N]=U(false),[W,V]=U(false),[oe,de]=U(false),[I,G]=U(false),[Q,Ae]=U(false),[me,Se]=U(false),[ie,pe]=U(false),[ke,Pe]=U(false),ge,Te=()=>(e.toolbarActions??[]).length>0,rt=()=>{let k=e.historyItemCount??0;return k>0?`History (${k})`:"History"},ct=()=>Ee("transition-colors",e.isHistoryPinned?"text-black/80":"text-[#B3B3B3]"),Ue=()=>C()==="left"||C()==="right",wt=()=>{if(!n)return;let k=n.getBoundingClientRect();Ue()?s=k.height:i=k.width;},bn=()=>!b()&&!e.isHistoryDropdownOpen&&!e.isMenuOpen&&!e.isClearPromptOpen,Ht=()=>{switch(C()){case "top":return "bottom";case "bottom":return "top";case "left":return "right";case "right":return "left"}},Bt=(k,q)=>hf(Ue(),k,q),Rt=()=>Ue()?"transition-[grid-template-rows,opacity] duration-150 ease-out":"transition-[grid-template-columns,opacity] duration-150 ease-out",yn=()=>bf(Ue()),xt=()=>yf(Ue()),Dn=()=>wf(Ue()),To=()=>{let k=Ht();return Ue()?`top-1/2 -translate-y-1/2 ${k==="left"?"right-full mr-0.5":"left-full ml-0.5"}`:`left-1/2 -translate-x-1/2 ${k==="top"?"bottom-full mb-0.5":"top-full mt-0.5"}`},It=k=>{k.stopImmediatePropagation();},st=(k,q)=>({onMouseEnter:()=>{H()||(r.stop(),k(true),q?.shouldFreezeInteractions!==false&&!o&&(o=Rs(),Ns(),$s()),q?.onHoverChange?.(true));},onMouseLeave:ee=>{k(false),q?.shouldFreezeInteractions!==false&&!e.isActive&&!e.isContextMenuOpen&&(o?.(),o=null,si(),ci());let ne=q?.safePolygonTargets?.();if(ne){r.start({x:ee.clientX,y:ee.clientY},ne,()=>q?.onHoverChange?.(false));return}q?.onHoverChange?.(false);}}),sn=()=>{if(!b())return "";let k=C(),q={top:"rounded-t-none rounded-b-[10px]",bottom:"rounded-b-none rounded-t-[10px]",left:"rounded-l-none rounded-r-[10px]",right:"rounded-r-none rounded-l-[10px]"}[k],ee=Ue()?"px-0.25 py-2":"px-2 py-0.25";return `${q} ${ee}`},Pt;be(He(()=>e.shakeCount,k=>{k&&!e.enabled&&(B(true),de(true),Pt&&clearTimeout(Pt),Pt=setTimeout(()=>{de(false);},ru));})),be(He(()=>e.enabled,k=>{k&&oe()&&(de(false),Pt&&clearTimeout(Pt));})),be(He(()=>[e.isActive,e.isContextMenuOpen],([k,q])=>{!k&&!q&&o&&(o(),o=null);}));let _o=()=>{if(!t)return;let k=t.getBoundingClientRect();Fe={width:k.width,height:k.height};let q=j(),ee=zt(),ne=C(),xe=q.x,ve=q.y;if(ne==="top"||ne==="bottom"){let Oe=ee.offsetLeft+_e,je=Math.max(Oe,ee.offsetLeft+ee.width-k.width-_e);xe=Nt(q.x,Oe,je),ve=ne==="top"?ee.offsetTop+_e:ee.offsetTop+ee.height-k.height-_e;}else {let Oe=ee.offsetTop+_e,je=Math.max(Oe,ee.offsetTop+ee.height-k.height-_e);ve=Nt(q.y,Oe,je),xe=ne==="left"?ee.offsetLeft+_e:ee.offsetLeft+ee.width-k.width-_e;}let he=Ut(ne,xe,ve,k.width,k.height);fe(he),(xe!==q.x||ve!==q.y)&&(v(true),Ve(()=>{Ve(()=>{le({x:xe,y:ve}),gt&&clearTimeout(gt),gt=setTimeout(()=>{v(false);},Pn);});}));};be(He(()=>e.clockFlashTrigger??0,()=>{if(e.isHistoryDropdownOpen)return;ge&&(ge.classList.remove("animate-clock-flash"),ge.offsetHeight,ge.classList.add("animate-clock-flash")),Se(true);let k=setTimeout(()=>{ge?.classList.remove("animate-clock-flash"),Se(false);},1500);Me(()=>{clearTimeout(k),Se(false);});},{defer:true})),be(He(()=>e.historyItemCount??0,()=>{b()||(Hn&&clearTimeout(Hn),Hn=setTimeout(()=>{wt(),_o();},Pn),Me(()=>{Hn&&clearTimeout(Hn);}));},{defer:true}));let qt={x:0,y:0,time:0},Po={x:0,y:0},Fe={width:nu,height:ou},[Zt,an]=U({width:uo,height:uo}),Nt=(k,q,ee)=>Math.max(q,Math.min(k,ee)),zt=()=>{let k=window.visualViewport;return k?{width:k.width,height:k.height,offsetLeft:k.offsetLeft,offsetTop:k.offsetTop}:{width:window.innerWidth,height:window.innerHeight,offsetLeft:0,offsetTop:0}},Vt=(k,q)=>{let ee=zt(),ne=ee.width,xe=ee.height,{width:ve,height:he}=Fe,De=t?.getBoundingClientRect(),Oe=De?.width??uo,je=De?.height??uo,qe;if(q==="top"||q==="bottom"){let Ne=(ve-Oe)/2,ut=k.x-Ne,at=Nt(ut,ee.offsetLeft+_e,ee.offsetLeft+ne-ve-_e),kt=q==="top"?ee.offsetTop+_e:ee.offsetTop+xe-he-_e;qe={x:at,y:kt};}else {let Ne=(he-je)/2,ut=k.y-Ne,at=Nt(ut,ee.offsetTop+_e,ee.offsetTop+xe-he-_e);qe={x:q==="left"?ee.offsetLeft+_e:ee.offsetLeft+ne-ve-_e,y:at};}let tt=Ut(q,qe.x,qe.y,ve,he);return {position:qe,ratio:tt}},Gt=(k,q,ee,ne)=>{let xe=zt(),ve=xe.width,he=xe.height,De=xe.offsetLeft+_e,Oe=Math.max(De,xe.offsetLeft+ve-ee-_e),je=xe.offsetTop+_e,qe=Math.max(je,xe.offsetTop+he-ne-_e);if(k==="top"||k==="bottom"){let at=Math.max(0,ve-ee-_e*2);return {x:Math.min(Oe,Math.max(De,xe.offsetLeft+_e+at*q)),y:k==="top"?je:qe}}let tt=Math.max(0,he-ne-_e*2),Ne=Math.min(qe,Math.max(je,xe.offsetTop+_e+tt*q));return {x:k==="left"?De:Oe,y:Ne}},Ut=(k,q,ee,ne,xe)=>{let ve=zt(),he=ve.width,De=ve.height;if(k==="top"||k==="bottom"){let je=he-ne-_e*2;return je<=0?.5:Math.max(0,Math.min(1,(q-ve.offsetLeft-_e)/je))}let Oe=De-xe-_e*2;return Oe<=0?.5:Math.max(0,Math.min(1,(ee-ve.offsetTop-_e)/Oe))},Qs=()=>{let k=Gt(C(),X(),Fe.width,Fe.height);le(k);},ko=false,wn=k=>q=>{if(q.stopImmediatePropagation(),ko){ko=false;return}k();},hr=wn(()=>e.onToggle?.()),br=wn(()=>e.onToggleHistory?.()),hi=wn(()=>e.onCopyAll?.()),Oo=wn(()=>e.onToggleMenu?.()),bi=wn(()=>{let k=t?.getBoundingClientRect(),q=b(),ee=X();if(q){let{position:ne,ratio:xe}=Vt(Jt(),C());ee=xe,le(ne),fe(ee);}else k&&(Fe={width:k.width,height:k.height});v(true),x(ne=>!ne),vn({edge:C(),ratio:ee,collapsed:!q,enabled:e.enabled??true}),gt&&clearTimeout(gt),gt=setTimeout(()=>{if(v(false),b()){let ne=t?.getBoundingClientRect();ne&&an({width:ne.width,height:ne.height});}},Pn);}),Fn=wn(()=>{let k=!!e.enabled,q=C(),ee=j(),ne=q==="left"||q==="right",xe=()=>ne?s:i;k&&n&&!I()&&wt();let ve=xe(),he=ve>0,De=0;if(n){let Oe=n.getBoundingClientRect();De=ne?Oe.height:Oe.width;}if(!k&&ve===0&&n){let Oe=(e.historyItemCount??0)>0,je=Te(),qe=Array.from(n.children).filter(Ne=>Ne instanceof HTMLElement?Ne.querySelector("[data-react-grab-toolbar-history]")?Oe:Ne.querySelector("[data-react-grab-toolbar-copy-all]")?!!e.isHistoryDropdownOpen:Ne.querySelector("[data-react-grab-toolbar-menu]")?je:true:false),tt=ne?"gridTemplateRows":"gridTemplateColumns";for(let Ne of qe)Ne.style.transition="none",Ne.style[tt]="1fr";n.offsetWidth,wt(),ve=xe();for(let Ne of qe)Ne.style[tt]="";n.offsetWidth;for(let Ne of qe)Ne.style.transition="";he=ve>0;}if(he&&(Ae(I()),G(true)),e.onToggleEnabled?.(),he){let Oe=k?-ve:ve;ne?Fe={width:Fe.width,height:Fe.height+Oe}:Fe={width:Fe.width+Oe,height:Fe.height};let je=ne?ee.y+De:ee.x+De,qe=tt=>{let Ne=zt(),ut=je-tt;if(ne){let un=Ne.offsetTop+_e,Cn=Ne.offsetTop+Ne.height-Fe.height-_e;return {x:ee.x,y:Nt(ut,un,Cn)}}let at=Ne.offsetLeft+_e,kt=Ne.offsetLeft+Ne.width-Fe.width-_e;return {x:Nt(ut,at,kt),y:ee.y}};if(vt!==void 0&&Ge(vt),Q())le(qe(k?0:ve)),vt=void 0;else {let tt=performance.now(),Ne=()=>{if(performance.now()-tt>Pn+tu){vt=void 0;return}if(n){let at=ne?n.getBoundingClientRect().height:n.getBoundingClientRect().width;le(qe(at));}vt=Ve(Ne);};vt=Ve(Ne);}clearTimeout(wr),wr=setTimeout(()=>{vt!==void 0&&(Ge(vt),vt=void 0),le(qe(k?0:ve)),G(false),Ae(false);let Ne=Ut(q,j().x,j().y,Fe.width,Fe.height);fe(Ne),vn({edge:q,ratio:Ne,collapsed:b(),enabled:!k});},Pn);}else vn({edge:q,ratio:X(),collapsed:b(),enabled:!k});}),yi=(k,q,ee,ne,xe,ve)=>{let he=zt(),De=he.width,Oe=he.height,je=k+xe*Aa,qe=q+ve*Aa,tt=qe-he.offsetTop+ne/2,Ne=he.offsetTop+Oe-qe-ne/2,ut=je-he.offsetLeft+ee/2,at=he.offsetLeft+De-je-ee/2,kt=Math.min(tt,Ne,ut,at);return kt===tt?{edge:"top",x:Math.max(he.offsetLeft+_e,Math.min(je,he.offsetLeft+De-ee-_e)),y:he.offsetTop+_e}:kt===ut?{edge:"left",x:he.offsetLeft+_e,y:Math.max(he.offsetTop+_e,Math.min(qe,he.offsetTop+Oe-ne-_e))}:kt===at?{edge:"right",x:he.offsetLeft+De-ee-_e,y:Math.max(he.offsetTop+_e,Math.min(qe,he.offsetTop+Oe-ne-_e))}:{edge:"bottom",x:Math.max(he.offsetLeft+_e,Math.min(je,he.offsetLeft+De-ee-_e)),y:he.offsetTop+Oe-ne-_e}},yr=k=>{if(!H()||(Math.sqrt(Math.pow(k.clientX-Po.x,2)+Math.pow(k.clientY-Po.y,2))>eu&&(S(true),o&&(o(),o=null,si(),ci())),!h()))return;let ee=performance.now(),ne=ee-qt.time;if(ne>0){let he=(k.clientX-qt.x)/ne,De=(k.clientY-qt.y)/ne;y({x:he,y:De});}qt={x:k.clientX,y:k.clientY,time:ee};let xe=k.clientX-ue().x,ve=k.clientY-ue().y;le({x:xe,y:ve});},$n=()=>{if(!H())return;window.removeEventListener("pointermove",yr),window.removeEventListener("pointerup",$n);let k=h();if(M(false),!k)return;ko=true;let q=t?.getBoundingClientRect();if(!q)return;let ee=A(),ne=yi(j().x,j().y,q.width,q.height,ee.x,ee.y),xe=Ut(ne.edge,ne.x,ne.y,q.width,q.height);R(ne.edge),fe(xe),m(true),Ve(()=>{let ve=t?.getBoundingClientRect();ve&&(Fe={width:ve.width,height:ve.height}),Ve(()=>{let he=Gt(ne.edge,xe,Fe.width,Fe.height);le(he),vn({edge:ne.edge,ratio:xe,collapsed:b(),enabled:e.enabled??true}),wi=setTimeout(()=>{m(false),e.enabled&&wt();},Qc);});});},ln=k=>{if(b())return;let q=t?.getBoundingClientRect();q&&(Po={x:k.clientX,y:k.clientY},L({x:k.clientX-q.left,y:k.clientY-q.top}),M(true),S(false),y({x:0,y:0}),qt={x:k.clientX,y:k.clientY,time:performance.now()},window.addEventListener("pointermove",yr),window.addEventListener("pointerup",$n));},cn=()=>{let k=C(),q=j(),{width:ee,height:ne}=Fe,{width:xe,height:ve}=Zt(),he=zt();switch(k){case "top":case "bottom":{let De=(ee-xe)/2,Oe=q.x+De;return {x:Nt(Oe,he.offsetLeft,he.offsetLeft+he.width-xe),y:k==="top"?he.offsetTop:he.offsetTop+he.height-ve}}case "left":case "right":{let De=(ne-ve)/2,Oe=q.y+De,je=Nt(Oe,he.offsetTop,he.offsetTop+he.height-ve);return {x:k==="left"?he.offsetLeft:he.offsetLeft+he.width-xe,y:je}}default:return q}},Lt=()=>{let k=C(),q=b();switch(k){case "top":return q?"rotate-180":"rotate-0";case "bottom":return q?"rotate-0":"rotate-180";case "left":return q?"rotate-90":"-rotate-90";case "right":return q?"-rotate-90":"rotate-90";default:return "rotate-0"}},xn,gt,wi,wr,vt,Hn,jt=()=>{H()||(T(true),Qs(),xn&&clearTimeout(xn),xn=setTimeout(()=>{T(false);let k=Ut(C(),j().x,j().y,Fe.width,Fe.height);fe(k),vn({edge:C(),ratio:k,collapsed:b(),enabled:e.enabled??true});},Sa));},vn=k=>{Qr(k),e.onStateChange?.(k);};mt(()=>{t&&e.onContainerRef?.(t);let k=t?.getBoundingClientRect(),q=zt();if(u){if(k&&(Fe={width:k.width,height:k.height}),u.collapsed){let xe=u.edge==="top"||u.edge==="bottom";an({width:xe?Ta:uo,height:xe?uo:Ta});}x(u.collapsed);let ne=Gt(u.edge,u.ratio,Fe.width,Fe.height);le(ne);}else if(k)Fe={width:k.width,height:k.height},le({x:q.offsetLeft+(q.width-k.width)/2,y:q.offsetTop+q.height-k.height-_e}),fe(.5);else {let ne=Gt("bottom",.5,Fe.width,Fe.height);le(ne);}if(e.enabled&&wt(),e.onSubscribeToStateChanges){let ne=e.onSubscribeToStateChanges(xe=>{if(w()||I()||!t?.getBoundingClientRect())return;let he=b()!==xe.collapsed;if(R(xe.edge),he&&!xe.collapsed){let De=Jt();v(true),x(xe.collapsed);let{position:Oe,ratio:je}=Vt(De,xe.edge);le(Oe),fe(je),clearTimeout(gt),gt=setTimeout(()=>{v(false);},Pn);}else {he&&(v(true),clearTimeout(gt),gt=setTimeout(()=>{v(false);},Pn)),x(xe.collapsed);let De=Gt(xe.edge,xe.ratio,Fe.width,Fe.height);le(De),fe(xe.ratio);}});Me(ne);}window.addEventListener("resize",jt),window.visualViewport?.addEventListener("resize",jt),window.visualViewport?.addEventListener("scroll",jt);let ee=setTimeout(()=>{p(true);},Sa);Me(()=>{clearTimeout(ee);});}),Me(()=>{window.removeEventListener("resize",jt),window.visualViewport?.removeEventListener("resize",jt),window.visualViewport?.removeEventListener("scroll",jt),window.removeEventListener("pointermove",yr),window.removeEventListener("pointerup",$n),clearTimeout(xn),clearTimeout(gt),clearTimeout(Pt),clearTimeout(wi),clearTimeout(wr),clearTimeout(Hn),vt!==void 0&&Ge(vt),o?.(),r.stop();});let Jt=()=>b()?cn():j(),ea=()=>b()?"cursor-pointer":H()?"cursor-grabbing":"cursor-grab",ta=()=>E()?"":Y()?"transition-[transform,opacity] duration-300 ease-out":w()?"transition-[transform,opacity] duration-150 ease-out":I()?"transition-opacity duration-150 ease-out":"transition-opacity duration-300 ease-out",xr=()=>{switch(C()){case "top":return "center top";case "bottom":return "center bottom";case "left":return "left center";case "right":return "right center";default:return "center center"}};return (()=>{var k=sy(),q=k.firstChild,ee=q.firstChild,ne=ee.firstChild,xe=ne.firstChild,ve=xe.firstChild,he=ve.firstChild,De=he.firstChild,Oe=ve.nextSibling,je=Oe.firstChild,qe=je.firstChild,tt=qe.firstChild,Ne=Oe.nextSibling,ut=Ne.firstChild,at=ut.firstChild,kt=Ne.nextSibling,un=kt.firstChild,Cn=un.firstChild,xi=xe.nextSibling,En=xi.firstChild,Qt=En.firstChild,Mo=Qt.firstChild,en=ee.nextSibling;k.addEventListener("mouseleave",()=>e.onSelectHoverChange?.(false)),k.addEventListener("mouseenter",()=>!b()&&e.onSelectHoverChange?.(true)),k.$$pointerdown=ln;var vi=t;typeof vi=="function"?Ke(vi,k):t=k,q.$$click=Z=>{if(b()){Z.stopPropagation();let{position:io,ratio:Bn}=Vt(Jt(),C());le(io),fe(Bn),v(true),x(false),vn({edge:C(),ratio:Bn,collapsed:false,enabled:e.enabled??true}),gt&&clearTimeout(gt),gt=setTimeout(()=>{v(false);},Pn);}},q.addEventListener("animationend",()=>B(false));var Qe=n;typeof Qe=="function"?Ke(Qe,xe):n=xe,De.$$click=Z=>{N(false),hr(Z);},Je(De,"mousedown",It),Je(De,"pointerdown",Z=>{It(Z),ln(Z);}),Lr(De,Bo({get"aria-label"(){return e.isActive?"Stop selecting element":"Select element"},get"aria-pressed"(){return !!e.isActive},get class(){return Ee("contain-layout flex items-center justify-center cursor-pointer interactive-scale touch-hitbox",yn(),Dn())}},()=>st(N)),false),z(De,O(Nd,{size:14,get class(){return Ee("transition-colors",e.isActive?"text-black":"text-black/70")}})),z(he,O(Ln,{get visible(){return Be(()=>!!$())()&&bn()},get position(){return Ht()},get children(){return ["Select element (",Be(()=>Jn("C")),")"]}}),null),qe.$$click=Z=>{Se(false),br(Z);},Je(qe,"mousedown",It),Je(qe,"pointerdown",Z=>{It(Z),ln(Z);}),Lr(qe,Bo({get"aria-label"(){return `Open history${(e.historyItemCount??0)>0?` (${e.historyItemCount??0} items)`:""}`},get"aria-expanded"(){return !!e.isHistoryDropdownOpen},get class(){return Ee("contain-layout flex items-center justify-center cursor-pointer interactive-scale touch-hitbox",yn(),Dn())}},()=>st(Z=>{Z&&e.isHistoryDropdownOpen||Se(Z);},{onHoverChange:Z=>e.onHistoryButtonHover?.(Z),shouldFreezeInteractions:false,safePolygonTargets:()=>e.isHistoryDropdownOpen?l("[data-react-grab-history-dropdown]","[data-react-grab-toolbar-copy-all]"):null})),false);var vr=ge;return typeof vr=="function"?Ke(vr,tt):ge=tt,z(tt,O(Dd,{size:14,get class(){return ct()}}),null),z(tt,O(ye,{get when(){return e.hasUnreadHistoryItems},get children(){return ry()}}),null),z(je,O(Ln,{get visible(){return Be(()=>!!me())()&&bn()},get position(){return Ht()},get children(){return rt()}}),null),at.$$click=Z=>{Pe(false),hi(Z);},Je(at,"mousedown",It),Je(at,"pointerdown",Z=>{It(Z),ln(Z);}),Lr(at,Bo({get class(){return Ee("contain-layout flex items-center justify-center cursor-pointer interactive-scale touch-hitbox",yn(),Dn())}},()=>st(Pe,{onHoverChange:Z=>e.onCopyAllHover?.(Z),shouldFreezeInteractions:false,safePolygonTargets:()=>e.isHistoryDropdownOpen?l("[data-react-grab-history-dropdown]","[data-react-grab-toolbar-history]"):null})),false),z(at,O(ei,{size:14,class:"text-[#B3B3B3] transition-colors"})),z(ut,O(Ln,{get visible(){return Be(()=>!!ke())()&&bn()},get position(){return Ht()},children:"Copy all"}),null),Cn.$$click=Z=>{pe(false),Oo(Z);},Je(Cn,"mousedown",It),Je(Cn,"pointerdown",Z=>{It(Z),ln(Z);}),Lr(Cn,Bo({get"aria-label"(){return e.isMenuOpen?"Close more actions menu":"Open more actions menu"},get"aria-expanded"(){return !!e.isMenuOpen},get class(){return Ee("contain-layout flex items-center justify-center cursor-pointer interactive-scale touch-hitbox",yn(),Dn())}},()=>st(Z=>{Z&&e.isMenuOpen||pe(Z);},{shouldFreezeInteractions:false})),false),z(Cn,O(Ss,{size:14,get class(){return Ee("transition-colors",e.isMenuOpen?"text-black/80":"text-[#B3B3B3]")}})),z(un,O(Ln,{get visible(){return Be(()=>!!ie())()&&bn()},get position(){return Ht()},children:"More actions"}),null),En.addEventListener("mouseleave",()=>V(false)),En.addEventListener("mouseenter",()=>V(true)),En.$$click=Z=>{V(false),Fn(Z);},z(xi,O(Ln,{get visible(){return Be(()=>!!W())()&&bn()},get position(){return Ht()},get children(){return e.enabled?"Disable":"Enable"}}),null),Je(en,"click",bi,true),z(en,O(Ld,{size:14,get class(){return Ee("text-[#B3B3B3] transition-transform duration-150",Lt())}})),z(q,O(ye,{get when(){return oe()},get children(){var Z=iy();return te(()=>Re(Z,Ee("absolute whitespace-nowrap px-1.5 py-0.5 rounded-[10px] text-[10px] text-black/60 pointer-events-none animate-tooltip-fade-in [corner-shape:superellipse(1.25)]",ht,To()))),Z}}),null),te(Z=>{var io=Ee("fixed left-0 top-0 font-sans text-[13px] antialiased filter-[drop-shadow(0px_1px_2px_#51515140)] select-none",ea(),ta(),f()?"opacity-100 pointer-events-auto":"opacity-0 pointer-events-none"),Bn=`translate(${Jt().x}px, ${Jt().y}px)`,Ro=xr(),Ze=Ee("flex items-center justify-center rounded-[10px] antialiased relative overflow-visible [font-synthesis:none] [corner-shape:superellipse(1.25)]",Ue()&&"flex-col",ht,!b()&&(Ue()?"px-1.5 gap-1.5 py-2":"py-1.5 gap-1.5 px-2"),sn(),D()&&"animate-shake"),Cr=xr(),so=Ee("grid",!Q()&&Rt(),Bt(!b(),"pointer-events-none")),Ci=Ee("flex",Ue()?"flex-col items-center min-h-0":"items-center min-w-0"),Ei=Ee("flex items-center",Ue()&&"flex-col"),Si=Ee("grid",!Q()&&Rt(),Bt(!!e.enabled)),Ai=Ee("relative overflow-visible",xt()),Ti=Ee("grid",!Q()&&Rt(),Bt(!!e.enabled&&(e.historyItemCount??0)>0,"pointer-events-none")),_i=Ee("relative overflow-visible",xt()),Pi=Ee("grid",!Q()&&Rt(),Bt(!!e.isHistoryDropdownOpen,"pointer-events-none")),Er=Ee("relative overflow-visible",xt()),Io=Ee("grid",!Q()&&Rt(),Bt(!!e.enabled&&Te(),"pointer-events-none")),ki=Ee("relative overflow-visible",xt()),Oi=e.enabled?"Disable React Grab":"Enable React Grab",Mi=!!e.enabled,Ri=Ee("contain-layout flex items-center justify-center cursor-pointer interactive-scale outline-none",Ue()?"my-0.5":"mx-0.5"),Ii=Ee("relative rounded-full transition-colors",Ue()?"w-3.5 h-2.5":"w-5 h-3",e.enabled?"bg-black":"bg-black/25"),Ni=Ee("absolute top-0.5 rounded-full bg-white transition-transform",Ue()?"w-1.5 h-1.5":"w-2 h-2",!e.enabled&&"left-0.5",e.enabled&&(Ue()?"left-1.5":"left-2.5")),Sr=b()?"Expand toolbar":"Collapse toolbar";return io!==Z.e&&Re(k,Z.e=io),Bn!==Z.t&&we(k,"transform",Z.t=Bn),Ro!==Z.a&&we(k,"transform-origin",Z.a=Ro),Ze!==Z.o&&Re(q,Z.o=Ze),Cr!==Z.i&&we(q,"transform-origin",Z.i=Cr),so!==Z.n&&Re(ee,Z.n=so),Ci!==Z.s&&Re(ne,Z.s=Ci),Ei!==Z.h&&Re(xe,Z.h=Ei),Si!==Z.r&&Re(ve,Z.r=Si),Ai!==Z.d&&Re(he,Z.d=Ai),Ti!==Z.l&&Re(Oe,Z.l=Ti),_i!==Z.u&&Re(je,Z.u=_i),Pi!==Z.c&&Re(Ne,Z.c=Pi),Er!==Z.w&&Re(ut,Z.w=Er),Io!==Z.m&&Re(kt,Z.m=Io),ki!==Z.f&&Re(un,Z.f=ki),Oi!==Z.y&&ae(En,"aria-label",Z.y=Oi),Mi!==Z.g&&ae(En,"aria-pressed",Z.g=Mi),Ri!==Z.p&&Re(En,Z.p=Ri),Ii!==Z.b&&Re(Qt,Z.b=Ii),Ni!==Z.T&&Re(Mo,Z.T=Ni),Sr!==Z.A&&ae(en,"aria-label",Z.A=Sr),Z},{e:void 0,t:void 0,a:void 0,o:void 0,i:void 0,n:void 0,s:void 0,h:void 0,r:void 0,d:void 0,l:void 0,u:void 0,c:void 0,w:void 0,m:void 0,f:void 0,y:void 0,g:void 0,p:void 0,b:void 0,T:void 0,A:void 0}),k})()};it(["pointerdown","click"]);var vl=(e,t,n,o)=>Math.max(o,Math.min(e,n-t-o));var fr=({anchor:e,measuredWidth:t,measuredHeight:n,viewportWidth:o,viewportHeight:i,anchorGapPx:s,viewportPaddingPx:r,offscreenPosition:c})=>{if(!e||t===0||n===0)return c;let l,u;return e.edge==="left"||e.edge==="right"?(l=e.edge==="left"?e.x+s:e.x-t-s,u=e.y-n/2):(l=e.x-t/2,u=e.edge==="top"?e.y+s:e.y-n-s),{left:vl(l,t,o,r),top:vl(u,n,i,r)}};var _t=(e,t)=>{try{return e.composedPath().some(n=>n instanceof HTMLElement&&n.hasAttribute(t))}catch{return  false}};var ui=(e,t)=>typeof e.enabled=="function"?t?e.enabled(t):false:e.enabled??true,di=e=>typeof e.enabled=="function"?e.enabled():e.enabled??true;var ay=K('<div data-react-grab-ignore-events data-react-grab-toolbar-menu class="fixed font-sans text-[13px] antialiased filter-[drop-shadow(0px_1px_2px_#51515140)] select-none transition-[opacity,transform] duration-100 ease-out will-change-[opacity,transform]"style=z-index:2147483647><div><div class="relative flex flex-col py-1"><div class="pointer-events-none absolute bg-black/5 opacity-0 transition-[top,left,width,height,opacity] duration-75 ease-out">'),ly=K("<div><div>"),cy=K('<button data-react-grab-ignore-events class="relative z-1 contain-layout flex items-center justify-between w-full px-2 py-1 cursor-pointer text-left border-none bg-transparent disabled:opacity-40 disabled:cursor-default"><span class="text-[13px] leading-4 font-sans font-medium text-black">'),uy=K('<span class="text-[11px] font-sans text-black/50 ml-4">'),vf=e=>{let t,{containerRef:n,highlightRef:o,updateHighlight:i,clearHighlight:s}=Qn(),[r,c]=U(0),[l,u]=U(0),[f,p]=U(false),[b,x]=U(false),[H,M]=U("bottom"),[Y,m]=U(0),E,T,C=()=>{t&&(c(t.offsetWidth),u(t.offsetHeight));};be(()=>{let j=e.position;j?(M(j.edge),clearTimeout(E),p(true),T!==void 0&&Ge(T),T=Ve(()=>{C(),t?.offsetHeight,x(true);})):(T!==void 0&&Ge(T),x(false),E=setTimeout(()=>{p(false);},Yo));});let R=se(j=>{let le=fr({anchor:e.position,measuredWidth:r(),measuredHeight:l(),viewportWidth:window.innerWidth,viewportHeight:window.innerHeight,anchorGapPx:qo,viewportPaddingPx:jn,offscreenPosition:Kt});return le.left!==Kt.left?le:j},Kt),X=j=>{j.type==="contextmenu"&&j.preventDefault(),j.stopImmediatePropagation();},fe=(j,le)=>{le.stopPropagation(),di(j)&&(j.onAction(),j.isActive!==void 0?m(ue=>ue+1):e.onDismiss());};return mt(()=>{C();let j=L=>{!e.position||_t(L,"data-react-grab-ignore-events")||e.onDismiss();},le=L=>{e.position&&L.code==="Escape"&&(L.preventDefault(),L.stopPropagation(),e.onDismiss());},ue=Ve(()=>{window.addEventListener("mousedown",j,{capture:true}),window.addEventListener("touchstart",j,{capture:true});});window.addEventListener("keydown",le,{capture:true}),Me(()=>{Ge(ue),clearTimeout(E),T!==void 0&&Ge(T),window.removeEventListener("mousedown",j,{capture:true}),window.removeEventListener("touchstart",j,{capture:true}),window.removeEventListener("keydown",le,{capture:true});});}),O(ye,{get when(){return f()},get children(){var j=ay(),le=j.firstChild,ue=le.firstChild,L=ue.firstChild;j.$$contextmenu=X,j.$$click=X,j.$$mousedown=X,j.$$pointerdown=X;var A=t;return typeof A=="function"?Ke(A,j):t=j,we(le,"min-width",`${bu}px`),Ke(n,ue),Ke(o,L),z(ue,O(on,{get each(){return e.actions},children:y=>{let h=()=>di(y),S=()=>y.isActive!==void 0,D=()=>(Y(),!!y.isActive?.());return (()=>{var B=cy(),w=B.firstChild;return B.$$click=v=>fe(y,v),Je(B,"pointerleave",s),B.addEventListener("pointerenter",v=>{h()&&i(v.currentTarget);}),B.$$pointerdown=v=>v.stopPropagation(),z(w,()=>y.label),z(B,O(ye,{get when(){return Be(()=>!S())()&&y.shortcut},children:v=>(()=>{var $=uy();return z($,()=>Jn(v())),$})()}),null),z(B,O(ye,{get when(){return S()},get children(){var v=ly(),$=v.firstChild;return te(N=>{var W=Ee("relative rounded-full transition-colors ml-4 shrink-0 w-5 h-3",D()?"bg-black":"bg-black/25"),V=Ee("absolute top-0.5 rounded-full bg-white transition-transform w-2 h-2",D()?"left-2.5":"left-0.5");return W!==N.e&&Re(v,N.e=W),V!==N.t&&Re($,N.t=V),N},{e:void 0,t:void 0}),v}}),null),te(v=>{var $=y.id,N=!h();return $!==v.e&&ae(B,"data-react-grab-menu-item",v.e=$),N!==v.t&&(B.disabled=v.t=N),v},{e:void 0,t:void 0}),B})()}}),null),te(y=>{var h=`${R().top}px`,S=`${R().left}px`,D=b()?"auto":"none",B=Zo[H()],w=b()?"1":"0",v=b()?"scale(1)":"scale(0.95)",$=Ee("contain-layout flex flex-col rounded-[10px] antialiased w-fit h-fit overflow-hidden [font-synthesis:none] [corner-shape:superellipse(1.25)]",ht);return h!==y.e&&we(j,"top",y.e=h),S!==y.t&&we(j,"left",y.t=S),D!==y.a&&we(j,"pointer-events",y.a=D),B!==y.o&&we(j,"transform-origin",y.o=B),w!==y.i&&we(j,"opacity",y.i=w),v!==y.n&&we(j,"transform",y.n=v),$!==y.s&&Re(le,y.s=$),y},{e:void 0,t:void 0,a:void 0,o:void 0,i:void 0,n:void 0,s:void 0}),j}})};it(["pointerdown","mousedown","click","contextmenu"]);var dy=K('<div class="relative flex flex-col w-[calc(100%+16px)] -mx-2 -my-1.5"><div class="pointer-events-none absolute bg-black/5 opacity-0 transition-[top,left,width,height,opacity] duration-75 ease-out">'),fy=K('<div data-react-grab-ignore-events data-react-grab-context-menu class="fixed font-sans text-[13px] antialiased filter-[drop-shadow(0px_1px_2px_#51515140)] select-none"style=z-index:2147483647;pointer-events:auto><div><div class="contain-layout shrink-0 flex items-center gap-1 pt-1.5 pb-1 w-fit h-fit px-2">'),my=K('<span class="text-[11px] font-sans text-black/50 ml-4">'),py=K('<button data-react-grab-ignore-events class="relative z-1 contain-layout flex items-center justify-between w-full px-2 py-1 cursor-pointer text-left border-none bg-transparent disabled:opacity-40 disabled:cursor-default"><span class="text-[13px] leading-4 font-sans font-medium text-black">'),Cf=e=>{let t,{containerRef:n,highlightRef:o,updateHighlight:i,clearHighlight:s}=Qn(),[r,c]=U(0),[l,u]=U(0),f=()=>e.position!==null,p=()=>ys({tagName:e.tagName,componentName:e.componentName}),b=()=>{if(t){let m=t.getBoundingClientRect();c(m.width),u(m.height);}};be(()=>{f()&&Ve(b);});let x=()=>{let m=e.selectionBounds,E=e.position,T=r(),C=l();if(T===0||C===0||!m||!E)return {left:-9999,top:-9999,arrowLeft:0,arrowPosition:"bottom"};let R=E.x??m.x+m.width/2,X=Math.max(rn,Math.min(R-T/2,window.innerWidth-T-rn)),fe=Math.max(Un,Math.min(R-X,T-Un)),j=m.y+m.height+Un+rn,le=m.y-C-Un-rn,ue=j+C>window.innerHeight,L=le>=0,A=ue&&L,y=A?le:j,h=A?"top":"bottom";if(ue&&!L){let S=E.y??m.y+m.height/2;y=Math.max(rn,Math.min(S+rn,window.innerHeight-C-rn)),h="top";}return {left:X,top:y,arrowLeft:fe,arrowPosition:h}},H=()=>{let m=e.actions??[],E=e.actionContext;return m.map(T=>({label:T.label,action:()=>{E&&T.onAction(E);},enabled:ui(T,E),shortcut:T.shortcut}))},M=m=>{m.type==="contextmenu"&&m.preventDefault(),m.stopImmediatePropagation();},Y=(m,E)=>{E.stopPropagation(),m.enabled&&(m.action(),e.onHide());};return mt(()=>{b();let m=C=>{!f()||_t(C,"data-react-grab-ignore-events")||C instanceof MouseEvent&&C.button===2||e.onDismiss();},E=C=>{if(!f())return;let R=C.code==="Escape",X=C.key==="Enter",fe=C.metaKey||C.ctrlKey,j=C.key.toLowerCase(),le=e.actions??[],ue=e.actionContext,L=y=>!ue||!ui(y,ue)?false:(C.preventDefault(),C.stopPropagation(),y.onAction(ue),e.onHide(),true);if(R){C.preventDefault(),C.stopPropagation(),e.onDismiss();return}if(X){let y=le.find(h=>h.shortcut==="Enter");y&&L(y);return}if(!fe||C.repeat)return;let A=le.find(y=>y.shortcut&&y.shortcut!=="Enter"&&j===y.shortcut.toLowerCase());A&&L(A);},T=Ve(()=>{window.addEventListener("mousedown",m,{capture:true}),window.addEventListener("touchstart",m,{capture:true});});window.addEventListener("keydown",E,{capture:true}),Me(()=>{Ge(T),window.removeEventListener("mousedown",m,{capture:true}),window.removeEventListener("touchstart",m,{capture:true}),window.removeEventListener("keydown",E,{capture:true});});}),O(ye,{get when(){return f()},get children(){var m=fy(),E=m.firstChild,T=E.firstChild;m.$$contextmenu=M,m.$$click=M,m.$$mousedown=M,m.$$pointerdown=M;var C=t;return typeof C=="function"?Ke(C,m):t=m,z(m,O(vs,{get position(){return x().arrowPosition},leftPercent:0,get leftOffsetPx(){return x().arrowLeft}}),E),z(T,O(qr,{get tagName(){return p().tagName},get componentName(){return p().componentName},get isClickable(){return e.hasFilePath},onClick:R=>{R.stopPropagation(),e.hasFilePath&&e.actionContext&&e.actions?.find(fe=>fe.id==="open")?.onAction(e.actionContext);},shrink:true,get forceShowIcon(){return e.hasFilePath}})),z(E,O(Mt,{get children(){var R=dy(),X=R.firstChild;return Ke(n,R),Ke(o,X),z(R,O(on,{get each(){return H()},children:fe=>(()=>{var j=py(),le=j.firstChild;return j.$$click=ue=>Y(fe,ue),Je(j,"pointerleave",s),j.addEventListener("pointerenter",ue=>{fe.enabled&&i(ue.currentTarget);}),j.$$pointerdown=ue=>ue.stopPropagation(),z(le,()=>fe.label),z(j,O(ye,{get when(){return fe.shortcut},get children(){var ue=my();return z(ue,()=>Jn(fe.shortcut)),ue}}),null),te(ue=>{var L=fe.label.toLowerCase(),A=!fe.enabled;return L!==ue.e&&ae(j,"data-react-grab-menu-item",ue.e=L),A!==ue.t&&(j.disabled=ue.t=A),ue},{e:void 0,t:void 0}),j})()}),null),R}}),null),te(R=>{var X=`${x().top}px`,fe=`${x().left}px`,j=Ee("contain-layout flex flex-col justify-center items-start rounded-[10px] antialiased w-fit h-fit min-w-[100px] [font-synthesis:none] [corner-shape:superellipse(1.25)]",ht);return X!==R.e&&we(m,"top",R.e=X),fe!==R.t&&we(m,"left",R.t=fe),j!==R.a&&Re(E,R.a=j),R},{e:void 0,t:void 0,a:void 0}),m}})};it(["pointerdown","mousedown","click","contextmenu"]);var gy=K('<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 24 24"fill=currentColor><path fill-rule=evenodd clip-rule=evenodd d="M4.63751 20.1665L3.82444 6.75092L3.73431 5.06621C3.72513 4.89447 3.8619 4.75018 4.03388 4.75018H19.9945C20.1685 4.75018 20.306 4.89769 20.2938 5.07124L20.1756 6.75092L19.3625 20.1665C19.2745 21.618 18.0717 22.7502 16.6176 22.7502H7.38247C5.9283 22.7502 4.72548 21.618 4.63751 20.1665ZM8.74963 16.5002C8.74963 16.9144 9.08542 17.2502 9.49963 17.2502C9.91385 17.2502 10.2496 16.9144 10.2496 16.5002V10.5002C10.2496 10.086 9.91385 9.75018 9.49963 9.75018C9.08542 9.75018 8.74963 10.086 8.74963 10.5002V16.5002ZM14.4996 9.75018C14.9138 9.75018 15.2496 10.086 15.2496 10.5002V16.5002C15.2496 16.9144 14.9138 17.2502 14.4996 17.2502C14.0854 17.2502 13.7496 16.9144 13.7496 16.5002V10.5002C13.7496 10.086 14.0854 9.75018 14.4996 9.75018Z"></path><path fill-rule=evenodd clip-rule=evenodd d="M8.31879 2.46286C8.63394 1.7275 9.35702 1.2507 10.1571 1.2507H13.8383C14.6383 1.2507 15.3614 1.7275 15.6766 2.46286L16.6569 4.75034H19.2239C19.2903 4.75034 19.3523 4.75034 19.4102 4.7507H19.4637C19.4857 4.74973 19.5079 4.74972 19.5303 4.7507H20.9977C21.55 4.7507 21.9977 5.19842 21.9977 5.7507C21.9977 6.30299 21.55 6.7507 20.9977 6.7507H2.99768C2.4454 6.7507 1.99768 6.30299 1.99768 5.7507C1.99768 5.19842 2.4454 4.7507 2.99768 4.7507H4.46507C4.48746 4.74972 4.50968 4.74973 4.53167 4.7507H4.58469C4.6426 4.75034 4.70457 4.75034 4.77093 4.75034H7.33844L8.31879 2.46286ZM13.8903 3.37192L14.481 4.75034H9.5144L10.1052 3.37192C10.1367 3.29838 10.209 3.2507 10.289 3.2507L13.7064 3.2507C13.7864 3.2507 13.8587 3.29838 13.8903 3.37192Z">'),Cl=e=>{let t=()=>e.size??14;return (()=>{var n=gy();return te(o=>{var i=t(),s=t(),r=e.class;return i!==o.e&&ae(n,"width",o.e=i),s!==o.t&&ae(n,"height",o.t=s),r!==o.a&&ae(n,"class",o.a=r),o},{e:void 0,t:void 0,a:void 0}),n})()};var hy=K('<div class="flex items-center gap-[5px]"><div class=relative><button data-react-grab-ignore-events data-react-grab-history-clear class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[#FEF2F2] cursor-pointer transition-all hover:bg-[#FEE2E2] press-scale h-[17px] text-[#B91C1C]"></button></div><div class=relative><button data-react-grab-ignore-events data-react-grab-history-copy-all class="contain-layout shrink-0 flex items-center justify-center gap-1 px-[3px] py-px rounded-sm bg-white [border-width:0.5px] border-solid border-[#B3B3B3] cursor-pointer transition-all hover:bg-[#F5F5F5] press-scale h-[17px] text-black/60">'),by=K('<div data-react-grab-ignore-events data-react-grab-history-dropdown class="fixed font-sans text-[13px] antialiased filter-[drop-shadow(0px_1px_2px_#51515140)] select-none transition-[opacity,transform] duration-100 ease-out will-change-[opacity,transform]"style=z-index:2147483647><div><div class="contain-layout shrink-0 flex items-center justify-between px-2 pt-1.5 pb-1"><span class="text-[11px] font-medium text-black/40">History</span></div><div class="min-h-0 [border-top-width:0.5px] border-t-solid border-t-[#D9D9D9] px-2 py-1.5"><div class="relative flex flex-col max-h-[240px] overflow-y-auto -mx-2 -my-1.5 [scrollbar-width:thin] [scrollbar-color:transparent_transparent] hover:[scrollbar-color:rgba(0,0,0,0.15)_transparent]"><div class="pointer-events-none absolute bg-black/5 opacity-0 transition-[top,left,width,height,opacity] duration-75 ease-out">'),yy=K('<span class="text-[11px] leading-3 font-sans text-black/40 truncate mt-0.5">'),wy=K('<div data-react-grab-ignore-events data-react-grab-history-item class="group relative z-1 contain-layout flex items-start justify-between w-full px-2 py-1 cursor-pointer text-left gap-2"tabindex=0><span class="flex flex-col min-w-0 flex-1"><span class="text-[12px] leading-4 font-sans font-medium text-black truncate"></span></span><span class="shrink-0 grid"><span class="text-[10px] font-sans text-black/25 group-hover:invisible group-focus-within:invisible [grid-area:1/1] flex items-center justify-end"></span><span class="invisible group-hover:visible group-focus-within:visible [grid-area:1/1] flex items-center justify-end gap-1.5"><button data-react-grab-ignore-events data-react-grab-history-item-remove></button><button data-react-grab-ignore-events data-react-grab-history-item-copy>'),Ef="flex items-center justify-center cursor-pointer text-black/25 transition-colors press-scale",xy=e=>{let t=Math.floor((Date.now()-e)/1e3);if(t<60)return "now";let n=Math.floor(t/60);if(n<60)return `${n}m`;let o=Math.floor(n/60);return o<24?`${o}h`:`${Math.floor(o/24)}d`},vy=e=>e.elementsCount&&e.elementsCount>1?`${e.elementsCount} elements`:e.componentName??e.tagName,Sf=e=>{let t,{containerRef:n,highlightRef:o,updateHighlight:i,clearHighlight:s}=Qn(),r=_s(),c=()=>{if(!t)return null;let $=t.getRootNode().querySelector("[data-react-grab-toolbar]");if(!$)return null;let N=$.getBoundingClientRect();return [{x:N.x-mn,y:N.y-mn,width:N.width+mn*2,height:N.height+mn*2}]},[l,u]=U(0),[f,p]=U(0),[b,x]=U(null),[H,M]=U(false),[Y,m]=U(null),E,T,C,R,X=()=>e.position!==null,[fe,j]=U(false),[le,ue]=U(false),[L,A]=U("bottom"),y=()=>{t&&(u(t.offsetWidth),p(t.offsetHeight));};be(()=>{X()?(e.position&&A(e.position.edge),clearTimeout(C),j(true),R!==void 0&&Ge(R),R=Ve(()=>{y(),t?.offsetHeight,ue(true);})):(R!==void 0&&Ge(R),ue(false),C=setTimeout(()=>{j(false);},Yo));}),be(He(le,v=>{v&&t?.matches(":hover")&&e.onDropdownHover?.(true);},{defer:true}));let h=se(v=>{let $=fr({anchor:e.position,measuredWidth:l(),measuredHeight:f(),viewportWidth:window.innerWidth,viewportHeight:window.innerHeight,anchorGapPx:qo,viewportPaddingPx:jn,offscreenPosition:Kt});return $.left!==Kt.left?$:v},Kt),S=()=>Math.min(hu,window.innerWidth-h().left-jn),D=()=>window.innerHeight-h().top-jn,B=()=>Math.max(gu,e.position?.toolbarWidth??0),w=v=>{v.type==="contextmenu"&&v.preventDefault(),v.stopImmediatePropagation();};return mt(()=>{y();let v=$=>{X()&&$.code==="Escape"&&($.preventDefault(),$.stopPropagation(),e.onDismiss?.());};window.addEventListener("keydown",v,{capture:true}),Me(()=>{clearTimeout(E),clearTimeout(T),clearTimeout(C),R!==void 0&&Ge(R),window.removeEventListener("keydown",v,{capture:true}),r.stop();});}),O(ye,{get when(){return fe()},get children(){var v=by(),$=v.firstChild,N=$.firstChild;N.firstChild;var V=N.nextSibling,oe=V.firstChild,de=oe.firstChild;v.addEventListener("mouseleave",G=>{let Q=c();if(Q){r.start({x:G.clientX,y:G.clientY},Q,()=>e.onDropdownHover?.(false));return}e.onDropdownHover?.(false);}),v.addEventListener("mouseenter",()=>{r.stop(),e.onDropdownHover?.(true);}),v.$$contextmenu=w,v.$$click=w,v.$$mousedown=w,v.$$pointerdown=w;var I=t;return typeof I=="function"?Ke(I,v):t=v,z(N,O(ye,{get when(){return e.items.length>0},get children(){var G=hy(),Q=G.firstChild,Ae=Q.firstChild,me=Q.nextSibling,Se=me.firstChild;return Ae.addEventListener("mouseleave",()=>x(null)),Ae.addEventListener("mouseenter",()=>x("clear")),Ae.$$click=ie=>{ie.stopPropagation(),x(null),e.onClearAll?.();},z(Ae,O(Cl,{size:fo})),z(Q,O(Ln,{get visible(){return b()==="clear"},position:"top",children:"Clear all"}),null),Se.addEventListener("mouseleave",()=>{x(null),e.onCopyAllHover?.(false);}),Se.addEventListener("mouseenter",()=>{x("copy"),H()||e.onCopyAllHover?.(true);}),Se.$$click=ie=>{ie.stopPropagation(),x(null),e.onCopyAll?.(),M(true),clearTimeout(E),E=setTimeout(()=>{M(false);},1500);},z(Se,O(ye,{get when(){return H()},get fallback(){return O(ei,{size:fo})},get children(){return O(Jr,{size:fo,class:"text-black"})}})),z(me,O(Ln,{get visible(){return b()==="copy"},position:"top",children:"Copy all"}),null),G}}),null),Ke(n,oe),Ke(o,de),z(oe,O(on,{get each(){return e.items},children:G=>(()=>{var Q=wy(),Ae=Q.firstChild,me=Ae.firstChild,Se=Ae.nextSibling,ie=Se.firstChild,pe=ie.nextSibling,ke=pe.firstChild,Pe=ke.nextSibling;return Je(Q,"blur",s),Q.addEventListener("focus",ge=>i(ge.currentTarget)),Q.addEventListener("mouseleave",()=>{e.onItemHover?.(null),s();}),Q.addEventListener("mouseenter",ge=>{e.disconnectedItemIds?.has(G.id)||e.onItemHover?.(G.id),i(ge.currentTarget);}),Q.$$keydown=ge=>{ge.code==="Space"&&ge.currentTarget===ge.target&&(ge.preventDefault(),ge.stopPropagation(),e.onSelectItem?.(G));},Q.$$click=ge=>{ge.stopPropagation(),e.onSelectItem?.(G),m(G.id),clearTimeout(T),T=setTimeout(()=>{m(null);},1500);},Q.$$pointerdown=ge=>ge.stopPropagation(),z(me,()=>vy(G)),z(Ae,O(ye,{get when(){return G.commentText},get children(){var ge=yy();return z(ge,()=>G.commentText),ge}}),null),z(ie,()=>xy(G.timestamp)),ke.$$click=ge=>{ge.stopPropagation(),e.onRemoveItem?.(G);},z(ke,O(Cl,{size:fo})),Pe.$$click=ge=>{ge.stopPropagation(),e.onCopyItem?.(G),m(G.id),clearTimeout(T),T=setTimeout(()=>{m(null);},1500);},z(Pe,O(ye,{get when(){return Y()===G.id},get fallback(){return O(ei,{size:fo})},get children(){return O(Jr,{size:fo,class:"text-black"})}})),te(ge=>{var Te={"opacity-40 hover:opacity-100":!!e.disconnectedItemIds?.has(G.id)},rt=Ee(Ef,"hover:text-[#B91C1C]"),ct=Ee(Ef,"hover:text-black/60");return ge.e=co(Q,Te,ge.e),rt!==ge.t&&Re(ke,ge.t=rt),ct!==ge.a&&Re(Pe,ge.a=ct),ge},{e:void 0,t:void 0,a:void 0}),Q})()}),null),te(G=>{var Q=`${h().top}px`,Ae=`${h().left}px`,me=le()?"auto":"none",Se=Zo[L()],ie=le()?"1":"0",pe=le()?"scale(1)":"scale(0.95)",ke=Ee("contain-layout flex flex-col rounded-[10px] antialiased w-fit h-fit overflow-hidden [font-synthesis:none] [corner-shape:superellipse(1.25)]",ht),Pe=`${B()}px`,ge=`${S()}px`,Te=`${D()}px`;return Q!==G.e&&we(v,"top",G.e=Q),Ae!==G.t&&we(v,"left",G.t=Ae),me!==G.a&&we(v,"pointer-events",G.a=me),Se!==G.o&&we(v,"transform-origin",G.o=Se),ie!==G.i&&we(v,"opacity",G.i=ie),pe!==G.n&&we(v,"transform",G.n=pe),ke!==G.s&&Re($,G.s=ke),Pe!==G.h&&we($,"min-width",G.h=Pe),ge!==G.r&&we($,"max-width",G.r=ge),Te!==G.d&&we($,"max-height",G.d=Te),G},{e:void 0,t:void 0,a:void 0,o:void 0,i:void 0,n:void 0,s:void 0,h:void 0,r:void 0,d:void 0}),v}})};it(["pointerdown","mousedown","click","contextmenu","keydown"]);var Cy=K('<div data-react-grab-ignore-events data-react-grab-clear-history-prompt class="fixed font-sans text-[13px] antialiased filter-[drop-shadow(0px_1px_2px_#51515140)] select-none transition-[opacity,transform] duration-100 ease-out will-change-[opacity,transform]"style=z-index:2147483647><div>'),Af=e=>{let t,[n,o]=U(0),[i,s]=U(0),[r,c]=U(false),[l,u]=U(false),[f,p]=U("bottom"),b,x,H=()=>{t&&(o(t.offsetWidth),s(t.offsetHeight));};be(()=>{let m=e.position;m?(p(m.edge),clearTimeout(b),c(true),x!==void 0&&Ge(x),x=Ve(()=>{H(),t?.offsetHeight,u(true);})):(x!==void 0&&Ge(x),u(false),b=setTimeout(()=>{c(false);},Yo));});let M=se(m=>{let E=fr({anchor:e.position,measuredWidth:n(),measuredHeight:i(),viewportWidth:window.innerWidth,viewportHeight:window.innerHeight,anchorGapPx:qo,viewportPaddingPx:jn,offscreenPosition:Kt});return E.left!==Kt.left?E:m},Kt),Y=m=>{m.type==="contextmenu"&&m.preventDefault(),m.stopImmediatePropagation();};return mt(()=>{H();let m=C=>{if(!e.position||St(C))return;let R=C.code==="Enter",X=C.code==="Escape";(R||X)&&(C.preventDefault(),C.stopImmediatePropagation(),X?e.onCancel():e.onConfirm());};window.addEventListener("keydown",m,{capture:true});let E=C=>{!e.position||_t(C,"data-react-grab-ignore-events")||e.onCancel();},T=Ve(()=>{window.addEventListener("mousedown",E,{capture:true}),window.addEventListener("touchstart",E,{capture:true});});Me(()=>{Ge(T),clearTimeout(b),x!==void 0&&Ge(x),window.removeEventListener("keydown",m,{capture:true}),window.removeEventListener("mousedown",E,{capture:true}),window.removeEventListener("touchstart",E,{capture:true});});}),O(ye,{get when(){return r()},get children(){var m=Cy(),E=m.firstChild;m.$$contextmenu=Y,m.$$click=Y,m.$$mousedown=Y,m.$$pointerdown=Y;var T=t;return typeof T=="function"?Ke(T,m):t=m,z(E,O(Zr,{label:"Clear history?",cancelOnEscape:true,get onConfirm(){return e.onConfirm},get onCancel(){return e.onCancel}})),te(C=>{var R=`${M().top}px`,X=`${M().left}px`,fe=l()?"auto":"none",j=Zo[f()],le=l()?"1":"0",ue=l()?"scale(1)":"scale(0.95)",L=Ee("contain-layout flex flex-col rounded-[10px] antialiased w-fit h-fit [font-synthesis:none] [corner-shape:superellipse(1.25)]",ht);return R!==C.e&&we(m,"top",C.e=R),X!==C.t&&we(m,"left",C.t=X),fe!==C.a&&we(m,"pointer-events",C.a=fe),j!==C.o&&we(m,"transform-origin",C.o=j),le!==C.i&&we(m,"opacity",C.i=le),ue!==C.n&&we(m,"transform",C.n=ue),L!==C.s&&Re(E,C.s=L),C},{e:void 0,t:void 0,a:void 0,o:void 0,i:void 0,n:void 0,s:void 0}),m}})};it(["pointerdown","mousedown","click","contextmenu"]);var Ey=K('<div style="position:fixed;top:0;right:0;bottom:0;left:0;pointer-events:none;transition:opacity 100ms ease-out;will-change:opacity;contain:strict;transform:translateZ(0)">'),Tf=e=>[O(md,{get crosshairVisible(){return e.crosshairVisible},get mouseX(){return e.mouseX},get mouseY(){return e.mouseY},get selectionVisible(){return e.selectionVisible},get selectionBounds(){return e.selectionBounds},get selectionBoundsMultiple(){return e.selectionBoundsMultiple},get selectionShouldSnap(){return e.selectionShouldSnap},get selectionIsFading(){return e.selectionLabelStatus==="fading"},get dragVisible(){return e.dragVisible},get dragBounds(){return e.dragBounds},get grabbedBoxes(){return e.grabbedBoxes},get agentSessions(){return e.agentSessions},get labelInstances(){return e.labelInstances}}),(()=>{var t=Ey();return we(t,"z-index",2147483645),we(t,"box-shadow",`inset 0 0 ${Vc}px ${zc}`),te(n=>we(t,"opacity",e.isFrozen?1:0)),t})(),O(Yi,{get each(){return Be(()=>!!e.agentSessions)()?Array.from(e.agentSessions.values()):[]},children:t=>O(ye,{get when(){return t().selectionBounds.length>0},get children(){return O(Ts,{get tagName(){return t().tagName},get componentName(){return t().componentName},get selectionBounds(){return t().selectionBounds[0]},get mouseX(){return t().position.x},visible:true,hasAgent:true,isAgentConnected:true,get status(){return t().isFading?"fading":t().isStreaming?"copying":"copied"},get statusText(){return t().lastStatus||"Thinking\u2026"},get inputValue(){return t().context.prompt},get previousPrompt(){return t().context.prompt},get supportsUndo(){return e.supportsUndo},get supportsFollowUp(){return e.supportsFollowUp},get dismissButtonText(){return e.dismissButtonText},onAbort:()=>e.onRequestAbortSession?.(t().id),get onDismiss(){return t().isStreaming?void 0:()=>e.onDismissSession?.(t().id)},get onUndo(){return t().isStreaming?void 0:()=>e.onUndoSession?.(t().id)},get onFollowUpSubmit(){return t().isStreaming?void 0:n=>e.onFollowUpSubmitSession?.(t().id,n)},get error(){return t().error},onAcknowledgeError:()=>e.onAcknowledgeSessionError?.(t().id),onRetry:()=>e.onRetrySession?.(t().id),get isPendingAbort(){return Be(()=>!!t().isStreaming)()&&e.pendingAbortSessionId===t().id},onConfirmAbort:()=>e.onAbortSession?.(t().id,true),onCancelAbort:()=>e.onAbortSession?.(t().id,false),onShowContextMenu:void 0})}})}),O(ye,{get when(){return Be(()=>!!e.selectionLabelVisible)()&&e.selectionBounds},get children(){return O(Ts,{get tagName(){return e.selectionTagName},get componentName(){return e.selectionComponentName},get elementsCount(){return e.selectionElementsCount},get selectionBounds(){return e.selectionBounds},get mouseX(){return e.mouseX},get visible(){return e.selectionLabelVisible},get isPromptMode(){return e.isPromptMode},get inputValue(){return e.inputValue},get replyToPrompt(){return e.replyToPrompt},get hasAgent(){return e.hasAgent},get isAgentConnected(){return e.isAgentConnected},get status(){return e.selectionLabelStatus},get actionCycleState(){return e.selectionActionCycleState},get arrowNavigationState(){return e.selectionArrowNavigationState},get onArrowNavigationSelect(){return e.onArrowNavigationSelect},get filePath(){return e.selectionFilePath},get lineNumber(){return e.selectionLineNumber},get onInputChange(){return e.onInputChange},get onSubmit(){return e.onInputSubmit},get onCancel(){return e.onInputCancel},get onToggleExpand(){return e.onToggleExpand},get isPendingDismiss(){return e.isPendingDismiss},get onConfirmDismiss(){return e.onConfirmDismiss},get onCancelDismiss(){return e.onCancelDismiss},onOpen:()=>{e.selectionFilePath&&or(e.selectionFilePath,e.selectionLineNumber);},get isContextMenuOpen(){return e.contextMenuPosition!==null}})}}),O(Yi,{get each(){return e.labelInstances??[]},children:t=>O(Ts,{get tagName(){return t().tagName},get componentName(){return t().componentName},get elementsCount(){return t().elementsCount},get selectionBounds(){return t().bounds},get mouseX(){return t().mouseX},visible:true,get status(){return t().status},get statusText(){return t().statusText},get hasAgent(){return !!t().statusText},get isPromptMode(){return t().isPromptMode},get inputValue(){return t().inputValue},get error(){return t().errorMessage},get hideArrow(){return t().hideArrow},get onShowContextMenu(){let n=t();if(!(!(n.status==="copied"||n.status==="fading")||!et(n.element)))return ()=>e.onShowContextMenuInstance?.(n.id)},onHoverChange:n=>e.onLabelInstanceHoverChange?.(t().id,n)})}),O(ye,{get when(){return e.toolbarVisible!==false},get children(){return O(xf,{get isActive(){return e.isActive},get isContextMenuOpen(){return e.contextMenuPosition!==null},get onToggle(){return e.onToggleActive},get enabled(){return e.enabled},get onToggleEnabled(){return e.onToggleEnabled},get shakeCount(){return e.shakeCount},get onStateChange(){return e.onToolbarStateChange},get onSubscribeToStateChanges(){return e.onSubscribeToToolbarStateChanges},get onSelectHoverChange(){return e.onToolbarSelectHoverChange},get onContainerRef(){return e.onToolbarRef},get historyItemCount(){return e.historyItemCount},get clockFlashTrigger(){return e.clockFlashTrigger},get hasUnreadHistoryItems(){return e.hasUnreadHistoryItems},get onToggleHistory(){return e.onToggleHistory},get onCopyAll(){return e.onCopyAll},get onCopyAllHover(){return e.onCopyAllHover},get onHistoryButtonHover(){return e.onHistoryButtonHover},get isHistoryDropdownOpen(){return !!e.historyDropdownPosition},get isHistoryPinned(){return e.isHistoryPinned},get toolbarActions(){return e.toolbarActions},get onToggleMenu(){return e.onToggleMenu},get isMenuOpen(){return !!e.toolbarMenuPosition},get isClearPromptOpen(){return !!e.clearPromptPosition}})}}),O(Cf,{get position(){return e.contextMenuPosition??null},get selectionBounds(){return e.contextMenuBounds??null},get tagName(){return e.contextMenuTagName},get componentName(){return e.contextMenuComponentName},get hasFilePath(){return e.contextMenuHasFilePath??false},get actions(){return e.actions},get actionContext(){return e.actionContext},get onDismiss(){return e.onContextMenuDismiss??(()=>{})},get onHide(){return e.onContextMenuHide??(()=>{})}}),O(vf,{get position(){return e.toolbarMenuPosition??null},get actions(){return e.toolbarActions??[]},get onDismiss(){return e.onToolbarMenuDismiss??(()=>{})}}),O(Af,{get position(){return e.clearPromptPosition??null},get onConfirm(){return e.onClearHistoryConfirm??(()=>{})},get onCancel(){return e.onClearHistoryCancel??(()=>{})}}),O(Sf,{get position(){return e.historyDropdownPosition??null},get items(){return e.historyItems??[]},get disconnectedItemIds(){return e.historyDisconnectedItemIds},get onSelectItem(){return e.onHistoryItemSelect},get onRemoveItem(){return e.onHistoryItemRemove},get onCopyItem(){return e.onHistoryItemCopy},get onItemHover(){return e.onHistoryItemHover},get onCopyAll(){return e.onHistoryCopyAll},get onCopyAllHover(){return e.onHistoryCopyAllHover},get onClearAll(){return e.onHistoryClear},get onDismiss(){return e.onHistoryDismiss},get onDropdownHover(){return e.onHistoryDropdownHover}})];var El=()=>({activate:()=>{},deactivate:()=>{},toggle:()=>{},comment:()=>{},isActive:()=>false,isEnabled:()=>false,setEnabled:()=>{},getToolbarState:()=>null,setToolbarState:()=>{},onToolbarStateChange:()=>()=>{},dispose:()=>{},copyElement:()=>Promise.resolve(false),getSource:()=>Promise.resolve(null),getStackContext:()=>Promise.resolve(""),getState:()=>({isActive:false,isDragging:false,isCopying:false,isPromptMode:false,isCrosshairVisible:false,isSelectionBoxVisible:false,isDragBoxVisible:false,targetElement:null,dragBounds:null,grabbedBoxes:[],labelInstances:[],selectionFilePath:null,toolbarState:null}),setOptions:()=>{},registerPlugin:()=>{},unregisterPlugin:()=>{},getPlugins:()=>[],getDisplayName:()=>null});var _f=()=>{let e=new AbortController,t=(o,i,s={})=>{window.addEventListener(o,i,{...s,signal:e.signal});},n=(o,i,s={})=>{document.addEventListener(o,i,{...s,signal:e.signal});};return {signal:e.signal,abort:()=>e.abort(),addWindowListener:t,addDocumentListener:n}};var Sy="application/x-lexical-editor",Ay="application/x-react-grab",Pf=()=>"xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g,e=>{let t=Math.random()*16|0;return (e==="x"?t:t&3|8).toString(16)}),Ty=(e,t,n,o)=>({detail:1,format:0,mode:"segmented",style:"",text:`@${e}`,type:"mention",version:1,mentionName:e,typeaheadType:n,storedKey:t,metadata:o,source:"chat"}),_y=e=>({detail:0,format:0,mode:"normal",style:"",text:e,type:"text",version:1}),Py=e=>e.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;"),ky=(e,t)=>{let n=String(Math.floor(Math.random()*1e4)),o=Pf(),i=`<${t}>`,s={case:"file",path:`${i}.tsx`,content:e},r={key:i,type:s,payload:{file:{path:`${i}.tsx`,content:e}},id:Pf(),name:i,_score:20,isSlash:false,labelMatch:[{start:0,end:2}]},c={selection:{type:0},selectedOption:r};return {plainText:`@${i}
+`;
+      let e = [];
+      for (let t of document.getAnimations()) {
+        if (t.effect instanceof KeyframeEffect) {
+          let n = t.effect.target;
+          if (n instanceof Element && n.getRootNode() instanceof ShadowRoot)
+            continue;
+        }
+        e.push(t);
+      }
+      (ef(e), cr.remove(), (cr = null), Qd(Is), (Is = []), Kd());
+    };
+  var nf = (e, t = window.getComputedStyle(e)) =>
+    t.display !== "none" && t.visibility !== "hidden" && t.opacity !== "0";
+  var vo = (e) => {
+    let t = pt(e);
+    return t === "html" || t === "body";
+  };
+  var Yb = (e) => {
+      if (e.hasAttribute("data-react-grab")) return true;
+      let t = e.getRootNode();
+      return t instanceof ShadowRoot && t.host.hasAttribute("data-react-grab");
+    },
+    qb = (e) => e.hasAttribute(Ea) || e.closest(`[${Ea}]`) !== null,
+    Zb = (e) => {
+      let t = parseInt(e.zIndex, 10);
+      return (
+        e.pointerEvents === "none" &&
+        e.position === "fixed" &&
+        !isNaN(t) &&
+        t >= qc
+      );
+    },
+    Jb = (e, t) => {
+      let n = t.position;
+      if (n !== "fixed" && n !== "absolute") return false;
+      let o = e.getBoundingClientRect();
+      if (
+        !(
+          o.width / window.innerWidth >= Br &&
+          o.height / window.innerHeight >= Br
+        )
+      )
+        return false;
+      let s = t.backgroundColor;
+      if (
+        s === "transparent" ||
+        s === "rgba(0, 0, 0, 0)" ||
+        parseFloat(t.opacity) < 0.1
+      )
+        return true;
+      let c = parseInt(t.zIndex, 10);
+      return !isNaN(c) && c > Yc;
+    },
+    Ls = new WeakMap(),
+    of = () => {
+      Ls = new WeakMap();
+    },
+    gn = (e) => {
+      if (vo(e) || Yb(e) || qb(e)) return false;
+      let t = performance.now(),
+        n = Ls.get(e);
+      if (n && t - n.timestamp < du) return n.isVisible;
+      let o = window.getComputedStyle(e);
+      return nf(e, o)
+        ? e.clientWidth / window.innerWidth >= Br &&
+          e.clientHeight / window.innerHeight >= Br &&
+          (Zb(o) || Jb(e, o))
+          ? false
+          : (Ls.set(e, { isVisible: true, timestamp: t }), true)
+        : (Ls.set(e, { isVisible: false, timestamp: t }), false);
+    };
+  var Co = null,
+    Eo = null,
+    rf = () => {
+      (Eo !== null && clearTimeout(Eo),
+        (Eo = setTimeout(() => {
+          ((Eo = null), li());
+        }, uu)));
+    },
+    yl = () => {
+      Eo !== null && (clearTimeout(Eo), (Eo = null));
+    },
+    Qb = (e, t, n, o) => {
+      let i = Math.abs(e - n),
+        s = Math.abs(t - o);
+      return i <= Oa && s <= Oa;
+    },
+    Ds = (e, t) => {
+      (yl(), ai());
+      let n = document.elementsFromPoint(e, t);
+      return (rf(), n);
+    },
+    dr = (e, t) => {
+      let n = performance.now();
+      if (Co) {
+        let s = Qb(e, t, Co.clientX, Co.clientY),
+          r = n - Co.timestamp < cu;
+        if (s || r) return Co.element;
+      }
+      (yl(), ai());
+      let o = null,
+        i = document.elementFromPoint(e, t);
+      if (i && gn(i)) o = i;
+      else {
+        let s = document.elementsFromPoint(e, t);
+        for (let r of s)
+          if (r !== i && gn(r)) {
+            o = r;
+            break;
+          }
+      }
+      return (
+        rf(), (Co = { clientX: e, clientY: t, element: o, timestamp: n }), o
+      );
+    },
+    Fs = () => {
+      (yl(), li(), (Co = null));
+    };
+  var ey = "html { pointer-events: none !important; }",
+    cf = [
+      "mouseenter",
+      "mouseleave",
+      "mouseover",
+      "mouseout",
+      "pointerenter",
+      "pointerleave",
+      "pointerover",
+      "pointerout",
+    ],
+    uf = ["focus", "blur", "focusin", "focusout"],
+    df = [
+      "background-color",
+      "color",
+      "border-color",
+      "box-shadow",
+      "transform",
+      "opacity",
+      "outline",
+      "filter",
+      "scale",
+      "visibility",
+    ],
+    ff = [
+      "background-color",
+      "color",
+      "border-color",
+      "box-shadow",
+      "outline",
+      "outline-offset",
+      "outline-width",
+      "outline-color",
+      "outline-style",
+      "filter",
+      "opacity",
+      "ring-color",
+      "ring-width",
+    ],
+    mf = new Map(),
+    wl = new Map(),
+    eo = null,
+    pf = (e) => {
+      e.stopImmediatePropagation();
+    },
+    gf = (e) => {
+      (e.preventDefault(), e.stopImmediatePropagation());
+    },
+    ty = (e, t) => {
+      let n = new Map();
+      for (let o of t) {
+        let i = e.style.getPropertyValue(o);
+        i && n.set(o, i);
+      }
+      return n;
+    },
+    sf = (e, t, n) => {
+      let o = [];
+      for (let i of document.querySelectorAll(e)) {
+        if (!(i instanceof HTMLElement) || n?.has(i)) continue;
+        let s = getComputedStyle(i),
+          r = i.style.cssText,
+          c = ty(i, t);
+        for (let l of t) {
+          let u = s.getPropertyValue(l);
+          u && (r += `${l}: ${u} !important; `);
+        }
+        o.push({ element: i, frozenStyles: r, originalPropertyValues: c });
+      }
+      return o;
+    },
+    af = (e, t) => {
+      for (let { element: n, frozenStyles: o, originalPropertyValues: i } of e)
+        (t.set(n, i), (n.style.cssText = o));
+    },
+    lf = (e, t) => {
+      for (let [n, o] of e)
+        for (let i of t) {
+          let s = o.get(i);
+          s ? n.style.setProperty(i, s) : n.style.removeProperty(i);
+        }
+      e.clear();
+    },
+    ai = () => {
+      eo && (eo.disabled = true);
+    },
+    li = () => {
+      eo && (eo.disabled = false);
+    },
+    $s = () => {
+      if (eo) return;
+      for (let n of cf) document.addEventListener(n, pf, true);
+      for (let n of uf) document.addEventListener(n, gf, true);
+      let e = sf(":hover", df),
+        t = sf(":focus, :focus-visible", ff, wl);
+      (af(e, mf), af(t, wl), (eo = ti("data-react-grab-frozen-pseudo", ey)));
+    },
+    ci = () => {
+      Fs();
+      for (let e of cf) document.removeEventListener(e, pf, true);
+      for (let e of uf) document.removeEventListener(e, gf, true);
+      (lf(mf, df), lf(wl, ff), eo?.remove(), (eo = null));
+    };
+  var ny = K("<div style=z-index:2147483647>"),
+    xl = 0,
+    oy = () => Date.now() - xl < Jc,
+    Ln = (e) => {
+      let [t, n] = U(false),
+        [o, i] = U(true),
+        s;
+      return (
+        be(
+          He(
+            () => e.visible,
+            (r) => {
+              (s !== void 0 && (clearTimeout(s), (s = void 0)),
+                r
+                  ? oy()
+                    ? (i(false), n(true))
+                    : (i(true),
+                      (s = setTimeout(() => {
+                        n(true);
+                      }, Zc)))
+                  : (t() && (xl = Date.now()), n(false)));
+            },
+          ),
+        ),
+        Me(() => {
+          (s !== void 0 && clearTimeout(s), t() && (xl = Date.now()));
+        }),
+        O(ye, {
+          get when() {
+            return t();
+          },
+          get children() {
+            var r = ny();
+            return (
+              z(r, () => e.children),
+              te(() =>
+                Re(
+                  r,
+                  Ee(
+                    "absolute whitespace-nowrap px-1.5 py-0.5 rounded-[10px] text-[10px] text-black/60 pointer-events-none [corner-shape:superellipse(1.25)]",
+                    ht,
+                    e.position === "left" || e.position === "right"
+                      ? "top-1/2 -translate-y-1/2"
+                      : "left-1/2 -translate-x-1/2",
+                    e.position === "top" && "bottom-full mb-2.5",
+                    e.position === "bottom" && "top-full mt-2.5",
+                    e.position === "left" && "right-full mr-2.5",
+                    e.position === "right" && "left-full ml-2.5",
+                    o() && "animate-tooltip-fade-in",
+                  ),
+                ),
+              ),
+              r
+            );
+          },
+        })
+      );
+    };
+  var hf = (e, t, n) => {
+      if (t)
+        return e
+          ? "grid-rows-[1fr] opacity-100"
+          : "grid-cols-[1fr] opacity-100";
+      let o = e ? "grid-rows-[0fr] opacity-0" : "grid-cols-[0fr] opacity-0";
+      return n ? `${o} ${n}` : o;
+    },
+    bf = (e) => (e ? "mb-1.5" : "mr-1.5"),
+    yf = (e) => (e ? "min-h-0" : "min-w-0"),
+    wf = (e) => (e ? "before:!min-h-full" : "before:!min-w-full");
+  var ry = K(
+      '<span data-react-grab-unread-indicator class="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-[#404040]">',
+    ),
+    iy = K("<div style=z-index:2147483647>Enable to continue"),
+    sy = K(
+      '<div data-react-grab-ignore-events data-react-grab-toolbar style=z-index:2147483647><div><div><div><div><div><div><button data-react-grab-ignore-events data-react-grab-toolbar-toggle></button></div></div><div><div><button data-react-grab-ignore-events data-react-grab-toolbar-history aria-haspopup=menu><span class="inline-flex relative"></span></button></div></div><div><div><button data-react-grab-ignore-events data-react-grab-toolbar-copy-all aria-label="Copy all history items"></button></div></div><div><div><button data-react-grab-ignore-events data-react-grab-toolbar-menu aria-haspopup=menu></button></div></div></div><div class="relative shrink-0 overflow-visible"><button data-react-grab-ignore-events data-react-grab-toolbar-enabled><div><div></div></div></button></div></div></div><button data-react-grab-ignore-events data-react-grab-toolbar-collapse class="contain-layout shrink-0 flex items-center justify-center cursor-pointer interactive-scale">',
+    ),
+    xf = (e) => {
+      let t,
+        n,
+        o = null,
+        i = 0,
+        s = 0,
+        r = _s(),
+        c = (k) => {
+          if (!t) return null;
+          let ee = t.getRootNode().querySelector(k);
+          if (!ee) return null;
+          let ne = ee.getBoundingClientRect();
+          return {
+            x: ne.x - mn,
+            y: ne.y - mn,
+            width: ne.width + mn * 2,
+            height: ne.height + mn * 2,
+          };
+        },
+        l = (...k) => {
+          let q = [];
+          for (let ee of k) {
+            let ne = c(ee);
+            ne && q.push(ne);
+          }
+          return q.length > 0 ? q : null;
+        },
+        u = yo(),
+        [f, p] = U(false),
+        [b, x] = U(false),
+        [H, M] = U(false),
+        [Y, m] = U(false),
+        [E, T] = U(false),
+        [C, R] = U(u?.edge ?? "bottom"),
+        [X, fe] = U(u?.ratio ?? 0.5),
+        [j, le] = U({ x: 0, y: 0 }),
+        [ue, L] = U({ x: 0, y: 0 }),
+        [A, y] = U({ x: 0, y: 0 }),
+        [h, S] = U(false),
+        [D, B] = U(false),
+        [w, v] = U(false),
+        [$, N] = U(false),
+        [W, V] = U(false),
+        [oe, de] = U(false),
+        [I, G] = U(false),
+        [Q, Ae] = U(false),
+        [me, Se] = U(false),
+        [ie, pe] = U(false),
+        [ke, Pe] = U(false),
+        ge,
+        Te = () => (e.toolbarActions ?? []).length > 0,
+        rt = () => {
+          let k = e.historyItemCount ?? 0;
+          return k > 0 ? `History (${k})` : "History";
+        },
+        ct = () =>
+          Ee(
+            "transition-colors",
+            e.isHistoryPinned ? "text-black/80" : "text-[#B3B3B3]",
+          ),
+        Ue = () => C() === "left" || C() === "right",
+        wt = () => {
+          if (!n) return;
+          let k = n.getBoundingClientRect();
+          Ue() ? (s = k.height) : (i = k.width);
+        },
+        bn = () =>
+          !b() &&
+          !e.isHistoryDropdownOpen &&
+          !e.isMenuOpen &&
+          !e.isClearPromptOpen,
+        Ht = () => {
+          switch (C()) {
+            case "top":
+              return "bottom";
+            case "bottom":
+              return "top";
+            case "left":
+              return "right";
+            case "right":
+              return "left";
+          }
+        },
+        Bt = (k, q) => hf(Ue(), k, q),
+        Rt = () =>
+          Ue()
+            ? "transition-[grid-template-rows,opacity] duration-150 ease-out"
+            : "transition-[grid-template-columns,opacity] duration-150 ease-out",
+        yn = () => bf(Ue()),
+        xt = () => yf(Ue()),
+        Dn = () => wf(Ue()),
+        To = () => {
+          let k = Ht();
+          return Ue()
+            ? `top-1/2 -translate-y-1/2 ${k === "left" ? "right-full mr-0.5" : "left-full ml-0.5"}`
+            : `left-1/2 -translate-x-1/2 ${k === "top" ? "bottom-full mb-0.5" : "top-full mt-0.5"}`;
+        },
+        It = (k) => {
+          k.stopImmediatePropagation();
+        },
+        st = (k, q) => ({
+          onMouseEnter: () => {
+            H() ||
+              (r.stop(),
+              k(true),
+              q?.shouldFreezeInteractions !== false &&
+                !o &&
+                ((o = Rs()), Ns(), $s()),
+              q?.onHoverChange?.(true));
+          },
+          onMouseLeave: (ee) => {
+            (k(false),
+              q?.shouldFreezeInteractions !== false &&
+                !e.isActive &&
+                !e.isContextMenuOpen &&
+                (o?.(), (o = null), si(), ci()));
+            let ne = q?.safePolygonTargets?.();
+            if (ne) {
+              r.start({ x: ee.clientX, y: ee.clientY }, ne, () =>
+                q?.onHoverChange?.(false),
+              );
+              return;
+            }
+            q?.onHoverChange?.(false);
+          },
+        }),
+        sn = () => {
+          if (!b()) return "";
+          let k = C(),
+            q = {
+              top: "rounded-t-none rounded-b-[10px]",
+              bottom: "rounded-b-none rounded-t-[10px]",
+              left: "rounded-l-none rounded-r-[10px]",
+              right: "rounded-r-none rounded-l-[10px]",
+            }[k],
+            ee = Ue() ? "px-0.25 py-2" : "px-2 py-0.25";
+          return `${q} ${ee}`;
+        },
+        Pt;
+      (be(
+        He(
+          () => e.shakeCount,
+          (k) => {
+            k &&
+              !e.enabled &&
+              (B(true),
+              de(true),
+              Pt && clearTimeout(Pt),
+              (Pt = setTimeout(() => {
+                de(false);
+              }, ru)));
+          },
+        ),
+      ),
+        be(
+          He(
+            () => e.enabled,
+            (k) => {
+              k && oe() && (de(false), Pt && clearTimeout(Pt));
+            },
+          ),
+        ),
+        be(
+          He(
+            () => [e.isActive, e.isContextMenuOpen],
+            ([k, q]) => {
+              !k && !q && o && (o(), (o = null));
+            },
+          ),
+        ));
+      let _o = () => {
+        if (!t) return;
+        let k = t.getBoundingClientRect();
+        Fe = { width: k.width, height: k.height };
+        let q = j(),
+          ee = zt(),
+          ne = C(),
+          xe = q.x,
+          ve = q.y;
+        if (ne === "top" || ne === "bottom") {
+          let Oe = ee.offsetLeft + _e,
+            je = Math.max(Oe, ee.offsetLeft + ee.width - k.width - _e);
+          ((xe = Nt(q.x, Oe, je)),
+            (ve =
+              ne === "top"
+                ? ee.offsetTop + _e
+                : ee.offsetTop + ee.height - k.height - _e));
+        } else {
+          let Oe = ee.offsetTop + _e,
+            je = Math.max(Oe, ee.offsetTop + ee.height - k.height - _e);
+          ((ve = Nt(q.y, Oe, je)),
+            (xe =
+              ne === "left"
+                ? ee.offsetLeft + _e
+                : ee.offsetLeft + ee.width - k.width - _e));
+        }
+        let he = Ut(ne, xe, ve, k.width, k.height);
+        (fe(he),
+          (xe !== q.x || ve !== q.y) &&
+            (v(true),
+            Ve(() => {
+              Ve(() => {
+                (le({ x: xe, y: ve }),
+                  gt && clearTimeout(gt),
+                  (gt = setTimeout(() => {
+                    v(false);
+                  }, Pn)));
+              });
+            })));
+      };
+      (be(
+        He(
+          () => e.clockFlashTrigger ?? 0,
+          () => {
+            if (e.isHistoryDropdownOpen) return;
+            (ge &&
+              (ge.classList.remove("animate-clock-flash"),
+              ge.offsetHeight,
+              ge.classList.add("animate-clock-flash")),
+              Se(true));
+            let k = setTimeout(() => {
+              (ge?.classList.remove("animate-clock-flash"), Se(false));
+            }, 1500);
+            Me(() => {
+              (clearTimeout(k), Se(false));
+            });
+          },
+          { defer: true },
+        ),
+      ),
+        be(
+          He(
+            () => e.historyItemCount ?? 0,
+            () => {
+              b() ||
+                (Hn && clearTimeout(Hn),
+                (Hn = setTimeout(() => {
+                  (wt(), _o());
+                }, Pn)),
+                Me(() => {
+                  Hn && clearTimeout(Hn);
+                }));
+            },
+            { defer: true },
+          ),
+        ));
+      let qt = { x: 0, y: 0, time: 0 },
+        Po = { x: 0, y: 0 },
+        Fe = { width: nu, height: ou },
+        [Zt, an] = U({ width: uo, height: uo }),
+        Nt = (k, q, ee) => Math.max(q, Math.min(k, ee)),
+        zt = () => {
+          let k = window.visualViewport;
+          return k
+            ? {
+                width: k.width,
+                height: k.height,
+                offsetLeft: k.offsetLeft,
+                offsetTop: k.offsetTop,
+              }
+            : {
+                width: window.innerWidth,
+                height: window.innerHeight,
+                offsetLeft: 0,
+                offsetTop: 0,
+              };
+        },
+        Vt = (k, q) => {
+          let ee = zt(),
+            ne = ee.width,
+            xe = ee.height,
+            { width: ve, height: he } = Fe,
+            De = t?.getBoundingClientRect(),
+            Oe = De?.width ?? uo,
+            je = De?.height ?? uo,
+            qe;
+          if (q === "top" || q === "bottom") {
+            let Ne = (ve - Oe) / 2,
+              ut = k.x - Ne,
+              at = Nt(ut, ee.offsetLeft + _e, ee.offsetLeft + ne - ve - _e),
+              kt =
+                q === "top" ? ee.offsetTop + _e : ee.offsetTop + xe - he - _e;
+            qe = { x: at, y: kt };
+          } else {
+            let Ne = (he - je) / 2,
+              ut = k.y - Ne,
+              at = Nt(ut, ee.offsetTop + _e, ee.offsetTop + xe - he - _e);
+            qe = {
+              x:
+                q === "left"
+                  ? ee.offsetLeft + _e
+                  : ee.offsetLeft + ne - ve - _e,
+              y: at,
+            };
+          }
+          let tt = Ut(q, qe.x, qe.y, ve, he);
+          return { position: qe, ratio: tt };
+        },
+        Gt = (k, q, ee, ne) => {
+          let xe = zt(),
+            ve = xe.width,
+            he = xe.height,
+            De = xe.offsetLeft + _e,
+            Oe = Math.max(De, xe.offsetLeft + ve - ee - _e),
+            je = xe.offsetTop + _e,
+            qe = Math.max(je, xe.offsetTop + he - ne - _e);
+          if (k === "top" || k === "bottom") {
+            let at = Math.max(0, ve - ee - _e * 2);
+            return {
+              x: Math.min(Oe, Math.max(De, xe.offsetLeft + _e + at * q)),
+              y: k === "top" ? je : qe,
+            };
+          }
+          let tt = Math.max(0, he - ne - _e * 2),
+            Ne = Math.min(qe, Math.max(je, xe.offsetTop + _e + tt * q));
+          return { x: k === "left" ? De : Oe, y: Ne };
+        },
+        Ut = (k, q, ee, ne, xe) => {
+          let ve = zt(),
+            he = ve.width,
+            De = ve.height;
+          if (k === "top" || k === "bottom") {
+            let je = he - ne - _e * 2;
+            return je <= 0
+              ? 0.5
+              : Math.max(0, Math.min(1, (q - ve.offsetLeft - _e) / je));
+          }
+          let Oe = De - xe - _e * 2;
+          return Oe <= 0
+            ? 0.5
+            : Math.max(0, Math.min(1, (ee - ve.offsetTop - _e) / Oe));
+        },
+        Qs = () => {
+          let k = Gt(C(), X(), Fe.width, Fe.height);
+          le(k);
+        },
+        ko = false,
+        wn = (k) => (q) => {
+          if ((q.stopImmediatePropagation(), ko)) {
+            ko = false;
+            return;
+          }
+          k();
+        },
+        hr = wn(() => e.onToggle?.()),
+        br = wn(() => e.onToggleHistory?.()),
+        hi = wn(() => e.onCopyAll?.()),
+        Oo = wn(() => e.onToggleMenu?.()),
+        bi = wn(() => {
+          let k = t?.getBoundingClientRect(),
+            q = b(),
+            ee = X();
+          if (q) {
+            let { position: ne, ratio: xe } = Vt(Jt(), C());
+            ((ee = xe), le(ne), fe(ee));
+          } else k && (Fe = { width: k.width, height: k.height });
+          (v(true),
+            x((ne) => !ne),
+            vn({
+              edge: C(),
+              ratio: ee,
+              collapsed: !q,
+              enabled: e.enabled ?? true,
+            }),
+            gt && clearTimeout(gt),
+            (gt = setTimeout(() => {
+              if ((v(false), b())) {
+                let ne = t?.getBoundingClientRect();
+                ne && an({ width: ne.width, height: ne.height });
+              }
+            }, Pn)));
+        }),
+        Fn = wn(() => {
+          let k = !!e.enabled,
+            q = C(),
+            ee = j(),
+            ne = q === "left" || q === "right",
+            xe = () => (ne ? s : i);
+          k && n && !I() && wt();
+          let ve = xe(),
+            he = ve > 0,
+            De = 0;
+          if (n) {
+            let Oe = n.getBoundingClientRect();
+            De = ne ? Oe.height : Oe.width;
+          }
+          if (!k && ve === 0 && n) {
+            let Oe = (e.historyItemCount ?? 0) > 0,
+              je = Te(),
+              qe = Array.from(n.children).filter((Ne) =>
+                Ne instanceof HTMLElement
+                  ? Ne.querySelector("[data-react-grab-toolbar-history]")
+                    ? Oe
+                    : Ne.querySelector("[data-react-grab-toolbar-copy-all]")
+                      ? !!e.isHistoryDropdownOpen
+                      : Ne.querySelector("[data-react-grab-toolbar-menu]")
+                        ? je
+                        : true
+                  : false,
+              ),
+              tt = ne ? "gridTemplateRows" : "gridTemplateColumns";
+            for (let Ne of qe)
+              ((Ne.style.transition = "none"), (Ne.style[tt] = "1fr"));
+            (n.offsetWidth, wt(), (ve = xe()));
+            for (let Ne of qe) Ne.style[tt] = "";
+            n.offsetWidth;
+            for (let Ne of qe) Ne.style.transition = "";
+            he = ve > 0;
+          }
+          if ((he && (Ae(I()), G(true)), e.onToggleEnabled?.(), he)) {
+            let Oe = k ? -ve : ve;
+            ne
+              ? (Fe = { width: Fe.width, height: Fe.height + Oe })
+              : (Fe = { width: Fe.width + Oe, height: Fe.height });
+            let je = ne ? ee.y + De : ee.x + De,
+              qe = (tt) => {
+                let Ne = zt(),
+                  ut = je - tt;
+                if (ne) {
+                  let un = Ne.offsetTop + _e,
+                    Cn = Ne.offsetTop + Ne.height - Fe.height - _e;
+                  return { x: ee.x, y: Nt(ut, un, Cn) };
+                }
+                let at = Ne.offsetLeft + _e,
+                  kt = Ne.offsetLeft + Ne.width - Fe.width - _e;
+                return { x: Nt(ut, at, kt), y: ee.y };
+              };
+            if ((vt !== void 0 && Ge(vt), Q()))
+              (le(qe(k ? 0 : ve)), (vt = void 0));
+            else {
+              let tt = performance.now(),
+                Ne = () => {
+                  if (performance.now() - tt > Pn + tu) {
+                    vt = void 0;
+                    return;
+                  }
+                  if (n) {
+                    let at = ne
+                      ? n.getBoundingClientRect().height
+                      : n.getBoundingClientRect().width;
+                    le(qe(at));
+                  }
+                  vt = Ve(Ne);
+                };
+              vt = Ve(Ne);
+            }
+            (clearTimeout(wr),
+              (wr = setTimeout(() => {
+                (vt !== void 0 && (Ge(vt), (vt = void 0)),
+                  le(qe(k ? 0 : ve)),
+                  G(false),
+                  Ae(false));
+                let Ne = Ut(q, j().x, j().y, Fe.width, Fe.height);
+                (fe(Ne),
+                  vn({ edge: q, ratio: Ne, collapsed: b(), enabled: !k }));
+              }, Pn)));
+          } else vn({ edge: q, ratio: X(), collapsed: b(), enabled: !k });
+        }),
+        yi = (k, q, ee, ne, xe, ve) => {
+          let he = zt(),
+            De = he.width,
+            Oe = he.height,
+            je = k + xe * Aa,
+            qe = q + ve * Aa,
+            tt = qe - he.offsetTop + ne / 2,
+            Ne = he.offsetTop + Oe - qe - ne / 2,
+            ut = je - he.offsetLeft + ee / 2,
+            at = he.offsetLeft + De - je - ee / 2,
+            kt = Math.min(tt, Ne, ut, at);
+          return kt === tt
+            ? {
+                edge: "top",
+                x: Math.max(
+                  he.offsetLeft + _e,
+                  Math.min(je, he.offsetLeft + De - ee - _e),
+                ),
+                y: he.offsetTop + _e,
+              }
+            : kt === ut
+              ? {
+                  edge: "left",
+                  x: he.offsetLeft + _e,
+                  y: Math.max(
+                    he.offsetTop + _e,
+                    Math.min(qe, he.offsetTop + Oe - ne - _e),
+                  ),
+                }
+              : kt === at
+                ? {
+                    edge: "right",
+                    x: he.offsetLeft + De - ee - _e,
+                    y: Math.max(
+                      he.offsetTop + _e,
+                      Math.min(qe, he.offsetTop + Oe - ne - _e),
+                    ),
+                  }
+                : {
+                    edge: "bottom",
+                    x: Math.max(
+                      he.offsetLeft + _e,
+                      Math.min(je, he.offsetLeft + De - ee - _e),
+                    ),
+                    y: he.offsetTop + Oe - ne - _e,
+                  };
+        },
+        yr = (k) => {
+          if (
+            !H() ||
+            (Math.sqrt(
+              Math.pow(k.clientX - Po.x, 2) + Math.pow(k.clientY - Po.y, 2),
+            ) > eu && (S(true), o && (o(), (o = null), si(), ci())),
+            !h())
+          )
+            return;
+          let ee = performance.now(),
+            ne = ee - qt.time;
+          if (ne > 0) {
+            let he = (k.clientX - qt.x) / ne,
+              De = (k.clientY - qt.y) / ne;
+            y({ x: he, y: De });
+          }
+          qt = { x: k.clientX, y: k.clientY, time: ee };
+          let xe = k.clientX - ue().x,
+            ve = k.clientY - ue().y;
+          le({ x: xe, y: ve });
+        },
+        $n = () => {
+          if (!H()) return;
+          (window.removeEventListener("pointermove", yr),
+            window.removeEventListener("pointerup", $n));
+          let k = h();
+          if ((M(false), !k)) return;
+          ko = true;
+          let q = t?.getBoundingClientRect();
+          if (!q) return;
+          let ee = A(),
+            ne = yi(j().x, j().y, q.width, q.height, ee.x, ee.y),
+            xe = Ut(ne.edge, ne.x, ne.y, q.width, q.height);
+          (R(ne.edge),
+            fe(xe),
+            m(true),
+            Ve(() => {
+              let ve = t?.getBoundingClientRect();
+              (ve && (Fe = { width: ve.width, height: ve.height }),
+                Ve(() => {
+                  let he = Gt(ne.edge, xe, Fe.width, Fe.height);
+                  (le(he),
+                    vn({
+                      edge: ne.edge,
+                      ratio: xe,
+                      collapsed: b(),
+                      enabled: e.enabled ?? true,
+                    }),
+                    (wi = setTimeout(() => {
+                      (m(false), e.enabled && wt());
+                    }, Qc)));
+                }));
+            }));
+        },
+        ln = (k) => {
+          if (b()) return;
+          let q = t?.getBoundingClientRect();
+          q &&
+            ((Po = { x: k.clientX, y: k.clientY }),
+            L({ x: k.clientX - q.left, y: k.clientY - q.top }),
+            M(true),
+            S(false),
+            y({ x: 0, y: 0 }),
+            (qt = { x: k.clientX, y: k.clientY, time: performance.now() }),
+            window.addEventListener("pointermove", yr),
+            window.addEventListener("pointerup", $n));
+        },
+        cn = () => {
+          let k = C(),
+            q = j(),
+            { width: ee, height: ne } = Fe,
+            { width: xe, height: ve } = Zt(),
+            he = zt();
+          switch (k) {
+            case "top":
+            case "bottom": {
+              let De = (ee - xe) / 2,
+                Oe = q.x + De;
+              return {
+                x: Nt(Oe, he.offsetLeft, he.offsetLeft + he.width - xe),
+                y: k === "top" ? he.offsetTop : he.offsetTop + he.height - ve,
+              };
+            }
+            case "left":
+            case "right": {
+              let De = (ne - ve) / 2,
+                Oe = q.y + De,
+                je = Nt(Oe, he.offsetTop, he.offsetTop + he.height - ve);
+              return {
+                x: k === "left" ? he.offsetLeft : he.offsetLeft + he.width - xe,
+                y: je,
+              };
+            }
+            default:
+              return q;
+          }
+        },
+        Lt = () => {
+          let k = C(),
+            q = b();
+          switch (k) {
+            case "top":
+              return q ? "rotate-180" : "rotate-0";
+            case "bottom":
+              return q ? "rotate-0" : "rotate-180";
+            case "left":
+              return q ? "rotate-90" : "-rotate-90";
+            case "right":
+              return q ? "-rotate-90" : "rotate-90";
+            default:
+              return "rotate-0";
+          }
+        },
+        xn,
+        gt,
+        wi,
+        wr,
+        vt,
+        Hn,
+        jt = () => {
+          H() ||
+            (T(true),
+            Qs(),
+            xn && clearTimeout(xn),
+            (xn = setTimeout(() => {
+              T(false);
+              let k = Ut(C(), j().x, j().y, Fe.width, Fe.height);
+              (fe(k),
+                vn({
+                  edge: C(),
+                  ratio: k,
+                  collapsed: b(),
+                  enabled: e.enabled ?? true,
+                }));
+            }, Sa)));
+        },
+        vn = (k) => {
+          (Qr(k), e.onStateChange?.(k));
+        };
+      (mt(() => {
+        t && e.onContainerRef?.(t);
+        let k = t?.getBoundingClientRect(),
+          q = zt();
+        if (u) {
+          if ((k && (Fe = { width: k.width, height: k.height }), u.collapsed)) {
+            let xe = u.edge === "top" || u.edge === "bottom";
+            an({ width: xe ? Ta : uo, height: xe ? uo : Ta });
+          }
+          x(u.collapsed);
+          let ne = Gt(u.edge, u.ratio, Fe.width, Fe.height);
+          le(ne);
+        } else if (k)
+          ((Fe = { width: k.width, height: k.height }),
+            le({
+              x: q.offsetLeft + (q.width - k.width) / 2,
+              y: q.offsetTop + q.height - k.height - _e,
+            }),
+            fe(0.5));
+        else {
+          let ne = Gt("bottom", 0.5, Fe.width, Fe.height);
+          le(ne);
+        }
+        if ((e.enabled && wt(), e.onSubscribeToStateChanges)) {
+          let ne = e.onSubscribeToStateChanges((xe) => {
+            if (w() || I() || !t?.getBoundingClientRect()) return;
+            let he = b() !== xe.collapsed;
+            if ((R(xe.edge), he && !xe.collapsed)) {
+              let De = Jt();
+              (v(true), x(xe.collapsed));
+              let { position: Oe, ratio: je } = Vt(De, xe.edge);
+              (le(Oe),
+                fe(je),
+                clearTimeout(gt),
+                (gt = setTimeout(() => {
+                  v(false);
+                }, Pn)));
+            } else {
+              (he &&
+                (v(true),
+                clearTimeout(gt),
+                (gt = setTimeout(() => {
+                  v(false);
+                }, Pn))),
+                x(xe.collapsed));
+              let De = Gt(xe.edge, xe.ratio, Fe.width, Fe.height);
+              (le(De), fe(xe.ratio));
+            }
+          });
+          Me(ne);
+        }
+        (window.addEventListener("resize", jt),
+          window.visualViewport?.addEventListener("resize", jt),
+          window.visualViewport?.addEventListener("scroll", jt));
+        let ee = setTimeout(() => {
+          p(true);
+        }, Sa);
+        Me(() => {
+          clearTimeout(ee);
+        });
+      }),
+        Me(() => {
+          (window.removeEventListener("resize", jt),
+            window.visualViewport?.removeEventListener("resize", jt),
+            window.visualViewport?.removeEventListener("scroll", jt),
+            window.removeEventListener("pointermove", yr),
+            window.removeEventListener("pointerup", $n),
+            clearTimeout(xn),
+            clearTimeout(gt),
+            clearTimeout(Pt),
+            clearTimeout(wi),
+            clearTimeout(wr),
+            clearTimeout(Hn),
+            vt !== void 0 && Ge(vt),
+            o?.(),
+            r.stop());
+        }));
+      let Jt = () => (b() ? cn() : j()),
+        ea = () =>
+          b() ? "cursor-pointer" : H() ? "cursor-grabbing" : "cursor-grab",
+        ta = () =>
+          E()
+            ? ""
+            : Y()
+              ? "transition-[transform,opacity] duration-300 ease-out"
+              : w()
+                ? "transition-[transform,opacity] duration-150 ease-out"
+                : I()
+                  ? "transition-opacity duration-150 ease-out"
+                  : "transition-opacity duration-300 ease-out",
+        xr = () => {
+          switch (C()) {
+            case "top":
+              return "center top";
+            case "bottom":
+              return "center bottom";
+            case "left":
+              return "left center";
+            case "right":
+              return "right center";
+            default:
+              return "center center";
+          }
+        };
+      return (() => {
+        var k = sy(),
+          q = k.firstChild,
+          ee = q.firstChild,
+          ne = ee.firstChild,
+          xe = ne.firstChild,
+          ve = xe.firstChild,
+          he = ve.firstChild,
+          De = he.firstChild,
+          Oe = ve.nextSibling,
+          je = Oe.firstChild,
+          qe = je.firstChild,
+          tt = qe.firstChild,
+          Ne = Oe.nextSibling,
+          ut = Ne.firstChild,
+          at = ut.firstChild,
+          kt = Ne.nextSibling,
+          un = kt.firstChild,
+          Cn = un.firstChild,
+          xi = xe.nextSibling,
+          En = xi.firstChild,
+          Qt = En.firstChild,
+          Mo = Qt.firstChild,
+          en = ee.nextSibling;
+        (k.addEventListener("mouseleave", () => e.onSelectHoverChange?.(false)),
+          k.addEventListener(
+            "mouseenter",
+            () => !b() && e.onSelectHoverChange?.(true),
+          ),
+          (k.$$pointerdown = ln));
+        var vi = t;
+        (typeof vi == "function" ? Ke(vi, k) : (t = k),
+          (q.$$click = (Z) => {
+            if (b()) {
+              Z.stopPropagation();
+              let { position: io, ratio: Bn } = Vt(Jt(), C());
+              (le(io),
+                fe(Bn),
+                v(true),
+                x(false),
+                vn({
+                  edge: C(),
+                  ratio: Bn,
+                  collapsed: false,
+                  enabled: e.enabled ?? true,
+                }),
+                gt && clearTimeout(gt),
+                (gt = setTimeout(() => {
+                  v(false);
+                }, Pn)));
+            }
+          }),
+          q.addEventListener("animationend", () => B(false)));
+        var Qe = n;
+        (typeof Qe == "function" ? Ke(Qe, xe) : (n = xe),
+          (De.$$click = (Z) => {
+            (N(false), hr(Z));
+          }),
+          Je(De, "mousedown", It),
+          Je(De, "pointerdown", (Z) => {
+            (It(Z), ln(Z));
+          }),
+          Lr(
+            De,
+            Bo(
+              {
+                get "aria-label"() {
+                  return e.isActive
+                    ? "Stop selecting element"
+                    : "Select element";
+                },
+                get "aria-pressed"() {
+                  return !!e.isActive;
+                },
+                get class() {
+                  return Ee(
+                    "contain-layout flex items-center justify-center cursor-pointer interactive-scale touch-hitbox",
+                    yn(),
+                    Dn(),
+                  );
+                },
+              },
+              () => st(N),
+            ),
+            false,
+          ),
+          z(
+            De,
+            O(Nd, {
+              size: 14,
+              get class() {
+                return Ee(
+                  "transition-colors",
+                  e.isActive ? "text-black" : "text-black/70",
+                );
+              },
+            }),
+          ),
+          z(
+            he,
+            O(Ln, {
+              get visible() {
+                return Be(() => !!$())() && bn();
+              },
+              get position() {
+                return Ht();
+              },
+              get children() {
+                return ["Select element (", Be(() => Jn("C")), ")"];
+              },
+            }),
+            null,
+          ),
+          (qe.$$click = (Z) => {
+            (Se(false), br(Z));
+          }),
+          Je(qe, "mousedown", It),
+          Je(qe, "pointerdown", (Z) => {
+            (It(Z), ln(Z));
+          }),
+          Lr(
+            qe,
+            Bo(
+              {
+                get "aria-label"() {
+                  return `Open history${(e.historyItemCount ?? 0) > 0 ? ` (${e.historyItemCount ?? 0} items)` : ""}`;
+                },
+                get "aria-expanded"() {
+                  return !!e.isHistoryDropdownOpen;
+                },
+                get class() {
+                  return Ee(
+                    "contain-layout flex items-center justify-center cursor-pointer interactive-scale touch-hitbox",
+                    yn(),
+                    Dn(),
+                  );
+                },
+              },
+              () =>
+                st(
+                  (Z) => {
+                    (Z && e.isHistoryDropdownOpen) || Se(Z);
+                  },
+                  {
+                    onHoverChange: (Z) => e.onHistoryButtonHover?.(Z),
+                    shouldFreezeInteractions: false,
+                    safePolygonTargets: () =>
+                      e.isHistoryDropdownOpen
+                        ? l(
+                            "[data-react-grab-history-dropdown]",
+                            "[data-react-grab-toolbar-copy-all]",
+                          )
+                        : null,
+                  },
+                ),
+            ),
+            false,
+          ));
+        var vr = ge;
+        return (
+          typeof vr == "function" ? Ke(vr, tt) : (ge = tt),
+          z(
+            tt,
+            O(Dd, {
+              size: 14,
+              get class() {
+                return ct();
+              },
+            }),
+            null,
+          ),
+          z(
+            tt,
+            O(ye, {
+              get when() {
+                return e.hasUnreadHistoryItems;
+              },
+              get children() {
+                return ry();
+              },
+            }),
+            null,
+          ),
+          z(
+            je,
+            O(Ln, {
+              get visible() {
+                return Be(() => !!me())() && bn();
+              },
+              get position() {
+                return Ht();
+              },
+              get children() {
+                return rt();
+              },
+            }),
+            null,
+          ),
+          (at.$$click = (Z) => {
+            (Pe(false), hi(Z));
+          }),
+          Je(at, "mousedown", It),
+          Je(at, "pointerdown", (Z) => {
+            (It(Z), ln(Z));
+          }),
+          Lr(
+            at,
+            Bo(
+              {
+                get class() {
+                  return Ee(
+                    "contain-layout flex items-center justify-center cursor-pointer interactive-scale touch-hitbox",
+                    yn(),
+                    Dn(),
+                  );
+                },
+              },
+              () =>
+                st(Pe, {
+                  onHoverChange: (Z) => e.onCopyAllHover?.(Z),
+                  shouldFreezeInteractions: false,
+                  safePolygonTargets: () =>
+                    e.isHistoryDropdownOpen
+                      ? l(
+                          "[data-react-grab-history-dropdown]",
+                          "[data-react-grab-toolbar-history]",
+                        )
+                      : null,
+                }),
+            ),
+            false,
+          ),
+          z(at, O(ei, { size: 14, class: "text-[#B3B3B3] transition-colors" })),
+          z(
+            ut,
+            O(Ln, {
+              get visible() {
+                return Be(() => !!ke())() && bn();
+              },
+              get position() {
+                return Ht();
+              },
+              children: "Copy all",
+            }),
+            null,
+          ),
+          (Cn.$$click = (Z) => {
+            (pe(false), Oo(Z));
+          }),
+          Je(Cn, "mousedown", It),
+          Je(Cn, "pointerdown", (Z) => {
+            (It(Z), ln(Z));
+          }),
+          Lr(
+            Cn,
+            Bo(
+              {
+                get "aria-label"() {
+                  return e.isMenuOpen
+                    ? "Close more actions menu"
+                    : "Open more actions menu";
+                },
+                get "aria-expanded"() {
+                  return !!e.isMenuOpen;
+                },
+                get class() {
+                  return Ee(
+                    "contain-layout flex items-center justify-center cursor-pointer interactive-scale touch-hitbox",
+                    yn(),
+                    Dn(),
+                  );
+                },
+              },
+              () =>
+                st(
+                  (Z) => {
+                    (Z && e.isMenuOpen) || pe(Z);
+                  },
+                  { shouldFreezeInteractions: false },
+                ),
+            ),
+            false,
+          ),
+          z(
+            Cn,
+            O(Ss, {
+              size: 14,
+              get class() {
+                return Ee(
+                  "transition-colors",
+                  e.isMenuOpen ? "text-black/80" : "text-[#B3B3B3]",
+                );
+              },
+            }),
+          ),
+          z(
+            un,
+            O(Ln, {
+              get visible() {
+                return Be(() => !!ie())() && bn();
+              },
+              get position() {
+                return Ht();
+              },
+              children: "More actions",
+            }),
+            null,
+          ),
+          En.addEventListener("mouseleave", () => V(false)),
+          En.addEventListener("mouseenter", () => V(true)),
+          (En.$$click = (Z) => {
+            (V(false), Fn(Z));
+          }),
+          z(
+            xi,
+            O(Ln, {
+              get visible() {
+                return Be(() => !!W())() && bn();
+              },
+              get position() {
+                return Ht();
+              },
+              get children() {
+                return e.enabled ? "Disable" : "Enable";
+              },
+            }),
+            null,
+          ),
+          Je(en, "click", bi, true),
+          z(
+            en,
+            O(Ld, {
+              size: 14,
+              get class() {
+                return Ee(
+                  "text-[#B3B3B3] transition-transform duration-150",
+                  Lt(),
+                );
+              },
+            }),
+          ),
+          z(
+            q,
+            O(ye, {
+              get when() {
+                return oe();
+              },
+              get children() {
+                var Z = iy();
+                return (
+                  te(() =>
+                    Re(
+                      Z,
+                      Ee(
+                        "absolute whitespace-nowrap px-1.5 py-0.5 rounded-[10px] text-[10px] text-black/60 pointer-events-none animate-tooltip-fade-in [corner-shape:superellipse(1.25)]",
+                        ht,
+                        To(),
+                      ),
+                    ),
+                  ),
+                  Z
+                );
+              },
+            }),
+            null,
+          ),
+          te(
+            (Z) => {
+              var io = Ee(
+                  "fixed left-0 top-0 font-sans text-[13px] antialiased filter-[drop-shadow(0px_1px_2px_#51515140)] select-none",
+                  ea(),
+                  ta(),
+                  f()
+                    ? "opacity-100 pointer-events-auto"
+                    : "opacity-0 pointer-events-none",
+                ),
+                Bn = `translate(${Jt().x}px, ${Jt().y}px)`,
+                Ro = xr(),
+                Ze = Ee(
+                  "flex items-center justify-center rounded-[10px] antialiased relative overflow-visible [font-synthesis:none] [corner-shape:superellipse(1.25)]",
+                  Ue() && "flex-col",
+                  ht,
+                  !b() &&
+                    (Ue() ? "px-1.5 gap-1.5 py-2" : "py-1.5 gap-1.5 px-2"),
+                  sn(),
+                  D() && "animate-shake",
+                ),
+                Cr = xr(),
+                so = Ee("grid", !Q() && Rt(), Bt(!b(), "pointer-events-none")),
+                Ci = Ee(
+                  "flex",
+                  Ue()
+                    ? "flex-col items-center min-h-0"
+                    : "items-center min-w-0",
+                ),
+                Ei = Ee("flex items-center", Ue() && "flex-col"),
+                Si = Ee("grid", !Q() && Rt(), Bt(!!e.enabled)),
+                Ai = Ee("relative overflow-visible", xt()),
+                Ti = Ee(
+                  "grid",
+                  !Q() && Rt(),
+                  Bt(
+                    !!e.enabled && (e.historyItemCount ?? 0) > 0,
+                    "pointer-events-none",
+                  ),
+                ),
+                _i = Ee("relative overflow-visible", xt()),
+                Pi = Ee(
+                  "grid",
+                  !Q() && Rt(),
+                  Bt(!!e.isHistoryDropdownOpen, "pointer-events-none"),
+                ),
+                Er = Ee("relative overflow-visible", xt()),
+                Io = Ee(
+                  "grid",
+                  !Q() && Rt(),
+                  Bt(!!e.enabled && Te(), "pointer-events-none"),
+                ),
+                ki = Ee("relative overflow-visible", xt()),
+                Oi = e.enabled ? "Disable React Grab" : "Enable React Grab",
+                Mi = !!e.enabled,
+                Ri = Ee(
+                  "contain-layout flex items-center justify-center cursor-pointer interactive-scale outline-none",
+                  Ue() ? "my-0.5" : "mx-0.5",
+                ),
+                Ii = Ee(
+                  "relative rounded-full transition-colors",
+                  Ue() ? "w-3.5 h-2.5" : "w-5 h-3",
+                  e.enabled ? "bg-black" : "bg-black/25",
+                ),
+                Ni = Ee(
+                  "absolute top-0.5 rounded-full bg-white transition-transform",
+                  Ue() ? "w-1.5 h-1.5" : "w-2 h-2",
+                  !e.enabled && "left-0.5",
+                  e.enabled && (Ue() ? "left-1.5" : "left-2.5"),
+                ),
+                Sr = b() ? "Expand toolbar" : "Collapse toolbar";
+              return (
+                io !== Z.e && Re(k, (Z.e = io)),
+                Bn !== Z.t && we(k, "transform", (Z.t = Bn)),
+                Ro !== Z.a && we(k, "transform-origin", (Z.a = Ro)),
+                Ze !== Z.o && Re(q, (Z.o = Ze)),
+                Cr !== Z.i && we(q, "transform-origin", (Z.i = Cr)),
+                so !== Z.n && Re(ee, (Z.n = so)),
+                Ci !== Z.s && Re(ne, (Z.s = Ci)),
+                Ei !== Z.h && Re(xe, (Z.h = Ei)),
+                Si !== Z.r && Re(ve, (Z.r = Si)),
+                Ai !== Z.d && Re(he, (Z.d = Ai)),
+                Ti !== Z.l && Re(Oe, (Z.l = Ti)),
+                _i !== Z.u && Re(je, (Z.u = _i)),
+                Pi !== Z.c && Re(Ne, (Z.c = Pi)),
+                Er !== Z.w && Re(ut, (Z.w = Er)),
+                Io !== Z.m && Re(kt, (Z.m = Io)),
+                ki !== Z.f && Re(un, (Z.f = ki)),
+                Oi !== Z.y && ae(En, "aria-label", (Z.y = Oi)),
+                Mi !== Z.g && ae(En, "aria-pressed", (Z.g = Mi)),
+                Ri !== Z.p && Re(En, (Z.p = Ri)),
+                Ii !== Z.b && Re(Qt, (Z.b = Ii)),
+                Ni !== Z.T && Re(Mo, (Z.T = Ni)),
+                Sr !== Z.A && ae(en, "aria-label", (Z.A = Sr)),
+                Z
+              );
+            },
+            {
+              e: void 0,
+              t: void 0,
+              a: void 0,
+              o: void 0,
+              i: void 0,
+              n: void 0,
+              s: void 0,
+              h: void 0,
+              r: void 0,
+              d: void 0,
+              l: void 0,
+              u: void 0,
+              c: void 0,
+              w: void 0,
+              m: void 0,
+              f: void 0,
+              y: void 0,
+              g: void 0,
+              p: void 0,
+              b: void 0,
+              T: void 0,
+              A: void 0,
+            },
+          ),
+          k
+        );
+      })();
+    };
+  it(["pointerdown", "click"]);
+  var vl = (e, t, n, o) => Math.max(o, Math.min(e, n - t - o));
+  var fr = ({
+    anchor: e,
+    measuredWidth: t,
+    measuredHeight: n,
+    viewportWidth: o,
+    viewportHeight: i,
+    anchorGapPx: s,
+    viewportPaddingPx: r,
+    offscreenPosition: c,
+  }) => {
+    if (!e || t === 0 || n === 0) return c;
+    let l, u;
+    return (
+      e.edge === "left" || e.edge === "right"
+        ? ((l = e.edge === "left" ? e.x + s : e.x - t - s), (u = e.y - n / 2))
+        : ((l = e.x - t / 2), (u = e.edge === "top" ? e.y + s : e.y - n - s)),
+      { left: vl(l, t, o, r), top: vl(u, n, i, r) }
+    );
+  };
+  var _t = (e, t) => {
+    try {
+      return e
+        .composedPath()
+        .some((n) => n instanceof HTMLElement && n.hasAttribute(t));
+    } catch {
+      return false;
+    }
+  };
+  var ui = (e, t) =>
+      typeof e.enabled == "function"
+        ? t
+          ? e.enabled(t)
+          : false
+        : (e.enabled ?? true),
+    di = (e) =>
+      typeof e.enabled == "function" ? e.enabled() : (e.enabled ?? true);
+  var ay = K(
+      '<div data-react-grab-ignore-events data-react-grab-toolbar-menu class="fixed font-sans text-[13px] antialiased filter-[drop-shadow(0px_1px_2px_#51515140)] select-none transition-[opacity,transform] duration-100 ease-out will-change-[opacity,transform]"style=z-index:2147483647><div><div class="relative flex flex-col py-1"><div class="pointer-events-none absolute bg-black/5 opacity-0 transition-[top,left,width,height,opacity] duration-75 ease-out">',
+    ),
+    ly = K("<div><div>"),
+    cy = K(
+      '<button data-react-grab-ignore-events class="relative z-1 contain-layout flex items-center justify-between w-full px-2 py-1 cursor-pointer text-left border-none bg-transparent disabled:opacity-40 disabled:cursor-default"><span class="text-[13px] leading-4 font-sans font-medium text-black">',
+    ),
+    uy = K('<span class="text-[11px] font-sans text-black/50 ml-4">'),
+    vf = (e) => {
+      let t,
+        {
+          containerRef: n,
+          highlightRef: o,
+          updateHighlight: i,
+          clearHighlight: s,
+        } = Qn(),
+        [r, c] = U(0),
+        [l, u] = U(0),
+        [f, p] = U(false),
+        [b, x] = U(false),
+        [H, M] = U("bottom"),
+        [Y, m] = U(0),
+        E,
+        T,
+        C = () => {
+          t && (c(t.offsetWidth), u(t.offsetHeight));
+        };
+      be(() => {
+        let j = e.position;
+        j
+          ? (M(j.edge),
+            clearTimeout(E),
+            p(true),
+            T !== void 0 && Ge(T),
+            (T = Ve(() => {
+              (C(), t?.offsetHeight, x(true));
+            })))
+          : (T !== void 0 && Ge(T),
+            x(false),
+            (E = setTimeout(() => {
+              p(false);
+            }, Yo)));
+      });
+      let R = se((j) => {
+          let le = fr({
+            anchor: e.position,
+            measuredWidth: r(),
+            measuredHeight: l(),
+            viewportWidth: window.innerWidth,
+            viewportHeight: window.innerHeight,
+            anchorGapPx: qo,
+            viewportPaddingPx: jn,
+            offscreenPosition: Kt,
+          });
+          return le.left !== Kt.left ? le : j;
+        }, Kt),
+        X = (j) => {
+          (j.type === "contextmenu" && j.preventDefault(),
+            j.stopImmediatePropagation());
+        },
+        fe = (j, le) => {
+          (le.stopPropagation(),
+            di(j) &&
+              (j.onAction(),
+              j.isActive !== void 0 ? m((ue) => ue + 1) : e.onDismiss()));
+        };
+      return (
+        mt(() => {
+          C();
+          let j = (L) => {
+              !e.position ||
+                _t(L, "data-react-grab-ignore-events") ||
+                e.onDismiss();
+            },
+            le = (L) => {
+              e.position &&
+                L.code === "Escape" &&
+                (L.preventDefault(), L.stopPropagation(), e.onDismiss());
+            },
+            ue = Ve(() => {
+              (window.addEventListener("mousedown", j, { capture: true }),
+                window.addEventListener("touchstart", j, { capture: true }));
+            });
+          (window.addEventListener("keydown", le, { capture: true }),
+            Me(() => {
+              (Ge(ue),
+                clearTimeout(E),
+                T !== void 0 && Ge(T),
+                window.removeEventListener("mousedown", j, { capture: true }),
+                window.removeEventListener("touchstart", j, { capture: true }),
+                window.removeEventListener("keydown", le, { capture: true }));
+            }));
+        }),
+        O(ye, {
+          get when() {
+            return f();
+          },
+          get children() {
+            var j = ay(),
+              le = j.firstChild,
+              ue = le.firstChild,
+              L = ue.firstChild;
+            ((j.$$contextmenu = X),
+              (j.$$click = X),
+              (j.$$mousedown = X),
+              (j.$$pointerdown = X));
+            var A = t;
+            return (
+              typeof A == "function" ? Ke(A, j) : (t = j),
+              we(le, "min-width", `${bu}px`),
+              Ke(n, ue),
+              Ke(o, L),
+              z(
+                ue,
+                O(on, {
+                  get each() {
+                    return e.actions;
+                  },
+                  children: (y) => {
+                    let h = () => di(y),
+                      S = () => y.isActive !== void 0,
+                      D = () => (Y(), !!y.isActive?.());
+                    return (() => {
+                      var B = cy(),
+                        w = B.firstChild;
+                      return (
+                        (B.$$click = (v) => fe(y, v)),
+                        Je(B, "pointerleave", s),
+                        B.addEventListener("pointerenter", (v) => {
+                          h() && i(v.currentTarget);
+                        }),
+                        (B.$$pointerdown = (v) => v.stopPropagation()),
+                        z(w, () => y.label),
+                        z(
+                          B,
+                          O(ye, {
+                            get when() {
+                              return Be(() => !S())() && y.shortcut;
+                            },
+                            children: (v) =>
+                              (() => {
+                                var $ = uy();
+                                return (z($, () => Jn(v())), $);
+                              })(),
+                          }),
+                          null,
+                        ),
+                        z(
+                          B,
+                          O(ye, {
+                            get when() {
+                              return S();
+                            },
+                            get children() {
+                              var v = ly(),
+                                $ = v.firstChild;
+                              return (
+                                te(
+                                  (N) => {
+                                    var W = Ee(
+                                        "relative rounded-full transition-colors ml-4 shrink-0 w-5 h-3",
+                                        D() ? "bg-black" : "bg-black/25",
+                                      ),
+                                      V = Ee(
+                                        "absolute top-0.5 rounded-full bg-white transition-transform w-2 h-2",
+                                        D() ? "left-2.5" : "left-0.5",
+                                      );
+                                    return (
+                                      W !== N.e && Re(v, (N.e = W)),
+                                      V !== N.t && Re($, (N.t = V)),
+                                      N
+                                    );
+                                  },
+                                  { e: void 0, t: void 0 },
+                                ),
+                                v
+                              );
+                            },
+                          }),
+                          null,
+                        ),
+                        te(
+                          (v) => {
+                            var $ = y.id,
+                              N = !h();
+                            return (
+                              $ !== v.e &&
+                                ae(B, "data-react-grab-menu-item", (v.e = $)),
+                              N !== v.t && (B.disabled = v.t = N),
+                              v
+                            );
+                          },
+                          { e: void 0, t: void 0 },
+                        ),
+                        B
+                      );
+                    })();
+                  },
+                }),
+                null,
+              ),
+              te(
+                (y) => {
+                  var h = `${R().top}px`,
+                    S = `${R().left}px`,
+                    D = b() ? "auto" : "none",
+                    B = Zo[H()],
+                    w = b() ? "1" : "0",
+                    v = b() ? "scale(1)" : "scale(0.95)",
+                    $ = Ee(
+                      "contain-layout flex flex-col rounded-[10px] antialiased w-fit h-fit overflow-hidden [font-synthesis:none] [corner-shape:superellipse(1.25)]",
+                      ht,
+                    );
+                  return (
+                    h !== y.e && we(j, "top", (y.e = h)),
+                    S !== y.t && we(j, "left", (y.t = S)),
+                    D !== y.a && we(j, "pointer-events", (y.a = D)),
+                    B !== y.o && we(j, "transform-origin", (y.o = B)),
+                    w !== y.i && we(j, "opacity", (y.i = w)),
+                    v !== y.n && we(j, "transform", (y.n = v)),
+                    $ !== y.s && Re(le, (y.s = $)),
+                    y
+                  );
+                },
+                {
+                  e: void 0,
+                  t: void 0,
+                  a: void 0,
+                  o: void 0,
+                  i: void 0,
+                  n: void 0,
+                  s: void 0,
+                },
+              ),
+              j
+            );
+          },
+        })
+      );
+    };
+  it(["pointerdown", "mousedown", "click", "contextmenu"]);
+  var dy = K(
+      '<div class="relative flex flex-col w-[calc(100%+16px)] -mx-2 -my-1.5"><div class="pointer-events-none absolute bg-black/5 opacity-0 transition-[top,left,width,height,opacity] duration-75 ease-out">',
+    ),
+    fy = K(
+      '<div data-react-grab-ignore-events data-react-grab-context-menu class="fixed font-sans text-[13px] antialiased filter-[drop-shadow(0px_1px_2px_#51515140)] select-none"style=z-index:2147483647;pointer-events:auto><div><div class="contain-layout shrink-0 flex items-center gap-1 pt-1.5 pb-1 w-fit h-fit px-2">',
+    ),
+    my = K('<span class="text-[11px] font-sans text-black/50 ml-4">'),
+    py = K(
+      '<button data-react-grab-ignore-events class="relative z-1 contain-layout flex items-center justify-between w-full px-2 py-1 cursor-pointer text-left border-none bg-transparent disabled:opacity-40 disabled:cursor-default"><span class="text-[13px] leading-4 font-sans font-medium text-black">',
+    ),
+    Cf = (e) => {
+      let t,
+        {
+          containerRef: n,
+          highlightRef: o,
+          updateHighlight: i,
+          clearHighlight: s,
+        } = Qn(),
+        [r, c] = U(0),
+        [l, u] = U(0),
+        f = () => e.position !== null,
+        p = () => ys({ tagName: e.tagName, componentName: e.componentName }),
+        b = () => {
+          if (t) {
+            let m = t.getBoundingClientRect();
+            (c(m.width), u(m.height));
+          }
+        };
+      be(() => {
+        f() && Ve(b);
+      });
+      let x = () => {
+          let m = e.selectionBounds,
+            E = e.position,
+            T = r(),
+            C = l();
+          if (T === 0 || C === 0 || !m || !E)
+            return {
+              left: -9999,
+              top: -9999,
+              arrowLeft: 0,
+              arrowPosition: "bottom",
+            };
+          let R = E.x ?? m.x + m.width / 2,
+            X = Math.max(rn, Math.min(R - T / 2, window.innerWidth - T - rn)),
+            fe = Math.max(Un, Math.min(R - X, T - Un)),
+            j = m.y + m.height + Un + rn,
+            le = m.y - C - Un - rn,
+            ue = j + C > window.innerHeight,
+            L = le >= 0,
+            A = ue && L,
+            y = A ? le : j,
+            h = A ? "top" : "bottom";
+          if (ue && !L) {
+            let S = E.y ?? m.y + m.height / 2;
+            ((y = Math.max(rn, Math.min(S + rn, window.innerHeight - C - rn))),
+              (h = "top"));
+          }
+          return { left: X, top: y, arrowLeft: fe, arrowPosition: h };
+        },
+        H = () => {
+          let m = e.actions ?? [],
+            E = e.actionContext;
+          return m.map((T) => ({
+            label: T.label,
+            action: () => {
+              E && T.onAction(E);
+            },
+            enabled: ui(T, E),
+            shortcut: T.shortcut,
+          }));
+        },
+        M = (m) => {
+          (m.type === "contextmenu" && m.preventDefault(),
+            m.stopImmediatePropagation());
+        },
+        Y = (m, E) => {
+          (E.stopPropagation(), m.enabled && (m.action(), e.onHide()));
+        };
+      return (
+        mt(() => {
+          b();
+          let m = (C) => {
+              !f() ||
+                _t(C, "data-react-grab-ignore-events") ||
+                (C instanceof MouseEvent && C.button === 2) ||
+                e.onDismiss();
+            },
+            E = (C) => {
+              if (!f()) return;
+              let R = C.code === "Escape",
+                X = C.key === "Enter",
+                fe = C.metaKey || C.ctrlKey,
+                j = C.key.toLowerCase(),
+                le = e.actions ?? [],
+                ue = e.actionContext,
+                L = (y) =>
+                  !ue || !ui(y, ue)
+                    ? false
+                    : (C.preventDefault(),
+                      C.stopPropagation(),
+                      y.onAction(ue),
+                      e.onHide(),
+                      true);
+              if (R) {
+                (C.preventDefault(), C.stopPropagation(), e.onDismiss());
+                return;
+              }
+              if (X) {
+                let y = le.find((h) => h.shortcut === "Enter");
+                y && L(y);
+                return;
+              }
+              if (!fe || C.repeat) return;
+              let A = le.find(
+                (y) =>
+                  y.shortcut &&
+                  y.shortcut !== "Enter" &&
+                  j === y.shortcut.toLowerCase(),
+              );
+              A && L(A);
+            },
+            T = Ve(() => {
+              (window.addEventListener("mousedown", m, { capture: true }),
+                window.addEventListener("touchstart", m, { capture: true }));
+            });
+          (window.addEventListener("keydown", E, { capture: true }),
+            Me(() => {
+              (Ge(T),
+                window.removeEventListener("mousedown", m, { capture: true }),
+                window.removeEventListener("touchstart", m, { capture: true }),
+                window.removeEventListener("keydown", E, { capture: true }));
+            }));
+        }),
+        O(ye, {
+          get when() {
+            return f();
+          },
+          get children() {
+            var m = fy(),
+              E = m.firstChild,
+              T = E.firstChild;
+            ((m.$$contextmenu = M),
+              (m.$$click = M),
+              (m.$$mousedown = M),
+              (m.$$pointerdown = M));
+            var C = t;
+            return (
+              typeof C == "function" ? Ke(C, m) : (t = m),
+              z(
+                m,
+                O(vs, {
+                  get position() {
+                    return x().arrowPosition;
+                  },
+                  leftPercent: 0,
+                  get leftOffsetPx() {
+                    return x().arrowLeft;
+                  },
+                }),
+                E,
+              ),
+              z(
+                T,
+                O(qr, {
+                  get tagName() {
+                    return p().tagName;
+                  },
+                  get componentName() {
+                    return p().componentName;
+                  },
+                  get isClickable() {
+                    return e.hasFilePath;
+                  },
+                  onClick: (R) => {
+                    (R.stopPropagation(),
+                      e.hasFilePath &&
+                        e.actionContext &&
+                        e.actions
+                          ?.find((fe) => fe.id === "open")
+                          ?.onAction(e.actionContext));
+                  },
+                  shrink: true,
+                  get forceShowIcon() {
+                    return e.hasFilePath;
+                  },
+                }),
+              ),
+              z(
+                E,
+                O(Mt, {
+                  get children() {
+                    var R = dy(),
+                      X = R.firstChild;
+                    return (
+                      Ke(n, R),
+                      Ke(o, X),
+                      z(
+                        R,
+                        O(on, {
+                          get each() {
+                            return H();
+                          },
+                          children: (fe) =>
+                            (() => {
+                              var j = py(),
+                                le = j.firstChild;
+                              return (
+                                (j.$$click = (ue) => Y(fe, ue)),
+                                Je(j, "pointerleave", s),
+                                j.addEventListener("pointerenter", (ue) => {
+                                  fe.enabled && i(ue.currentTarget);
+                                }),
+                                (j.$$pointerdown = (ue) =>
+                                  ue.stopPropagation()),
+                                z(le, () => fe.label),
+                                z(
+                                  j,
+                                  O(ye, {
+                                    get when() {
+                                      return fe.shortcut;
+                                    },
+                                    get children() {
+                                      var ue = my();
+                                      return (z(ue, () => Jn(fe.shortcut)), ue);
+                                    },
+                                  }),
+                                  null,
+                                ),
+                                te(
+                                  (ue) => {
+                                    var L = fe.label.toLowerCase(),
+                                      A = !fe.enabled;
+                                    return (
+                                      L !== ue.e &&
+                                        ae(
+                                          j,
+                                          "data-react-grab-menu-item",
+                                          (ue.e = L),
+                                        ),
+                                      A !== ue.t && (j.disabled = ue.t = A),
+                                      ue
+                                    );
+                                  },
+                                  { e: void 0, t: void 0 },
+                                ),
+                                j
+                              );
+                            })(),
+                        }),
+                        null,
+                      ),
+                      R
+                    );
+                  },
+                }),
+                null,
+              ),
+              te(
+                (R) => {
+                  var X = `${x().top}px`,
+                    fe = `${x().left}px`,
+                    j = Ee(
+                      "contain-layout flex flex-col justify-center items-start rounded-[10px] antialiased w-fit h-fit min-w-[100px] [font-synthesis:none] [corner-shape:superellipse(1.25)]",
+                      ht,
+                    );
+                  return (
+                    X !== R.e && we(m, "top", (R.e = X)),
+                    fe !== R.t && we(m, "left", (R.t = fe)),
+                    j !== R.a && Re(E, (R.a = j)),
+                    R
+                  );
+                },
+                { e: void 0, t: void 0, a: void 0 },
+              ),
+              m
+            );
+          },
+        })
+      );
+    };
+  it(["pointerdown", "mousedown", "click", "contextmenu"]);
+  var gy = K(
+      '<svg xmlns=http://www.w3.org/2000/svg viewBox="0 0 24 24"fill=currentColor><path fill-rule=evenodd clip-rule=evenodd d="M4.63751 20.1665L3.82444 6.75092L3.73431 5.06621C3.72513 4.89447 3.8619 4.75018 4.03388 4.75018H19.9945C20.1685 4.75018 20.306 4.89769 20.2938 5.07124L20.1756 6.75092L19.3625 20.1665C19.2745 21.618 18.0717 22.7502 16.6176 22.7502H7.38247C5.9283 22.7502 4.72548 21.618 4.63751 20.1665ZM8.74963 16.5002C8.74963 16.9144 9.08542 17.2502 9.49963 17.2502C9.91385 17.2502 10.2496 16.9144 10.2496 16.5002V10.5002C10.2496 10.086 9.91385 9.75018 9.49963 9.75018C9.08542 9.75018 8.74963 10.086 8.74963 10.5002V16.5002ZM14.4996 9.75018C14.9138 9.75018 15.2496 10.086 15.2496 10.5002V16.5002C15.2496 16.9144 14.9138 17.2502 14.4996 17.2502C14.0854 17.2502 13.7496 16.9144 13.7496 16.5002V10.5002C13.7496 10.086 14.0854 9.75018 14.4996 9.75018Z"></path><path fill-rule=evenodd clip-rule=evenodd d="M8.31879 2.46286C8.63394 1.7275 9.35702 1.2507 10.1571 1.2507H13.8383C14.6383 1.2507 15.3614 1.7275 15.6766 2.46286L16.6569 4.75034H19.2239C19.2903 4.75034 19.3523 4.75034 19.4102 4.7507H19.4637C19.4857 4.74973 19.5079 4.74972 19.5303 4.7507H20.9977C21.55 4.7507 21.9977 5.19842 21.9977 5.7507C21.9977 6.30299 21.55 6.7507 20.9977 6.7507H2.99768C2.4454 6.7507 1.99768 6.30299 1.99768 5.7507C1.99768 5.19842 2.4454 4.7507 2.99768 4.7507H4.46507C4.48746 4.74972 4.50968 4.74973 4.53167 4.7507H4.58469C4.6426 4.75034 4.70457 4.75034 4.77093 4.75034H7.33844L8.31879 2.46286ZM13.8903 3.37192L14.481 4.75034H9.5144L10.1052 3.37192C10.1367 3.29838 10.209 3.2507 10.289 3.2507L13.7064 3.2507C13.7864 3.2507 13.8587 3.29838 13.8903 3.37192Z">',
+    ),
+    Cl = (e) => {
+      let t = () => e.size ?? 14;
+      return (() => {
+        var n = gy();
+        return (
+          te(
+            (o) => {
+              var i = t(),
+                s = t(),
+                r = e.class;
+              return (
+                i !== o.e && ae(n, "width", (o.e = i)),
+                s !== o.t && ae(n, "height", (o.t = s)),
+                r !== o.a && ae(n, "class", (o.a = r)),
+                o
+              );
+            },
+            { e: void 0, t: void 0, a: void 0 },
+          ),
+          n
+        );
+      })();
+    };
+  var hy = K(
+      '<div class="flex items-center gap-[5px]"><div class=relative><button data-react-grab-ignore-events data-react-grab-history-clear class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[#FEF2F2] cursor-pointer transition-all hover:bg-[#FEE2E2] press-scale h-[17px] text-[#B91C1C]"></button></div><div class=relative><button data-react-grab-ignore-events data-react-grab-history-copy-all class="contain-layout shrink-0 flex items-center justify-center gap-1 px-[3px] py-px rounded-sm bg-white [border-width:0.5px] border-solid border-[#B3B3B3] cursor-pointer transition-all hover:bg-[#F5F5F5] press-scale h-[17px] text-black/60">',
+    ),
+    by = K(
+      '<div data-react-grab-ignore-events data-react-grab-history-dropdown class="fixed font-sans text-[13px] antialiased filter-[drop-shadow(0px_1px_2px_#51515140)] select-none transition-[opacity,transform] duration-100 ease-out will-change-[opacity,transform]"style=z-index:2147483647><div><div class="contain-layout shrink-0 flex items-center justify-between px-2 pt-1.5 pb-1"><span class="text-[11px] font-medium text-black/40">History</span></div><div class="min-h-0 [border-top-width:0.5px] border-t-solid border-t-[#D9D9D9] px-2 py-1.5"><div class="relative flex flex-col max-h-[240px] overflow-y-auto -mx-2 -my-1.5 [scrollbar-width:thin] [scrollbar-color:transparent_transparent] hover:[scrollbar-color:rgba(0,0,0,0.15)_transparent]"><div class="pointer-events-none absolute bg-black/5 opacity-0 transition-[top,left,width,height,opacity] duration-75 ease-out">',
+    ),
+    yy = K(
+      '<span class="text-[11px] leading-3 font-sans text-black/40 truncate mt-0.5">',
+    ),
+    wy = K(
+      '<div data-react-grab-ignore-events data-react-grab-history-item class="group relative z-1 contain-layout flex items-start justify-between w-full px-2 py-1 cursor-pointer text-left gap-2"tabindex=0><span class="flex flex-col min-w-0 flex-1"><span class="text-[12px] leading-4 font-sans font-medium text-black truncate"></span></span><span class="shrink-0 grid"><span class="text-[10px] font-sans text-black/25 group-hover:invisible group-focus-within:invisible [grid-area:1/1] flex items-center justify-end"></span><span class="invisible group-hover:visible group-focus-within:visible [grid-area:1/1] flex items-center justify-end gap-1.5"><button data-react-grab-ignore-events data-react-grab-history-item-remove></button><button data-react-grab-ignore-events data-react-grab-history-item-copy>',
+    ),
+    Ef =
+      "flex items-center justify-center cursor-pointer text-black/25 transition-colors press-scale",
+    xy = (e) => {
+      let t = Math.floor((Date.now() - e) / 1e3);
+      if (t < 60) return "now";
+      let n = Math.floor(t / 60);
+      if (n < 60) return `${n}m`;
+      let o = Math.floor(n / 60);
+      return o < 24 ? `${o}h` : `${Math.floor(o / 24)}d`;
+    },
+    vy = (e) =>
+      e.elementsCount && e.elementsCount > 1
+        ? `${e.elementsCount} elements`
+        : (e.componentName ?? e.tagName),
+    Sf = (e) => {
+      let t,
+        {
+          containerRef: n,
+          highlightRef: o,
+          updateHighlight: i,
+          clearHighlight: s,
+        } = Qn(),
+        r = _s(),
+        c = () => {
+          if (!t) return null;
+          let $ = t.getRootNode().querySelector("[data-react-grab-toolbar]");
+          if (!$) return null;
+          let N = $.getBoundingClientRect();
+          return [
+            {
+              x: N.x - mn,
+              y: N.y - mn,
+              width: N.width + mn * 2,
+              height: N.height + mn * 2,
+            },
+          ];
+        },
+        [l, u] = U(0),
+        [f, p] = U(0),
+        [b, x] = U(null),
+        [H, M] = U(false),
+        [Y, m] = U(null),
+        E,
+        T,
+        C,
+        R,
+        X = () => e.position !== null,
+        [fe, j] = U(false),
+        [le, ue] = U(false),
+        [L, A] = U("bottom"),
+        y = () => {
+          t && (u(t.offsetWidth), p(t.offsetHeight));
+        };
+      (be(() => {
+        X()
+          ? (e.position && A(e.position.edge),
+            clearTimeout(C),
+            j(true),
+            R !== void 0 && Ge(R),
+            (R = Ve(() => {
+              (y(), t?.offsetHeight, ue(true));
+            })))
+          : (R !== void 0 && Ge(R),
+            ue(false),
+            (C = setTimeout(() => {
+              j(false);
+            }, Yo)));
+      }),
+        be(
+          He(
+            le,
+            (v) => {
+              v && t?.matches(":hover") && e.onDropdownHover?.(true);
+            },
+            { defer: true },
+          ),
+        ));
+      let h = se((v) => {
+          let $ = fr({
+            anchor: e.position,
+            measuredWidth: l(),
+            measuredHeight: f(),
+            viewportWidth: window.innerWidth,
+            viewportHeight: window.innerHeight,
+            anchorGapPx: qo,
+            viewportPaddingPx: jn,
+            offscreenPosition: Kt,
+          });
+          return $.left !== Kt.left ? $ : v;
+        }, Kt),
+        S = () => Math.min(hu, window.innerWidth - h().left - jn),
+        D = () => window.innerHeight - h().top - jn,
+        B = () => Math.max(gu, e.position?.toolbarWidth ?? 0),
+        w = (v) => {
+          (v.type === "contextmenu" && v.preventDefault(),
+            v.stopImmediatePropagation());
+        };
+      return (
+        mt(() => {
+          y();
+          let v = ($) => {
+            X() &&
+              $.code === "Escape" &&
+              ($.preventDefault(), $.stopPropagation(), e.onDismiss?.());
+          };
+          (window.addEventListener("keydown", v, { capture: true }),
+            Me(() => {
+              (clearTimeout(E),
+                clearTimeout(T),
+                clearTimeout(C),
+                R !== void 0 && Ge(R),
+                window.removeEventListener("keydown", v, { capture: true }),
+                r.stop());
+            }));
+        }),
+        O(ye, {
+          get when() {
+            return fe();
+          },
+          get children() {
+            var v = by(),
+              $ = v.firstChild,
+              N = $.firstChild;
+            N.firstChild;
+            var V = N.nextSibling,
+              oe = V.firstChild,
+              de = oe.firstChild;
+            (v.addEventListener("mouseleave", (G) => {
+              let Q = c();
+              if (Q) {
+                r.start({ x: G.clientX, y: G.clientY }, Q, () =>
+                  e.onDropdownHover?.(false),
+                );
+                return;
+              }
+              e.onDropdownHover?.(false);
+            }),
+              v.addEventListener("mouseenter", () => {
+                (r.stop(), e.onDropdownHover?.(true));
+              }),
+              (v.$$contextmenu = w),
+              (v.$$click = w),
+              (v.$$mousedown = w),
+              (v.$$pointerdown = w));
+            var I = t;
+            return (
+              typeof I == "function" ? Ke(I, v) : (t = v),
+              z(
+                N,
+                O(ye, {
+                  get when() {
+                    return e.items.length > 0;
+                  },
+                  get children() {
+                    var G = hy(),
+                      Q = G.firstChild,
+                      Ae = Q.firstChild,
+                      me = Q.nextSibling,
+                      Se = me.firstChild;
+                    return (
+                      Ae.addEventListener("mouseleave", () => x(null)),
+                      Ae.addEventListener("mouseenter", () => x("clear")),
+                      (Ae.$$click = (ie) => {
+                        (ie.stopPropagation(), x(null), e.onClearAll?.());
+                      }),
+                      z(Ae, O(Cl, { size: fo })),
+                      z(
+                        Q,
+                        O(Ln, {
+                          get visible() {
+                            return b() === "clear";
+                          },
+                          position: "top",
+                          children: "Clear all",
+                        }),
+                        null,
+                      ),
+                      Se.addEventListener("mouseleave", () => {
+                        (x(null), e.onCopyAllHover?.(false));
+                      }),
+                      Se.addEventListener("mouseenter", () => {
+                        (x("copy"), H() || e.onCopyAllHover?.(true));
+                      }),
+                      (Se.$$click = (ie) => {
+                        (ie.stopPropagation(),
+                          x(null),
+                          e.onCopyAll?.(),
+                          M(true),
+                          clearTimeout(E),
+                          (E = setTimeout(() => {
+                            M(false);
+                          }, 1500)));
+                      }),
+                      z(
+                        Se,
+                        O(ye, {
+                          get when() {
+                            return H();
+                          },
+                          get fallback() {
+                            return O(ei, { size: fo });
+                          },
+                          get children() {
+                            return O(Jr, { size: fo, class: "text-black" });
+                          },
+                        }),
+                      ),
+                      z(
+                        me,
+                        O(Ln, {
+                          get visible() {
+                            return b() === "copy";
+                          },
+                          position: "top",
+                          children: "Copy all",
+                        }),
+                        null,
+                      ),
+                      G
+                    );
+                  },
+                }),
+                null,
+              ),
+              Ke(n, oe),
+              Ke(o, de),
+              z(
+                oe,
+                O(on, {
+                  get each() {
+                    return e.items;
+                  },
+                  children: (G) =>
+                    (() => {
+                      var Q = wy(),
+                        Ae = Q.firstChild,
+                        me = Ae.firstChild,
+                        Se = Ae.nextSibling,
+                        ie = Se.firstChild,
+                        pe = ie.nextSibling,
+                        ke = pe.firstChild,
+                        Pe = ke.nextSibling;
+                      return (
+                        Je(Q, "blur", s),
+                        Q.addEventListener("focus", (ge) =>
+                          i(ge.currentTarget),
+                        ),
+                        Q.addEventListener("mouseleave", () => {
+                          (e.onItemHover?.(null), s());
+                        }),
+                        Q.addEventListener("mouseenter", (ge) => {
+                          (e.disconnectedItemIds?.has(G.id) ||
+                            e.onItemHover?.(G.id),
+                            i(ge.currentTarget));
+                        }),
+                        (Q.$$keydown = (ge) => {
+                          ge.code === "Space" &&
+                            ge.currentTarget === ge.target &&
+                            (ge.preventDefault(),
+                            ge.stopPropagation(),
+                            e.onSelectItem?.(G));
+                        }),
+                        (Q.$$click = (ge) => {
+                          (ge.stopPropagation(),
+                            e.onSelectItem?.(G),
+                            m(G.id),
+                            clearTimeout(T),
+                            (T = setTimeout(() => {
+                              m(null);
+                            }, 1500)));
+                        }),
+                        (Q.$$pointerdown = (ge) => ge.stopPropagation()),
+                        z(me, () => vy(G)),
+                        z(
+                          Ae,
+                          O(ye, {
+                            get when() {
+                              return G.commentText;
+                            },
+                            get children() {
+                              var ge = yy();
+                              return (z(ge, () => G.commentText), ge);
+                            },
+                          }),
+                          null,
+                        ),
+                        z(ie, () => xy(G.timestamp)),
+                        (ke.$$click = (ge) => {
+                          (ge.stopPropagation(), e.onRemoveItem?.(G));
+                        }),
+                        z(ke, O(Cl, { size: fo })),
+                        (Pe.$$click = (ge) => {
+                          (ge.stopPropagation(),
+                            e.onCopyItem?.(G),
+                            m(G.id),
+                            clearTimeout(T),
+                            (T = setTimeout(() => {
+                              m(null);
+                            }, 1500)));
+                        }),
+                        z(
+                          Pe,
+                          O(ye, {
+                            get when() {
+                              return Y() === G.id;
+                            },
+                            get fallback() {
+                              return O(ei, { size: fo });
+                            },
+                            get children() {
+                              return O(Jr, { size: fo, class: "text-black" });
+                            },
+                          }),
+                        ),
+                        te(
+                          (ge) => {
+                            var Te = {
+                                "opacity-40 hover:opacity-100":
+                                  !!e.disconnectedItemIds?.has(G.id),
+                              },
+                              rt = Ee(Ef, "hover:text-[#B91C1C]"),
+                              ct = Ee(Ef, "hover:text-black/60");
+                            return (
+                              (ge.e = co(Q, Te, ge.e)),
+                              rt !== ge.t && Re(ke, (ge.t = rt)),
+                              ct !== ge.a && Re(Pe, (ge.a = ct)),
+                              ge
+                            );
+                          },
+                          { e: void 0, t: void 0, a: void 0 },
+                        ),
+                        Q
+                      );
+                    })(),
+                }),
+                null,
+              ),
+              te(
+                (G) => {
+                  var Q = `${h().top}px`,
+                    Ae = `${h().left}px`,
+                    me = le() ? "auto" : "none",
+                    Se = Zo[L()],
+                    ie = le() ? "1" : "0",
+                    pe = le() ? "scale(1)" : "scale(0.95)",
+                    ke = Ee(
+                      "contain-layout flex flex-col rounded-[10px] antialiased w-fit h-fit overflow-hidden [font-synthesis:none] [corner-shape:superellipse(1.25)]",
+                      ht,
+                    ),
+                    Pe = `${B()}px`,
+                    ge = `${S()}px`,
+                    Te = `${D()}px`;
+                  return (
+                    Q !== G.e && we(v, "top", (G.e = Q)),
+                    Ae !== G.t && we(v, "left", (G.t = Ae)),
+                    me !== G.a && we(v, "pointer-events", (G.a = me)),
+                    Se !== G.o && we(v, "transform-origin", (G.o = Se)),
+                    ie !== G.i && we(v, "opacity", (G.i = ie)),
+                    pe !== G.n && we(v, "transform", (G.n = pe)),
+                    ke !== G.s && Re($, (G.s = ke)),
+                    Pe !== G.h && we($, "min-width", (G.h = Pe)),
+                    ge !== G.r && we($, "max-width", (G.r = ge)),
+                    Te !== G.d && we($, "max-height", (G.d = Te)),
+                    G
+                  );
+                },
+                {
+                  e: void 0,
+                  t: void 0,
+                  a: void 0,
+                  o: void 0,
+                  i: void 0,
+                  n: void 0,
+                  s: void 0,
+                  h: void 0,
+                  r: void 0,
+                  d: void 0,
+                },
+              ),
+              v
+            );
+          },
+        })
+      );
+    };
+  it(["pointerdown", "mousedown", "click", "contextmenu", "keydown"]);
+  var Cy = K(
+      '<div data-react-grab-ignore-events data-react-grab-clear-history-prompt class="fixed font-sans text-[13px] antialiased filter-[drop-shadow(0px_1px_2px_#51515140)] select-none transition-[opacity,transform] duration-100 ease-out will-change-[opacity,transform]"style=z-index:2147483647><div>',
+    ),
+    Af = (e) => {
+      let t,
+        [n, o] = U(0),
+        [i, s] = U(0),
+        [r, c] = U(false),
+        [l, u] = U(false),
+        [f, p] = U("bottom"),
+        b,
+        x,
+        H = () => {
+          t && (o(t.offsetWidth), s(t.offsetHeight));
+        };
+      be(() => {
+        let m = e.position;
+        m
+          ? (p(m.edge),
+            clearTimeout(b),
+            c(true),
+            x !== void 0 && Ge(x),
+            (x = Ve(() => {
+              (H(), t?.offsetHeight, u(true));
+            })))
+          : (x !== void 0 && Ge(x),
+            u(false),
+            (b = setTimeout(() => {
+              c(false);
+            }, Yo)));
+      });
+      let M = se((m) => {
+          let E = fr({
+            anchor: e.position,
+            measuredWidth: n(),
+            measuredHeight: i(),
+            viewportWidth: window.innerWidth,
+            viewportHeight: window.innerHeight,
+            anchorGapPx: qo,
+            viewportPaddingPx: jn,
+            offscreenPosition: Kt,
+          });
+          return E.left !== Kt.left ? E : m;
+        }, Kt),
+        Y = (m) => {
+          (m.type === "contextmenu" && m.preventDefault(),
+            m.stopImmediatePropagation());
+        };
+      return (
+        mt(() => {
+          H();
+          let m = (C) => {
+            if (!e.position || St(C)) return;
+            let R = C.code === "Enter",
+              X = C.code === "Escape";
+            (R || X) &&
+              (C.preventDefault(),
+              C.stopImmediatePropagation(),
+              X ? e.onCancel() : e.onConfirm());
+          };
+          window.addEventListener("keydown", m, { capture: true });
+          let E = (C) => {
+              !e.position ||
+                _t(C, "data-react-grab-ignore-events") ||
+                e.onCancel();
+            },
+            T = Ve(() => {
+              (window.addEventListener("mousedown", E, { capture: true }),
+                window.addEventListener("touchstart", E, { capture: true }));
+            });
+          Me(() => {
+            (Ge(T),
+              clearTimeout(b),
+              x !== void 0 && Ge(x),
+              window.removeEventListener("keydown", m, { capture: true }),
+              window.removeEventListener("mousedown", E, { capture: true }),
+              window.removeEventListener("touchstart", E, { capture: true }));
+          });
+        }),
+        O(ye, {
+          get when() {
+            return r();
+          },
+          get children() {
+            var m = Cy(),
+              E = m.firstChild;
+            ((m.$$contextmenu = Y),
+              (m.$$click = Y),
+              (m.$$mousedown = Y),
+              (m.$$pointerdown = Y));
+            var T = t;
+            return (
+              typeof T == "function" ? Ke(T, m) : (t = m),
+              z(
+                E,
+                O(Zr, {
+                  label: "Clear history?",
+                  cancelOnEscape: true,
+                  get onConfirm() {
+                    return e.onConfirm;
+                  },
+                  get onCancel() {
+                    return e.onCancel;
+                  },
+                }),
+              ),
+              te(
+                (C) => {
+                  var R = `${M().top}px`,
+                    X = `${M().left}px`,
+                    fe = l() ? "auto" : "none",
+                    j = Zo[f()],
+                    le = l() ? "1" : "0",
+                    ue = l() ? "scale(1)" : "scale(0.95)",
+                    L = Ee(
+                      "contain-layout flex flex-col rounded-[10px] antialiased w-fit h-fit [font-synthesis:none] [corner-shape:superellipse(1.25)]",
+                      ht,
+                    );
+                  return (
+                    R !== C.e && we(m, "top", (C.e = R)),
+                    X !== C.t && we(m, "left", (C.t = X)),
+                    fe !== C.a && we(m, "pointer-events", (C.a = fe)),
+                    j !== C.o && we(m, "transform-origin", (C.o = j)),
+                    le !== C.i && we(m, "opacity", (C.i = le)),
+                    ue !== C.n && we(m, "transform", (C.n = ue)),
+                    L !== C.s && Re(E, (C.s = L)),
+                    C
+                  );
+                },
+                {
+                  e: void 0,
+                  t: void 0,
+                  a: void 0,
+                  o: void 0,
+                  i: void 0,
+                  n: void 0,
+                  s: void 0,
+                },
+              ),
+              m
+            );
+          },
+        })
+      );
+    };
+  it(["pointerdown", "mousedown", "click", "contextmenu"]);
+  var Ey = K(
+      '<div style="position:fixed;top:0;right:0;bottom:0;left:0;pointer-events:none;transition:opacity 100ms ease-out;will-change:opacity;contain:strict;transform:translateZ(0)">',
+    ),
+    Tf = (e) => [
+      O(md, {
+        get crosshairVisible() {
+          return e.crosshairVisible;
+        },
+        get mouseX() {
+          return e.mouseX;
+        },
+        get mouseY() {
+          return e.mouseY;
+        },
+        get selectionVisible() {
+          return e.selectionVisible;
+        },
+        get selectionBounds() {
+          return e.selectionBounds;
+        },
+        get selectionBoundsMultiple() {
+          return e.selectionBoundsMultiple;
+        },
+        get selectionShouldSnap() {
+          return e.selectionShouldSnap;
+        },
+        get selectionIsFading() {
+          return e.selectionLabelStatus === "fading";
+        },
+        get dragVisible() {
+          return e.dragVisible;
+        },
+        get dragBounds() {
+          return e.dragBounds;
+        },
+        get grabbedBoxes() {
+          return e.grabbedBoxes;
+        },
+        get agentSessions() {
+          return e.agentSessions;
+        },
+        get labelInstances() {
+          return e.labelInstances;
+        },
+      }),
+      (() => {
+        var t = Ey();
+        return (
+          we(t, "z-index", 2147483645),
+          we(t, "box-shadow", `inset 0 0 ${Vc}px ${zc}`),
+          te((n) => we(t, "opacity", e.isFrozen ? 1 : 0)),
+          t
+        );
+      })(),
+      O(Yi, {
+        get each() {
+          return Be(() => !!e.agentSessions)()
+            ? Array.from(e.agentSessions.values())
+            : [];
+        },
+        children: (t) =>
+          O(ye, {
+            get when() {
+              return t().selectionBounds.length > 0;
+            },
+            get children() {
+              return O(Ts, {
+                get tagName() {
+                  return t().tagName;
+                },
+                get componentName() {
+                  return t().componentName;
+                },
+                get selectionBounds() {
+                  return t().selectionBounds[0];
+                },
+                get mouseX() {
+                  return t().position.x;
+                },
+                visible: true,
+                hasAgent: true,
+                isAgentConnected: true,
+                get status() {
+                  return t().isFading
+                    ? "fading"
+                    : t().isStreaming
+                      ? "copying"
+                      : "copied";
+                },
+                get statusText() {
+                  return t().lastStatus || "Thinking\u2026";
+                },
+                get inputValue() {
+                  return t().context.prompt;
+                },
+                get previousPrompt() {
+                  return t().context.prompt;
+                },
+                get supportsUndo() {
+                  return e.supportsUndo;
+                },
+                get supportsFollowUp() {
+                  return e.supportsFollowUp;
+                },
+                get dismissButtonText() {
+                  return e.dismissButtonText;
+                },
+                onAbort: () => e.onRequestAbortSession?.(t().id),
+                get onDismiss() {
+                  return t().isStreaming
+                    ? void 0
+                    : () => e.onDismissSession?.(t().id);
+                },
+                get onUndo() {
+                  return t().isStreaming
+                    ? void 0
+                    : () => e.onUndoSession?.(t().id);
+                },
+                get onFollowUpSubmit() {
+                  return t().isStreaming
+                    ? void 0
+                    : (n) => e.onFollowUpSubmitSession?.(t().id, n);
+                },
+                get error() {
+                  return t().error;
+                },
+                onAcknowledgeError: () => e.onAcknowledgeSessionError?.(t().id),
+                onRetry: () => e.onRetrySession?.(t().id),
+                get isPendingAbort() {
+                  return (
+                    Be(() => !!t().isStreaming)() &&
+                    e.pendingAbortSessionId === t().id
+                  );
+                },
+                onConfirmAbort: () => e.onAbortSession?.(t().id, true),
+                onCancelAbort: () => e.onAbortSession?.(t().id, false),
+                onShowContextMenu: void 0,
+              });
+            },
+          }),
+      }),
+      O(ye, {
+        get when() {
+          return Be(() => !!e.selectionLabelVisible)() && e.selectionBounds;
+        },
+        get children() {
+          return O(Ts, {
+            get tagName() {
+              return e.selectionTagName;
+            },
+            get componentName() {
+              return e.selectionComponentName;
+            },
+            get elementsCount() {
+              return e.selectionElementsCount;
+            },
+            get selectionBounds() {
+              return e.selectionBounds;
+            },
+            get mouseX() {
+              return e.mouseX;
+            },
+            get visible() {
+              return e.selectionLabelVisible;
+            },
+            get isPromptMode() {
+              return e.isPromptMode;
+            },
+            get inputValue() {
+              return e.inputValue;
+            },
+            get replyToPrompt() {
+              return e.replyToPrompt;
+            },
+            get hasAgent() {
+              return e.hasAgent;
+            },
+            get isAgentConnected() {
+              return e.isAgentConnected;
+            },
+            get status() {
+              return e.selectionLabelStatus;
+            },
+            get actionCycleState() {
+              return e.selectionActionCycleState;
+            },
+            get arrowNavigationState() {
+              return e.selectionArrowNavigationState;
+            },
+            get onArrowNavigationSelect() {
+              return e.onArrowNavigationSelect;
+            },
+            get filePath() {
+              return e.selectionFilePath;
+            },
+            get lineNumber() {
+              return e.selectionLineNumber;
+            },
+            get onInputChange() {
+              return e.onInputChange;
+            },
+            get onSubmit() {
+              return e.onInputSubmit;
+            },
+            get onCancel() {
+              return e.onInputCancel;
+            },
+            get onToggleExpand() {
+              return e.onToggleExpand;
+            },
+            get isPendingDismiss() {
+              return e.isPendingDismiss;
+            },
+            get onConfirmDismiss() {
+              return e.onConfirmDismiss;
+            },
+            get onCancelDismiss() {
+              return e.onCancelDismiss;
+            },
+            onOpen: () => {
+              e.selectionFilePath &&
+                or(e.selectionFilePath, e.selectionLineNumber);
+            },
+            get isContextMenuOpen() {
+              return e.contextMenuPosition !== null;
+            },
+          });
+        },
+      }),
+      O(Yi, {
+        get each() {
+          return e.labelInstances ?? [];
+        },
+        children: (t) =>
+          O(Ts, {
+            get tagName() {
+              return t().tagName;
+            },
+            get componentName() {
+              return t().componentName;
+            },
+            get elementsCount() {
+              return t().elementsCount;
+            },
+            get selectionBounds() {
+              return t().bounds;
+            },
+            get mouseX() {
+              return t().mouseX;
+            },
+            visible: true,
+            get status() {
+              return t().status;
+            },
+            get statusText() {
+              return t().statusText;
+            },
+            get hasAgent() {
+              return !!t().statusText;
+            },
+            get isPromptMode() {
+              return t().isPromptMode;
+            },
+            get inputValue() {
+              return t().inputValue;
+            },
+            get error() {
+              return t().errorMessage;
+            },
+            get hideArrow() {
+              return t().hideArrow;
+            },
+            get onShowContextMenu() {
+              let n = t();
+              if (
+                !(
+                  !(n.status === "copied" || n.status === "fading") ||
+                  !et(n.element)
+                )
+              )
+                return () => e.onShowContextMenuInstance?.(n.id);
+            },
+            onHoverChange: (n) => e.onLabelInstanceHoverChange?.(t().id, n),
+          }),
+      }),
+      O(ye, {
+        get when() {
+          return e.toolbarVisible !== false;
+        },
+        get children() {
+          return O(xf, {
+            get isActive() {
+              return e.isActive;
+            },
+            get isContextMenuOpen() {
+              return e.contextMenuPosition !== null;
+            },
+            get onToggle() {
+              return e.onToggleActive;
+            },
+            get enabled() {
+              return e.enabled;
+            },
+            get onToggleEnabled() {
+              return e.onToggleEnabled;
+            },
+            get shakeCount() {
+              return e.shakeCount;
+            },
+            get onStateChange() {
+              return e.onToolbarStateChange;
+            },
+            get onSubscribeToStateChanges() {
+              return e.onSubscribeToToolbarStateChanges;
+            },
+            get onSelectHoverChange() {
+              return e.onToolbarSelectHoverChange;
+            },
+            get onContainerRef() {
+              return e.onToolbarRef;
+            },
+            get historyItemCount() {
+              return e.historyItemCount;
+            },
+            get clockFlashTrigger() {
+              return e.clockFlashTrigger;
+            },
+            get hasUnreadHistoryItems() {
+              return e.hasUnreadHistoryItems;
+            },
+            get onToggleHistory() {
+              return e.onToggleHistory;
+            },
+            get onCopyAll() {
+              return e.onCopyAll;
+            },
+            get onCopyAllHover() {
+              return e.onCopyAllHover;
+            },
+            get onHistoryButtonHover() {
+              return e.onHistoryButtonHover;
+            },
+            get isHistoryDropdownOpen() {
+              return !!e.historyDropdownPosition;
+            },
+            get isHistoryPinned() {
+              return e.isHistoryPinned;
+            },
+            get toolbarActions() {
+              return e.toolbarActions;
+            },
+            get onToggleMenu() {
+              return e.onToggleMenu;
+            },
+            get isMenuOpen() {
+              return !!e.toolbarMenuPosition;
+            },
+            get isClearPromptOpen() {
+              return !!e.clearPromptPosition;
+            },
+          });
+        },
+      }),
+      O(Cf, {
+        get position() {
+          return e.contextMenuPosition ?? null;
+        },
+        get selectionBounds() {
+          return e.contextMenuBounds ?? null;
+        },
+        get tagName() {
+          return e.contextMenuTagName;
+        },
+        get componentName() {
+          return e.contextMenuComponentName;
+        },
+        get hasFilePath() {
+          return e.contextMenuHasFilePath ?? false;
+        },
+        get actions() {
+          return e.actions;
+        },
+        get actionContext() {
+          return e.actionContext;
+        },
+        get onDismiss() {
+          return e.onContextMenuDismiss ?? (() => {});
+        },
+        get onHide() {
+          return e.onContextMenuHide ?? (() => {});
+        },
+      }),
+      O(vf, {
+        get position() {
+          return e.toolbarMenuPosition ?? null;
+        },
+        get actions() {
+          return e.toolbarActions ?? [];
+        },
+        get onDismiss() {
+          return e.onToolbarMenuDismiss ?? (() => {});
+        },
+      }),
+      O(Af, {
+        get position() {
+          return e.clearPromptPosition ?? null;
+        },
+        get onConfirm() {
+          return e.onClearHistoryConfirm ?? (() => {});
+        },
+        get onCancel() {
+          return e.onClearHistoryCancel ?? (() => {});
+        },
+      }),
+      O(Sf, {
+        get position() {
+          return e.historyDropdownPosition ?? null;
+        },
+        get items() {
+          return e.historyItems ?? [];
+        },
+        get disconnectedItemIds() {
+          return e.historyDisconnectedItemIds;
+        },
+        get onSelectItem() {
+          return e.onHistoryItemSelect;
+        },
+        get onRemoveItem() {
+          return e.onHistoryItemRemove;
+        },
+        get onCopyItem() {
+          return e.onHistoryItemCopy;
+        },
+        get onItemHover() {
+          return e.onHistoryItemHover;
+        },
+        get onCopyAll() {
+          return e.onHistoryCopyAll;
+        },
+        get onCopyAllHover() {
+          return e.onHistoryCopyAllHover;
+        },
+        get onClearAll() {
+          return e.onHistoryClear;
+        },
+        get onDismiss() {
+          return e.onHistoryDismiss;
+        },
+        get onDropdownHover() {
+          return e.onHistoryDropdownHover;
+        },
+      }),
+    ];
+  var El = () => ({
+    activate: () => {},
+    deactivate: () => {},
+    toggle: () => {},
+    comment: () => {},
+    isActive: () => false,
+    isEnabled: () => false,
+    setEnabled: () => {},
+    getToolbarState: () => null,
+    setToolbarState: () => {},
+    onToolbarStateChange: () => () => {},
+    dispose: () => {},
+    copyElement: () => Promise.resolve(false),
+    getSource: () => Promise.resolve(null),
+    getStackContext: () => Promise.resolve(""),
+    getState: () => ({
+      isActive: false,
+      isDragging: false,
+      isCopying: false,
+      isPromptMode: false,
+      isCrosshairVisible: false,
+      isSelectionBoxVisible: false,
+      isDragBoxVisible: false,
+      targetElement: null,
+      dragBounds: null,
+      grabbedBoxes: [],
+      labelInstances: [],
+      selectionFilePath: null,
+      toolbarState: null,
+    }),
+    setOptions: () => {},
+    registerPlugin: () => {},
+    unregisterPlugin: () => {},
+    getPlugins: () => [],
+    getDisplayName: () => null,
+  });
+  var _f = () => {
+    let e = new AbortController(),
+      t = (o, i, s = {}) => {
+        window.addEventListener(o, i, { ...s, signal: e.signal });
+      },
+      n = (o, i, s = {}) => {
+        document.addEventListener(o, i, { ...s, signal: e.signal });
+      };
+    return {
+      signal: e.signal,
+      abort: () => e.abort(),
+      addWindowListener: t,
+      addDocumentListener: n,
+    };
+  };
+  var Sy = "application/x-lexical-editor",
+    Ay = "application/x-react-grab",
+    Pf = () =>
+      "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (e) => {
+        let t = (Math.random() * 16) | 0;
+        return (e === "x" ? t : (t & 3) | 8).toString(16);
+      }),
+    Ty = (e, t, n, o) => ({
+      detail: 1,
+      format: 0,
+      mode: "segmented",
+      style: "",
+      text: `@${e}`,
+      type: "mention",
+      version: 1,
+      mentionName: e,
+      typeaheadType: n,
+      storedKey: t,
+      metadata: o,
+      source: "chat",
+    }),
+    _y = (e) => ({
+      detail: 0,
+      format: 0,
+      mode: "normal",
+      style: "",
+      text: e,
+      type: "text",
+      version: 1,
+    }),
+    Py = (e) =>
+      e
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;"),
+    ky = (e, t) => {
+      let n = String(Math.floor(Math.random() * 1e4)),
+        o = Pf(),
+        i = `<${t}>`,
+        s = { case: "file", path: `${i}.tsx`, content: e },
+        r = {
+          key: i,
+          type: s,
+          payload: { file: { path: `${i}.tsx`, content: e } },
+          id: Pf(),
+          name: i,
+          _score: 20,
+          isSlash: false,
+          labelMatch: [{ start: 0, end: 2 }],
+        },
+        c = { selection: { type: 0 }, selectedOption: r };
+      return {
+        plainText: `@${i}
 
 ${e}
-`,htmlContent:`<meta charset='utf-8'><pre><code>${Py(e)}</code></pre>`,lexicalData:JSON.stringify({namespace:`chat-input${o}-pane`,nodes:[Ty(i,n,s,c),_y(`
+`,
+        htmlContent: `<meta charset='utf-8'><pre><code>${Py(e)}</code></pre>`,
+        lexicalData: JSON.stringify({
+          namespace: `chat-input${o}-pane`,
+          nodes: [
+            Ty(i, n, s, c),
+            _y(`
 
-${e}`)]})}},Xt=(e,t)=>{let n=t?.componentName??"div",{plainText:o,htmlContent:i,lexicalData:s}=ky(e,n),r=t?.entries??[{tagName:t?.tagName,componentName:n,content:e,commentText:t?.commentText}],c={version:Fc,content:e,entries:r,timestamp:Date.now()},l=f=>{f.preventDefault(),f.clipboardData?.setData("text/plain",o),f.clipboardData?.setData("text/html",i),f.clipboardData?.setData(Sy,s),f.clipboardData?.setData(Ay,JSON.stringify(c));};document.addEventListener("copy",l);let u=document.createElement("textarea");u.value=e,u.style.position="fixed",u.style.left="-9999px",u.ariaHidden="true",document.body.appendChild(u),u.select();try{let f=document.execCommand("copy");return f&&t?.onSuccess?.(),f}finally{document.removeEventListener("copy",l),u.remove();}};var mr=async(e,t={})=>(await Promise.allSettled(e.map(i=>gs(i,t)))).map(i=>i.status==="fulfilled"?i.value:"");var Hs=e=>e.length<=1?e[0]??"":e.map((t,n)=>`[${n+1}]
-${t}`).join(`
+${e}`),
+          ],
+        }),
+      };
+    },
+    Xt = (e, t) => {
+      let n = t?.componentName ?? "div",
+        { plainText: o, htmlContent: i, lexicalData: s } = ky(e, n),
+        r = t?.entries ?? [
+          {
+            tagName: t?.tagName,
+            componentName: n,
+            content: e,
+            commentText: t?.commentText,
+          },
+        ],
+        c = { version: Fc, content: e, entries: r, timestamp: Date.now() },
+        l = (f) => {
+          (f.preventDefault(),
+            f.clipboardData?.setData("text/plain", o),
+            f.clipboardData?.setData("text/html", i),
+            f.clipboardData?.setData(Sy, s),
+            f.clipboardData?.setData(Ay, JSON.stringify(c)));
+        };
+      document.addEventListener("copy", l);
+      let u = document.createElement("textarea");
+      ((u.value = e),
+        (u.style.position = "fixed"),
+        (u.style.left = "-9999px"),
+        (u.ariaHidden = "true"),
+        document.body.appendChild(u),
+        u.select());
+      try {
+        let f = document.execCommand("copy");
+        return (f && t?.onSuccess?.(), f);
+      } finally {
+        (document.removeEventListener("copy", l), u.remove());
+      }
+    };
+  var mr = async (e, t = {}) =>
+    (await Promise.allSettled(e.map((i) => gs(i, t)))).map((i) =>
+      i.status === "fulfilled" ? i.value : "",
+    );
+  var Hs = (e) =>
+    e.length <= 1
+      ? (e[0] ?? "")
+      : e.map(
+          (t, n) => `[${n + 1}]
+${t}`,
+        ).join(`
 
-`);var kf=async(e,t,n,o)=>{let i=false,s="";await t.onBeforeCopy(n);try{let r,c;if(e.getContent)r=await e.getContent(n);else {let l=await mr(n,{maxLines:e.maxContextLines}),f=(await Promise.all(l.map((p,b)=>p.trim()?t.transformSnippet(p,n[b]):Promise.resolve("")))).map((p,b)=>({snippet:p,element:n[b]})).filter(({snippet:p})=>p.trim());r=Hs(f.map(({snippet:p})=>p)),c=f.map(({snippet:p,element:b})=>({tagName:b.localName,content:p,commentText:o}));}if(r.trim()){let l=await t.transformCopyContent(r,n);s=o?`${o}
+`);
+  var kf = async (e, t, n, o) => {
+    let i = false,
+      s = "";
+    await t.onBeforeCopy(n);
+    try {
+      let r, c;
+      if (e.getContent) r = await e.getContent(n);
+      else {
+        let l = await mr(n, { maxLines: e.maxContextLines }),
+          f = (
+            await Promise.all(
+              l.map((p, b) =>
+                p.trim() ? t.transformSnippet(p, n[b]) : Promise.resolve(""),
+              ),
+            )
+          )
+            .map((p, b) => ({ snippet: p, element: n[b] }))
+            .filter(({ snippet: p }) => p.trim());
+        ((r = Hs(f.map(({ snippet: p }) => p))),
+          (c = f.map(({ snippet: p, element: b }) => ({
+            tagName: b.localName,
+            content: p,
+            commentText: o,
+          }))));
+      }
+      if (r.trim()) {
+        let l = await t.transformCopyContent(r, n);
+        ((s = o
+          ? `${o}
 
-${l}`:l,i=Xt(s,{componentName:e.componentName,entries:c});}}catch(r){let c=r instanceof Error?r:new Error(String(r));t.onCopyError(c);}return i&&t.onCopySuccess(n,s),t.onAfterCopy(n,i),i};var Oy=(e,t)=>{let n=Math.max(e.left,t.left),o=Math.max(e.top,t.top),i=Math.min(e.right,t.right),s=Math.min(e.bottom,t.bottom),r=Math.max(0,i-n),c=Math.max(0,s-o);return r*c},My=(e,t)=>e.left<t.right&&e.right>t.left&&e.top<t.bottom&&e.bottom>t.top,pr=(e,t,n)=>Math.min(n,Math.max(t,e)),Ry=e=>e.sort((t,n)=>{if(t===n)return 0;let o=t.compareDocumentPosition(n);return o&Node.DOCUMENT_POSITION_FOLLOWING?-1:o&Node.DOCUMENT_POSITION_PRECEDING?1:0}),Iy=e=>{if(e.width<=0||e.height<=0)return [];let t=window.innerWidth,n=window.innerHeight,o=e.x,i=e.y,s=e.x+e.width,r=e.y+e.height,c=o+e.width/2,l=i+e.height/2,u=pr(Math.ceil(e.width/_a),zr,Vr),f=pr(Math.ceil(e.height/_a),zr,Vr),p=u*f,b=p>Pa?Math.sqrt(Pa/p):1,x=pr(Math.floor(u*b),zr,Vr),H=pr(Math.floor(f*b),zr,Vr),M=new Set,Y=[],m=(E,T)=>{let C=pr(Math.round(E),0,t-1),R=pr(Math.round(T),0,n-1),X=`${C}:${R}`;M.has(X)||(M.add(X),Y.push({x:C,y:R}));};m(o+$t,i+$t),m(s-$t,i+$t),m(o+$t,r-$t),m(s-$t,r-$t),m(c,i+$t),m(c,r-$t),m(o+$t,l),m(s-$t,l),m(c,l);for(let E=0;E<x;E+=1){let T=o+(E+.5)/x*e.width;for(let C=0;C<H;C+=1){let R=i+(C+.5)/H*e.height;m(T,R);}}return Y},Ny=(e,t,n)=>{let o={left:e.x,top:e.y,right:e.x+e.width,bottom:e.y+e.height},i=new Set,s=Iy(e);ai();try{for(let c of s){let l=document.elementsFromPoint(c.x,c.y);for(let u of l)i.add(u);}}finally{li();}let r=[];for(let c of i){if(!n&&vo(c)||!t(c))continue;let l=c.getBoundingClientRect();if(l.width<=0||l.height<=0)continue;let u={left:l.left,top:l.top,right:l.left+l.width,bottom:l.top+l.height};if(n){let f=Oy(o,u),p=l.width*l.height;p>0&&f/p>=iu&&r.push(c);}else My(u,o)&&r.push(c);}return Ry(r)},Ly=e=>e.filter(t=>!e.some(n=>n!==t&&n.contains(t))),fi=(e,t,n=true)=>{let o=Ny(e,t,n);return Ly(o)};var Dy=new Set(["role","name","aria-label","rel","href"]);function Tl(e,t){let n=Dy.has(e);n||=e.startsWith("data-")&&mi(e);let o=mi(t)&&t.length<100;return o||=t.startsWith("#")&&mi(t.slice(1)),n&&o}function Fy(e){return mi(e)}function $y(e){return mi(e)}function Hy(e){return  true}function Mf(e,t){if(e.nodeType!==Node.ELEMENT_NODE)throw new Error("Can't generate CSS selector for non-element node type.");if(e.tagName.toLowerCase()==="html")return "html";let n={root:document.body,idName:Fy,className:$y,tagName:Hy,attr:Tl,timeoutMs:1e3,seedMinLength:3,optimizedMinLength:2,maxNumberOfPathChecks:1/0},o=new Date,i={...n,...t},s=Uy(i.root,n),r,c=0;for(let u of By(e,i,s)){if(new Date().getTime()-o.getTime()>i.timeoutMs||c>=i.maxNumberOfPathChecks){let p=Vy(e,s);if(!p)throw new Error(`Timeout: Can't find a unique selector after ${i.timeoutMs}ms`);return pi(p)}if(c++,_l(u,s)){r=u;break}}if(!r)throw new Error("Selector was not found.");let l=[...Nf(r,e,i,s,o)];return l.sort(Sl),l.length>0?pi(l[0]):pi(r)}function*By(e,t,n){let o=[],i=[],s=e,r=0;for(;s&&s!==n;){let c=zy(s,t);for(let l of c)l.level=r;if(o.push(c),s=s.parentElement,r++,i.push(...If(o)),r>=t.seedMinLength){i.sort(Sl);for(let l of i)yield l;i=[];}}i.sort(Sl);for(let c of i)yield c;}function mi(e){if(/^[a-z\-]{3,}$/i.test(e)){let t=e.split(/-|[A-Z]/);for(let n of t)if(n.length<=2||/[^aeiou]{4,}/i.test(n))return  false;return  true}return  false}function zy(e,t){let n=[],o=e.getAttribute("id");o&&t.idName(o)&&n.push({name:"#"+CSS.escape(o),penalty:0});for(let r=0;r<e.classList.length;r++){let c=e.classList[r];t.className(c)&&n.push({name:"."+CSS.escape(c),penalty:1});}for(let r=0;r<e.attributes.length;r++){let c=e.attributes[r];t.attr(c.name,c.value)&&n.push({name:`[${CSS.escape(c.name)}="${CSS.escape(c.value)}"]`,penalty:2});}let i=e.tagName.toLowerCase();if(t.tagName(i)){n.push({name:i,penalty:5});let r=Al(e,i);r!==void 0&&n.push({name:Rf(i,r),penalty:10});}let s=Al(e);return s!==void 0&&n.push({name:Gy(i,s),penalty:50}),n}function pi(e){let t=e[0],n=t.name;for(let o=1;o<e.length;o++){let i=e[o].level||0;t.level===i-1?n=`${e[o].name} > ${n}`:n=`${e[o].name} ${n}`,t=e[o];}return n}function Of(e){return e.map(t=>t.penalty).reduce((t,n)=>t+n,0)}function Sl(e,t){return Of(e)-Of(t)}function Al(e,t){let n=e.parentNode;if(!n)return;let o=n.firstChild;if(!o)return;let i=0;for(;o&&(o.nodeType===Node.ELEMENT_NODE&&(t===void 0||o.tagName.toLowerCase()===t)&&i++,o!==e);)o=o.nextSibling;return i}function Vy(e,t){let n=0,o=e,i=[];for(;o&&o!==t;){let s=o.tagName.toLowerCase(),r=Al(o,s);if(r===void 0)return;i.push({name:Rf(s,r),penalty:NaN,level:n}),o=o.parentElement,n++;}if(_l(i,t))return i}function Gy(e,t){return e==="html"?"html":`${e}:nth-child(${t})`}function Rf(e,t){return e==="html"?"html":`${e}:nth-of-type(${t})`}function*If(e,t=[]){if(e.length>0)for(let n of e[0])yield*If(e.slice(1,e.length),t.concat(n));else yield t;}function Uy(e,t){return e.nodeType===Node.DOCUMENT_NODE?e:e===t.root?e.ownerDocument:e}function _l(e,t){let n=pi(e);switch(t.querySelectorAll(n).length){case 0:throw new Error(`Can't select any node with this selector: ${n}`);case 1:return  true;default:return  false}}function*Nf(e,t,n,o,i){if(e.length>2&&e.length>n.optimizedMinLength)for(let s=1;s<e.length-1;s++){if(new Date().getTime()-i.getTime()>n.timeoutMs)return;let c=[...e];c.splice(s,1),_l(c,o)&&o.querySelector(pi(c))===t&&(yield c,yield*Nf(c,t,n,o,i));}}var Lf=e=>typeof CSS<"u"&&typeof CSS.escape=="function"?CSS.escape(e):e.replace(/[^a-zA-Z0-9_-]/g,t=>`\\${t}`),Df=e=>e.ownerDocument.body??e.ownerDocument.documentElement,Ff=new Set(["data-testid","data-test-id","data-test","data-cy","data-qa","aria-label","role","name","title","alt"]),$f=e=>e.length>0&&e.length<=120,Pl=(e,t)=>{try{let n=e.ownerDocument.querySelectorAll(t);return n.length===1&&n[0]===e}catch{return  false}},Ky=e=>{if(e instanceof HTMLElement&&e.id){let t=`#${Lf(e.id)}`;if(Pl(e,t))return t}for(let t of Ff){let n=e.getAttribute(t);if(!n||!$f(n))continue;let o=JSON.stringify(n),i=`[${t}=${o}]`;if(Pl(e,i))return i;let s=`${e.tagName.toLowerCase()}${i}`;if(Pl(e,s))return s}return null},Xy=e=>{let t=[],n=Df(e),o=e;for(;o;){if(o instanceof HTMLElement&&o.id){t.unshift(`#${Lf(o.id)}`);break}let i=o.parentElement;if(!i){t.unshift(o.tagName.toLowerCase());break}let r=Array.from(i.children).indexOf(o),c=r>=0?r+1:1;if(t.unshift(`${o.tagName.toLowerCase()}:nth-child(${c})`),i===n){t.unshift(n.tagName.toLowerCase());break}o=i;}return t.join(" > ")},Hf=(e,t=true)=>{let n=Ky(e);if(n)return n;if(t)try{let o=Mf(e,{root:Df(e),timeoutMs:200,attr:(i,s)=>Tl(i,s)||Ff.has(i)&&$f(s)});if(o)return o}catch{}return Xy(e)};var Bf=()=>{Au(),Fs(),of();};var Bs=e=>({x:e.pageX-window.scrollX,y:e.pageY-window.scrollY,width:e.width,height:e.height,borderRadius:"0px",transform:"none"}),kl=e=>({pageX:e.x+window.scrollX,pageY:e.y+window.scrollY,width:e.width,height:e.height}),zs=e=>({...e,borderRadius:"0px",transform:"none"});var Yy=new Set(["c","C","\u0441","\u0421","\u023C","\u023B","\u2184","\u2183","\u1D04","\u1D9C","\u2C7C","\u217D","\u216D","\xE7","\xC7","\u0107","\u0106","\u010D","\u010C","\u0109","\u0108","\u010B","\u010A"]),Vs=(e,t)=>t==="KeyC"?true:!e||e.length!==1?false:Yy.has(e);var zf=(e,t)=>{let n=e.toLowerCase();return t==="Space"?n==="space"||n===" ":t.startsWith("Key")?t.slice(3).toLowerCase()===n:t.startsWith("Digit")?t.slice(5)===n:false};var qy={meta:"metaKey",cmd:"metaKey",command:"metaKey",win:"metaKey",windows:"metaKey",ctrl:"ctrlKey",control:"ctrlKey",shift:"shiftKey",alt:"altKey",option:"altKey",opt:"altKey"},Vf=e=>{let t=e.split("+").map(o=>o.trim().toLowerCase()),n={metaKey:false,ctrlKey:false,shiftKey:false,altKey:false,key:null};for(let o of t){let i=qy[o];i?n[i]=true:n.key=o;}return n},Gs=e=>{if(typeof e=="function")return e;let t=Vf(e),n=t.key;return o=>{if(n===null){let c=t.metaKey?o.metaKey||o.key==="Meta":true,l=t.ctrlKey?o.ctrlKey||o.key==="Control":true,u=t.shiftKey?o.shiftKey||o.key==="Shift":true,f=t.altKey?o.altKey||o.key==="Alt":true,p=c&&l&&u&&f,b=[t.metaKey,t.ctrlKey,t.shiftKey,t.altKey].filter(Boolean).length,x=[o.metaKey||o.key==="Meta",o.ctrlKey||o.key==="Control",o.shiftKey||o.key==="Shift",o.altKey||o.key==="Alt"].filter(Boolean).length;return p&&x>=b}let i=o.key?.toLowerCase()===n||zf(n,o.code),r=t.metaKey||t.ctrlKey||t.shiftKey||t.altKey?(t.metaKey?o.metaKey:true)&&(t.ctrlKey?o.ctrlKey:true)&&(t.shiftKey?o.shiftKey:true)&&(t.altKey?o.altKey:true):!o.metaKey&&!o.ctrlKey&&!o.shiftKey&&!o.altKey;return i&&r}},Gf=e=>!e||typeof e=="function"?{metaKey:In(),ctrlKey:!In(),shiftKey:false,altKey:false,key:null}:Vf(e);var Us=(e,t)=>{if(t.activationKey)return Gs(t.activationKey)(e);let o=(In()?e.metaKey:e.ctrlKey)&&!e.shiftKey&&!e.altKey;return !!(e.key&&o&&Vs(e.key,e.code))};var Ol=e=>{if(e.length===0)return {x:0,y:0,width:0,height:0};if(e.length===1)return e[0];let t=1/0,n=1/0,o=-1/0,i=-1/0;for(let s of e)t=Math.min(t,s.x),n=Math.min(n,s.y),o=Math.max(o,s.x+s.width),i=Math.max(i,s.y+s.height);return {x:t,y:n,width:o-t,height:i-n}};var to={enabled:true,hue:0,selectionBox:{enabled:true},dragBox:{enabled:true},grabbedBoxes:{enabled:true},elementLabel:{enabled:true},crosshair:{enabled:true},toolbar:{enabled:true}},js=(e,t)=>({enabled:t.enabled??e.enabled,hue:t.hue??e.hue,selectionBox:{enabled:t.selectionBox?.enabled??e.selectionBox.enabled},dragBox:{enabled:t.dragBox?.enabled??e.dragBox.enabled},grabbedBoxes:{enabled:t.grabbedBoxes?.enabled??e.grabbedBoxes.enabled},elementLabel:{enabled:t.elementLabel?.enabled??e.elementLabel.enabled},crosshair:{enabled:t.crosshair?.enabled??e.crosshair.enabled},toolbar:{enabled:t.toolbar?.enabled??e.toolbar.enabled}});var Uf={activationMode:"toggle",keyHoldDuration:100,allowActivationInsideInput:true,maxContextLines:3,activationKey:void 0,getContent:void 0,freezeReactUpdates:true},jf=(e={})=>{let t=new Map,n={},[o,i]=Qi({theme:to,options:{...Uf,...e},actions:[],toolbarActions:[]}),s=m=>m.target==="toolbar",r=()=>{let m=to,E={...Uf,...e},T=[],C=[];for(let{config:R}of t.values())if(R.theme&&(m=js(m,R.theme)),R.options&&(E={...E,...R.options}),R.actions)for(let X of R.actions)if(s(X)){let fe=X.onAction;C.push({...X,onAction:()=>{p("cancelPendingToolbarActions"),fe();}});}else T.push(X);E={...E,...n},i("theme",m),i("options",E),i("actions",T),i("toolbarActions",C);},c=m=>{for(let[E,T]of Object.entries(m))T!==void 0&&(n[E]=T,i("options",E,T));},l=(m,E)=>{t.has(m.name)&&u(m.name);let T=m.setup?.(E,Y)??{};return m.theme&&(T.theme=T.theme?js(js(to,m.theme),T.theme):m.theme),m.actions&&(T.actions=[...m.actions,...T.actions??[]]),m.hooks&&(T.hooks=T.hooks?{...m.hooks,...T.hooks}:m.hooks),m.options&&(T.options=T.options?{...m.options,...T.options}:m.options),t.set(m.name,{plugin:m,config:T}),r(),T},u=m=>{let E=t.get(m);E&&(E.config.cleanup&&E.config.cleanup(),t.delete(m),r());},f=()=>Array.from(t.keys()),p=(m,...E)=>{for(let{config:T}of t.values()){let C=T.hooks?.[m];C&&C(...E);}},b=(m,...E)=>{let T=false;for(let{config:C}of t.values()){let R=C.hooks?.[m];R&&R(...E)===true&&(T=true);}return T},x=async(m,...E)=>{for(let{config:T}of t.values()){let C=T.hooks?.[m];C&&await C(...E);}},H=async(m,E,...T)=>{let C=E;for(let{config:R}of t.values()){let X=R.hooks?.[m];X&&(C=await X(C,...T));}return C},M=(m,E,...T)=>{let C=E;for(let{config:R}of t.values()){let X=R.hooks?.[m];X&&(C=X(C,...T));}return C},Y={onActivate:()=>p("onActivate"),onDeactivate:()=>p("onDeactivate"),onElementHover:m=>p("onElementHover",m),onElementSelect:m=>{let E=false,T;for(let{config:C}of t.values()){let R=C.hooks?.onElementSelect;if(R){let X=R(m);X===true?E=true:X instanceof Promise&&(E=true,T=X);}}return {wasIntercepted:E,pendingResult:T}},onDragStart:(m,E)=>p("onDragStart",m,E),onDragEnd:(m,E)=>p("onDragEnd",m,E),onBeforeCopy:async m=>x("onBeforeCopy",m),transformCopyContent:async(m,E)=>H("transformCopyContent",m,E),onAfterCopy:(m,E)=>p("onAfterCopy",m,E),onCopySuccess:(m,E)=>p("onCopySuccess",m,E),onCopyError:m=>p("onCopyError",m),onStateChange:m=>p("onStateChange",m),onPromptModeChange:(m,E)=>p("onPromptModeChange",m,E),onSelectionBox:(m,E,T)=>p("onSelectionBox",m,E,T),onDragBox:(m,E)=>p("onDragBox",m,E),onGrabbedBox:(m,E)=>p("onGrabbedBox",m,E),onElementLabel:(m,E,T)=>p("onElementLabel",m,E,T),onCrosshair:(m,E)=>p("onCrosshair",m,E),onContextMenu:(m,E)=>p("onContextMenu",m,E),cancelPendingToolbarActions:()=>p("cancelPendingToolbarActions"),onOpenFile:(m,E)=>b("onOpenFile",m,E),transformHtmlContent:async(m,E)=>H("transformHtmlContent",m,E),transformAgentContext:async(m,E)=>H("transformAgentContext",m,E),transformActionContext:m=>M("transformActionContext",m),transformOpenFileUrl:(m,E,T)=>M("transformOpenFileUrl",m,E,T),transformSnippet:async(m,E)=>H("transformSnippet",m,E)};return {register:l,unregister:u,getPluginNames:f,setOptions:c,store:o,hooks:Y}};var Ml="react-grab:agent-sessions",Zy=()=>`session-${Date.now()}-${Math.random().toString(36).slice(2,9)}`,Kf=(e,t,n,o,i)=>{let s=Date.now();return {id:Zy(),context:e,lastStatus:"",isStreaming:true,createdAt:s,lastUpdatedAt:s,position:t,selectionBounds:n,tagName:o,componentName:i}},hn=new Map,Wf=()=>{for(;hn.size>su;){let e=hn.keys().next().value;e!==void 0&&hn.delete(e);}},Ws=(e,t)=>{if(!t){hn.clear(),e.forEach((n,o)=>hn.set(o,n)),Wf();return}try{let n=Object.fromEntries(e);t.setItem(Ml,JSON.stringify(n));}catch{hn.clear(),e.forEach((n,o)=>hn.set(o,n)),Wf();}},Ks=(e,t)=>{let n=Xs(t);n.set(e.id,e),Ws(n,t);},Xs=e=>{if(!e)return new Map(hn);try{let t=e.getItem(Ml);if(!t)return new Map;let n=JSON.parse(t);return new Map(Object.entries(n))}catch{return new Map}},Ys=e=>{if(!e){hn.clear();return}try{e.removeItem(Ml);}catch{hn.clear();}},Rl=(e,t)=>{let n=Xs(t);n.delete(e),Ws(n,t);},no=(e,t,n)=>{let o={...e,...t,lastUpdatedAt:Date.now()};return Ks(o,n),o};var Il=(e,t)=>{let[n,o]=U(new Map),[i,s]=U(false),[r,c]=U(false),l=new Map,u=new Map,f=new Map,p=[],b=[],x=e,H=w=>f.get(w)?.agent??x,M=w=>f.get(w)?.elements??[],Y=w=>{let v=w??x,$=v?.provider?.canUndo?.()??false,N=v?.provider?.canRedo?.()??false;s($),c(N);},m=w=>{x=w,Y();},E=()=>x,T=()=>Array.from(n().values()).some(w=>w.isStreaming),C=async(w,v,$,N)=>{let W=N??x,V=W?.storage,oe=false,de=()=>l.get(w.id)===$;try{for await(let Q of v){if(!de())break;let me=n().get(w.id);if(!me)break;let Se=no(me,{lastStatus:Q},V);o(ie=>new Map(ie).set(w.id,Se)),W?.onStatus?.(Q,Se);}if(!de())return;let G=n().get(w.id);if(G){let Q=W?.provider?.getCompletionMessage?.(),Ae=no(G,{isStreaming:!1,...Q?{lastStatus:Q}:{}},V);o(pe=>new Map(pe).set(w.id,Ae));let me=M(w.id),Se=await W?.onComplete?.(Ae,me),ie=b.findIndex(pe=>pe.session.id===w.id);if(ie!==-1&&b.splice(ie,1),b.push({session:Ae,elements:me,agent:W}),Y(W),p.length=0,Se?.error){let pe=no(Ae,{error:Se.error},V);o(ke=>new Map(ke).set(w.id,pe));}}}catch(I){if(!de())return;let Q=n().get(w.id);if(I instanceof Error&&I.name==="AbortError"){if(oe=true,Q){let Ae=M(w.id);W?.onAbort?.(Q,Ae);}}else {let Ae=I instanceof Error?I.message:"Unknown error";if(Q){let me=no(Q,{error:Ae,isStreaming:false},V);o(Se=>new Map(Se).set(w.id,me)),I instanceof Error&&W?.onError?.(I,me);}}}finally{if(!de())return;if(l.delete(w.id),oe){let I=u.get(w.id);I&&(clearTimeout(I),u.delete(w.id)),f.delete(w.id),Rl(w.id,V),o(G=>{let Q=new Map(G);return Q.delete(w.id),Q});}}},R=w=>{let{selectionBounds:v,tagName:$}=w,N=v[0];if(!N)return;let W=N.x+N.width/2,V=N.y+N.height/2,oe=document.elementFromPoint(W,V);if(!(!oe||$&&!$.includes(" ")&&pt(oe)!==$))return oe},X=()=>{let w=x?.storage;if(!w)return;let v=Xs(w);if(v.size===0)return;let $=Date.now(),N=Array.from(v.values()).filter(V=>{if(V.isStreaming)return  true;let oe=V.lastUpdatedAt??V.createdAt;return $-oe<1e4&&!!V.error});if(N.length===0){Ys(w);return}if(!x?.provider?.supportsResume||!x.provider.resume){Ys(w);return}u.forEach(V=>clearTimeout(V)),u.clear(),l.forEach(V=>V.abort()),l.clear(),f.clear();let W=new Map(N.map(V=>[V.id,V]));o(W),Ws(W,w);for(let V of N){let oe=R(V);oe&&x&&f.set(V.id,{elements:[oe],agent:x});let de={...V,isStreaming:true,error:void 0,lastStatus:V.lastStatus||"Resuming...",position:V.position??{x:window.innerWidth/2,y:window.innerHeight/2}};o(Q=>new Map(Q).set(V.id,de)),x?.onResume?.(de);let I=new AbortController;l.set(V.id,I);let G=x.provider.resume(V.id,I.signal,w);C(V,G,I);}},fe=async w=>{let{elements:v,prompt:$,position:N,selectionBounds:W,sessionId:V,agent:oe}=w,de=oe??(V?H(V):x),I=de?.storage;if(!de?.provider||v.length===0)return;let G=v[0],Q=V?n().get(V):void 0,Ae=!!V,Se={content:Q?Q.context.content:(await mr(v,{maxLines:1/0})).filter(Te=>Te.trim()),prompt:$,options:de?.getOptions?.(),sessionId:Ae?V:void 0},ie;if(Q)ie=no(Q,{context:Se,isStreaming:true,lastStatus:"Thinking\u2026"},I);else {let Te=v.length>1?`${v.length} elements`:pt(G)||void 0,rt=v.length>1?void 0:await nr(G)||void 0;ie=Kf(Se,N,W,Te,rt),ie.lastStatus="Thinking\u2026";}f.set(ie.id,{elements:v,agent:de}),o(Te=>new Map(Te).set(ie.id,ie)),Ks(ie,I),de.onStart?.(ie,v);let pe=new AbortController;l.set(ie.id,pe);let ke={...Se,sessionId:V??ie.id},Pe;try{Pe=t?.transformAgentContext?await t.transformAgentContext(ke,v):ke;}catch(Te){let rt=Te instanceof Error?Te.message:"Context transformation failed",ct=no(ie,{error:rt,isStreaming:false},I);o(Ue=>new Map(Ue).set(ie.id,ct)),l.delete(ie.id),Te instanceof Error&&de.onError?.(Te,ct);return}let ge=de.provider.send(Pe,pe.signal);C(ie,ge,pe,de);},j=w=>{if(w){let v=l.get(w);v&&v.abort();}else l.forEach(v=>v.abort()),l.clear(),u.forEach(v=>clearTimeout(v)),u.clear(),f.clear(),b.length=0,p.length=0,o(new Map),Ys(x?.storage),Y();},le=(w,v,$)=>{let W=n().get(w),V=v??H(w),oe=$??M(w);if(W?.isFading)return;W&&oe.length>0&&V?.onDismiss?.(W,oe),o(G=>{let Q=new Map(G),Ae=Q.get(w);return Ae&&Q.set(w,{...Ae,isFading:true}),Q});let de=u.get(w);de&&clearTimeout(de);let I=setTimeout(()=>{u.delete(w);let G=l.get(w);G&&(G.abort(),l.delete(w)),f.delete(w),Rl(w,V?.storage),o(Q=>{let Ae=new Map(Q);return Ae.delete(w),Ae});},150);u.set(w,I);};return {sessions:n,isProcessing:T,canUndo:i,canRedo:r,session:{start:fe,abort:j,dismiss:le,retry:w=>{let $=n().get(w),N=H(w);if(!$||!N?.provider)return;let W=N.storage,V=M(w),oe=no($,{error:void 0,isStreaming:true,lastStatus:"Retrying\u2026"},W);o(Q=>new Map(Q).set(w,oe)),Ks(oe,W),V.length>0&&N.onStart?.(oe,V);let de=new AbortController;l.set(w,de);let I={...oe.context,sessionId:w},G=N.provider.send(I,de.signal);C(oe,G,de,N);},undo:w=>{let $=n().get(w),N=H(w),W=M(w);if($){p.push({session:$,elements:W,agent:N});let V=b.findIndex(oe=>oe.session.id===w);V!==-1&&b.splice(V,1),N?.onUndo?.($,W),N?.provider?.undo?.();}le(w,N,W),Y(N);},getElement:w=>M(w)[0],getElements:w=>M(w),tryResume:X,acknowledgeError:w=>{let N=n().get(w)?.context.prompt;return le(w),N}},history:{undo:()=>{let w=b.pop();if(!w)return;let{session:v,elements:$,agent:N}=w,W=N??x;p.push(w),W?.onUndo?.(v,$),W?.provider?.undo?.(),le(v.id,W,$),Y(W);},redo:()=>{let w=p.pop();if(!w)return;let v=w.agent??x,{session:$,elements:N}=w;v?.provider?.redo?.();let W=N.filter(V=>et(V));if(W.length===0){let V=R($);V&&(W=[V]);}if(W.length>0&&v){b.push(w);let V=W.map(de=>ze(de)),oe={...$,selectionBounds:V};f.set($.id,{elements:W,agent:v}),o(de=>new Map(de).set($.id,oe));}Y(v);}},_internal:{updateBoundsOnViewportChange:()=>{let w=n();if(w.size===0)return;let v=new Map(w),$=false;for(let[N,W]of w){let V=M(N),oe=V[0];if(et(oe)){let de=V.filter(I=>et(I)).map(I=>ze(I));if(de.length>0){let I=W.selectionBounds[0],G=de[0],Q=ns({currentPosition:W.position,previousBounds:I,nextBounds:G});v.set(N,{...W,selectionBounds:de,position:Q}),$=true;}}}$&&o(v);},setOptions:m,getOptions:E}}};var Xf=(e,t)=>{let n=[],o=(u,f)=>{let p=t(u),b=Ds(p.x+p.width/2,p.y+p.height/2).filter(e),x=b.indexOf(u);return x===-1?null:b[x+f]??null},i=u=>{let f=o(u,1);return f&&(n.push(u),n.length>ka&&(n=n.slice(-ka))),f},s=u=>{if(n.length>0){let f=n.pop();if(et(f))return f}return o(u,-1)},r=(u,f)=>{let p=H=>{let M=Array.from(H.children),Y=f?M:M.reverse();for(let m of Y)if(f){if(e(m))return m;let E=p(m);if(E)return E}else {let E=p(m);if(E)return E;if(e(m))return m}return null},b=H=>f?H.nextElementSibling:H.previousElementSibling,x=null;if(f&&(x=p(u)),!x){let H=u;for(;H;){let M=b(H);for(;M;){let m=p(M);if(m){x=m;break}if(e(M)){x=M;break}M=b(M);}if(x)break;let Y=H.parentElement;if(!f&&Y&&e(Y)){x=Y;break}H=Y;}}return x};return {findNext:(u,f)=>{switch(u){case "ArrowUp":return i(f);case "ArrowDown":return s(f);case "ArrowRight":return r(f,true);case "ArrowLeft":return r(f,false);default:return null}},clearHistory:()=>{n=[];}}};var Yf=e=>{let{metaKey:t,ctrlKey:n,shiftKey:o,altKey:i}=Gf(e.activationKey);return {metaKey:t,ctrlKey:n,shiftKey:o,altKey:i}},qf=()=>{let e=new WeakSet,t=Object.getOwnPropertyDescriptor(KeyboardEvent.prototype,"key"),n=false;if(t?.get&&!t.get.__reactGrabPatched){n=true;let i=t.get,s=function(){return e.has(this)?"":i.call(this)};s.__reactGrabPatched=true,Object.defineProperty(KeyboardEvent.prototype,"key",{get:s,configurable:true});}return {claimedEvents:e,originalKeyDescriptor:t,didPatch:n,restore:()=>{n&&t&&Object.defineProperty(KeyboardEvent.prototype,"key",t);}}};var Nl=(e,t)=>({top:t<25,bottom:t>window.innerHeight-25,left:e<25,right:e>window.innerWidth-25}),Zf=(e,t)=>{let n=null,o=()=>{if(!t()){s();return}let c=e(),l=Nl(c.x,c.y);l.top&&window.scrollBy(0,-10),l.bottom&&window.scrollBy(0,10),l.left&&window.scrollBy(-10,0),l.right&&window.scrollBy(10,0),l.top||l.bottom||l.left||l.right?n=Ve(o):n=null;},i=()=>{o();},s=()=>{n!==null&&(Ge(n),n=null);};return {start:i,stop:s,isActive:()=>n!==null}};var Jf=()=>{let e=globalThis;return !!(e.chrome?.runtime?.id||e.browser?.runtime?.id)};var Qf=()=>{try{let e="0.1.21",t=`data:image/svg+xml;base64,${btoa(yu)}`;console.log(`%cReact Grab${e?` v${e}`:""}%c
-https://react-grab.com`,`background: #330039; color: #ffffff; border: 1px solid #d75fcb; padding: 4px 4px 4px 24px; border-radius: 4px; background-image: url("${t}"); background-size: 16px 16px; background-repeat: no-repeat; background-position: 4px center; display: inline-block; margin-bottom: 4px;`,""),navigator.onLine&&e&&!Jf()&&fetch(`https://www.react-grab.com/api/version?source=browser&t=${Date.now()}`,{referrerPolicy:"origin",keepalive:!0,priority:"low",cache:"no-store"}).then(n=>n.text()).then(n=>{n&&n!==e&&console.warn(`[React Grab] v${e} is outdated (latest: v${n})`);}).catch(()=>null);}catch{}};var em=e=>{if("scheduler"in globalThis){globalThis.scheduler.postTask(e,{priority:"background"});return}if(typeof window<"u"&&"requestIdleCallback"in window){requestIdleCallback(e);return}setTimeout(e,0);};var tm=()=>{if(typeof window>"u")return null;try{let e=document.currentScript?.getAttribute("data-options");return e?JSON.parse(e):null}catch{return null}};var So=e=>e==="Enter"||e==="NumpadEnter";var nm={name:"copy",setup:e=>{let t=false;return {hooks:{onElementSelect:n=>{if(t)return t=false,e.copyElement(n),true},onDeactivate:()=>{t=false;},cancelPendingToolbarActions:()=>{t=false;}},actions:[{id:"copy",label:"Copy",shortcut:"C",onAction:n=>{n.copy?.();}},{id:"copy-toolbar",label:"Copy element",shortcut:"C",target:"toolbar",onAction:()=>{t=true,e.activate();}}]}}};var Ll={name:"comment",setup:e=>({actions:[{id:"comment",label:"Comment",shortcut:"Enter",onAction:t=>{t.enterPromptMode?.();}},{id:"comment-toolbar",label:"Comment",shortcut:"Enter",target:"toolbar",onAction:()=>{e.comment();}}]})};var Dl={name:"open",actions:[{id:"open",label:"Open",shortcut:"O",enabled:e=>!!e.filePath,onAction:e=>{if(!e.filePath)return;e.hooks.onOpenFile(e.filePath,e.lineNumber)||or(e.filePath,e.lineNumber,e.hooks.transformOpenFileUrl),e.hideContextMenu(),e.cleanup();}}]};var gr=(e,t)=>t?`${e}
-${t}`:e;var om={name:"copy-html",setup:(e,t)=>{let n=false;return {hooks:{onElementSelect:o=>{if(n)return n=false,Promise.all([t.transformHtmlContent(o.outerHTML,[o]),e.getStackContext(o)]).then(([i,s])=>{i&&Xt(gr(i,s));}).catch(()=>{}),true},onDeactivate:()=>{n=false;},cancelPendingToolbarActions:()=>{n=false;}},actions:[{id:"copy-html",label:"Copy HTML",onAction:async o=>{await o.performWithFeedback(async()=>{let i=o.elements.map(c=>c.outerHTML).join(`
+${l}`
+          : l),
+          (i = Xt(s, { componentName: e.componentName, entries: c })));
+      }
+    } catch (r) {
+      let c = r instanceof Error ? r : new Error(String(r));
+      t.onCopyError(c);
+    }
+    return (i && t.onCopySuccess(n, s), t.onAfterCopy(n, i), i);
+  };
+  var Oy = (e, t) => {
+      let n = Math.max(e.left, t.left),
+        o = Math.max(e.top, t.top),
+        i = Math.min(e.right, t.right),
+        s = Math.min(e.bottom, t.bottom),
+        r = Math.max(0, i - n),
+        c = Math.max(0, s - o);
+      return r * c;
+    },
+    My = (e, t) =>
+      e.left < t.right &&
+      e.right > t.left &&
+      e.top < t.bottom &&
+      e.bottom > t.top,
+    pr = (e, t, n) => Math.min(n, Math.max(t, e)),
+    Ry = (e) =>
+      e.sort((t, n) => {
+        if (t === n) return 0;
+        let o = t.compareDocumentPosition(n);
+        return o & Node.DOCUMENT_POSITION_FOLLOWING
+          ? -1
+          : o & Node.DOCUMENT_POSITION_PRECEDING
+            ? 1
+            : 0;
+      }),
+    Iy = (e) => {
+      if (e.width <= 0 || e.height <= 0) return [];
+      let t = window.innerWidth,
+        n = window.innerHeight,
+        o = e.x,
+        i = e.y,
+        s = e.x + e.width,
+        r = e.y + e.height,
+        c = o + e.width / 2,
+        l = i + e.height / 2,
+        u = pr(Math.ceil(e.width / _a), zr, Vr),
+        f = pr(Math.ceil(e.height / _a), zr, Vr),
+        p = u * f,
+        b = p > Pa ? Math.sqrt(Pa / p) : 1,
+        x = pr(Math.floor(u * b), zr, Vr),
+        H = pr(Math.floor(f * b), zr, Vr),
+        M = new Set(),
+        Y = [],
+        m = (E, T) => {
+          let C = pr(Math.round(E), 0, t - 1),
+            R = pr(Math.round(T), 0, n - 1),
+            X = `${C}:${R}`;
+          M.has(X) || (M.add(X), Y.push({ x: C, y: R }));
+        };
+      (m(o + $t, i + $t),
+        m(s - $t, i + $t),
+        m(o + $t, r - $t),
+        m(s - $t, r - $t),
+        m(c, i + $t),
+        m(c, r - $t),
+        m(o + $t, l),
+        m(s - $t, l),
+        m(c, l));
+      for (let E = 0; E < x; E += 1) {
+        let T = o + ((E + 0.5) / x) * e.width;
+        for (let C = 0; C < H; C += 1) {
+          let R = i + ((C + 0.5) / H) * e.height;
+          m(T, R);
+        }
+      }
+      return Y;
+    },
+    Ny = (e, t, n) => {
+      let o = {
+          left: e.x,
+          top: e.y,
+          right: e.x + e.width,
+          bottom: e.y + e.height,
+        },
+        i = new Set(),
+        s = Iy(e);
+      ai();
+      try {
+        for (let c of s) {
+          let l = document.elementsFromPoint(c.x, c.y);
+          for (let u of l) i.add(u);
+        }
+      } finally {
+        li();
+      }
+      let r = [];
+      for (let c of i) {
+        if ((!n && vo(c)) || !t(c)) continue;
+        let l = c.getBoundingClientRect();
+        if (l.width <= 0 || l.height <= 0) continue;
+        let u = {
+          left: l.left,
+          top: l.top,
+          right: l.left + l.width,
+          bottom: l.top + l.height,
+        };
+        if (n) {
+          let f = Oy(o, u),
+            p = l.width * l.height;
+          p > 0 && f / p >= iu && r.push(c);
+        } else My(u, o) && r.push(c);
+      }
+      return Ry(r);
+    },
+    Ly = (e) => e.filter((t) => !e.some((n) => n !== t && n.contains(t))),
+    fi = (e, t, n = true) => {
+      let o = Ny(e, t, n);
+      return Ly(o);
+    };
+  var Dy = new Set(["role", "name", "aria-label", "rel", "href"]);
+  function Tl(e, t) {
+    let n = Dy.has(e);
+    n ||= e.startsWith("data-") && mi(e);
+    let o = mi(t) && t.length < 100;
+    return ((o ||= t.startsWith("#") && mi(t.slice(1))), n && o);
+  }
+  function Fy(e) {
+    return mi(e);
+  }
+  function $y(e) {
+    return mi(e);
+  }
+  function Hy(e) {
+    return true;
+  }
+  function Mf(e, t) {
+    if (e.nodeType !== Node.ELEMENT_NODE)
+      throw new Error("Can't generate CSS selector for non-element node type.");
+    if (e.tagName.toLowerCase() === "html") return "html";
+    let n = {
+        root: document.body,
+        idName: Fy,
+        className: $y,
+        tagName: Hy,
+        attr: Tl,
+        timeoutMs: 1e3,
+        seedMinLength: 3,
+        optimizedMinLength: 2,
+        maxNumberOfPathChecks: 1 / 0,
+      },
+      o = new Date(),
+      i = { ...n, ...t },
+      s = Uy(i.root, n),
+      r,
+      c = 0;
+    for (let u of By(e, i, s)) {
+      if (
+        new Date().getTime() - o.getTime() > i.timeoutMs ||
+        c >= i.maxNumberOfPathChecks
+      ) {
+        let p = Vy(e, s);
+        if (!p)
+          throw new Error(
+            `Timeout: Can't find a unique selector after ${i.timeoutMs}ms`,
+          );
+        return pi(p);
+      }
+      if ((c++, _l(u, s))) {
+        r = u;
+        break;
+      }
+    }
+    if (!r) throw new Error("Selector was not found.");
+    let l = [...Nf(r, e, i, s, o)];
+    return (l.sort(Sl), l.length > 0 ? pi(l[0]) : pi(r));
+  }
+  function* By(e, t, n) {
+    let o = [],
+      i = [],
+      s = e,
+      r = 0;
+    for (; s && s !== n; ) {
+      let c = zy(s, t);
+      for (let l of c) l.level = r;
+      if (
+        (o.push(c),
+        (s = s.parentElement),
+        r++,
+        i.push(...If(o)),
+        r >= t.seedMinLength)
+      ) {
+        i.sort(Sl);
+        for (let l of i) yield l;
+        i = [];
+      }
+    }
+    i.sort(Sl);
+    for (let c of i) yield c;
+  }
+  function mi(e) {
+    if (/^[a-z\-]{3,}$/i.test(e)) {
+      let t = e.split(/-|[A-Z]/);
+      for (let n of t)
+        if (n.length <= 2 || /[^aeiou]{4,}/i.test(n)) return false;
+      return true;
+    }
+    return false;
+  }
+  function zy(e, t) {
+    let n = [],
+      o = e.getAttribute("id");
+    o && t.idName(o) && n.push({ name: "#" + CSS.escape(o), penalty: 0 });
+    for (let r = 0; r < e.classList.length; r++) {
+      let c = e.classList[r];
+      t.className(c) && n.push({ name: "." + CSS.escape(c), penalty: 1 });
+    }
+    for (let r = 0; r < e.attributes.length; r++) {
+      let c = e.attributes[r];
+      t.attr(c.name, c.value) &&
+        n.push({
+          name: `[${CSS.escape(c.name)}="${CSS.escape(c.value)}"]`,
+          penalty: 2,
+        });
+    }
+    let i = e.tagName.toLowerCase();
+    if (t.tagName(i)) {
+      n.push({ name: i, penalty: 5 });
+      let r = Al(e, i);
+      r !== void 0 && n.push({ name: Rf(i, r), penalty: 10 });
+    }
+    let s = Al(e);
+    return (s !== void 0 && n.push({ name: Gy(i, s), penalty: 50 }), n);
+  }
+  function pi(e) {
+    let t = e[0],
+      n = t.name;
+    for (let o = 1; o < e.length; o++) {
+      let i = e[o].level || 0;
+      (t.level === i - 1
+        ? (n = `${e[o].name} > ${n}`)
+        : (n = `${e[o].name} ${n}`),
+        (t = e[o]));
+    }
+    return n;
+  }
+  function Of(e) {
+    return e.map((t) => t.penalty).reduce((t, n) => t + n, 0);
+  }
+  function Sl(e, t) {
+    return Of(e) - Of(t);
+  }
+  function Al(e, t) {
+    let n = e.parentNode;
+    if (!n) return;
+    let o = n.firstChild;
+    if (!o) return;
+    let i = 0;
+    for (
+      ;
+      o &&
+      (o.nodeType === Node.ELEMENT_NODE &&
+        (t === void 0 || o.tagName.toLowerCase() === t) &&
+        i++,
+      o !== e);
+    )
+      o = o.nextSibling;
+    return i;
+  }
+  function Vy(e, t) {
+    let n = 0,
+      o = e,
+      i = [];
+    for (; o && o !== t; ) {
+      let s = o.tagName.toLowerCase(),
+        r = Al(o, s);
+      if (r === void 0) return;
+      (i.push({ name: Rf(s, r), penalty: NaN, level: n }),
+        (o = o.parentElement),
+        n++);
+    }
+    if (_l(i, t)) return i;
+  }
+  function Gy(e, t) {
+    return e === "html" ? "html" : `${e}:nth-child(${t})`;
+  }
+  function Rf(e, t) {
+    return e === "html" ? "html" : `${e}:nth-of-type(${t})`;
+  }
+  function* If(e, t = []) {
+    if (e.length > 0)
+      for (let n of e[0]) yield* If(e.slice(1, e.length), t.concat(n));
+    else yield t;
+  }
+  function Uy(e, t) {
+    return e.nodeType === Node.DOCUMENT_NODE
+      ? e
+      : e === t.root
+        ? e.ownerDocument
+        : e;
+  }
+  function _l(e, t) {
+    let n = pi(e);
+    switch (t.querySelectorAll(n).length) {
+      case 0:
+        throw new Error(`Can't select any node with this selector: ${n}`);
+      case 1:
+        return true;
+      default:
+        return false;
+    }
+  }
+  function* Nf(e, t, n, o, i) {
+    if (e.length > 2 && e.length > n.optimizedMinLength)
+      for (let s = 1; s < e.length - 1; s++) {
+        if (new Date().getTime() - i.getTime() > n.timeoutMs) return;
+        let c = [...e];
+        (c.splice(s, 1),
+          _l(c, o) &&
+            o.querySelector(pi(c)) === t &&
+            (yield c, yield* Nf(c, t, n, o, i)));
+      }
+  }
+  var Lf = (e) =>
+      typeof CSS < "u" && typeof CSS.escape == "function"
+        ? CSS.escape(e)
+        : e.replace(/[^a-zA-Z0-9_-]/g, (t) => `\\${t}`),
+    Df = (e) => e.ownerDocument.body ?? e.ownerDocument.documentElement,
+    Ff = new Set([
+      "data-testid",
+      "data-test-id",
+      "data-test",
+      "data-cy",
+      "data-qa",
+      "aria-label",
+      "role",
+      "name",
+      "title",
+      "alt",
+    ]),
+    $f = (e) => e.length > 0 && e.length <= 120,
+    Pl = (e, t) => {
+      try {
+        let n = e.ownerDocument.querySelectorAll(t);
+        return n.length === 1 && n[0] === e;
+      } catch {
+        return false;
+      }
+    },
+    Ky = (e) => {
+      if (e instanceof HTMLElement && e.id) {
+        let t = `#${Lf(e.id)}`;
+        if (Pl(e, t)) return t;
+      }
+      for (let t of Ff) {
+        let n = e.getAttribute(t);
+        if (!n || !$f(n)) continue;
+        let o = JSON.stringify(n),
+          i = `[${t}=${o}]`;
+        if (Pl(e, i)) return i;
+        let s = `${e.tagName.toLowerCase()}${i}`;
+        if (Pl(e, s)) return s;
+      }
+      return null;
+    },
+    Xy = (e) => {
+      let t = [],
+        n = Df(e),
+        o = e;
+      for (; o; ) {
+        if (o instanceof HTMLElement && o.id) {
+          t.unshift(`#${Lf(o.id)}`);
+          break;
+        }
+        let i = o.parentElement;
+        if (!i) {
+          t.unshift(o.tagName.toLowerCase());
+          break;
+        }
+        let r = Array.from(i.children).indexOf(o),
+          c = r >= 0 ? r + 1 : 1;
+        if (
+          (t.unshift(`${o.tagName.toLowerCase()}:nth-child(${c})`), i === n)
+        ) {
+          t.unshift(n.tagName.toLowerCase());
+          break;
+        }
+        o = i;
+      }
+      return t.join(" > ");
+    },
+    Hf = (e, t = true) => {
+      let n = Ky(e);
+      if (n) return n;
+      if (t)
+        try {
+          let o = Mf(e, {
+            root: Df(e),
+            timeoutMs: 200,
+            attr: (i, s) => Tl(i, s) || (Ff.has(i) && $f(s)),
+          });
+          if (o) return o;
+        } catch {}
+      return Xy(e);
+    };
+  var Bf = () => {
+    (Au(), Fs(), of());
+  };
+  var Bs = (e) => ({
+      x: e.pageX - window.scrollX,
+      y: e.pageY - window.scrollY,
+      width: e.width,
+      height: e.height,
+      borderRadius: "0px",
+      transform: "none",
+    }),
+    kl = (e) => ({
+      pageX: e.x + window.scrollX,
+      pageY: e.y + window.scrollY,
+      width: e.width,
+      height: e.height,
+    }),
+    zs = (e) => ({ ...e, borderRadius: "0px", transform: "none" });
+  var Yy = new Set([
+      "c",
+      "C",
+      "\u0441",
+      "\u0421",
+      "\u023C",
+      "\u023B",
+      "\u2184",
+      "\u2183",
+      "\u1D04",
+      "\u1D9C",
+      "\u2C7C",
+      "\u217D",
+      "\u216D",
+      "\xE7",
+      "\xC7",
+      "\u0107",
+      "\u0106",
+      "\u010D",
+      "\u010C",
+      "\u0109",
+      "\u0108",
+      "\u010B",
+      "\u010A",
+    ]),
+    Vs = (e, t) =>
+      t === "KeyC" ? true : !e || e.length !== 1 ? false : Yy.has(e);
+  var zf = (e, t) => {
+    let n = e.toLowerCase();
+    return t === "Space"
+      ? n === "space" || n === " "
+      : t.startsWith("Key")
+        ? t.slice(3).toLowerCase() === n
+        : t.startsWith("Digit")
+          ? t.slice(5) === n
+          : false;
+  };
+  var qy = {
+      meta: "metaKey",
+      cmd: "metaKey",
+      command: "metaKey",
+      win: "metaKey",
+      windows: "metaKey",
+      ctrl: "ctrlKey",
+      control: "ctrlKey",
+      shift: "shiftKey",
+      alt: "altKey",
+      option: "altKey",
+      opt: "altKey",
+    },
+    Vf = (e) => {
+      let t = e.split("+").map((o) => o.trim().toLowerCase()),
+        n = {
+          metaKey: false,
+          ctrlKey: false,
+          shiftKey: false,
+          altKey: false,
+          key: null,
+        };
+      for (let o of t) {
+        let i = qy[o];
+        i ? (n[i] = true) : (n.key = o);
+      }
+      return n;
+    },
+    Gs = (e) => {
+      if (typeof e == "function") return e;
+      let t = Vf(e),
+        n = t.key;
+      return (o) => {
+        if (n === null) {
+          let c = t.metaKey ? o.metaKey || o.key === "Meta" : true,
+            l = t.ctrlKey ? o.ctrlKey || o.key === "Control" : true,
+            u = t.shiftKey ? o.shiftKey || o.key === "Shift" : true,
+            f = t.altKey ? o.altKey || o.key === "Alt" : true,
+            p = c && l && u && f,
+            b = [t.metaKey, t.ctrlKey, t.shiftKey, t.altKey].filter(
+              Boolean,
+            ).length,
+            x = [
+              o.metaKey || o.key === "Meta",
+              o.ctrlKey || o.key === "Control",
+              o.shiftKey || o.key === "Shift",
+              o.altKey || o.key === "Alt",
+            ].filter(Boolean).length;
+          return p && x >= b;
+        }
+        let i = o.key?.toLowerCase() === n || zf(n, o.code),
+          r =
+            t.metaKey || t.ctrlKey || t.shiftKey || t.altKey
+              ? (t.metaKey ? o.metaKey : true) &&
+                (t.ctrlKey ? o.ctrlKey : true) &&
+                (t.shiftKey ? o.shiftKey : true) &&
+                (t.altKey ? o.altKey : true)
+              : !o.metaKey && !o.ctrlKey && !o.shiftKey && !o.altKey;
+        return i && r;
+      };
+    },
+    Gf = (e) =>
+      !e || typeof e == "function"
+        ? {
+            metaKey: In(),
+            ctrlKey: !In(),
+            shiftKey: false,
+            altKey: false,
+            key: null,
+          }
+        : Vf(e);
+  var Us = (e, t) => {
+    if (t.activationKey) return Gs(t.activationKey)(e);
+    let o = (In() ? e.metaKey : e.ctrlKey) && !e.shiftKey && !e.altKey;
+    return !!(e.key && o && Vs(e.key, e.code));
+  };
+  var Ol = (e) => {
+    if (e.length === 0) return { x: 0, y: 0, width: 0, height: 0 };
+    if (e.length === 1) return e[0];
+    let t = 1 / 0,
+      n = 1 / 0,
+      o = -1 / 0,
+      i = -1 / 0;
+    for (let s of e)
+      ((t = Math.min(t, s.x)),
+        (n = Math.min(n, s.y)),
+        (o = Math.max(o, s.x + s.width)),
+        (i = Math.max(i, s.y + s.height)));
+    return { x: t, y: n, width: o - t, height: i - n };
+  };
+  var to = {
+      enabled: true,
+      hue: 0,
+      selectionBox: { enabled: true },
+      dragBox: { enabled: true },
+      grabbedBoxes: { enabled: true },
+      elementLabel: { enabled: true },
+      crosshair: { enabled: true },
+      toolbar: { enabled: true },
+    },
+    js = (e, t) => ({
+      enabled: t.enabled ?? e.enabled,
+      hue: t.hue ?? e.hue,
+      selectionBox: {
+        enabled: t.selectionBox?.enabled ?? e.selectionBox.enabled,
+      },
+      dragBox: { enabled: t.dragBox?.enabled ?? e.dragBox.enabled },
+      grabbedBoxes: {
+        enabled: t.grabbedBoxes?.enabled ?? e.grabbedBoxes.enabled,
+      },
+      elementLabel: {
+        enabled: t.elementLabel?.enabled ?? e.elementLabel.enabled,
+      },
+      crosshair: { enabled: t.crosshair?.enabled ?? e.crosshair.enabled },
+      toolbar: { enabled: t.toolbar?.enabled ?? e.toolbar.enabled },
+    });
+  var Uf = {
+      activationMode: "toggle",
+      keyHoldDuration: 100,
+      allowActivationInsideInput: true,
+      maxContextLines: 3,
+      activationKey: void 0,
+      getContent: void 0,
+      freezeReactUpdates: true,
+    },
+    jf = (e = {}) => {
+      let t = new Map(),
+        n = {},
+        [o, i] = Qi({
+          theme: to,
+          options: { ...Uf, ...e },
+          actions: [],
+          toolbarActions: [],
+        }),
+        s = (m) => m.target === "toolbar",
+        r = () => {
+          let m = to,
+            E = { ...Uf, ...e },
+            T = [],
+            C = [];
+          for (let { config: R } of t.values())
+            if (
+              (R.theme && (m = js(m, R.theme)),
+              R.options && (E = { ...E, ...R.options }),
+              R.actions)
+            )
+              for (let X of R.actions)
+                if (s(X)) {
+                  let fe = X.onAction;
+                  C.push({
+                    ...X,
+                    onAction: () => {
+                      (p("cancelPendingToolbarActions"), fe());
+                    },
+                  });
+                } else T.push(X);
+          ((E = { ...E, ...n }),
+            i("theme", m),
+            i("options", E),
+            i("actions", T),
+            i("toolbarActions", C));
+        },
+        c = (m) => {
+          for (let [E, T] of Object.entries(m))
+            T !== void 0 && ((n[E] = T), i("options", E, T));
+        },
+        l = (m, E) => {
+          t.has(m.name) && u(m.name);
+          let T = m.setup?.(E, Y) ?? {};
+          return (
+            m.theme &&
+              (T.theme = T.theme ? js(js(to, m.theme), T.theme) : m.theme),
+            m.actions && (T.actions = [...m.actions, ...(T.actions ?? [])]),
+            m.hooks &&
+              (T.hooks = T.hooks ? { ...m.hooks, ...T.hooks } : m.hooks),
+            m.options &&
+              (T.options = T.options
+                ? { ...m.options, ...T.options }
+                : m.options),
+            t.set(m.name, { plugin: m, config: T }),
+            r(),
+            T
+          );
+        },
+        u = (m) => {
+          let E = t.get(m);
+          E && (E.config.cleanup && E.config.cleanup(), t.delete(m), r());
+        },
+        f = () => Array.from(t.keys()),
+        p = (m, ...E) => {
+          for (let { config: T } of t.values()) {
+            let C = T.hooks?.[m];
+            C && C(...E);
+          }
+        },
+        b = (m, ...E) => {
+          let T = false;
+          for (let { config: C } of t.values()) {
+            let R = C.hooks?.[m];
+            R && R(...E) === true && (T = true);
+          }
+          return T;
+        },
+        x = async (m, ...E) => {
+          for (let { config: T } of t.values()) {
+            let C = T.hooks?.[m];
+            C && (await C(...E));
+          }
+        },
+        H = async (m, E, ...T) => {
+          let C = E;
+          for (let { config: R } of t.values()) {
+            let X = R.hooks?.[m];
+            X && (C = await X(C, ...T));
+          }
+          return C;
+        },
+        M = (m, E, ...T) => {
+          let C = E;
+          for (let { config: R } of t.values()) {
+            let X = R.hooks?.[m];
+            X && (C = X(C, ...T));
+          }
+          return C;
+        },
+        Y = {
+          onActivate: () => p("onActivate"),
+          onDeactivate: () => p("onDeactivate"),
+          onElementHover: (m) => p("onElementHover", m),
+          onElementSelect: (m) => {
+            let E = false,
+              T;
+            for (let { config: C } of t.values()) {
+              let R = C.hooks?.onElementSelect;
+              if (R) {
+                let X = R(m);
+                X === true
+                  ? (E = true)
+                  : X instanceof Promise && ((E = true), (T = X));
+              }
+            }
+            return { wasIntercepted: E, pendingResult: T };
+          },
+          onDragStart: (m, E) => p("onDragStart", m, E),
+          onDragEnd: (m, E) => p("onDragEnd", m, E),
+          onBeforeCopy: async (m) => x("onBeforeCopy", m),
+          transformCopyContent: async (m, E) => H("transformCopyContent", m, E),
+          onAfterCopy: (m, E) => p("onAfterCopy", m, E),
+          onCopySuccess: (m, E) => p("onCopySuccess", m, E),
+          onCopyError: (m) => p("onCopyError", m),
+          onStateChange: (m) => p("onStateChange", m),
+          onPromptModeChange: (m, E) => p("onPromptModeChange", m, E),
+          onSelectionBox: (m, E, T) => p("onSelectionBox", m, E, T),
+          onDragBox: (m, E) => p("onDragBox", m, E),
+          onGrabbedBox: (m, E) => p("onGrabbedBox", m, E),
+          onElementLabel: (m, E, T) => p("onElementLabel", m, E, T),
+          onCrosshair: (m, E) => p("onCrosshair", m, E),
+          onContextMenu: (m, E) => p("onContextMenu", m, E),
+          cancelPendingToolbarActions: () => p("cancelPendingToolbarActions"),
+          onOpenFile: (m, E) => b("onOpenFile", m, E),
+          transformHtmlContent: async (m, E) => H("transformHtmlContent", m, E),
+          transformAgentContext: async (m, E) =>
+            H("transformAgentContext", m, E),
+          transformActionContext: (m) => M("transformActionContext", m),
+          transformOpenFileUrl: (m, E, T) => M("transformOpenFileUrl", m, E, T),
+          transformSnippet: async (m, E) => H("transformSnippet", m, E),
+        };
+      return {
+        register: l,
+        unregister: u,
+        getPluginNames: f,
+        setOptions: c,
+        store: o,
+        hooks: Y,
+      };
+    };
+  var Ml = "react-grab:agent-sessions",
+    Zy = () =>
+      `session-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+    Kf = (e, t, n, o, i) => {
+      let s = Date.now();
+      return {
+        id: Zy(),
+        context: e,
+        lastStatus: "",
+        isStreaming: true,
+        createdAt: s,
+        lastUpdatedAt: s,
+        position: t,
+        selectionBounds: n,
+        tagName: o,
+        componentName: i,
+      };
+    },
+    hn = new Map(),
+    Wf = () => {
+      for (; hn.size > su; ) {
+        let e = hn.keys().next().value;
+        e !== void 0 && hn.delete(e);
+      }
+    },
+    Ws = (e, t) => {
+      if (!t) {
+        (hn.clear(), e.forEach((n, o) => hn.set(o, n)), Wf());
+        return;
+      }
+      try {
+        let n = Object.fromEntries(e);
+        t.setItem(Ml, JSON.stringify(n));
+      } catch {
+        (hn.clear(), e.forEach((n, o) => hn.set(o, n)), Wf());
+      }
+    },
+    Ks = (e, t) => {
+      let n = Xs(t);
+      (n.set(e.id, e), Ws(n, t));
+    },
+    Xs = (e) => {
+      if (!e) return new Map(hn);
+      try {
+        let t = e.getItem(Ml);
+        if (!t) return new Map();
+        let n = JSON.parse(t);
+        return new Map(Object.entries(n));
+      } catch {
+        return new Map();
+      }
+    },
+    Ys = (e) => {
+      if (!e) {
+        hn.clear();
+        return;
+      }
+      try {
+        e.removeItem(Ml);
+      } catch {
+        hn.clear();
+      }
+    },
+    Rl = (e, t) => {
+      let n = Xs(t);
+      (n.delete(e), Ws(n, t));
+    },
+    no = (e, t, n) => {
+      let o = { ...e, ...t, lastUpdatedAt: Date.now() };
+      return (Ks(o, n), o);
+    };
+  var Il = (e, t) => {
+    let [n, o] = U(new Map()),
+      [i, s] = U(false),
+      [r, c] = U(false),
+      l = new Map(),
+      u = new Map(),
+      f = new Map(),
+      p = [],
+      b = [],
+      x = e,
+      H = (w) => f.get(w)?.agent ?? x,
+      M = (w) => f.get(w)?.elements ?? [],
+      Y = (w) => {
+        let v = w ?? x,
+          $ = v?.provider?.canUndo?.() ?? false,
+          N = v?.provider?.canRedo?.() ?? false;
+        (s($), c(N));
+      },
+      m = (w) => {
+        ((x = w), Y());
+      },
+      E = () => x,
+      T = () => Array.from(n().values()).some((w) => w.isStreaming),
+      C = async (w, v, $, N) => {
+        let W = N ?? x,
+          V = W?.storage,
+          oe = false,
+          de = () => l.get(w.id) === $;
+        try {
+          for await (let Q of v) {
+            if (!de()) break;
+            let me = n().get(w.id);
+            if (!me) break;
+            let Se = no(me, { lastStatus: Q }, V);
+            (o((ie) => new Map(ie).set(w.id, Se)), W?.onStatus?.(Q, Se));
+          }
+          if (!de()) return;
+          let G = n().get(w.id);
+          if (G) {
+            let Q = W?.provider?.getCompletionMessage?.(),
+              Ae = no(
+                G,
+                { isStreaming: !1, ...(Q ? { lastStatus: Q } : {}) },
+                V,
+              );
+            o((pe) => new Map(pe).set(w.id, Ae));
+            let me = M(w.id),
+              Se = await W?.onComplete?.(Ae, me),
+              ie = b.findIndex((pe) => pe.session.id === w.id);
+            if (
+              (ie !== -1 && b.splice(ie, 1),
+              b.push({ session: Ae, elements: me, agent: W }),
+              Y(W),
+              (p.length = 0),
+              Se?.error)
+            ) {
+              let pe = no(Ae, { error: Se.error }, V);
+              o((ke) => new Map(ke).set(w.id, pe));
+            }
+          }
+        } catch (I) {
+          if (!de()) return;
+          let Q = n().get(w.id);
+          if (I instanceof Error && I.name === "AbortError") {
+            if (((oe = true), Q)) {
+              let Ae = M(w.id);
+              W?.onAbort?.(Q, Ae);
+            }
+          } else {
+            let Ae = I instanceof Error ? I.message : "Unknown error";
+            if (Q) {
+              let me = no(Q, { error: Ae, isStreaming: false }, V);
+              (o((Se) => new Map(Se).set(w.id, me)),
+                I instanceof Error && W?.onError?.(I, me));
+            }
+          }
+        } finally {
+          if (!de()) return;
+          if ((l.delete(w.id), oe)) {
+            let I = u.get(w.id);
+            (I && (clearTimeout(I), u.delete(w.id)),
+              f.delete(w.id),
+              Rl(w.id, V),
+              o((G) => {
+                let Q = new Map(G);
+                return (Q.delete(w.id), Q);
+              }));
+          }
+        }
+      },
+      R = (w) => {
+        let { selectionBounds: v, tagName: $ } = w,
+          N = v[0];
+        if (!N) return;
+        let W = N.x + N.width / 2,
+          V = N.y + N.height / 2,
+          oe = document.elementFromPoint(W, V);
+        if (!(!oe || ($ && !$.includes(" ") && pt(oe) !== $))) return oe;
+      },
+      X = () => {
+        let w = x?.storage;
+        if (!w) return;
+        let v = Xs(w);
+        if (v.size === 0) return;
+        let $ = Date.now(),
+          N = Array.from(v.values()).filter((V) => {
+            if (V.isStreaming) return true;
+            let oe = V.lastUpdatedAt ?? V.createdAt;
+            return $ - oe < 1e4 && !!V.error;
+          });
+        if (N.length === 0) {
+          Ys(w);
+          return;
+        }
+        if (!x?.provider?.supportsResume || !x.provider.resume) {
+          Ys(w);
+          return;
+        }
+        (u.forEach((V) => clearTimeout(V)),
+          u.clear(),
+          l.forEach((V) => V.abort()),
+          l.clear(),
+          f.clear());
+        let W = new Map(N.map((V) => [V.id, V]));
+        (o(W), Ws(W, w));
+        for (let V of N) {
+          let oe = R(V);
+          oe && x && f.set(V.id, { elements: [oe], agent: x });
+          let de = {
+            ...V,
+            isStreaming: true,
+            error: void 0,
+            lastStatus: V.lastStatus || "Resuming...",
+            position: V.position ?? {
+              x: window.innerWidth / 2,
+              y: window.innerHeight / 2,
+            },
+          };
+          (o((Q) => new Map(Q).set(V.id, de)), x?.onResume?.(de));
+          let I = new AbortController();
+          l.set(V.id, I);
+          let G = x.provider.resume(V.id, I.signal, w);
+          C(V, G, I);
+        }
+      },
+      fe = async (w) => {
+        let {
+            elements: v,
+            prompt: $,
+            position: N,
+            selectionBounds: W,
+            sessionId: V,
+            agent: oe,
+          } = w,
+          de = oe ?? (V ? H(V) : x),
+          I = de?.storage;
+        if (!de?.provider || v.length === 0) return;
+        let G = v[0],
+          Q = V ? n().get(V) : void 0,
+          Ae = !!V,
+          Se = {
+            content: Q
+              ? Q.context.content
+              : (await mr(v, { maxLines: 1 / 0 })).filter((Te) => Te.trim()),
+            prompt: $,
+            options: de?.getOptions?.(),
+            sessionId: Ae ? V : void 0,
+          },
+          ie;
+        if (Q)
+          ie = no(
+            Q,
+            { context: Se, isStreaming: true, lastStatus: "Thinking\u2026" },
+            I,
+          );
+        else {
+          let Te = v.length > 1 ? `${v.length} elements` : pt(G) || void 0,
+            rt = v.length > 1 ? void 0 : (await nr(G)) || void 0;
+          ((ie = Kf(Se, N, W, Te, rt)), (ie.lastStatus = "Thinking\u2026"));
+        }
+        (f.set(ie.id, { elements: v, agent: de }),
+          o((Te) => new Map(Te).set(ie.id, ie)),
+          Ks(ie, I),
+          de.onStart?.(ie, v));
+        let pe = new AbortController();
+        l.set(ie.id, pe);
+        let ke = { ...Se, sessionId: V ?? ie.id },
+          Pe;
+        try {
+          Pe = t?.transformAgentContext
+            ? await t.transformAgentContext(ke, v)
+            : ke;
+        } catch (Te) {
+          let rt =
+              Te instanceof Error
+                ? Te.message
+                : "Context transformation failed",
+            ct = no(ie, { error: rt, isStreaming: false }, I);
+          (o((Ue) => new Map(Ue).set(ie.id, ct)),
+            l.delete(ie.id),
+            Te instanceof Error && de.onError?.(Te, ct));
+          return;
+        }
+        let ge = de.provider.send(Pe, pe.signal);
+        C(ie, ge, pe, de);
+      },
+      j = (w) => {
+        if (w) {
+          let v = l.get(w);
+          v && v.abort();
+        } else
+          (l.forEach((v) => v.abort()),
+            l.clear(),
+            u.forEach((v) => clearTimeout(v)),
+            u.clear(),
+            f.clear(),
+            (b.length = 0),
+            (p.length = 0),
+            o(new Map()),
+            Ys(x?.storage),
+            Y());
+      },
+      le = (w, v, $) => {
+        let W = n().get(w),
+          V = v ?? H(w),
+          oe = $ ?? M(w);
+        if (W?.isFading) return;
+        (W && oe.length > 0 && V?.onDismiss?.(W, oe),
+          o((G) => {
+            let Q = new Map(G),
+              Ae = Q.get(w);
+            return (Ae && Q.set(w, { ...Ae, isFading: true }), Q);
+          }));
+        let de = u.get(w);
+        de && clearTimeout(de);
+        let I = setTimeout(() => {
+          u.delete(w);
+          let G = l.get(w);
+          (G && (G.abort(), l.delete(w)),
+            f.delete(w),
+            Rl(w, V?.storage),
+            o((Q) => {
+              let Ae = new Map(Q);
+              return (Ae.delete(w), Ae);
+            }));
+        }, 150);
+        u.set(w, I);
+      };
+    return {
+      sessions: n,
+      isProcessing: T,
+      canUndo: i,
+      canRedo: r,
+      session: {
+        start: fe,
+        abort: j,
+        dismiss: le,
+        retry: (w) => {
+          let $ = n().get(w),
+            N = H(w);
+          if (!$ || !N?.provider) return;
+          let W = N.storage,
+            V = M(w),
+            oe = no(
+              $,
+              {
+                error: void 0,
+                isStreaming: true,
+                lastStatus: "Retrying\u2026",
+              },
+              W,
+            );
+          (o((Q) => new Map(Q).set(w, oe)),
+            Ks(oe, W),
+            V.length > 0 && N.onStart?.(oe, V));
+          let de = new AbortController();
+          l.set(w, de);
+          let I = { ...oe.context, sessionId: w },
+            G = N.provider.send(I, de.signal);
+          C(oe, G, de, N);
+        },
+        undo: (w) => {
+          let $ = n().get(w),
+            N = H(w),
+            W = M(w);
+          if ($) {
+            p.push({ session: $, elements: W, agent: N });
+            let V = b.findIndex((oe) => oe.session.id === w);
+            (V !== -1 && b.splice(V, 1),
+              N?.onUndo?.($, W),
+              N?.provider?.undo?.());
+          }
+          (le(w, N, W), Y(N));
+        },
+        getElement: (w) => M(w)[0],
+        getElements: (w) => M(w),
+        tryResume: X,
+        acknowledgeError: (w) => {
+          let N = n().get(w)?.context.prompt;
+          return (le(w), N);
+        },
+      },
+      history: {
+        undo: () => {
+          let w = b.pop();
+          if (!w) return;
+          let { session: v, elements: $, agent: N } = w,
+            W = N ?? x;
+          (p.push(w),
+            W?.onUndo?.(v, $),
+            W?.provider?.undo?.(),
+            le(v.id, W, $),
+            Y(W));
+        },
+        redo: () => {
+          let w = p.pop();
+          if (!w) return;
+          let v = w.agent ?? x,
+            { session: $, elements: N } = w;
+          v?.provider?.redo?.();
+          let W = N.filter((V) => et(V));
+          if (W.length === 0) {
+            let V = R($);
+            V && (W = [V]);
+          }
+          if (W.length > 0 && v) {
+            b.push(w);
+            let V = W.map((de) => ze(de)),
+              oe = { ...$, selectionBounds: V };
+            (f.set($.id, { elements: W, agent: v }),
+              o((de) => new Map(de).set($.id, oe)));
+          }
+          Y(v);
+        },
+      },
+      _internal: {
+        updateBoundsOnViewportChange: () => {
+          let w = n();
+          if (w.size === 0) return;
+          let v = new Map(w),
+            $ = false;
+          for (let [N, W] of w) {
+            let V = M(N),
+              oe = V[0];
+            if (et(oe)) {
+              let de = V.filter((I) => et(I)).map((I) => ze(I));
+              if (de.length > 0) {
+                let I = W.selectionBounds[0],
+                  G = de[0],
+                  Q = ns({
+                    currentPosition: W.position,
+                    previousBounds: I,
+                    nextBounds: G,
+                  });
+                (v.set(N, { ...W, selectionBounds: de, position: Q }),
+                  ($ = true));
+              }
+            }
+          }
+          $ && o(v);
+        },
+        setOptions: m,
+        getOptions: E,
+      },
+    };
+  };
+  var Xf = (e, t) => {
+    let n = [],
+      o = (u, f) => {
+        let p = t(u),
+          b = Ds(p.x + p.width / 2, p.y + p.height / 2).filter(e),
+          x = b.indexOf(u);
+        return x === -1 ? null : (b[x + f] ?? null);
+      },
+      i = (u) => {
+        let f = o(u, 1);
+        return (f && (n.push(u), n.length > ka && (n = n.slice(-ka))), f);
+      },
+      s = (u) => {
+        if (n.length > 0) {
+          let f = n.pop();
+          if (et(f)) return f;
+        }
+        return o(u, -1);
+      },
+      r = (u, f) => {
+        let p = (H) => {
+            let M = Array.from(H.children),
+              Y = f ? M : M.reverse();
+            for (let m of Y)
+              if (f) {
+                if (e(m)) return m;
+                let E = p(m);
+                if (E) return E;
+              } else {
+                let E = p(m);
+                if (E) return E;
+                if (e(m)) return m;
+              }
+            return null;
+          },
+          b = (H) => (f ? H.nextElementSibling : H.previousElementSibling),
+          x = null;
+        if ((f && (x = p(u)), !x)) {
+          let H = u;
+          for (; H; ) {
+            let M = b(H);
+            for (; M; ) {
+              let m = p(M);
+              if (m) {
+                x = m;
+                break;
+              }
+              if (e(M)) {
+                x = M;
+                break;
+              }
+              M = b(M);
+            }
+            if (x) break;
+            let Y = H.parentElement;
+            if (!f && Y && e(Y)) {
+              x = Y;
+              break;
+            }
+            H = Y;
+          }
+        }
+        return x;
+      };
+    return {
+      findNext: (u, f) => {
+        switch (u) {
+          case "ArrowUp":
+            return i(f);
+          case "ArrowDown":
+            return s(f);
+          case "ArrowRight":
+            return r(f, true);
+          case "ArrowLeft":
+            return r(f, false);
+          default:
+            return null;
+        }
+      },
+      clearHistory: () => {
+        n = [];
+      },
+    };
+  };
+  var Yf = (e) => {
+      let {
+        metaKey: t,
+        ctrlKey: n,
+        shiftKey: o,
+        altKey: i,
+      } = Gf(e.activationKey);
+      return { metaKey: t, ctrlKey: n, shiftKey: o, altKey: i };
+    },
+    qf = () => {
+      let e = new WeakSet(),
+        t = Object.getOwnPropertyDescriptor(KeyboardEvent.prototype, "key"),
+        n = false;
+      if (t?.get && !t.get.__reactGrabPatched) {
+        n = true;
+        let i = t.get,
+          s = function () {
+            return e.has(this) ? "" : i.call(this);
+          };
+        ((s.__reactGrabPatched = true),
+          Object.defineProperty(KeyboardEvent.prototype, "key", {
+            get: s,
+            configurable: true,
+          }));
+      }
+      return {
+        claimedEvents: e,
+        originalKeyDescriptor: t,
+        didPatch: n,
+        restore: () => {
+          n && t && Object.defineProperty(KeyboardEvent.prototype, "key", t);
+        },
+      };
+    };
+  var Nl = (e, t) => ({
+      top: t < 25,
+      bottom: t > window.innerHeight - 25,
+      left: e < 25,
+      right: e > window.innerWidth - 25,
+    }),
+    Zf = (e, t) => {
+      let n = null,
+        o = () => {
+          if (!t()) {
+            s();
+            return;
+          }
+          let c = e(),
+            l = Nl(c.x, c.y);
+          (l.top && window.scrollBy(0, -10),
+            l.bottom && window.scrollBy(0, 10),
+            l.left && window.scrollBy(-10, 0),
+            l.right && window.scrollBy(10, 0),
+            l.top || l.bottom || l.left || l.right ? (n = Ve(o)) : (n = null));
+        },
+        i = () => {
+          o();
+        },
+        s = () => {
+          n !== null && (Ge(n), (n = null));
+        };
+      return { start: i, stop: s, isActive: () => n !== null };
+    };
+  var Jf = () => {
+    let e = globalThis;
+    return !!(e.chrome?.runtime?.id || e.browser?.runtime?.id);
+  };
+  var Qf = () => {
+    try {
+      let e = "0.1.21",
+        t = `data:image/svg+xml;base64,${btoa(yu)}`;
+      (console.log(
+        `%cReact Grab${e ? ` v${e}` : ""}%c
+https://react-grab.com`,
+        `background: #330039; color: #ffffff; border: 1px solid #d75fcb; padding: 4px 4px 4px 24px; border-radius: 4px; background-image: url("${t}"); background-size: 16px 16px; background-repeat: no-repeat; background-position: 4px center; display: inline-block; margin-bottom: 4px;`,
+        "",
+      ),
+        navigator.onLine &&
+          e &&
+          !Jf() &&
+          fetch(
+            `https://www.react-grab.com/api/version?source=browser&t=${Date.now()}`,
+            {
+              referrerPolicy: "origin",
+              keepalive: !0,
+              priority: "low",
+              cache: "no-store",
+            },
+          )
+            .then((n) => n.text())
+            .then((n) => {
+              n &&
+                n !== e &&
+                console.warn(`[React Grab] v${e} is outdated (latest: v${n})`);
+            })
+            .catch(() => null));
+    } catch {}
+  };
+  var em = (e) => {
+    if ("scheduler" in globalThis) {
+      globalThis.scheduler.postTask(e, { priority: "background" });
+      return;
+    }
+    if (typeof window < "u" && "requestIdleCallback" in window) {
+      requestIdleCallback(e);
+      return;
+    }
+    setTimeout(e, 0);
+  };
+  var tm = () => {
+    if (typeof window > "u") return null;
+    try {
+      let e = document.currentScript?.getAttribute("data-options");
+      return e ? JSON.parse(e) : null;
+    } catch {
+      return null;
+    }
+  };
+  var So = (e) => e === "Enter" || e === "NumpadEnter";
+  var nm = {
+    name: "copy",
+    setup: (e) => {
+      let t = false;
+      return {
+        hooks: {
+          onElementSelect: (n) => {
+            if (t) return ((t = false), e.copyElement(n), true);
+          },
+          onDeactivate: () => {
+            t = false;
+          },
+          cancelPendingToolbarActions: () => {
+            t = false;
+          },
+        },
+        actions: [
+          {
+            id: "copy",
+            label: "Copy",
+            shortcut: "C",
+            onAction: (n) => {
+              n.copy?.();
+            },
+          },
+          {
+            id: "copy-toolbar",
+            label: "Copy element",
+            shortcut: "C",
+            target: "toolbar",
+            onAction: () => {
+              ((t = true), e.activate());
+            },
+          },
+        ],
+      };
+    },
+  };
+  var Ll = {
+    name: "comment",
+    setup: (e) => ({
+      actions: [
+        {
+          id: "comment",
+          label: "Comment",
+          shortcut: "Enter",
+          onAction: (t) => {
+            t.enterPromptMode?.();
+          },
+        },
+        {
+          id: "comment-toolbar",
+          label: "Comment",
+          shortcut: "Enter",
+          target: "toolbar",
+          onAction: () => {
+            e.comment();
+          },
+        },
+      ],
+    }),
+  };
+  var Dl = {
+    name: "open",
+    actions: [
+      {
+        id: "open",
+        label: "Open",
+        shortcut: "O",
+        enabled: (e) => !!e.filePath,
+        onAction: (e) => {
+          if (!e.filePath) return;
+          (e.hooks.onOpenFile(e.filePath, e.lineNumber) ||
+            or(e.filePath, e.lineNumber, e.hooks.transformOpenFileUrl),
+            e.hideContextMenu(),
+            e.cleanup());
+        },
+      },
+    ],
+  };
+  var gr = (e, t) =>
+    t
+      ? `${e}
+${t}`
+      : e;
+  var om = {
+    name: "copy-html",
+    setup: (e, t) => {
+      let n = false;
+      return {
+        hooks: {
+          onElementSelect: (o) => {
+            if (n)
+              return (
+                (n = false),
+                Promise.all([
+                  t.transformHtmlContent(o.outerHTML, [o]),
+                  e.getStackContext(o),
+                ])
+                  .then(([i, s]) => {
+                    i && Xt(gr(i, s));
+                  })
+                  .catch(() => {}),
+                true
+              );
+          },
+          onDeactivate: () => {
+            n = false;
+          },
+          cancelPendingToolbarActions: () => {
+            n = false;
+          },
+        },
+        actions: [
+          {
+            id: "copy-html",
+            label: "Copy HTML",
+            onAction: async (o) => {
+              await o.performWithFeedback(async () => {
+                let i = o.elements.map((c) => c.outerHTML).join(`
 
-`),s=await o.hooks.transformHtmlContent(i,o.elements);if(!s)return  false;let r=await e.getStackContext(o.element);return Xt(gr(s,r),{componentName:o.componentName,tagName:o.tagName})});}},{id:"copy-html-toolbar",label:"Copy HTML",target:"toolbar",onAction:()=>{n=true,e.activate();}}]}}};var ew=new Map(["top","right","bottom","left"].flatMap(e=>[[`border-${e}-style`,e],[`border-${e}-color`,e]])),oo=null,Fl=new Map,tw=()=>oo||(oo=document.createElement("iframe"),oo.style.cssText="position:fixed;left:-9999px;width:0;height:0;border:none;visibility:hidden;",document.body.appendChild(oo),oo),nw=e=>{let t=Fl.get(e);if(t)return t;let n=tw(),o=n.contentDocument,i=o.createElement(e);o.body.appendChild(i);let s=n.contentWindow.getComputedStyle(i),r=new Map;for(let c of Ia){let l=s.getPropertyValue(c);l&&r.set(c,l);}return i.remove(),Fl.set(e,r),r},ow=(e,t)=>{let n=ew.get(e);if(!n)return  false;let o=t.getPropertyValue(`border-${n}-width`);return o==="0px"||o==="0"},$l=e=>{let t=e.tagName.toLowerCase(),n=nw(t),o=getComputedStyle(e),i=[];for(let c of Ia){let l=o.getPropertyValue(c);l&&l!==n.get(c)&&(ow(c,o)||i.push(`${c}: ${l};`));}let s=e.getAttribute("class")?.trim(),r=i.join(`
-`);return s?r?`className: ${s}
+`),
+                  s = await o.hooks.transformHtmlContent(i, o.elements);
+                if (!s) return false;
+                let r = await e.getStackContext(o.element);
+                return Xt(gr(s, r), {
+                  componentName: o.componentName,
+                  tagName: o.tagName,
+                });
+              });
+            },
+          },
+          {
+            id: "copy-html-toolbar",
+            label: "Copy HTML",
+            target: "toolbar",
+            onAction: () => {
+              ((n = true), e.activate());
+            },
+          },
+        ],
+      };
+    },
+  };
+  var ew = new Map(
+      ["top", "right", "bottom", "left"].flatMap((e) => [
+        [`border-${e}-style`, e],
+        [`border-${e}-color`, e],
+      ]),
+    ),
+    oo = null,
+    Fl = new Map(),
+    tw = () =>
+      oo ||
+      ((oo = document.createElement("iframe")),
+      (oo.style.cssText =
+        "position:fixed;left:-9999px;width:0;height:0;border:none;visibility:hidden;"),
+      document.body.appendChild(oo),
+      oo),
+    nw = (e) => {
+      let t = Fl.get(e);
+      if (t) return t;
+      let n = tw(),
+        o = n.contentDocument,
+        i = o.createElement(e);
+      o.body.appendChild(i);
+      let s = n.contentWindow.getComputedStyle(i),
+        r = new Map();
+      for (let c of Ia) {
+        let l = s.getPropertyValue(c);
+        l && r.set(c, l);
+      }
+      return (i.remove(), Fl.set(e, r), r);
+    },
+    ow = (e, t) => {
+      let n = ew.get(e);
+      if (!n) return false;
+      let o = t.getPropertyValue(`border-${n}-width`);
+      return o === "0px" || o === "0";
+    },
+    $l = (e) => {
+      let t = e.tagName.toLowerCase(),
+        n = nw(t),
+        o = getComputedStyle(e),
+        i = [];
+      for (let c of Ia) {
+        let l = o.getPropertyValue(c);
+        l && l !== n.get(c) && (ow(c, o) || i.push(`${c}: ${l};`));
+      }
+      let s = e.getAttribute("class")?.trim(),
+        r = i.join(`
+`);
+      return s
+        ? r
+          ? `className: ${s}
 
-${r}`:`className: ${s}`:r},rm=()=>{oo?.remove(),oo=null,Fl.clear();};var im={name:"copy-styles",setup:e=>{let t=false;return {hooks:{onElementSelect:n=>{if(!t)return;t=false;let o=$l(n);return e.getStackContext(n).then(i=>{Xt(gr(o,i));}).catch(()=>{}),true},onDeactivate:()=>{t=false;},cancelPendingToolbarActions:()=>{t=false;}},actions:[{id:"copy-styles",label:"Copy styles",onAction:async n=>{await n.performWithFeedback(async()=>{let o=n.elements.map($l).join(`
+${r}`
+          : `className: ${s}`
+        : r;
+    },
+    rm = () => {
+      (oo?.remove(), (oo = null), Fl.clear());
+    };
+  var im = {
+    name: "copy-styles",
+    setup: (e) => {
+      let t = false;
+      return {
+        hooks: {
+          onElementSelect: (n) => {
+            if (!t) return;
+            t = false;
+            let o = $l(n);
+            return (
+              e
+                .getStackContext(n)
+                .then((i) => {
+                  Xt(gr(o, i));
+                })
+                .catch(() => {}),
+              true
+            );
+          },
+          onDeactivate: () => {
+            t = false;
+          },
+          cancelPendingToolbarActions: () => {
+            t = false;
+          },
+        },
+        actions: [
+          {
+            id: "copy-styles",
+            label: "Copy styles",
+            onAction: async (n) => {
+              await n.performWithFeedback(async () => {
+                let o = n.elements.map($l).join(`
 
-`),i=await e.getStackContext(n.element);return Xt(gr(o,i),{componentName:n.componentName,tagName:n.tagName})});}},{id:"copy-styles-toolbar",label:"Copy styles",target:"toolbar",onAction:()=>{t=true,e.activate();}}],cleanup:rm}}};var sm="react-grab-history-items",rw=()=>{try{let e=sessionStorage.getItem(sm);return e?JSON.parse(e).map(n=>({...n,elementsCount:Math.max(1,n.elementsCount??1),previewBounds:n.previewBounds??[],elementSelectors:n.elementSelectors??[]})):[]}catch{return []}},iw=e=>{let t=e;for(;t.length>0;){let n=JSON.stringify(t);if(new Blob([n]).size<=pu)return t;t=t.slice(0,-1);}return t},Hl=e=>{try{let t=iw(e);sessionStorage.setItem(sm,JSON.stringify(t));}catch{}},Yt=rw(),sw=()=>`history-${Date.now()}-${Math.random().toString(36).substring(2,9)}`,Bl=()=>Yt,am=e=>(Yt=[{...e,id:sw()},...Yt].slice(0,mu),Hl(Yt),Yt),zl=e=>(Yt=Yt.filter(t=>t.id!==e),Hl(Yt),Yt),lm=()=>(Yt=[],Hl(Yt),Yt);var ww=[nm,Ll,om,im,Dl],Vl=false,ro=new Set,Gl=e=>{if(typeof window>"u")return El();let t=tm(),n={enabled:true,activationMode:"toggle",keyHoldDuration:100,allowActivationInsideInput:true,maxContextLines:3,...t,...e};if(n.enabled===false||Vl)return El();Vl=true,Qf();let{enabled:o,...i}=n;return Tn(s=>{let r=jf(i),c=()=>{for(let a of r.store.actions)if(a.agent?.provider)return a.agent},{store:l,actions:u}=Tu({theme:to,hasAgentProvider:!!c()?.provider,keyHoldDuration:r.store.options.keyHoldDuration??100}),f=se(()=>l.current.state==="holding"),p=se(()=>l.current.state==="active");be(He(p,(a,d)=>{a&&!d?($s(),Ns(),document.body.style.touchAction="none"):!a&&d&&(ci(),si(),document.body.style.touchAction="");}));let b=se(()=>l.current.state==="active"&&l.current.phase==="frozen"),x=se(()=>l.current.state==="active"&&l.current.phase==="dragging"),H=se(()=>l.current.state==="active"&&l.current.phase==="justDragged"),M=se(()=>l.current.state==="copying"),Y=se(()=>l.current.state==="justCopied"),m=se(()=>l.current.state==="active"&&l.current.isPromptMode),E=se(()=>l.pendingCommentMode||m()),T=se(()=>l.current.state==="active"&&l.current.isPromptMode&&l.current.isPendingDismiss),C=yo(),[R,X]=U(C?.enabled??true),[fe,j]=U(0),[le,ue]=U(C),[L,A]=U(false),[y,h]=U(Bl()),[S,D]=U(null),[B,w]=U(null),[v,$]=U(null),N,W=null,V=new Map,[oe,de]=U(false),[I,G]=U(0),[Q,Ae]=U(false),me=[],Se=a=>V.get(a)??[],ie=a=>{let d=a.elementSelectors??[];if(d.length===0)return [];let g=[];for(let _ of d)if(_)try{let P=document.querySelector(_);et(P)&&g.push(P);}catch{}return g},pe=a=>{let d=Se(a.id),g=d.filter(F=>et(F));if(d.length>0&&g.length===d.length)return g;let P=ie(a);return P.length>0?(V.set(a.id,P),P):g},ke=a=>pe(a)[0],Pe=se(()=>{S();let a=new Set;for(let d of y())pe(d).length===0&&a.add(d.id);return a},void 0,{equals:(a,d)=>{if(a.size!==d.size)return  false;for(let g of d)if(!a.has(g))return  false;return  true}}),ge=se(()=>l.pendingAbortSessionId),Te=se(()=>l.hasAgentProvider),rt=()=>{sn!==null&&(clearTimeout(sn),sn=null);},ct=()=>{_o=false,qt=false,Pt=null;};be(()=>{if(l.current.state!=="holding"){rt();return}Pt=Date.now(),sn=window.setTimeout(()=>{if(sn=null,_o){qt=true;return}u.activate();},l.keyHoldDuration),Me(rt);}),be(()=>{if(l.current.state!=="active"||l.current.phase!=="justDragged")return;let a=setTimeout(()=>{u.finishJustDragged();},1500);Me(()=>clearTimeout(a));}),be(()=>{if(l.current.state!=="justCopied")return;let a=setTimeout(()=>{u.finishJustCopied();},1500);Me(()=>clearTimeout(a));}),be(He(f,(a,d=false)=>{!d||a||!p()||(r.store.options.activationMode!=="hold"&&u.setWasActivatedByToggle(true),r.hooks.onActivate());}));let Ue=(a,d,g)=>{bn(a,d,g),u.clearInputText();},wt=()=>{let a=l.frozenElement||ee();a&&u.enterPromptMode({x:l.pointer.x,y:l.pointer.y},a);},bn=(a,d,g)=>(u.setCopyStart({x:d,y:g},a),ze(a)),Ht=0,Bt=0,Rt=0,yn=0,xt=null,[Dn,To]=U(null),It=(a,d)=>{xt!==null&&clearTimeout(xt),To(null),xt=window.setTimeout(()=>{To({x:a,y:d}),xt=null;},32);},st=null,sn=null,Pt=null,_o=false,qt=false,Po=0,Fe=false,Zt=null,an=null,Nt=0,zt=0,Vt=null,Gt=null,Ut=false,[Qs,ko]=U(null),[wn,hr]=U(void 0),[br,hi]=U([]),[Oo,bi]=U(null),[Fn,yi]=U([]),[yr,$n]=U(0),ln=Xf(gn,ze),cn=Zf(()=>l.pointer,()=>x()),Lt=se(()=>p()&&!M()),xn=se(()=>r.store.theme.enabled&&r.store.theme.crosshair.enabled&&Lt()&&!x()&&!l.isTouchMode&&!b()&&!m()&&!L()&&l.contextMenuPosition===null),gt=new Map,wi=(a,d)=>{let g=`grabbed-${Date.now()}-${Math.random()}`,_=Date.now(),P={id:g,bounds:a,createdAt:_,element:d};u.addGrabbedBox(P),r.hooks.onGrabbedBox(a,d);let F=window.setTimeout(()=>{gt.delete(g),u.removeGrabbedBox(g);},1500);gt.set(g,F);},wr=async a=>{let d=await Promise.all(a.map(async g=>{let _=await Mn(g),P=null,F,re,ce;if(_&&_.length>0)for(let Ce of _){let We=Ce.functionName&&er(Ce.functionName),nt=Ce.fileName&&ho(Ce.fileName);if(We&&!P&&(P=Ce.functionName),nt&&!F&&(F=go(Ce.fileName),re=Ce.lineNumber||void 0,ce=Ce.columnNumber||void 0),P&&F)break}P||(P=Kr(g));let Le=g instanceof HTMLElement?g.innerText?.slice(0,$r):void 0;return {tagName:pt(g),id:g.id||void 0,className:g.getAttribute("class")||void 0,textContent:Le,componentName:P??void 0,filePath:F,lineNumber:re,columnNumber:ce}}));window.dispatchEvent(new CustomEvent("react-grab:element-selected",{detail:{elements:d}}));},vt=(a,d,g,_,P)=>{u.clearLabelInstances();let F=`label-${Date.now()}-${Math.random().toString(36).slice(2)}`,re=a.x+a.width/2,ce=a.width/2,Le=P?.mouseX,Ce=Le!==void 0?Le-re:void 0,We={id:F,bounds:a,boundsMultiple:P?.boundsMultiple,tagName:d,componentName:g,status:_,createdAt:Date.now(),element:P?.element,elements:P?.elements,mouseX:Le,mouseXOffsetFromCenter:Ce,mouseXOffsetRatio:Ce!==void 0&&ce>0?Ce/ce:void 0,hideArrow:P?.hideArrow};return u.addLabelInstance(We),F},Hn=a=>{jt.delete(a),u.removeLabelInstance(a);},jt=new Map,vn=a=>{let d=jt.get(a);d!==void 0&&(window.clearTimeout(d),jt.delete(a));},Jt=a=>{vn(a);let d=window.setTimeout(()=>{jt.delete(a),u.updateLabelInstance(a,"fading"),setTimeout(()=>{Hn(a);},150);},1500);jt.set(a,d);},ea=(a,d)=>{if(d)vn(a);else {let g=l.labelInstances.find(_=>_.id===a);g&&g.status==="copied"&&Jt(a);}},ta=async({positionX:a,operation:d,bounds:g,tagName:_,componentName:P,element:F,shouldDeactivateAfter:re,elements:ce,existingInstanceId:Le})=>{Fe=false,l.current.state!=="copying"&&u.startCopy();let Ce=Le??null;!Ce&&g&&_&&(Ce=vt(g,_,P,"copying",{element:F,mouseX:a,elements:ce}));let We=false,nt;try{await d(),We=!0;}catch(lt){nt=lt instanceof Error&&lt.message?lt.message:"Action failed";}Ce&&(We?u.updateLabelInstance(Ce,"copied"):u.updateLabelInstance(Ce,"error",nt||"Unknown error"),Jt(Ce)),l.current.state==="copying"&&(We&&u.completeCopy(F),re?Qe():We?(u.activate(),Fe=true,Zt!==null&&window.clearTimeout(Zt),Zt=window.setTimeout(()=>{Fe=false,Zt=null;},1500)):u.unfreeze());},xr=(a,d,g)=>{let _=a[0],P=g??(_?Kr(_):null),F=_?pt(_):null,re=P??F??void 0;return kf({maxContextLines:r.store.options.maxContextLines,getContent:r.store.options.getContent,componentName:re},{onBeforeCopy:r.hooks.onBeforeCopy,transformSnippet:r.hooks.transformSnippet,transformCopyContent:r.hooks.transformCopyContent,onAfterCopy:r.hooks.onAfterCopy,onCopySuccess:(ce,Le)=>{r.hooks.onCopySuccess(ce,Le);let Ce=ce.length>0,We=!!d;if(Ce){let At=y();for(let[dn,fn]of V.entries()){if(!(fn.length===ce.length&&fn.every((fa,ep)=>fa===ce[ep])))continue;let Vn=At.find(fa=>fa.id===dn);if(!Vn)continue;if(We?Vn.isComment&&Vn.commentText===d:!Vn.isComment){zl(dn),V.delete(dn);break}}}let nt=ce.map((At,dn)=>Hf(At,dn===0)),lt=am({content:Le,elementName:re??"element",tagName:F??"div",componentName:P??void 0,elementsCount:ce.length,previewBounds:ce.map(At=>ze(At)),elementSelectors:nt,isComment:We,commentText:d??void 0,timestamp:Date.now()});h(lt),de(true),G(At=>At+1);let Dt=lt[0];Dt&&Ce&&V.set(Dt.id,[...ce]);let Or=new Set(lt.map(At=>At.id));for(let At of V.keys())Or.has(At)||V.delete(At);},onCopyError:r.hooks.onCopyError},a,d)},k=async(a,d,g)=>{if(a.length===0)return;let _=[],P=[];for(let F of a){let{wasIntercepted:re,pendingResult:ce}=r.hooks.onElementSelect(F);re||_.push(F),ce&&P.push(ce),r.store.theme.grabbedBoxes.enabled&&wi(ze(F),F);}if(await Mu(),_.length>0)await xr(_,d,g);else if(P.length>0&&!(await Promise.all(P)).every(Boolean))throw new Error("Failed to copy");wr(a);},q=({element:a,positionX:d,elements:g,extraPrompt:_,shouldDeactivateAfter:P,onComplete:F,dragRect:re})=>{let ce=g??[a],Le=re??l.frozenDragRect,Ce;Le&&ce.length>1?Ce=Bs(Le):Ce=zs(ze(a));let We=ce.length>1?Ce.x+Ce.width/2:d,nt=pt(a);Fe=false,u.startCopy();let lt=nt?vt(Ce,nt,void 0,"copying",{element:a,mouseX:We,elements:g}):null;nr(a).then(Dt=>{ta({positionX:We,operation:()=>k(ce,_,Dt??void 0),bounds:Ce,tagName:nt,componentName:Dt??void 0,element:a,shouldDeactivateAfter:P,elements:g,existingInstanceId:lt}).then(()=>{F?.();});});},ee=se(()=>{if(l.viewportVersion,!Lt()||x())return null;let a=l.detectedElement;return et(a)?a:null}),ne=se(()=>l.frozenElement||(b()?null:ee()));be(()=>{let a=l.detectedElement;if(!a)return;let d=setInterval(()=>{et(a)||u.setDetectedElement(null);},100);Me(()=>clearInterval(d));}),be(He(ne,a=>{if(Vt!==null&&(clearTimeout(Vt),Vt=null),!a){ko(null);return}Vt=window.setTimeout(()=>{Vt=null,ko(a);},100);})),Me(()=>{Vt!==null&&(clearTimeout(Vt),Vt=null);}),be(()=>{let a=l.frozenElements,d=tf(a);Me(d);}),be(He(p,a=>{if(!a||!r.store.options.freezeReactUpdates)return;let d=Rs();Me(d);}));let xe=()=>{if(l.isTouchMode&&x()){let d=l.detectedElement;return !d||vo(d)?void 0:d}let a=ne();if(!(!a||vo(a)))return a},ve=se(()=>xe()),he=()=>ve()?l.isTouchMode&&x()?Lt():Lt()&&!x():false,De=se(()=>{l.viewportVersion;let a=l.frozenElements;if(a.length===0)return [];let d=l.frozenDragRect;return d&&a.length>1?[Bs(d)]:a.filter(g=>g!==null).map(g=>ze(g))}),Oe=se(()=>{l.viewportVersion;let a=l.frozenElements;if(a.length>0){let g=De();if(a.length===1){let P=g[0];if(P)return P}let _=l.frozenDragRect;return _?g[0]??Bs(_):zs(Ol(g))}let d=ve();if(d)return ze(d)}),je=se(()=>l.frozenElements.length),qe=(a,d)=>{let g=a+window.scrollX,_=d+window.scrollY;return {x:Math.abs(g-l.dragStart.x),y:Math.abs(_-l.dragStart.y)}},tt=se(()=>{if(!x())return  false;let a=qe(l.pointer.x,l.pointer.y);return a.x>2||a.y>2}),Ne=(a,d)=>{let g=a+window.scrollX,_=d+window.scrollY,P=Math.min(l.dragStart.x,g),F=Math.min(l.dragStart.y,_),re=Math.abs(g-l.dragStart.x),ce=Math.abs(_-l.dragStart.y);return {x:P-window.scrollX,y:F-window.scrollY,width:re,height:ce}},ut=se(()=>{if(l.viewportVersion,!tt())return;let a=Ne(l.pointer.x,l.pointer.y);return {borderRadius:"0px",height:a.height,transform:"none",width:a.width,x:a.x,y:a.y}}),at=se(()=>{if(l.viewportVersion,!tt())return [];let a=Dn();if(!a)return [];let d=Ne(a.x,a.y),g=fi(d,gn);return (g.length>0?g:fi(d,gn,false)).map(P=>ze(P))}),kt=se(()=>{let a=at();return a.length>0?a:De()}),un=se(()=>{if(M()||m()){l.viewportVersion;let a=l.frozenElement||ee();if(a){let d=ze(a);return {x:kn(d).x+l.copyOffsetFromCenterX,y:l.copyStart.y}}return {x:l.copyStart.x,y:l.copyStart.y}}return {x:l.pointer.x,y:l.pointer.y}});be(He(()=>[ee(),l.lastGrabbedElement],([a,d])=>{d&&a&&d!==a&&u.setLastGrabbed(null),a&&r.hooks.onElementHover(a);})),be(He(()=>ee(),a=>{let d=++Nt,g=()=>{Nt===d&&u.setSelectionSource(null,null);};if(!a){g();return}Mn(a).then(_=>{if(Nt===d&&_){for(let P of _)if(P.fileName&&ho(P.fileName)){u.setSelectionSource(go(P.fileName),P.lineNumber??null);return}g();}}).catch(()=>{Nt===d&&u.setSelectionSource(null,null);});})),be(He(()=>l.viewportVersion,()=>Ze._internal.updateBoundsOnViewportChange()));let Cn=se(()=>l.grabbedBoxes.map(a=>({id:a.id,bounds:a.bounds,createdAt:a.createdAt}))),xi=se(()=>l.labelInstances.map(a=>({id:a.id,status:a.status,tagName:a.tagName,componentName:a.componentName,createdAt:a.createdAt}))),En=se(()=>{let a=p(),d=x(),g=M(),_=m(),P=xn(),F=ee(),re=ut(),ce=r.store.theme.enabled,Le=r.store.theme.selectionBox.enabled,Ce=r.store.theme.dragBox.enabled,We=tt(),nt=ne(),lt=Y(),Dt=!!(ce&&Le&&a&&!g&&!lt&&!d&&nt!=null);return {isActive:a,isDragging:d,isCopying:g,isPromptMode:_,isCrosshairVisible:P??false,isSelectionBoxVisible:Dt,isDragBoxVisible:!!(ce&&Ce&&a&&!g&&We),targetElement:F,dragBounds:re?{x:re.x,y:re.y,width:re.width,height:re.height}:null,grabbedBoxes:Cn(),labelInstances:xi(),selectionFilePath:l.selectionFilePath,toolbarState:le()}});be(He(En,a=>{r.hooks.onStateChange(a);})),be(He(()=>[m(),l.pointer.x,l.pointer.y,ee()],([a,d,g,_])=>{r.hooks.onPromptModeChange(a,{x:d,y:g,targetElement:_});})),be(He(()=>[sa(),Oe(),ee()],([a,d,g])=>{r.hooks.onSelectionBox(!!a,d??null,g);})),be(He(()=>[aa(),ut()],([a,d])=>{r.hooks.onDragBox(!!a,d??null);})),be(He(()=>[xn(),l.pointer.x,l.pointer.y],([a,d,g])=>{r.hooks.onCrosshair(!!a,{x:d,y:g});})),be(He(()=>[Dm(),Lm(),un(),ee(),l.selectionFilePath,l.selectionLineNumber],([a,d,g,_,P,F])=>{r.hooks.onElementLabel(!!a,d,{x:g.x,y:g.y,content:"",element:_??void 0,tagName:_&&pt(_)||void 0,filePath:P??void 0,lineNumber:F??void 0});}));let Qt=null,Mo=a=>{a?(Qt||(Qt=document.createElement("style"),Qt.setAttribute("data-react-grab-cursor",""),document.head.appendChild(Qt)),Qt.textContent=`* { cursor: ${a} !important; }`):Qt&&(Qt.remove(),Qt=null);};be(He(()=>[p(),M(),m()],([a,d,g])=>{Mo(d?"progress":a&&!g?"crosshair":null);}));let en=()=>{let a=f();u.activate(),a||r.hooks.onActivate();},vi=()=>{Zt!==null&&(window.clearTimeout(Zt),Zt=null),Fe=false;},Qe=()=>{let a=x(),d=l.previouslyFocusedElement;u.deactivate(),Ar(),Gt=null,Ut=false,a&&(document.body.style.userSelect=""),st&&window.clearTimeout(st),cn.stop(),d instanceof HTMLElement&&et(d)&&d.focus(),r.hooks.onDeactivate();},vr=()=>{f()&&u.release(),p()&&Qe(),vi();},Z=()=>{u.setWasActivatedByToggle(true),en();},io=(a,d,g)=>{let _=d[0];if(et(_)){let P=_.getBoundingClientRect(),F=P.top+P.height/2;u.setPointer({x:a.position.x,y:F}),u.setFrozenElements(d),u.setInputText(a.context.prompt),u.setWasActivatedByToggle(true),g&&u.setSelectedAgent(g),p()||en();}},Bn=a=>({...a,onAbort:(d,g)=>{a.onAbort?.(d,g),io(d,g,a);},onUndo:(d,g)=>{a.onUndo?.(d,g),io(d,g,a);}}),Ro=()=>{let a=c();if(a)return Bn(a)},Ze=Il(Ro(),{transformAgentContext:r.hooks.transformAgentContext}),Cr=()=>{u.clearLastCopied();let a=[...l.frozenElements],d=l.frozenElement||ee(),g=m()?l.inputText.trim():"";if(!d){Qe();return}let _=a.length>0?a:d?[d]:[],P=_.map(Ce=>ze(Ce)),F=P[0],re=F.x+F.width/2,ce=F.y+F.height/2,Le=re+l.copyOffsetFromCenterX;if((l.selectedAgent||Te())&&g){let Ce=l.replySessionId,We=l.selectedAgent;Qe(),u.clearReplySessionId(),u.setSelectedAgent(null),Ze.session.start({elements:_,prompt:g,position:{x:Le,y:ce},selectionBounds:P,sessionId:Ce??void 0,agent:We?Bn(We):void 0});return}u.setPointer({x:re,y:ce}),u.exitPromptMode(),u.clearInputText(),u.clearReplySessionId(),q({element:d,positionX:Le,elements:_,extraPrompt:g||void 0,onComplete:Qe});},so=()=>{if(u.clearLastCopied(),!m())return;if(l.inputText.trim()&&!T()){u.setPendingDismiss(true);return}u.clearInputText(),u.clearReplySessionId(),Qe();},Ci=()=>{u.clearInputText(),u.clearReplySessionId(),Qe();},Ei=()=>{u.setPendingDismiss(false);},Si=(a,d)=>{u.setPendingAbortSessionId(null),d&&Ze.session.abort(a);},Ai=()=>{let a=l.frozenElement||ee();a&&Ue(a,l.pointer.x,l.pointer.y),wt();},Ti=(a,d)=>{let g=Ze.sessions().get(a),_=Ze.session.getElements(a),P=g?.selectionBounds??[],F=P[0];if(g&&_.length>0&&F){let re=g.position.x,ce=g.context.sessionId??a;Ze.session.dismiss(a),Ze.session.start({elements:_,prompt:d,position:{x:re,y:F.y+F.height/2},selectionBounds:P,sessionId:ce});}},_i=a=>{let d=Ze.session.acknowledgeError(a);d&&u.setInputText(d);},Pi=()=>{p()?Qe():R()&&(Ut=true,Z());},Er=(a,d,g)=>{u.setPendingCommentMode(false),u.clearInputText(),u.enterPromptMode({x:d,y:g},a);},Io=(a,d)=>{u.showContextMenu(d,a),Ar(),rc(),r.hooks.onContextMenu(a,d);},ki=()=>{if(!R())return;if(p()&&E()){Qe();return}u.setPendingCommentMode(true),p()||Z();},Oi=()=>{let a=!R();X(a);let d=yo(),g={edge:d?.edge??"bottom",ratio:d?.ratio??.5,collapsed:d?.collapsed??false,enabled:a};Qr(g),ue(g),ro.forEach(_=>_(g)),a||(vr(),rc());},Mi=(a,d)=>{if(!R()||m()||b()||l.contextMenuPosition!==null)return;u.setPointer({x:a,y:d}),Rt=a,yn=d;let g=performance.now(),_=Bt>0&&g-Bt<200;if(g-Ht>=32&&!_&&(Ht=g,Bt=g,em(()=>{let P=dr(Rt,yn);P!==l.detectedElement&&u.setDetectedElement(P),Bt=0;})),x()){It(a,d);let P=Nl(a,d),F=P.top||P.bottom||P.left||P.right;F&&!cn.isActive()?cn.start():!F&&cn.isActive()&&cn.stop();}},Ri=(a,d)=>!Lt()||M()?false:(u.startDrag({x:a,y:d}),u.setPointer({x:a,y:d}),document.body.style.userSelect="none",It(a,d),r.hooks.onDragStart(a+window.scrollX,d+window.scrollY),true),Ii=(a,d)=>{let g=fi(a,gn),_=g.length>0?g:fi(a,gn,false);if(_.length===0)return;ur(_),r.hooks.onDragEnd(_,a);let P=_[0],F=kn(ze(P));u.setPointer(F),u.setFrozenElements(_);let re=kl(a);if(u.setFrozenDragRect(re),u.freeze(),u.setLastGrabbed(P),l.pendingCommentMode){Er(P,F.x,F.y);return}if(Ut){Ut=false,Io(P,F);return}let ce=l.wasActivatedByToggle&&!d;q({element:P,positionX:F.x,elements:_,shouldDeactivateAfter:ce,dragRect:re});},Ni=(a,d,g)=>{let _=et(l.frozenElement)?l.frozenElement:null,P=et(Gt)?Gt:null,F=_??P??dr(a,d)??(et(l.detectedElement)?l.detectedElement:null);if(!F)return;let re=!_&&P===F,ce,Le;if(_)ce=l.pointer.x,Le=l.pointer.y;else if(re){let We=kn(ze(F));ce=We.x,Le=We.y;}else ce=a,Le=d;if(Gt=null,l.pendingCommentMode){Er(F,ce,Le);return}if(Ut){Ut=false;let{wasIntercepted:We}=r.hooks.onElementSelect(F);if(We)return;ur([F]),u.setFrozenElement(F);let nt={x:ce,y:Le};u.setPointer(nt),u.freeze(),Io(F,nt);return}let Ce=l.wasActivatedByToggle&&!g;u.setLastGrabbed(F),q({element:F,positionX:ce,shouldDeactivateAfter:Ce});},Sr=()=>{x()&&(u.cancelDrag(),cn.stop(),document.body.style.userSelect="");},dm=(a,d,g)=>{if(!x())return;xt!==null&&(clearTimeout(xt),xt=null),To(null);let _=qe(a,d),P=_.x>2||_.y>2,F=P?Ne(a,d):null;P?u.endDrag():u.cancelDrag(),cn.stop(),document.body.style.userSelect="",F?Ii(F,g):Ni(a,d,g);},dt=_f(),Li=qf(),No=a=>{let d;try{d=Li.originalKeyDescriptor?.get?Li.originalKeyDescriptor.get.call(a):a.key;}catch{return  false}let g=d==="Enter"||So(a.code),_=p()||f();return g&&_&&!m()&&!l.wasActivatedByToggle&&v()===null?(Li.claimedEvents.add(a),a.preventDefault(),a.stopImmediatePropagation(),true):false};dt.addDocumentListener("keydown",No,{capture:true}),dt.addDocumentListener("keyup",No,{capture:true}),dt.addDocumentListener("keypress",No,{capture:true});let fm=a=>{if(!(a.code==="KeyZ"&&(a.metaKey||a.ctrlKey))||Array.from(Ze.sessions().values()).some(P=>!P.isStreaming&&!P.error))return  false;let _=a.shiftKey;return _&&Ze.canRedo()?(a.preventDefault(),a.stopPropagation(),Ze.history.redo(),true):!_&&Ze.canUndo()?(a.preventDefault(),a.stopPropagation(),Ze.history.undo(),true):false},Ar=()=>{yi([]),$n(0),ln.clearHistory();},na=a=>{u.setFrozenElement(a),u.freeze(),Gt=a;let d=ze(a),g=kn(d);u.setPointer(g),l.contextMenuPosition!==null&&u.showContextMenu(g,a);},Ul=a=>{let d=ze(a),g=Ds(d.x+d.width/2,d.y+d.height/2).filter(gn).reverse();yi(g),$n(Math.max(0,g.indexOf(a)));},mm=a=>{let d=Fn()[a];d&&($n(a),ln.clearHistory(),na(d));},jl=a=>{if(!p()||m()||!Ca.has(a.key))return  false;let d=ne(),g=!d;if(d||(d=dr(window.innerWidth/2,window.innerHeight/2)),!d)return  false;if(!(a.key==="ArrowUp"||a.key==="ArrowDown")){Ar();let ce=ln.findNext(a.key,d);return !ce&&!g?false:(a.preventDefault(),a.stopPropagation(),na(ce??d),true)}Fn().length===0&&Ul(d);let F=ln.findNext(a.key,d)??d;a.preventDefault(),a.stopPropagation(),na(F);let re=Fn().indexOf(F);return re!==-1?$n(re):Ul(F),true},pm=a=>{if(!So(a.code)||St(a))return  false;let d=l.lastCopiedElement;if(!f()&&!m()&&!p()&&d&&et(d)&&!l.labelInstances.some(P=>P.status==="copied"||P.status==="fading")){a.preventDefault(),a.stopImmediatePropagation();let P=kn(ze(d));return u.setPointer(P),Ue(d,P.x,P.y),u.setFrozenElement(d),u.clearLastCopied(),wt(),p()||en(),true}if(f()&&!m()){a.preventDefault(),a.stopImmediatePropagation();let P=l.frozenElement||ee();return P&&Ue(P,l.pointer.x,l.pointer.y),u.setPointer({x:l.pointer.x,y:l.pointer.y}),P&&u.setFrozenElement(P),wt(),st!==null&&(window.clearTimeout(st),st=null),p()||en(),true}return  false},gm=a=>{if(a.key?.toLowerCase()!=="o"||m()||!p()||!(a.metaKey||a.ctrlKey))return  false;let d=l.selectionFilePath,g=l.selectionLineNumber;return d?(a.preventDefault(),a.stopPropagation(),r.hooks.onOpenFile(d,g??void 0)||or(d,g??void 0,r.hooks.transformOpenFileUrl),true):false},Wl=()=>{an!==null&&(window.clearTimeout(an),an=null);},Lo=()=>{Wl(),hi([]),bi(null);},Kl=se(()=>!!ve()&&Lt()&&!m()&&!x()&&l.contextMenuPosition===null),hm=se(()=>({items:br(),activeIndex:Oo(),isVisible:Oo()!==null&&br().length>0})),bm=se(()=>Fn().map(a=>({tagName:pt(a)||"element",componentName:Kr(a)??void 0}))),ym=se(()=>({items:bm(),activeIndex:yr(),isVisible:Fn().length>0}));be(He(ve,()=>{Lo();})),be(He(Kl,a=>{a||Lo();}));let wm=a=>r.store.actions.find(d=>d.id===a),xm=()=>{let a=ve();if(!a)return;let d=Oe();return tc({element:a,filePath:l.selectionFilePath??void 0,lineNumber:l.selectionLineNumber??void 0,tagName:pt(a)||void 0,componentName:wn(),position:l.pointer,performWithFeedbackOptions:{fallbackBounds:d,fallbackSelectionBounds:d?[d]:[]},shouldDeferHideContextMenu:false,onBeforePrompt:Lo})},vm=se(()=>{if(!ve())return [];let a=[];for(let d of r.store.actions)typeof d.enabled=="boolean"&&!d.enabled||a.push({id:d.id,label:d.label,shortcut:d.shortcut});return a}),Cm=()=>{Wl(),an=window.setTimeout(()=>{an=null;let a=Oo(),d=br();if(a===null||d.length===0)return;let g=d[a];if(!g)return;let _=wm(g.id);if(!_){Lo();return}let P=xm();if(!P||!ui(_,P)){Lo();return}Lo();_.onAction(P);},600);},Em=()=>{if(!Kl())return  false;let a=vm();if(a.length===0)return  false;hi(a);let d=Oo(),_=d!==null&&d<a.length?(d+1)%a.length:0;return bi(_),Cm(),true},Sm=a=>a.code!=="KeyC"||a.altKey||a.repeat||St(a)||!Em()?false:(a.preventDefault(),a.stopPropagation(),(a.metaKey||a.ctrlKey)&&a.stopImmediatePropagation(),true),Am=a=>{if(!(!r.store.options.allowActivationInsideInput&&St(a))&&!(!Us(a,r.store.options)&&((a.metaKey||a.ctrlKey)&&!Xc.includes(a.key)&&!So(a.code)&&(p()&&!l.wasActivatedByToggle?Qe():f()&&(rt(),ct(),u.release())),!So(a.code)||!f()))){if((p()||f())&&!m()&&(a.preventDefault(),So(a.code)&&a.stopImmediatePropagation()),p()){if(l.wasActivatedByToggle&&r.store.options.activationMode!=="hold"||a.repeat)return;st!==null&&window.clearTimeout(st),st=window.setTimeout(()=>{Qe();},200);return}if(f()&&a.repeat){if(_o){let d=qt;ct(),d&&u.activate();}return}if(!(M()||Y())&&!f()){let g=r.store.options.keyHoldDuration??100;St(a)?_u(a)?g+=600:g+=400:Pu()&&(g+=600),ct(),u.startHold(g);}}};dt.addWindowListener("keydown",a=>{if(No(a),!R()){Us(a,r.store.options)&&!a.repeat&&j(F=>F+1);return}if(fm(a))return;let d=So(a.code)&&f()&&!m(),g=_t(a,"data-react-grab-input");if(m()&&Us(a,r.store.options)&&!a.repeat&&!g){a.preventDefault(),a.stopPropagation(),so();return}if(a.key==="Escape"&&v()!==null)return;if(a.key==="Escape"&&S()!==null){tn();return}if(B()!==null){if(a.key==="Escape"){lo();return}let F=r.store.toolbarActions,re=(a.metaKey||a.ctrlKey)&&!a.repeat,ce=F.find(Le=>Le.shortcut?a.key==="Enter"?Le.shortcut==="Enter":re&&a.key.toLowerCase()===Le.shortcut.toLowerCase():false);ce&&di(ce)&&(a.preventDefault(),a.stopPropagation(),ce.onAction(),lo());return}let _=_t(a,"data-react-grab-ignore-events")&&!d;if(m()||_)return a.key==="Escape"&&(ge()?(a.preventDefault(),a.stopPropagation(),u.setPendingAbortSessionId(null)):m()?so():l.wasActivatedByToggle&&Qe()),_&&Ca.has(a.key)&&jl(a),void 0;if(a.key==="Escape"){if(ge()){a.preventDefault(),a.stopPropagation(),u.setPendingAbortSessionId(null);return}if(Ze.isProcessing())return;if(f()||l.wasActivatedByToggle){Qe();return}}let P=Date.now()-Po<200;!P&&Sm(a)||jl(a)||pm(a)||gm(a)||P||Am(a);},{capture:true}),dt.addWindowListener("keyup",a=>{if(No(a))return;let d=Yf(r.store.options),g=d.metaKey||d.ctrlKey?In()?!a.metaKey:!a.ctrlKey:d.shiftKey&&!a.shiftKey||d.altKey&&!a.altKey,_=r.store.options.activationKey?typeof r.store.options.activationKey=="function"?r.store.options.activationKey(a):Gs(r.store.options.activationKey)(a):Vs(a.key,a.code);if(Y()||Fe){(_||g)&&(Fe=false,Qe());return}if(!f()&&!p()||m())return;let P=!!r.store.options.activationKey,F=r.store.options.activationMode==="hold";if(p()){let re=l.contextMenuPosition!==null;if(g){if(l.wasActivatedByToggle&&r.store.options.activationMode!=="hold"||re)return;Qe();}else if(F&&_){if(st!==null&&(window.clearTimeout(st),st=null),re)return;Qe();}else !P&&_&&st!==null&&(window.clearTimeout(st),st=null);return}if(_||g){if(l.wasActivatedByToggle&&r.store.options.activationMode!=="hold")return;if(f()||qt&&g){rt();let Le=(Pt?Date.now()-Pt:0)>=200,Ce=qt&&Le&&(r.store.options.allowActivationInsideInput||!St(a));ct(),Ce?u.activate():u.release();}else Qe();}},{capture:true}),dt.addDocumentListener("copy",()=>{f()&&(_o=true);}),dt.addWindowListener("keypress",No,{capture:true}),dt.addWindowListener("pointermove",a=>{if(!a.isPrimary)return;let d=a.pointerType==="touch";if(u.setTouchMode(d),_t(a,"data-react-grab-ignore-events")||l.contextMenuPosition!==null||d&&!f()&&!p())return;(d?f():p())&&!m()&&b()&&(u.unfreeze(),Ar()),Mi(a.clientX,a.clientY);},{passive:true}),dt.addWindowListener("pointerdown",a=>{if(a.button!==0||!a.isPrimary||(u.setTouchMode(a.pointerType==="touch"),_t(a,"data-react-grab-ignore-events"))||l.contextMenuPosition!==null||B()!==null)return;if(m()){let g=Oe();g&&a.clientX>=g.x&&a.clientX<=g.x+g.width&&a.clientY>=g.y&&a.clientY<=g.y+g.height?Cr():so();return}Ri(a.clientX,a.clientY)&&(document.documentElement.setPointerCapture(a.pointerId),a.preventDefault(),a.stopImmediatePropagation());},{capture:true}),dt.addWindowListener("pointerup",a=>{if(a.button!==0||!a.isPrimary||_t(a,"data-react-grab-ignore-events")||l.contextMenuPosition!==null)return;let d=a.metaKey||a.ctrlKey;dm(a.clientX,a.clientY,d);},{capture:true}),dt.addWindowListener("contextmenu",a=>{if(!Lt()||M()||m())return;let d=_t(a,"data-react-grab-ignore-events");if(d&&Fn().length>0)Ar();else if(d)return;if(l.contextMenuPosition!==null){a.preventDefault();return}a.preventDefault(),a.stopPropagation();let g=dr(a.clientX,a.clientY);if(!g)return;let _=l.frozenElements;_.length>1&&_.includes(g)?ur(_):(ur([g]),u.setFrozenElement(g));let F={x:a.clientX,y:a.clientY};u.setPointer(F),u.freeze(),Io(g,F);},{capture:true}),dt.addWindowListener("pointercancel",a=>{a.isPrimary&&Sr();}),dt.addWindowListener("click",a=>{_t(a,"data-react-grab-ignore-events")||l.contextMenuPosition===null&&(Lt()||M()||H())&&(a.preventDefault(),a.stopImmediatePropagation(),l.wasActivatedByToggle&&!M()&&!m()&&(f()?u.setWasActivatedByToggle(false):Qe()));},{capture:true}),dt.addDocumentListener("visibilitychange",()=>{if(document.hidden){u.clearGrabbedBoxes();let a=l.activationTimestamp;p()&&!m()&&a!==null&&Date.now()-a>500&&Qe();}}),dt.addWindowListener("blur",()=>{Sr(),f()&&(rt(),u.release(),ct());}),dt.addWindowListener("focus",()=>{Po=Date.now();});let Tm=()=>{if(!(l.isTouchMode&&!f()&&!p())&&R()&&!m()&&!b()&&!x()&&l.contextMenuPosition===null&&l.frozenElements.length===0){let a=dr(l.pointer.x,l.pointer.y);u.setDetectedElement(a);}},Xl=()=>{Bf(),Tm(),u.incrementViewportVersion(),u.updateSessionBounds(),u.updateContextMenuPosition();};dt.addWindowListener("scroll",Xl,{capture:true});let oa=window.innerWidth,ra=window.innerHeight;dt.addWindowListener("resize",()=>{let a=window.innerWidth,d=window.innerHeight;if(oa>0&&ra>0){let g=a/oa,_=d/ra,P=Math.abs(g-_)<Ma,F=Math.abs(g-1)>Ma;P&&F&&u.setPointer({x:l.pointer.x*g,y:l.pointer.y*_});}oa=a,ra=d,Xl();});let ao=null,zn=null,_m=()=>{let a=r.store.theme.enabled&&(p()||M()||l.labelInstances.length>0||l.grabbedBoxes.length>0||Ze.sessions().size>0);a&&ao===null?ao=window.setInterval(()=>{zn===null&&(zn=Ve(()=>{zn=null,u.incrementViewportVersion(),u.updateSessionBounds();}));},100):!a&&ao!==null&&(window.clearInterval(ao),ao=null,zn!==null&&(Ge(zn),zn=null));};be(()=>{r.store.theme.enabled,p(),M(),l.labelInstances.length,l.grabbedBoxes.length,Ze.sessions().size,_m();}),Me(()=>{ao!==null&&window.clearInterval(ao),zn!==null&&Ge(zn);}),dt.addDocumentListener("copy",a=>{m()||_t(a,"data-react-grab-ignore-events")||(Lt()||M())&&a.preventDefault();},{capture:true}),Me(()=>{dt.abort(),xt!==null&&window.clearTimeout(xt),st&&window.clearTimeout(st),Zt&&window.clearTimeout(Zt),an&&window.clearTimeout(an),W!==null&&Ge(W),gt.forEach(a=>window.clearTimeout(a)),gt.clear(),cn.stop(),document.body.style.userSelect="",document.body.style.touchAction="",Mo(null),Li.restore();});let ia=Ou(Mc),Tr=se(()=>r.store.theme.enabled),Pm=se(()=>r.store.theme.selectionBox.enabled),Yl=se(()=>r.store.theme.elementLabel.enabled),km=se(()=>r.store.theme.dragBox.enabled),ql=se(()=>Y()||L()&&!b()),Om=se(()=>at().length>0),sa=se(()=>!Tr()||!Pm()||ql()?false:Om()?true:he()),Mm=se(()=>{let a=ve();if(a)return pt(a)||void 0});be(He(()=>Qs(),a=>{let d=++zt;if(!a){hr(void 0);return}nr(a).then(g=>{zt===d&&hr(g??void 0);}).catch(()=>{zt===d&&hr(void 0);});}));let Rm=se(()=>l.contextMenuPosition!==null||!Yl()||ql()?false:he()),Di=new Map,Im=se(()=>{if(!Tr())return [];if(!r.store.theme.grabbedBoxes.enabled)return [];l.viewportVersion;let a=new Set(l.labelInstances.map(d=>d.id));for(let d of Di.keys())a.has(d)||Di.delete(d);return l.labelInstances.map(d=>{let g=d.elements&&d.elements.length>1,_=d.element,F=!g&&_&&document.body.contains(_)?ze(_):d.bounds,re=Di.get(d.id),ce=re&&re.bounds.x===F.x&&re.bounds.y===F.y&&re.bounds.width===F.width&&re.bounds.height===F.height;if(re&&re.status===d.status&&re.errorMessage===d.errorMessage&&ce)return re;let Le=F.x+F.width/2,Ce=F.width/2,We=d.mouseXOffsetRatio!==void 0&&Ce>0?Le+d.mouseXOffsetRatio*Ce:d.mouseXOffsetFromCenter!==void 0?Le+d.mouseXOffsetFromCenter:d.mouseX,nt={...d,bounds:F,mouseX:We};return Di.set(d.id,nt),nt})}),Nm=se(()=>Tr()?r.store.theme.grabbedBoxes.enabled?(l.viewportVersion,l.grabbedBoxes.map(a=>!a.element||!document.body.contains(a.element)?a:{...a,bounds:ze(a.element)})):[]:[]),aa=se(()=>Tr()&&km()&&Lt()&&tt()),Lm=se(()=>M()?"processing":"hover"),Dm=se(()=>{if(!Tr())return  false;let a=Yl(),d=m(),g=M(),_=Lt(),P=x(),F=!!ne(),re=L(),ce=b();return !a||d||re&&!ce?false:g?true:_&&!P&&F}),Zl=se(()=>{l.viewportVersion;let a=l.contextMenuElement;return a?ze(a):null}),Fm=se(()=>(l.viewportVersion,l.contextMenuPosition)),Jl=se(()=>{let a=l.contextMenuElement;if(!a)return;let d=l.frozenElements.length;return d>1?`${d} elements`:pt(a)||void 0}),[Ql]=ba(()=>({element:l.contextMenuElement,frozenCount:l.frozenElements.length}),async({element:a,frozenCount:d})=>!a||d>1?void 0:await nr(a)??void 0),[ec]=ba(()=>l.contextMenuElement,async a=>{if(!a)return null;let d=await Mn(a);return nl(d)}),$m=(a,d,g,_,P)=>async F=>{let re=P?.fallbackBounds??null,ce=P?.fallbackSelectionBounds??[],Le=P?.position??l.contextMenuPosition??l.pointer,Ce=De(),We=Zl()??re,nt=d.length>1,lt=nt?zs(Ol(Ce)):We,Dt=l.wasActivatedByToggle,Or=nt?Ce:We?[We]:ce;if(u.hideContextMenu(),lt){let At=nt?lt.x+lt.width/2:Le.x,dn=vt(lt,g||"element",_,"copying",{element:a,mouseX:At,elements:nt?d:void 0,boundsMultiple:Or}),fn=false,$i;try{fn=await F(),fn||($i="Failed to copy");}catch(Vn){$i=Vn instanceof Error&&Vn.message?Vn.message:"Action failed";}u.updateLabelInstance(dn,fn?"copied":"error",fn?void 0:$i||"Unknown error"),Jt(dn);}else try{await F();}catch{}Dt?Qe():u.unfreeze();},la=()=>{setTimeout(()=>{u.hideContextMenu();},0);},tc=a=>{let{element:d,filePath:g,lineNumber:_,tagName:P,componentName:F,position:re,performWithFeedbackOptions:ce,shouldDeferHideContextMenu:Le,onBeforeCopy:Ce,onBeforePrompt:We,customEnterPromptMode:nt}=a,lt=l.frozenElements.length>0?l.frozenElements:[d],Dt=Le?la:u.hideContextMenu,dn={element:d,elements:lt,filePath:g,lineNumber:_,componentName:F,tagName:P,enterPromptMode:nt??(fn=>{fn&&u.setSelectedAgent(fn),u.clearLabelInstances(),We?.(),Ue(d,re.x,re.y),u.setPointer({x:re.x,y:re.y}),u.setFrozenElement(d),wt(),p()||en(),Dt();}),copy:()=>{Ce?.(),q({element:d,positionX:re.x,elements:lt.length>1?lt:void 0,shouldDeactivateAfter:l.wasActivatedByToggle}),Dt();},hooks:{transformHtmlContent:r.hooks.transformHtmlContent,onOpenFile:r.hooks.onOpenFile,transformOpenFileUrl:r.hooks.transformOpenFileUrl},performWithFeedback:$m(d,lt,P,F,ce),hideContextMenu:Dt,cleanup:()=>{l.wasActivatedByToggle?Qe():u.unfreeze();}};return r.hooks.transformActionContext(dn)},Hm=se(()=>{let a=l.contextMenuElement;if(!a)return;let d=ec(),g=l.contextMenuPosition??l.pointer;return tc({element:a,filePath:d?.filePath,lineNumber:d?.lineNumber,tagName:Jl(),componentName:Ql(),position:g,shouldDeferHideContextMenu:true,onBeforeCopy:()=>{Gt=null;},customEnterPromptMode:_=>{_&&u.setSelectedAgent(_),u.clearLabelInstances(),u.clearInputText(),u.enterPromptMode(g,a),la();}})}),Bm=()=>{setTimeout(()=>{u.hideContextMenu(),Qe();},0);},Sn=()=>{for(let{boxId:a,labelId:d}of me)u.removeGrabbedBox(a),d&&u.removeLabelInstance(d);me=[];},zm=(a,d,g,_)=>{if(d.length===0)return;let P=a.isComment&&a.commentText;for(let[F,re]of d.entries()){let ce=g[F],Le=`${_}-${a.id}-${F}`;u.addGrabbedBox({id:Le,bounds:re,createdAt:0,element:ce});let Ce=null;F===0&&(Ce=`${_}-label-${a.id}`,u.addLabelInstance({id:Ce,bounds:re,tagName:a.tagName,componentName:a.componentName,elementsCount:a.elementsCount,status:"idle",isPromptMode:!!P,inputValue:P?a.commentText:void 0,createdAt:0,element:ce,mouseX:re.x+re.width/2})),me.push({boxId:Le,labelId:Ce});}},nc=(a,d)=>{let g=pe(a),_=g.map(P=>ze(P));zm(a,_,g,d);},_r=()=>{W!==null&&(Ge(W),W=null);},ca=a=>{_r();let d=()=>{a(),W=Ve(d);};d();},Vm=a=>{let d=a.left+a.width/2,g=a.top+a.height/2,_=g,P=window.innerHeight-g,F=d,re=window.innerWidth-d,ce=Math.min(_,P,F,re);return ce===_?"top":ce===F?"left":ce===re?"right":"bottom"},ua=()=>{if(!N)return null;let a=N.getBoundingClientRect(),d=Vm(a);return d==="left"||d==="right"?{x:d==="left"?a.right:a.left,y:a.top+a.height/2,edge:d,toolbarWidth:a.width}:{x:a.left+a.width/2,y:d==="top"?a.bottom:a.top,edge:d,toolbarWidth:a.width}},tn=()=>{Fi(),Do(),_r(),Sn(),D(null),Ae(false);},oc=()=>{u.hideContextMenu(),lo(),kr(),h(Bl()),de(false),ca(()=>{let a=ua();a&&D(a);});},Pr=null,An=null,Fi=()=>{Pr!==null&&(clearTimeout(Pr),Pr=null);},Do=()=>{An!==null&&(clearTimeout(An),An=null);},lo=()=>{_r(),w(null);},Gm=()=>{tn(),lo(),ca(()=>{let a=ua();a&&$(a);});},kr=()=>{_r(),$(null);},rc=()=>{tn(),lo(),kr();},Um=()=>{B()!==null?lo():(u.hideContextMenu(),tn(),kr(),ca(()=>{let a=ua();a&&w(a);}));},jm=()=>{Fi(),Do(),S()!==null?Q()?(Sn(),Ae(false)):tn():(Sn(),oc());},ic=a=>{Xt(a.content,{tagName:a.tagName,componentName:a.componentName??a.elementName,commentText:a.commentText});let d=ke(a);d&&(u.clearLabelInstances(),Ve(()=>{if(!et(d))return;let g=ze(d),_=vt(g,a.tagName,a.componentName,"copied",{element:d,mouseX:g.x+g.width/2});Jt(_);}));},Wm=a=>{Sn(),m()&&(u.exitPromptMode(),u.clearInputText());let d=ke(a);if(a.isComment&&a.commentText&&d){let g=ze(d),_=g.x+g.width/2,P=g.y+g.height/2;u.enterPromptMode({x:_,y:P},d),u.setInputText(a.commentText);}else ic(a);},Km=a=>{Sn(),V.delete(a.id);let d=zl(a.id);h(d),d.length===0&&(de(false),tn());},sc=()=>{Sn();let a=y();if(a.length===0)return;let d=Hs(a.map(_=>_.content)),g=a[0];Xt(d,{componentName:g.componentName??g.tagName,entries:a.map(_=>({tagName:_.tagName,componentName:_.componentName??_.elementName,content:_.content,commentText:_.commentText}))}),Gm(),u.clearLabelInstances(),Ve(()=>{ji(()=>{for(let _ of a){let P=pe(_);for(let F of P){let re=ze(F),ce=`label-${Date.now()}-${Math.random().toString(36).slice(2)}`;u.addLabelInstance({id:ce,bounds:re,tagName:_.tagName,componentName:_.componentName,status:"copied",createdAt:Date.now(),element:F,mouseX:re.x+re.width/2}),Jt(ce);}}});});},Xm=a=>{if(Sn(),!a)return;let d=y().find(g=>g.id===a);d&&nc(d,"history-hover");},Ym=a=>{Fi(),Sn(),a?(Do(),S()===null&&v()===null&&(lc(),Pr=setTimeout(()=>{Pr=null,Ae(true),oc();},Gr))):Q()&&(An=setTimeout(()=>{An=null,tn();},Gr));},qm=a=>{a?Do():Q()&&(An=setTimeout(()=>{An=null,tn();},Gr));},ac=a=>{Sn(),a?(Do(),lc()):Q()&&(An=setTimeout(()=>{An=null,tn();},Gr));},lc=()=>{for(let a of y())nc(a,"history-all-hover");},cc=()=>{V.clear();let a=lm();h(a),de(false),tn();},Zm=a=>{let d=Ze.sessions().get(a);if(!d)return;let g=Ze.session.getElement(a);g&&et(g)&&setTimeout(()=>{p()||(u.setWasActivatedByToggle(true),en()),u.setPointer(d.position),u.setFrozenElement(g),u.freeze(),u.showContextMenu(d.position,g);},0);},Jm=a=>{let d=l.labelInstances.find(F=>F.id===a);if(!d?.element||!et(d.element))return;let g=ze(d.element),_={x:d.mouseX??g.x+g.width/2,y:g.y+g.height/2},P=d.elements&&d.elements.length>0?d.elements.filter(F=>et(F)):[d.element];setTimeout(()=>{p()||(u.setWasActivatedByToggle(true),en()),u.setPointer(_),u.setFrozenElements(P),P.length>1&&d.bounds&&u.setFrozenDragRect(kl(d.bounds)),u.freeze(),u.showContextMenu(_,d.element);},0);};be(()=>{let a=r.store.theme.hue;a!==0?ia.style.filter=`hue-rotate(${a}deg)`:ia.style.filter="";}),r.store.theme.enabled&&Oc(()=>O(Tf,{get selectionVisible(){return sa()},get selectionBounds(){return Oe()},get selectionBoundsMultiple(){return kt()},get selectionShouldSnap(){return l.frozenElements.length>0||at().length>0},get selectionElementsCount(){return je()},get selectionFilePath(){return l.selectionFilePath??void 0},get selectionLineNumber(){return l.selectionLineNumber??void 0},get selectionTagName(){return Mm()},get selectionComponentName(){return wn()},get selectionLabelVisible(){return Rm()},selectionLabelStatus:"idle",get selectionActionCycleState(){return hm()},get selectionArrowNavigationState(){return ym()},onArrowNavigationSelect:mm,get labelInstances(){return Im()},get dragVisible(){return aa()},get dragBounds(){return ut()},get grabbedBoxes(){return Nm()},labelZIndex:2147483647,get mouseX(){return Be(()=>l.frozenElements.length>1)()?void 0:un().x},get mouseY(){return un().y},get crosshairVisible(){return xn()},get isFrozen(){return b()||p()||L()},get inputValue(){return l.inputText},get isPromptMode(){return m()},get hasAgent(){return Te()},get isAgentConnected(){return l.isAgentConnected},get agentSessions(){return Ze.sessions()},get supportsUndo(){return l.supportsUndo},get supportsFollowUp(){return l.supportsFollowUp},get dismissButtonText(){return l.dismissButtonText},get onDismissSession(){return Ze.session.dismiss},get onUndoSession(){return Ze.session.undo},onFollowUpSubmitSession:Ti,onAcknowledgeSessionError:_i,get onRetrySession(){return Ze.session.retry},onShowContextMenuSession:Zm,onShowContextMenuInstance:Jm,onLabelInstanceHoverChange:ea,get onInputChange(){return u.setInputText},onInputSubmit:()=>void Cr(),onInputCancel:so,onToggleExpand:Ai,get isPendingDismiss(){return T()},onConfirmDismiss:Ci,onCancelDismiss:Ei,get pendingAbortSessionId(){return ge()},onRequestAbortSession:a=>u.setPendingAbortSessionId(a),onAbortSession:Si,get theme(){return r.store.theme},get toolbarVisible(){return r.store.theme.toolbar.enabled},get isActive(){return p()},onToggleActive:Pi,get enabled(){return R()},onToggleEnabled:Oi,get shakeCount(){return fe()},onToolbarStateChange:a=>{ue(a),ro.forEach(d=>d(a));},onSubscribeToToolbarStateChanges:a=>(ro.add(a),()=>{ro.delete(a);}),onToolbarSelectHoverChange:A,onToolbarRef:a=>{N=a;},get contextMenuPosition(){return Fm()},get contextMenuBounds(){return Zl()},get contextMenuTagName(){return Jl()},get contextMenuComponentName(){return Ql()},get contextMenuHasFilePath(){return !!ec()?.filePath},get actions(){return r.store.actions},get toolbarActions(){return r.store.toolbarActions},get actionContext(){return Hm()},onContextMenuDismiss:Bm,onContextMenuHide:la,get historyItems(){return y()},get historyDisconnectedItemIds(){return Pe()},get historyItemCount(){return y().length},get clockFlashTrigger(){return I()},get hasUnreadHistoryItems(){return oe()},get historyDropdownPosition(){return S()},get isHistoryPinned(){return Be(()=>S()!==null)()&&!Q()},onToggleHistory:jm,onCopyAll:sc,onCopyAllHover:ac,onHistoryButtonHover:Ym,onHistoryItemSelect:Wm,onHistoryItemRemove:Km,onHistoryItemCopy:ic,onHistoryItemHover:Xm,onHistoryCopyAll:sc,onHistoryCopyAllHover:ac,onHistoryClear:cc,onHistoryDismiss:tn,onHistoryDropdownHover:qm,get toolbarMenuPosition(){return B()},onToggleMenu:Um,onToolbarMenuDismiss:lo,get clearPromptPosition(){return v()},onClearHistoryConfirm:()=>{kr(),cc();},onClearHistoryCancel:kr}),ia),Te()&&Ze.session.tryResume();let Qm=async a=>{let d=Array.isArray(a)?a:[a];return d.length===0?false:await xr(d)},uc=()=>{let a=Ro();a&&Ze._internal.setOptions(a);let d=!!a?.provider;if(u.setHasAgentProvider(d),d&&a?.provider){let g=a.provider;u.setAgentCapabilities({supportsUndo:!!g.undo,supportsFollowUp:!!g.supportsFollowUp,dismissButtonText:g.dismissButtonText,isAgentConnected:false}),g.checkConnection&&g.checkConnection().then(_=>{Ro()?.provider===g&&u.setAgentCapabilities({supportsUndo:!!g.undo,supportsFollowUp:!!g.supportsFollowUp,dismissButtonText:g.dismissButtonText,isAgentConnected:_});}).catch(()=>{}),Ze.session.tryResume();}else u.setAgentCapabilities({supportsUndo:false,supportsFollowUp:false,dismissButtonText:void 0,isAgentConnected:false});},da={activate:()=>{u.setPendingCommentMode(false),!p()&&R()&&Z();},deactivate:()=>{(p()||M())&&Qe();},toggle:()=>{p()?Qe():R()&&Z();},comment:ki,isActive:()=>p(),isEnabled:()=>R(),setEnabled:a=>{a!==R()&&(X(a),a||vr());},getToolbarState:()=>yo(),setToolbarState:a=>{let d=yo(),g={edge:a.edge??d?.edge??"bottom",ratio:a.ratio??d?.ratio??.5,collapsed:a.collapsed??d?.collapsed??false,enabled:a.enabled??d?.enabled??true};Qr(g),ue(g),a.enabled!==void 0&&a.enabled!==R()&&X(a.enabled),ro.forEach(_=>_(g));},onToolbarStateChange:a=>(ro.add(a),()=>{ro.delete(a);}),dispose:()=>{Vl=false,Fi(),Do(),_r(),ro.clear(),s();},copyElement:Qm,getSource:async a=>{let d=await Mn(a),g=nl(d);return g?{filePath:g.filePath,lineNumber:g.lineNumber??null,componentName:g.componentName}:null},getStackContext:ol,getState:()=>({isActive:p(),isDragging:x(),isCopying:M(),isPromptMode:m(),isCrosshairVisible:xn()??false,isSelectionBoxVisible:sa()??false,isDragBoxVisible:aa()??false,targetElement:ee(),dragBounds:ut()??null,grabbedBoxes:l.grabbedBoxes.map(a=>({id:a.id,bounds:a.bounds,createdAt:a.createdAt})),labelInstances:l.labelInstances.map(a=>({id:a.id,status:a.status,tagName:a.tagName,componentName:a.componentName,createdAt:a.createdAt})),selectionFilePath:l.selectionFilePath,toolbarState:le()}),setOptions:a=>{r.setOptions(a);},registerPlugin:a=>{r.register(a,da),uc();},unregisterPlugin:a=>{r.unregister(a),uc();},getPlugins:()=>r.getPluginNames(),getDisplayName:Kr};for(let a of ww)r.register(a,da);return setTimeout(()=>{tr(true);},wu),da})};var Ao=null,H5=()=>typeof window>"u"?Ao:window.__REACT_GRAB__??Ao??null,B5=e=>{Ao=e,typeof window<"u"&&(e?window.__REACT_GRAB__=e:delete window.__REACT_GRAB__);};typeof window<"u"&&(window.__REACT_GRAB__?Ao=window.__REACT_GRAB__:(Ao=Gl(),window.__REACT_GRAB__=Ao),window.dispatchEvent(new CustomEvent("react-grab:init",{detail:Ao})));/*! Bundled license information:
+`),
+                  i = await e.getStackContext(n.element);
+                return Xt(gr(o, i), {
+                  componentName: n.componentName,
+                  tagName: n.tagName,
+                });
+              });
+            },
+          },
+          {
+            id: "copy-styles-toolbar",
+            label: "Copy styles",
+            target: "toolbar",
+            onAction: () => {
+              ((t = true), e.activate());
+            },
+          },
+        ],
+        cleanup: rm,
+      };
+    },
+  };
+  var sm = "react-grab-history-items",
+    rw = () => {
+      try {
+        let e = sessionStorage.getItem(sm);
+        return e
+          ? JSON.parse(e).map((n) => ({
+              ...n,
+              elementsCount: Math.max(1, n.elementsCount ?? 1),
+              previewBounds: n.previewBounds ?? [],
+              elementSelectors: n.elementSelectors ?? [],
+            }))
+          : [];
+      } catch {
+        return [];
+      }
+    },
+    iw = (e) => {
+      let t = e;
+      for (; t.length > 0; ) {
+        let n = JSON.stringify(t);
+        if (new Blob([n]).size <= pu) return t;
+        t = t.slice(0, -1);
+      }
+      return t;
+    },
+    Hl = (e) => {
+      try {
+        let t = iw(e);
+        sessionStorage.setItem(sm, JSON.stringify(t));
+      } catch {}
+    },
+    Yt = rw(),
+    sw = () =>
+      `history-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+    Bl = () => Yt,
+    am = (e) => ((Yt = [{ ...e, id: sw() }, ...Yt].slice(0, mu)), Hl(Yt), Yt),
+    zl = (e) => ((Yt = Yt.filter((t) => t.id !== e)), Hl(Yt), Yt),
+    lm = () => ((Yt = []), Hl(Yt), Yt);
+  var ww = [nm, Ll, om, im, Dl],
+    Vl = false,
+    ro = new Set(),
+    Gl = (e) => {
+      if (typeof window > "u") return El();
+      let t = tm(),
+        n = {
+          enabled: true,
+          activationMode: "toggle",
+          keyHoldDuration: 100,
+          allowActivationInsideInput: true,
+          maxContextLines: 3,
+          ...t,
+          ...e,
+        };
+      if (n.enabled === false || Vl) return El();
+      ((Vl = true), Qf());
+      let { enabled: o, ...i } = n;
+      return Tn((s) => {
+        let r = jf(i),
+          c = () => {
+            for (let a of r.store.actions)
+              if (a.agent?.provider) return a.agent;
+          },
+          { store: l, actions: u } = Tu({
+            theme: to,
+            hasAgentProvider: !!c()?.provider,
+            keyHoldDuration: r.store.options.keyHoldDuration ?? 100,
+          }),
+          f = se(() => l.current.state === "holding"),
+          p = se(() => l.current.state === "active");
+        be(
+          He(p, (a, d) => {
+            a && !d
+              ? ($s(), Ns(), (document.body.style.touchAction = "none"))
+              : !a && d && (ci(), si(), (document.body.style.touchAction = ""));
+          }),
+        );
+        let b = se(
+            () => l.current.state === "active" && l.current.phase === "frozen",
+          ),
+          x = se(
+            () =>
+              l.current.state === "active" && l.current.phase === "dragging",
+          ),
+          H = se(
+            () =>
+              l.current.state === "active" && l.current.phase === "justDragged",
+          ),
+          M = se(() => l.current.state === "copying"),
+          Y = se(() => l.current.state === "justCopied"),
+          m = se(() => l.current.state === "active" && l.current.isPromptMode),
+          E = se(() => l.pendingCommentMode || m()),
+          T = se(
+            () =>
+              l.current.state === "active" &&
+              l.current.isPromptMode &&
+              l.current.isPendingDismiss,
+          ),
+          C = yo(),
+          [R, X] = U(C?.enabled ?? true),
+          [fe, j] = U(0),
+          [le, ue] = U(C),
+          [L, A] = U(false),
+          [y, h] = U(Bl()),
+          [S, D] = U(null),
+          [B, w] = U(null),
+          [v, $] = U(null),
+          N,
+          W = null,
+          V = new Map(),
+          [oe, de] = U(false),
+          [I, G] = U(0),
+          [Q, Ae] = U(false),
+          me = [],
+          Se = (a) => V.get(a) ?? [],
+          ie = (a) => {
+            let d = a.elementSelectors ?? [];
+            if (d.length === 0) return [];
+            let g = [];
+            for (let _ of d)
+              if (_)
+                try {
+                  let P = document.querySelector(_);
+                  et(P) && g.push(P);
+                } catch {}
+            return g;
+          },
+          pe = (a) => {
+            let d = Se(a.id),
+              g = d.filter((F) => et(F));
+            if (d.length > 0 && g.length === d.length) return g;
+            let P = ie(a);
+            return P.length > 0 ? (V.set(a.id, P), P) : g;
+          },
+          ke = (a) => pe(a)[0],
+          Pe = se(
+            () => {
+              S();
+              let a = new Set();
+              for (let d of y()) pe(d).length === 0 && a.add(d.id);
+              return a;
+            },
+            void 0,
+            {
+              equals: (a, d) => {
+                if (a.size !== d.size) return false;
+                for (let g of d) if (!a.has(g)) return false;
+                return true;
+              },
+            },
+          ),
+          ge = se(() => l.pendingAbortSessionId),
+          Te = se(() => l.hasAgentProvider),
+          rt = () => {
+            sn !== null && (clearTimeout(sn), (sn = null));
+          },
+          ct = () => {
+            ((_o = false), (qt = false), (Pt = null));
+          };
+        (be(() => {
+          if (l.current.state !== "holding") {
+            rt();
+            return;
+          }
+          ((Pt = Date.now()),
+            (sn = window.setTimeout(() => {
+              if (((sn = null), _o)) {
+                qt = true;
+                return;
+              }
+              u.activate();
+            }, l.keyHoldDuration)),
+            Me(rt));
+        }),
+          be(() => {
+            if (
+              l.current.state !== "active" ||
+              l.current.phase !== "justDragged"
+            )
+              return;
+            let a = setTimeout(() => {
+              u.finishJustDragged();
+            }, 1500);
+            Me(() => clearTimeout(a));
+          }),
+          be(() => {
+            if (l.current.state !== "justCopied") return;
+            let a = setTimeout(() => {
+              u.finishJustCopied();
+            }, 1500);
+            Me(() => clearTimeout(a));
+          }),
+          be(
+            He(f, (a, d = false) => {
+              !d ||
+                a ||
+                !p() ||
+                (r.store.options.activationMode !== "hold" &&
+                  u.setWasActivatedByToggle(true),
+                r.hooks.onActivate());
+            }),
+          ));
+        let Ue = (a, d, g) => {
+            (bn(a, d, g), u.clearInputText());
+          },
+          wt = () => {
+            let a = l.frozenElement || ee();
+            a && u.enterPromptMode({ x: l.pointer.x, y: l.pointer.y }, a);
+          },
+          bn = (a, d, g) => (u.setCopyStart({ x: d, y: g }, a), ze(a)),
+          Ht = 0,
+          Bt = 0,
+          Rt = 0,
+          yn = 0,
+          xt = null,
+          [Dn, To] = U(null),
+          It = (a, d) => {
+            (xt !== null && clearTimeout(xt),
+              To(null),
+              (xt = window.setTimeout(() => {
+                (To({ x: a, y: d }), (xt = null));
+              }, 32)));
+          },
+          st = null,
+          sn = null,
+          Pt = null,
+          _o = false,
+          qt = false,
+          Po = 0,
+          Fe = false,
+          Zt = null,
+          an = null,
+          Nt = 0,
+          zt = 0,
+          Vt = null,
+          Gt = null,
+          Ut = false,
+          [Qs, ko] = U(null),
+          [wn, hr] = U(void 0),
+          [br, hi] = U([]),
+          [Oo, bi] = U(null),
+          [Fn, yi] = U([]),
+          [yr, $n] = U(0),
+          ln = Xf(gn, ze),
+          cn = Zf(
+            () => l.pointer,
+            () => x(),
+          ),
+          Lt = se(() => p() && !M()),
+          xn = se(
+            () =>
+              r.store.theme.enabled &&
+              r.store.theme.crosshair.enabled &&
+              Lt() &&
+              !x() &&
+              !l.isTouchMode &&
+              !b() &&
+              !m() &&
+              !L() &&
+              l.contextMenuPosition === null,
+          ),
+          gt = new Map(),
+          wi = (a, d) => {
+            let g = `grabbed-${Date.now()}-${Math.random()}`,
+              _ = Date.now(),
+              P = { id: g, bounds: a, createdAt: _, element: d };
+            (u.addGrabbedBox(P), r.hooks.onGrabbedBox(a, d));
+            let F = window.setTimeout(() => {
+              (gt.delete(g), u.removeGrabbedBox(g));
+            }, 1500);
+            gt.set(g, F);
+          },
+          wr = async (a) => {
+            let d = await Promise.all(
+              a.map(async (g) => {
+                let _ = await Mn(g),
+                  P = null,
+                  F,
+                  re,
+                  ce;
+                if (_ && _.length > 0)
+                  for (let Ce of _) {
+                    let We = Ce.functionName && er(Ce.functionName),
+                      nt = Ce.fileName && ho(Ce.fileName);
+                    if (
+                      (We && !P && (P = Ce.functionName),
+                      nt &&
+                        !F &&
+                        ((F = go(Ce.fileName)),
+                        (re = Ce.lineNumber || void 0),
+                        (ce = Ce.columnNumber || void 0)),
+                      P && F)
+                    )
+                      break;
+                  }
+                P || (P = Kr(g));
+                let Le =
+                  g instanceof HTMLElement ? g.innerText?.slice(0, $r) : void 0;
+                return {
+                  tagName: pt(g),
+                  id: g.id || void 0,
+                  className: g.getAttribute("class") || void 0,
+                  textContent: Le,
+                  componentName: P ?? void 0,
+                  filePath: F,
+                  lineNumber: re,
+                  columnNumber: ce,
+                };
+              }),
+            );
+            window.dispatchEvent(
+              new CustomEvent("react-grab:element-selected", {
+                detail: { elements: d },
+              }),
+            );
+          },
+          vt = (a, d, g, _, P) => {
+            u.clearLabelInstances();
+            let F = `label-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+              re = a.x + a.width / 2,
+              ce = a.width / 2,
+              Le = P?.mouseX,
+              Ce = Le !== void 0 ? Le - re : void 0,
+              We = {
+                id: F,
+                bounds: a,
+                boundsMultiple: P?.boundsMultiple,
+                tagName: d,
+                componentName: g,
+                status: _,
+                createdAt: Date.now(),
+                element: P?.element,
+                elements: P?.elements,
+                mouseX: Le,
+                mouseXOffsetFromCenter: Ce,
+                mouseXOffsetRatio: Ce !== void 0 && ce > 0 ? Ce / ce : void 0,
+                hideArrow: P?.hideArrow,
+              };
+            return (u.addLabelInstance(We), F);
+          },
+          Hn = (a) => {
+            (jt.delete(a), u.removeLabelInstance(a));
+          },
+          jt = new Map(),
+          vn = (a) => {
+            let d = jt.get(a);
+            d !== void 0 && (window.clearTimeout(d), jt.delete(a));
+          },
+          Jt = (a) => {
+            vn(a);
+            let d = window.setTimeout(() => {
+              (jt.delete(a),
+                u.updateLabelInstance(a, "fading"),
+                setTimeout(() => {
+                  Hn(a);
+                }, 150));
+            }, 1500);
+            jt.set(a, d);
+          },
+          ea = (a, d) => {
+            if (d) vn(a);
+            else {
+              let g = l.labelInstances.find((_) => _.id === a);
+              g && g.status === "copied" && Jt(a);
+            }
+          },
+          ta = async ({
+            positionX: a,
+            operation: d,
+            bounds: g,
+            tagName: _,
+            componentName: P,
+            element: F,
+            shouldDeactivateAfter: re,
+            elements: ce,
+            existingInstanceId: Le,
+          }) => {
+            ((Fe = false), l.current.state !== "copying" && u.startCopy());
+            let Ce = Le ?? null;
+            !Ce &&
+              g &&
+              _ &&
+              (Ce = vt(g, _, P, "copying", {
+                element: F,
+                mouseX: a,
+                elements: ce,
+              }));
+            let We = false,
+              nt;
+            try {
+              (await d(), (We = !0));
+            } catch (lt) {
+              nt =
+                lt instanceof Error && lt.message
+                  ? lt.message
+                  : "Action failed";
+            }
+            (Ce &&
+              (We
+                ? u.updateLabelInstance(Ce, "copied")
+                : u.updateLabelInstance(Ce, "error", nt || "Unknown error"),
+              Jt(Ce)),
+              l.current.state === "copying" &&
+                (We && u.completeCopy(F),
+                re
+                  ? Qe()
+                  : We
+                    ? (u.activate(),
+                      (Fe = true),
+                      Zt !== null && window.clearTimeout(Zt),
+                      (Zt = window.setTimeout(() => {
+                        ((Fe = false), (Zt = null));
+                      }, 1500)))
+                    : u.unfreeze()));
+          },
+          xr = (a, d, g) => {
+            let _ = a[0],
+              P = g ?? (_ ? Kr(_) : null),
+              F = _ ? pt(_) : null,
+              re = P ?? F ?? void 0;
+            return kf(
+              {
+                maxContextLines: r.store.options.maxContextLines,
+                getContent: r.store.options.getContent,
+                componentName: re,
+              },
+              {
+                onBeforeCopy: r.hooks.onBeforeCopy,
+                transformSnippet: r.hooks.transformSnippet,
+                transformCopyContent: r.hooks.transformCopyContent,
+                onAfterCopy: r.hooks.onAfterCopy,
+                onCopySuccess: (ce, Le) => {
+                  r.hooks.onCopySuccess(ce, Le);
+                  let Ce = ce.length > 0,
+                    We = !!d;
+                  if (Ce) {
+                    let At = y();
+                    for (let [dn, fn] of V.entries()) {
+                      if (
+                        !(
+                          fn.length === ce.length &&
+                          fn.every((fa, ep) => fa === ce[ep])
+                        )
+                      )
+                        continue;
+                      let Vn = At.find((fa) => fa.id === dn);
+                      if (!Vn) continue;
+                      if (
+                        We
+                          ? Vn.isComment && Vn.commentText === d
+                          : !Vn.isComment
+                      ) {
+                        (zl(dn), V.delete(dn));
+                        break;
+                      }
+                    }
+                  }
+                  let nt = ce.map((At, dn) => Hf(At, dn === 0)),
+                    lt = am({
+                      content: Le,
+                      elementName: re ?? "element",
+                      tagName: F ?? "div",
+                      componentName: P ?? void 0,
+                      elementsCount: ce.length,
+                      previewBounds: ce.map((At) => ze(At)),
+                      elementSelectors: nt,
+                      isComment: We,
+                      commentText: d ?? void 0,
+                      timestamp: Date.now(),
+                    });
+                  (h(lt), de(true), G((At) => At + 1));
+                  let Dt = lt[0];
+                  Dt && Ce && V.set(Dt.id, [...ce]);
+                  let Or = new Set(lt.map((At) => At.id));
+                  for (let At of V.keys()) Or.has(At) || V.delete(At);
+                },
+                onCopyError: r.hooks.onCopyError,
+              },
+              a,
+              d,
+            );
+          },
+          k = async (a, d, g) => {
+            if (a.length === 0) return;
+            let _ = [],
+              P = [];
+            for (let F of a) {
+              let { wasIntercepted: re, pendingResult: ce } =
+                r.hooks.onElementSelect(F);
+              (re || _.push(F),
+                ce && P.push(ce),
+                r.store.theme.grabbedBoxes.enabled && wi(ze(F), F));
+            }
+            if ((await Mu(), _.length > 0)) await xr(_, d, g);
+            else if (P.length > 0 && !(await Promise.all(P)).every(Boolean))
+              throw new Error("Failed to copy");
+            wr(a);
+          },
+          q = ({
+            element: a,
+            positionX: d,
+            elements: g,
+            extraPrompt: _,
+            shouldDeactivateAfter: P,
+            onComplete: F,
+            dragRect: re,
+          }) => {
+            let ce = g ?? [a],
+              Le = re ?? l.frozenDragRect,
+              Ce;
+            Le && ce.length > 1 ? (Ce = Bs(Le)) : (Ce = zs(ze(a)));
+            let We = ce.length > 1 ? Ce.x + Ce.width / 2 : d,
+              nt = pt(a);
+            ((Fe = false), u.startCopy());
+            let lt = nt
+              ? vt(Ce, nt, void 0, "copying", {
+                  element: a,
+                  mouseX: We,
+                  elements: g,
+                })
+              : null;
+            nr(a).then((Dt) => {
+              ta({
+                positionX: We,
+                operation: () => k(ce, _, Dt ?? void 0),
+                bounds: Ce,
+                tagName: nt,
+                componentName: Dt ?? void 0,
+                element: a,
+                shouldDeactivateAfter: P,
+                elements: g,
+                existingInstanceId: lt,
+              }).then(() => {
+                F?.();
+              });
+            });
+          },
+          ee = se(() => {
+            if ((l.viewportVersion, !Lt() || x())) return null;
+            let a = l.detectedElement;
+            return et(a) ? a : null;
+          }),
+          ne = se(() => l.frozenElement || (b() ? null : ee()));
+        (be(() => {
+          let a = l.detectedElement;
+          if (!a) return;
+          let d = setInterval(() => {
+            et(a) || u.setDetectedElement(null);
+          }, 100);
+          Me(() => clearInterval(d));
+        }),
+          be(
+            He(ne, (a) => {
+              if ((Vt !== null && (clearTimeout(Vt), (Vt = null)), !a)) {
+                ko(null);
+                return;
+              }
+              Vt = window.setTimeout(() => {
+                ((Vt = null), ko(a));
+              }, 100);
+            }),
+          ),
+          Me(() => {
+            Vt !== null && (clearTimeout(Vt), (Vt = null));
+          }),
+          be(() => {
+            let a = l.frozenElements,
+              d = tf(a);
+            Me(d);
+          }),
+          be(
+            He(p, (a) => {
+              if (!a || !r.store.options.freezeReactUpdates) return;
+              let d = Rs();
+              Me(d);
+            }),
+          ));
+        let xe = () => {
+            if (l.isTouchMode && x()) {
+              let d = l.detectedElement;
+              return !d || vo(d) ? void 0 : d;
+            }
+            let a = ne();
+            if (!(!a || vo(a))) return a;
+          },
+          ve = se(() => xe()),
+          he = () =>
+            ve() ? (l.isTouchMode && x() ? Lt() : Lt() && !x()) : false,
+          De = se(() => {
+            l.viewportVersion;
+            let a = l.frozenElements;
+            if (a.length === 0) return [];
+            let d = l.frozenDragRect;
+            return d && a.length > 1
+              ? [Bs(d)]
+              : a.filter((g) => g !== null).map((g) => ze(g));
+          }),
+          Oe = se(() => {
+            l.viewportVersion;
+            let a = l.frozenElements;
+            if (a.length > 0) {
+              let g = De();
+              if (a.length === 1) {
+                let P = g[0];
+                if (P) return P;
+              }
+              let _ = l.frozenDragRect;
+              return _ ? (g[0] ?? Bs(_)) : zs(Ol(g));
+            }
+            let d = ve();
+            if (d) return ze(d);
+          }),
+          je = se(() => l.frozenElements.length),
+          qe = (a, d) => {
+            let g = a + window.scrollX,
+              _ = d + window.scrollY;
+            return {
+              x: Math.abs(g - l.dragStart.x),
+              y: Math.abs(_ - l.dragStart.y),
+            };
+          },
+          tt = se(() => {
+            if (!x()) return false;
+            let a = qe(l.pointer.x, l.pointer.y);
+            return a.x > 2 || a.y > 2;
+          }),
+          Ne = (a, d) => {
+            let g = a + window.scrollX,
+              _ = d + window.scrollY,
+              P = Math.min(l.dragStart.x, g),
+              F = Math.min(l.dragStart.y, _),
+              re = Math.abs(g - l.dragStart.x),
+              ce = Math.abs(_ - l.dragStart.y);
+            return {
+              x: P - window.scrollX,
+              y: F - window.scrollY,
+              width: re,
+              height: ce,
+            };
+          },
+          ut = se(() => {
+            if ((l.viewportVersion, !tt())) return;
+            let a = Ne(l.pointer.x, l.pointer.y);
+            return {
+              borderRadius: "0px",
+              height: a.height,
+              transform: "none",
+              width: a.width,
+              x: a.x,
+              y: a.y,
+            };
+          }),
+          at = se(() => {
+            if ((l.viewportVersion, !tt())) return [];
+            let a = Dn();
+            if (!a) return [];
+            let d = Ne(a.x, a.y),
+              g = fi(d, gn);
+            return (g.length > 0 ? g : fi(d, gn, false)).map((P) => ze(P));
+          }),
+          kt = se(() => {
+            let a = at();
+            return a.length > 0 ? a : De();
+          }),
+          un = se(() => {
+            if (M() || m()) {
+              l.viewportVersion;
+              let a = l.frozenElement || ee();
+              if (a) {
+                let d = ze(a);
+                return {
+                  x: kn(d).x + l.copyOffsetFromCenterX,
+                  y: l.copyStart.y,
+                };
+              }
+              return { x: l.copyStart.x, y: l.copyStart.y };
+            }
+            return { x: l.pointer.x, y: l.pointer.y };
+          });
+        (be(
+          He(
+            () => [ee(), l.lastGrabbedElement],
+            ([a, d]) => {
+              (d && a && d !== a && u.setLastGrabbed(null),
+                a && r.hooks.onElementHover(a));
+            },
+          ),
+        ),
+          be(
+            He(
+              () => ee(),
+              (a) => {
+                let d = ++Nt,
+                  g = () => {
+                    Nt === d && u.setSelectionSource(null, null);
+                  };
+                if (!a) {
+                  g();
+                  return;
+                }
+                Mn(a)
+                  .then((_) => {
+                    if (Nt === d && _) {
+                      for (let P of _)
+                        if (P.fileName && ho(P.fileName)) {
+                          u.setSelectionSource(
+                            go(P.fileName),
+                            P.lineNumber ?? null,
+                          );
+                          return;
+                        }
+                      g();
+                    }
+                  })
+                  .catch(() => {
+                    Nt === d && u.setSelectionSource(null, null);
+                  });
+              },
+            ),
+          ),
+          be(
+            He(
+              () => l.viewportVersion,
+              () => Ze._internal.updateBoundsOnViewportChange(),
+            ),
+          ));
+        let Cn = se(() =>
+            l.grabbedBoxes.map((a) => ({
+              id: a.id,
+              bounds: a.bounds,
+              createdAt: a.createdAt,
+            })),
+          ),
+          xi = se(() =>
+            l.labelInstances.map((a) => ({
+              id: a.id,
+              status: a.status,
+              tagName: a.tagName,
+              componentName: a.componentName,
+              createdAt: a.createdAt,
+            })),
+          ),
+          En = se(() => {
+            let a = p(),
+              d = x(),
+              g = M(),
+              _ = m(),
+              P = xn(),
+              F = ee(),
+              re = ut(),
+              ce = r.store.theme.enabled,
+              Le = r.store.theme.selectionBox.enabled,
+              Ce = r.store.theme.dragBox.enabled,
+              We = tt(),
+              nt = ne(),
+              lt = Y(),
+              Dt = !!(ce && Le && a && !g && !lt && !d && nt != null);
+            return {
+              isActive: a,
+              isDragging: d,
+              isCopying: g,
+              isPromptMode: _,
+              isCrosshairVisible: P ?? false,
+              isSelectionBoxVisible: Dt,
+              isDragBoxVisible: !!(ce && Ce && a && !g && We),
+              targetElement: F,
+              dragBounds: re
+                ? { x: re.x, y: re.y, width: re.width, height: re.height }
+                : null,
+              grabbedBoxes: Cn(),
+              labelInstances: xi(),
+              selectionFilePath: l.selectionFilePath,
+              toolbarState: le(),
+            };
+          });
+        (be(
+          He(En, (a) => {
+            r.hooks.onStateChange(a);
+          }),
+        ),
+          be(
+            He(
+              () => [m(), l.pointer.x, l.pointer.y, ee()],
+              ([a, d, g, _]) => {
+                r.hooks.onPromptModeChange(a, { x: d, y: g, targetElement: _ });
+              },
+            ),
+          ),
+          be(
+            He(
+              () => [sa(), Oe(), ee()],
+              ([a, d, g]) => {
+                r.hooks.onSelectionBox(!!a, d ?? null, g);
+              },
+            ),
+          ),
+          be(
+            He(
+              () => [aa(), ut()],
+              ([a, d]) => {
+                r.hooks.onDragBox(!!a, d ?? null);
+              },
+            ),
+          ),
+          be(
+            He(
+              () => [xn(), l.pointer.x, l.pointer.y],
+              ([a, d, g]) => {
+                r.hooks.onCrosshair(!!a, { x: d, y: g });
+              },
+            ),
+          ),
+          be(
+            He(
+              () => [
+                Dm(),
+                Lm(),
+                un(),
+                ee(),
+                l.selectionFilePath,
+                l.selectionLineNumber,
+              ],
+              ([a, d, g, _, P, F]) => {
+                r.hooks.onElementLabel(!!a, d, {
+                  x: g.x,
+                  y: g.y,
+                  content: "",
+                  element: _ ?? void 0,
+                  tagName: (_ && pt(_)) || void 0,
+                  filePath: P ?? void 0,
+                  lineNumber: F ?? void 0,
+                });
+              },
+            ),
+          ));
+        let Qt = null,
+          Mo = (a) => {
+            a
+              ? (Qt ||
+                  ((Qt = document.createElement("style")),
+                  Qt.setAttribute("data-react-grab-cursor", ""),
+                  document.head.appendChild(Qt)),
+                (Qt.textContent = `* { cursor: ${a} !important; }`))
+              : Qt && (Qt.remove(), (Qt = null));
+          };
+        be(
+          He(
+            () => [p(), M(), m()],
+            ([a, d, g]) => {
+              Mo(d ? "progress" : a && !g ? "crosshair" : null);
+            },
+          ),
+        );
+        let en = () => {
+            let a = f();
+            (u.activate(), a || r.hooks.onActivate());
+          },
+          vi = () => {
+            (Zt !== null && (window.clearTimeout(Zt), (Zt = null)),
+              (Fe = false));
+          },
+          Qe = () => {
+            let a = x(),
+              d = l.previouslyFocusedElement;
+            (u.deactivate(),
+              Ar(),
+              (Gt = null),
+              (Ut = false),
+              a && (document.body.style.userSelect = ""),
+              st && window.clearTimeout(st),
+              cn.stop(),
+              d instanceof HTMLElement && et(d) && d.focus(),
+              r.hooks.onDeactivate());
+          },
+          vr = () => {
+            (f() && u.release(), p() && Qe(), vi());
+          },
+          Z = () => {
+            (u.setWasActivatedByToggle(true), en());
+          },
+          io = (a, d, g) => {
+            let _ = d[0];
+            if (et(_)) {
+              let P = _.getBoundingClientRect(),
+                F = P.top + P.height / 2;
+              (u.setPointer({ x: a.position.x, y: F }),
+                u.setFrozenElements(d),
+                u.setInputText(a.context.prompt),
+                u.setWasActivatedByToggle(true),
+                g && u.setSelectedAgent(g),
+                p() || en());
+            }
+          },
+          Bn = (a) => ({
+            ...a,
+            onAbort: (d, g) => {
+              (a.onAbort?.(d, g), io(d, g, a));
+            },
+            onUndo: (d, g) => {
+              (a.onUndo?.(d, g), io(d, g, a));
+            },
+          }),
+          Ro = () => {
+            let a = c();
+            if (a) return Bn(a);
+          },
+          Ze = Il(Ro(), {
+            transformAgentContext: r.hooks.transformAgentContext,
+          }),
+          Cr = () => {
+            u.clearLastCopied();
+            let a = [...l.frozenElements],
+              d = l.frozenElement || ee(),
+              g = m() ? l.inputText.trim() : "";
+            if (!d) {
+              Qe();
+              return;
+            }
+            let _ = a.length > 0 ? a : d ? [d] : [],
+              P = _.map((Ce) => ze(Ce)),
+              F = P[0],
+              re = F.x + F.width / 2,
+              ce = F.y + F.height / 2,
+              Le = re + l.copyOffsetFromCenterX;
+            if ((l.selectedAgent || Te()) && g) {
+              let Ce = l.replySessionId,
+                We = l.selectedAgent;
+              (Qe(),
+                u.clearReplySessionId(),
+                u.setSelectedAgent(null),
+                Ze.session.start({
+                  elements: _,
+                  prompt: g,
+                  position: { x: Le, y: ce },
+                  selectionBounds: P,
+                  sessionId: Ce ?? void 0,
+                  agent: We ? Bn(We) : void 0,
+                }));
+              return;
+            }
+            (u.setPointer({ x: re, y: ce }),
+              u.exitPromptMode(),
+              u.clearInputText(),
+              u.clearReplySessionId(),
+              q({
+                element: d,
+                positionX: Le,
+                elements: _,
+                extraPrompt: g || void 0,
+                onComplete: Qe,
+              }));
+          },
+          so = () => {
+            if ((u.clearLastCopied(), !m())) return;
+            if (l.inputText.trim() && !T()) {
+              u.setPendingDismiss(true);
+              return;
+            }
+            (u.clearInputText(), u.clearReplySessionId(), Qe());
+          },
+          Ci = () => {
+            (u.clearInputText(), u.clearReplySessionId(), Qe());
+          },
+          Ei = () => {
+            u.setPendingDismiss(false);
+          },
+          Si = (a, d) => {
+            (u.setPendingAbortSessionId(null), d && Ze.session.abort(a));
+          },
+          Ai = () => {
+            let a = l.frozenElement || ee();
+            (a && Ue(a, l.pointer.x, l.pointer.y), wt());
+          },
+          Ti = (a, d) => {
+            let g = Ze.sessions().get(a),
+              _ = Ze.session.getElements(a),
+              P = g?.selectionBounds ?? [],
+              F = P[0];
+            if (g && _.length > 0 && F) {
+              let re = g.position.x,
+                ce = g.context.sessionId ?? a;
+              (Ze.session.dismiss(a),
+                Ze.session.start({
+                  elements: _,
+                  prompt: d,
+                  position: { x: re, y: F.y + F.height / 2 },
+                  selectionBounds: P,
+                  sessionId: ce,
+                }));
+            }
+          },
+          _i = (a) => {
+            let d = Ze.session.acknowledgeError(a);
+            d && u.setInputText(d);
+          },
+          Pi = () => {
+            p() ? Qe() : R() && ((Ut = true), Z());
+          },
+          Er = (a, d, g) => {
+            (u.setPendingCommentMode(false),
+              u.clearInputText(),
+              u.enterPromptMode({ x: d, y: g }, a));
+          },
+          Io = (a, d) => {
+            (u.showContextMenu(d, a), Ar(), rc(), r.hooks.onContextMenu(a, d));
+          },
+          ki = () => {
+            if (!R()) return;
+            if (p() && E()) {
+              Qe();
+              return;
+            }
+            (u.setPendingCommentMode(true), p() || Z());
+          },
+          Oi = () => {
+            let a = !R();
+            X(a);
+            let d = yo(),
+              g = {
+                edge: d?.edge ?? "bottom",
+                ratio: d?.ratio ?? 0.5,
+                collapsed: d?.collapsed ?? false,
+                enabled: a,
+              };
+            (Qr(g), ue(g), ro.forEach((_) => _(g)), a || (vr(), rc()));
+          },
+          Mi = (a, d) => {
+            if (!R() || m() || b() || l.contextMenuPosition !== null) return;
+            (u.setPointer({ x: a, y: d }), (Rt = a), (yn = d));
+            let g = performance.now(),
+              _ = Bt > 0 && g - Bt < 200;
+            if (
+              (g - Ht >= 32 &&
+                !_ &&
+                ((Ht = g),
+                (Bt = g),
+                em(() => {
+                  let P = dr(Rt, yn);
+                  (P !== l.detectedElement && u.setDetectedElement(P),
+                    (Bt = 0));
+                })),
+              x())
+            ) {
+              It(a, d);
+              let P = Nl(a, d),
+                F = P.top || P.bottom || P.left || P.right;
+              F && !cn.isActive()
+                ? cn.start()
+                : !F && cn.isActive() && cn.stop();
+            }
+          },
+          Ri = (a, d) =>
+            !Lt() || M()
+              ? false
+              : (u.startDrag({ x: a, y: d }),
+                u.setPointer({ x: a, y: d }),
+                (document.body.style.userSelect = "none"),
+                It(a, d),
+                r.hooks.onDragStart(a + window.scrollX, d + window.scrollY),
+                true),
+          Ii = (a, d) => {
+            let g = fi(a, gn),
+              _ = g.length > 0 ? g : fi(a, gn, false);
+            if (_.length === 0) return;
+            (ur(_), r.hooks.onDragEnd(_, a));
+            let P = _[0],
+              F = kn(ze(P));
+            (u.setPointer(F), u.setFrozenElements(_));
+            let re = kl(a);
+            if (
+              (u.setFrozenDragRect(re),
+              u.freeze(),
+              u.setLastGrabbed(P),
+              l.pendingCommentMode)
+            ) {
+              Er(P, F.x, F.y);
+              return;
+            }
+            if (Ut) {
+              ((Ut = false), Io(P, F));
+              return;
+            }
+            let ce = l.wasActivatedByToggle && !d;
+            q({
+              element: P,
+              positionX: F.x,
+              elements: _,
+              shouldDeactivateAfter: ce,
+              dragRect: re,
+            });
+          },
+          Ni = (a, d, g) => {
+            let _ = et(l.frozenElement) ? l.frozenElement : null,
+              P = et(Gt) ? Gt : null,
+              F =
+                _ ??
+                P ??
+                dr(a, d) ??
+                (et(l.detectedElement) ? l.detectedElement : null);
+            if (!F) return;
+            let re = !_ && P === F,
+              ce,
+              Le;
+            if (_) ((ce = l.pointer.x), (Le = l.pointer.y));
+            else if (re) {
+              let We = kn(ze(F));
+              ((ce = We.x), (Le = We.y));
+            } else ((ce = a), (Le = d));
+            if (((Gt = null), l.pendingCommentMode)) {
+              Er(F, ce, Le);
+              return;
+            }
+            if (Ut) {
+              Ut = false;
+              let { wasIntercepted: We } = r.hooks.onElementSelect(F);
+              if (We) return;
+              (ur([F]), u.setFrozenElement(F));
+              let nt = { x: ce, y: Le };
+              (u.setPointer(nt), u.freeze(), Io(F, nt));
+              return;
+            }
+            let Ce = l.wasActivatedByToggle && !g;
+            (u.setLastGrabbed(F),
+              q({ element: F, positionX: ce, shouldDeactivateAfter: Ce }));
+          },
+          Sr = () => {
+            x() &&
+              (u.cancelDrag(),
+              cn.stop(),
+              (document.body.style.userSelect = ""));
+          },
+          dm = (a, d, g) => {
+            if (!x()) return;
+            (xt !== null && (clearTimeout(xt), (xt = null)), To(null));
+            let _ = qe(a, d),
+              P = _.x > 2 || _.y > 2,
+              F = P ? Ne(a, d) : null;
+            (P ? u.endDrag() : u.cancelDrag(),
+              cn.stop(),
+              (document.body.style.userSelect = ""),
+              F ? Ii(F, g) : Ni(a, d, g));
+          },
+          dt = _f(),
+          Li = qf(),
+          No = (a) => {
+            let d;
+            try {
+              d = Li.originalKeyDescriptor?.get
+                ? Li.originalKeyDescriptor.get.call(a)
+                : a.key;
+            } catch {
+              return false;
+            }
+            let g = d === "Enter" || So(a.code),
+              _ = p() || f();
+            return g && _ && !m() && !l.wasActivatedByToggle && v() === null
+              ? (Li.claimedEvents.add(a),
+                a.preventDefault(),
+                a.stopImmediatePropagation(),
+                true)
+              : false;
+          };
+        (dt.addDocumentListener("keydown", No, { capture: true }),
+          dt.addDocumentListener("keyup", No, { capture: true }),
+          dt.addDocumentListener("keypress", No, { capture: true }));
+        let fm = (a) => {
+            if (
+              !(a.code === "KeyZ" && (a.metaKey || a.ctrlKey)) ||
+              Array.from(Ze.sessions().values()).some(
+                (P) => !P.isStreaming && !P.error,
+              )
+            )
+              return false;
+            let _ = a.shiftKey;
+            return _ && Ze.canRedo()
+              ? (a.preventDefault(),
+                a.stopPropagation(),
+                Ze.history.redo(),
+                true)
+              : !_ && Ze.canUndo()
+                ? (a.preventDefault(),
+                  a.stopPropagation(),
+                  Ze.history.undo(),
+                  true)
+                : false;
+          },
+          Ar = () => {
+            (yi([]), $n(0), ln.clearHistory());
+          },
+          na = (a) => {
+            (u.setFrozenElement(a), u.freeze(), (Gt = a));
+            let d = ze(a),
+              g = kn(d);
+            (u.setPointer(g),
+              l.contextMenuPosition !== null && u.showContextMenu(g, a));
+          },
+          Ul = (a) => {
+            let d = ze(a),
+              g = Ds(d.x + d.width / 2, d.y + d.height / 2)
+                .filter(gn)
+                .reverse();
+            (yi(g), $n(Math.max(0, g.indexOf(a))));
+          },
+          mm = (a) => {
+            let d = Fn()[a];
+            d && ($n(a), ln.clearHistory(), na(d));
+          },
+          jl = (a) => {
+            if (!p() || m() || !Ca.has(a.key)) return false;
+            let d = ne(),
+              g = !d;
+            if (
+              (d || (d = dr(window.innerWidth / 2, window.innerHeight / 2)), !d)
+            )
+              return false;
+            if (!(a.key === "ArrowUp" || a.key === "ArrowDown")) {
+              Ar();
+              let ce = ln.findNext(a.key, d);
+              return !ce && !g
+                ? false
+                : (a.preventDefault(), a.stopPropagation(), na(ce ?? d), true);
+            }
+            Fn().length === 0 && Ul(d);
+            let F = ln.findNext(a.key, d) ?? d;
+            (a.preventDefault(), a.stopPropagation(), na(F));
+            let re = Fn().indexOf(F);
+            return (re !== -1 ? $n(re) : Ul(F), true);
+          },
+          pm = (a) => {
+            if (!So(a.code) || St(a)) return false;
+            let d = l.lastCopiedElement;
+            if (
+              !f() &&
+              !m() &&
+              !p() &&
+              d &&
+              et(d) &&
+              !l.labelInstances.some(
+                (P) => P.status === "copied" || P.status === "fading",
+              )
+            ) {
+              (a.preventDefault(), a.stopImmediatePropagation());
+              let P = kn(ze(d));
+              return (
+                u.setPointer(P),
+                Ue(d, P.x, P.y),
+                u.setFrozenElement(d),
+                u.clearLastCopied(),
+                wt(),
+                p() || en(),
+                true
+              );
+            }
+            if (f() && !m()) {
+              (a.preventDefault(), a.stopImmediatePropagation());
+              let P = l.frozenElement || ee();
+              return (
+                P && Ue(P, l.pointer.x, l.pointer.y),
+                u.setPointer({ x: l.pointer.x, y: l.pointer.y }),
+                P && u.setFrozenElement(P),
+                wt(),
+                st !== null && (window.clearTimeout(st), (st = null)),
+                p() || en(),
+                true
+              );
+            }
+            return false;
+          },
+          gm = (a) => {
+            if (
+              a.key?.toLowerCase() !== "o" ||
+              m() ||
+              !p() ||
+              !(a.metaKey || a.ctrlKey)
+            )
+              return false;
+            let d = l.selectionFilePath,
+              g = l.selectionLineNumber;
+            return d
+              ? (a.preventDefault(),
+                a.stopPropagation(),
+                r.hooks.onOpenFile(d, g ?? void 0) ||
+                  or(d, g ?? void 0, r.hooks.transformOpenFileUrl),
+                true)
+              : false;
+          },
+          Wl = () => {
+            an !== null && (window.clearTimeout(an), (an = null));
+          },
+          Lo = () => {
+            (Wl(), hi([]), bi(null));
+          },
+          Kl = se(
+            () =>
+              !!ve() && Lt() && !m() && !x() && l.contextMenuPosition === null,
+          ),
+          hm = se(() => ({
+            items: br(),
+            activeIndex: Oo(),
+            isVisible: Oo() !== null && br().length > 0,
+          })),
+          bm = se(() =>
+            Fn().map((a) => ({
+              tagName: pt(a) || "element",
+              componentName: Kr(a) ?? void 0,
+            })),
+          ),
+          ym = se(() => ({
+            items: bm(),
+            activeIndex: yr(),
+            isVisible: Fn().length > 0,
+          }));
+        (be(
+          He(ve, () => {
+            Lo();
+          }),
+        ),
+          be(
+            He(Kl, (a) => {
+              a || Lo();
+            }),
+          ));
+        let wm = (a) => r.store.actions.find((d) => d.id === a),
+          xm = () => {
+            let a = ve();
+            if (!a) return;
+            let d = Oe();
+            return tc({
+              element: a,
+              filePath: l.selectionFilePath ?? void 0,
+              lineNumber: l.selectionLineNumber ?? void 0,
+              tagName: pt(a) || void 0,
+              componentName: wn(),
+              position: l.pointer,
+              performWithFeedbackOptions: {
+                fallbackBounds: d,
+                fallbackSelectionBounds: d ? [d] : [],
+              },
+              shouldDeferHideContextMenu: false,
+              onBeforePrompt: Lo,
+            });
+          },
+          vm = se(() => {
+            if (!ve()) return [];
+            let a = [];
+            for (let d of r.store.actions)
+              (typeof d.enabled == "boolean" && !d.enabled) ||
+                a.push({ id: d.id, label: d.label, shortcut: d.shortcut });
+            return a;
+          }),
+          Cm = () => {
+            (Wl(),
+              (an = window.setTimeout(() => {
+                an = null;
+                let a = Oo(),
+                  d = br();
+                if (a === null || d.length === 0) return;
+                let g = d[a];
+                if (!g) return;
+                let _ = wm(g.id);
+                if (!_) {
+                  Lo();
+                  return;
+                }
+                let P = xm();
+                if (!P || !ui(_, P)) {
+                  Lo();
+                  return;
+                }
+                Lo();
+                _.onAction(P);
+              }, 600)));
+          },
+          Em = () => {
+            if (!Kl()) return false;
+            let a = vm();
+            if (a.length === 0) return false;
+            hi(a);
+            let d = Oo(),
+              _ = d !== null && d < a.length ? (d + 1) % a.length : 0;
+            return (bi(_), Cm(), true);
+          },
+          Sm = (a) =>
+            a.code !== "KeyC" || a.altKey || a.repeat || St(a) || !Em()
+              ? false
+              : (a.preventDefault(),
+                a.stopPropagation(),
+                (a.metaKey || a.ctrlKey) && a.stopImmediatePropagation(),
+                true),
+          Am = (a) => {
+            if (
+              !(!r.store.options.allowActivationInsideInput && St(a)) &&
+              !(
+                !Us(a, r.store.options) &&
+                ((a.metaKey || a.ctrlKey) &&
+                  !Xc.includes(a.key) &&
+                  !So(a.code) &&
+                  (p() && !l.wasActivatedByToggle
+                    ? Qe()
+                    : f() && (rt(), ct(), u.release())),
+                !So(a.code) || !f())
+              )
+            ) {
+              if (
+                ((p() || f()) &&
+                  !m() &&
+                  (a.preventDefault(),
+                  So(a.code) && a.stopImmediatePropagation()),
+                p())
+              ) {
+                if (
+                  (l.wasActivatedByToggle &&
+                    r.store.options.activationMode !== "hold") ||
+                  a.repeat
+                )
+                  return;
+                (st !== null && window.clearTimeout(st),
+                  (st = window.setTimeout(() => {
+                    Qe();
+                  }, 200)));
+                return;
+              }
+              if (f() && a.repeat) {
+                if (_o) {
+                  let d = qt;
+                  (ct(), d && u.activate());
+                }
+                return;
+              }
+              if (!(M() || Y()) && !f()) {
+                let g = r.store.options.keyHoldDuration ?? 100;
+                (St(a) ? (_u(a) ? (g += 600) : (g += 400)) : Pu() && (g += 600),
+                  ct(),
+                  u.startHold(g));
+              }
+            }
+          };
+        (dt.addWindowListener(
+          "keydown",
+          (a) => {
+            if ((No(a), !R())) {
+              Us(a, r.store.options) && !a.repeat && j((F) => F + 1);
+              return;
+            }
+            if (fm(a)) return;
+            let d = So(a.code) && f() && !m(),
+              g = _t(a, "data-react-grab-input");
+            if (m() && Us(a, r.store.options) && !a.repeat && !g) {
+              (a.preventDefault(), a.stopPropagation(), so());
+              return;
+            }
+            if (a.key === "Escape" && v() !== null) return;
+            if (a.key === "Escape" && S() !== null) {
+              tn();
+              return;
+            }
+            if (B() !== null) {
+              if (a.key === "Escape") {
+                lo();
+                return;
+              }
+              let F = r.store.toolbarActions,
+                re = (a.metaKey || a.ctrlKey) && !a.repeat,
+                ce = F.find((Le) =>
+                  Le.shortcut
+                    ? a.key === "Enter"
+                      ? Le.shortcut === "Enter"
+                      : re && a.key.toLowerCase() === Le.shortcut.toLowerCase()
+                    : false,
+                );
+              ce &&
+                di(ce) &&
+                (a.preventDefault(), a.stopPropagation(), ce.onAction(), lo());
+              return;
+            }
+            let _ = _t(a, "data-react-grab-ignore-events") && !d;
+            if (m() || _)
+              return (
+                a.key === "Escape" &&
+                  (ge()
+                    ? (a.preventDefault(),
+                      a.stopPropagation(),
+                      u.setPendingAbortSessionId(null))
+                    : m()
+                      ? so()
+                      : l.wasActivatedByToggle && Qe()),
+                _ && Ca.has(a.key) && jl(a),
+                void 0
+              );
+            if (a.key === "Escape") {
+              if (ge()) {
+                (a.preventDefault(),
+                  a.stopPropagation(),
+                  u.setPendingAbortSessionId(null));
+                return;
+              }
+              if (Ze.isProcessing()) return;
+              if (f() || l.wasActivatedByToggle) {
+                Qe();
+                return;
+              }
+            }
+            let P = Date.now() - Po < 200;
+            (!P && Sm(a)) || jl(a) || pm(a) || gm(a) || P || Am(a);
+          },
+          { capture: true },
+        ),
+          dt.addWindowListener(
+            "keyup",
+            (a) => {
+              if (No(a)) return;
+              let d = Yf(r.store.options),
+                g =
+                  d.metaKey || d.ctrlKey
+                    ? In()
+                      ? !a.metaKey
+                      : !a.ctrlKey
+                    : (d.shiftKey && !a.shiftKey) || (d.altKey && !a.altKey),
+                _ = r.store.options.activationKey
+                  ? typeof r.store.options.activationKey == "function"
+                    ? r.store.options.activationKey(a)
+                    : Gs(r.store.options.activationKey)(a)
+                  : Vs(a.key, a.code);
+              if (Y() || Fe) {
+                (_ || g) && ((Fe = false), Qe());
+                return;
+              }
+              if ((!f() && !p()) || m()) return;
+              let P = !!r.store.options.activationKey,
+                F = r.store.options.activationMode === "hold";
+              if (p()) {
+                let re = l.contextMenuPosition !== null;
+                if (g) {
+                  if (
+                    (l.wasActivatedByToggle &&
+                      r.store.options.activationMode !== "hold") ||
+                    re
+                  )
+                    return;
+                  Qe();
+                } else if (F && _) {
+                  if (
+                    (st !== null && (window.clearTimeout(st), (st = null)), re)
+                  )
+                    return;
+                  Qe();
+                } else
+                  !P &&
+                    _ &&
+                    st !== null &&
+                    (window.clearTimeout(st), (st = null));
+                return;
+              }
+              if (_ || g) {
+                if (
+                  l.wasActivatedByToggle &&
+                  r.store.options.activationMode !== "hold"
+                )
+                  return;
+                if (f() || (qt && g)) {
+                  rt();
+                  let Le = (Pt ? Date.now() - Pt : 0) >= 200,
+                    Ce =
+                      qt &&
+                      Le &&
+                      (r.store.options.allowActivationInsideInput || !St(a));
+                  (ct(), Ce ? u.activate() : u.release());
+                } else Qe();
+              }
+            },
+            { capture: true },
+          ),
+          dt.addDocumentListener("copy", () => {
+            f() && (_o = true);
+          }),
+          dt.addWindowListener("keypress", No, { capture: true }),
+          dt.addWindowListener(
+            "pointermove",
+            (a) => {
+              if (!a.isPrimary) return;
+              let d = a.pointerType === "touch";
+              if (
+                (u.setTouchMode(d),
+                _t(a, "data-react-grab-ignore-events") ||
+                  l.contextMenuPosition !== null ||
+                  (d && !f() && !p()))
+              )
+                return;
+              ((d ? f() : p()) && !m() && b() && (u.unfreeze(), Ar()),
+                Mi(a.clientX, a.clientY));
+            },
+            { passive: true },
+          ),
+          dt.addWindowListener(
+            "pointerdown",
+            (a) => {
+              if (
+                a.button !== 0 ||
+                !a.isPrimary ||
+                (u.setTouchMode(a.pointerType === "touch"),
+                _t(a, "data-react-grab-ignore-events")) ||
+                l.contextMenuPosition !== null ||
+                B() !== null
+              )
+                return;
+              if (m()) {
+                let g = Oe();
+                g &&
+                a.clientX >= g.x &&
+                a.clientX <= g.x + g.width &&
+                a.clientY >= g.y &&
+                a.clientY <= g.y + g.height
+                  ? Cr()
+                  : so();
+                return;
+              }
+              Ri(a.clientX, a.clientY) &&
+                (document.documentElement.setPointerCapture(a.pointerId),
+                a.preventDefault(),
+                a.stopImmediatePropagation());
+            },
+            { capture: true },
+          ),
+          dt.addWindowListener(
+            "pointerup",
+            (a) => {
+              if (
+                a.button !== 0 ||
+                !a.isPrimary ||
+                _t(a, "data-react-grab-ignore-events") ||
+                l.contextMenuPosition !== null
+              )
+                return;
+              let d = a.metaKey || a.ctrlKey;
+              dm(a.clientX, a.clientY, d);
+            },
+            { capture: true },
+          ),
+          dt.addWindowListener(
+            "contextmenu",
+            (a) => {
+              if (!Lt() || M() || m()) return;
+              let d = _t(a, "data-react-grab-ignore-events");
+              if (d && Fn().length > 0) Ar();
+              else if (d) return;
+              if (l.contextMenuPosition !== null) {
+                a.preventDefault();
+                return;
+              }
+              (a.preventDefault(), a.stopPropagation());
+              let g = dr(a.clientX, a.clientY);
+              if (!g) return;
+              let _ = l.frozenElements;
+              _.length > 1 && _.includes(g)
+                ? ur(_)
+                : (ur([g]), u.setFrozenElement(g));
+              let F = { x: a.clientX, y: a.clientY };
+              (u.setPointer(F), u.freeze(), Io(g, F));
+            },
+            { capture: true },
+          ),
+          dt.addWindowListener("pointercancel", (a) => {
+            a.isPrimary && Sr();
+          }),
+          dt.addWindowListener(
+            "click",
+            (a) => {
+              _t(a, "data-react-grab-ignore-events") ||
+                (l.contextMenuPosition === null &&
+                  (Lt() || M() || H()) &&
+                  (a.preventDefault(),
+                  a.stopImmediatePropagation(),
+                  l.wasActivatedByToggle &&
+                    !M() &&
+                    !m() &&
+                    (f() ? u.setWasActivatedByToggle(false) : Qe())));
+            },
+            { capture: true },
+          ),
+          dt.addDocumentListener("visibilitychange", () => {
+            if (document.hidden) {
+              u.clearGrabbedBoxes();
+              let a = l.activationTimestamp;
+              p() && !m() && a !== null && Date.now() - a > 500 && Qe();
+            }
+          }),
+          dt.addWindowListener("blur", () => {
+            (Sr(), f() && (rt(), u.release(), ct()));
+          }),
+          dt.addWindowListener("focus", () => {
+            Po = Date.now();
+          }));
+        let Tm = () => {
+            if (
+              !(l.isTouchMode && !f() && !p()) &&
+              R() &&
+              !m() &&
+              !b() &&
+              !x() &&
+              l.contextMenuPosition === null &&
+              l.frozenElements.length === 0
+            ) {
+              let a = dr(l.pointer.x, l.pointer.y);
+              u.setDetectedElement(a);
+            }
+          },
+          Xl = () => {
+            (Bf(),
+              Tm(),
+              u.incrementViewportVersion(),
+              u.updateSessionBounds(),
+              u.updateContextMenuPosition());
+          };
+        dt.addWindowListener("scroll", Xl, { capture: true });
+        let oa = window.innerWidth,
+          ra = window.innerHeight;
+        dt.addWindowListener("resize", () => {
+          let a = window.innerWidth,
+            d = window.innerHeight;
+          if (oa > 0 && ra > 0) {
+            let g = a / oa,
+              _ = d / ra,
+              P = Math.abs(g - _) < Ma,
+              F = Math.abs(g - 1) > Ma;
+            P && F && u.setPointer({ x: l.pointer.x * g, y: l.pointer.y * _ });
+          }
+          ((oa = a), (ra = d), Xl());
+        });
+        let ao = null,
+          zn = null,
+          _m = () => {
+            let a =
+              r.store.theme.enabled &&
+              (p() ||
+                M() ||
+                l.labelInstances.length > 0 ||
+                l.grabbedBoxes.length > 0 ||
+                Ze.sessions().size > 0);
+            a && ao === null
+              ? (ao = window.setInterval(() => {
+                  zn === null &&
+                    (zn = Ve(() => {
+                      ((zn = null),
+                        u.incrementViewportVersion(),
+                        u.updateSessionBounds());
+                    }));
+                }, 100))
+              : !a &&
+                ao !== null &&
+                (window.clearInterval(ao),
+                (ao = null),
+                zn !== null && (Ge(zn), (zn = null)));
+          };
+        (be(() => {
+          (r.store.theme.enabled,
+            p(),
+            M(),
+            l.labelInstances.length,
+            l.grabbedBoxes.length,
+            Ze.sessions().size,
+            _m());
+        }),
+          Me(() => {
+            (ao !== null && window.clearInterval(ao), zn !== null && Ge(zn));
+          }),
+          dt.addDocumentListener(
+            "copy",
+            (a) => {
+              m() ||
+                _t(a, "data-react-grab-ignore-events") ||
+                ((Lt() || M()) && a.preventDefault());
+            },
+            { capture: true },
+          ),
+          Me(() => {
+            (dt.abort(),
+              xt !== null && window.clearTimeout(xt),
+              st && window.clearTimeout(st),
+              Zt && window.clearTimeout(Zt),
+              an && window.clearTimeout(an),
+              W !== null && Ge(W),
+              gt.forEach((a) => window.clearTimeout(a)),
+              gt.clear(),
+              cn.stop(),
+              (document.body.style.userSelect = ""),
+              (document.body.style.touchAction = ""),
+              Mo(null),
+              Li.restore());
+          }));
+        let ia = Ou(Mc),
+          Tr = se(() => r.store.theme.enabled),
+          Pm = se(() => r.store.theme.selectionBox.enabled),
+          Yl = se(() => r.store.theme.elementLabel.enabled),
+          km = se(() => r.store.theme.dragBox.enabled),
+          ql = se(() => Y() || (L() && !b())),
+          Om = se(() => at().length > 0),
+          sa = se(() => (!Tr() || !Pm() || ql() ? false : Om() ? true : he())),
+          Mm = se(() => {
+            let a = ve();
+            if (a) return pt(a) || void 0;
+          });
+        be(
+          He(
+            () => Qs(),
+            (a) => {
+              let d = ++zt;
+              if (!a) {
+                hr(void 0);
+                return;
+              }
+              nr(a)
+                .then((g) => {
+                  zt === d && hr(g ?? void 0);
+                })
+                .catch(() => {
+                  zt === d && hr(void 0);
+                });
+            },
+          ),
+        );
+        let Rm = se(() =>
+            l.contextMenuPosition !== null || !Yl() || ql() ? false : he(),
+          ),
+          Di = new Map(),
+          Im = se(() => {
+            if (!Tr()) return [];
+            if (!r.store.theme.grabbedBoxes.enabled) return [];
+            l.viewportVersion;
+            let a = new Set(l.labelInstances.map((d) => d.id));
+            for (let d of Di.keys()) a.has(d) || Di.delete(d);
+            return l.labelInstances.map((d) => {
+              let g = d.elements && d.elements.length > 1,
+                _ = d.element,
+                F = !g && _ && document.body.contains(_) ? ze(_) : d.bounds,
+                re = Di.get(d.id),
+                ce =
+                  re &&
+                  re.bounds.x === F.x &&
+                  re.bounds.y === F.y &&
+                  re.bounds.width === F.width &&
+                  re.bounds.height === F.height;
+              if (
+                re &&
+                re.status === d.status &&
+                re.errorMessage === d.errorMessage &&
+                ce
+              )
+                return re;
+              let Le = F.x + F.width / 2,
+                Ce = F.width / 2,
+                We =
+                  d.mouseXOffsetRatio !== void 0 && Ce > 0
+                    ? Le + d.mouseXOffsetRatio * Ce
+                    : d.mouseXOffsetFromCenter !== void 0
+                      ? Le + d.mouseXOffsetFromCenter
+                      : d.mouseX,
+                nt = { ...d, bounds: F, mouseX: We };
+              return (Di.set(d.id, nt), nt);
+            });
+          }),
+          Nm = se(() =>
+            Tr()
+              ? r.store.theme.grabbedBoxes.enabled
+                ? (l.viewportVersion,
+                  l.grabbedBoxes.map((a) =>
+                    !a.element || !document.body.contains(a.element)
+                      ? a
+                      : { ...a, bounds: ze(a.element) },
+                  ))
+                : []
+              : [],
+          ),
+          aa = se(() => Tr() && km() && Lt() && tt()),
+          Lm = se(() => (M() ? "processing" : "hover")),
+          Dm = se(() => {
+            if (!Tr()) return false;
+            let a = Yl(),
+              d = m(),
+              g = M(),
+              _ = Lt(),
+              P = x(),
+              F = !!ne(),
+              re = L(),
+              ce = b();
+            return !a || d || (re && !ce) ? false : g ? true : _ && !P && F;
+          }),
+          Zl = se(() => {
+            l.viewportVersion;
+            let a = l.contextMenuElement;
+            return a ? ze(a) : null;
+          }),
+          Fm = se(() => (l.viewportVersion, l.contextMenuPosition)),
+          Jl = se(() => {
+            let a = l.contextMenuElement;
+            if (!a) return;
+            let d = l.frozenElements.length;
+            return d > 1 ? `${d} elements` : pt(a) || void 0;
+          }),
+          [Ql] = ba(
+            () => ({
+              element: l.contextMenuElement,
+              frozenCount: l.frozenElements.length,
+            }),
+            async ({ element: a, frozenCount: d }) =>
+              !a || d > 1 ? void 0 : ((await nr(a)) ?? void 0),
+          ),
+          [ec] = ba(
+            () => l.contextMenuElement,
+            async (a) => {
+              if (!a) return null;
+              let d = await Mn(a);
+              return nl(d);
+            },
+          ),
+          $m = (a, d, g, _, P) => async (F) => {
+            let re = P?.fallbackBounds ?? null,
+              ce = P?.fallbackSelectionBounds ?? [],
+              Le = P?.position ?? l.contextMenuPosition ?? l.pointer,
+              Ce = De(),
+              We = Zl() ?? re,
+              nt = d.length > 1,
+              lt = nt ? zs(Ol(Ce)) : We,
+              Dt = l.wasActivatedByToggle,
+              Or = nt ? Ce : We ? [We] : ce;
+            if ((u.hideContextMenu(), lt)) {
+              let At = nt ? lt.x + lt.width / 2 : Le.x,
+                dn = vt(lt, g || "element", _, "copying", {
+                  element: a,
+                  mouseX: At,
+                  elements: nt ? d : void 0,
+                  boundsMultiple: Or,
+                }),
+                fn = false,
+                $i;
+              try {
+                ((fn = await F()), fn || ($i = "Failed to copy"));
+              } catch (Vn) {
+                $i =
+                  Vn instanceof Error && Vn.message
+                    ? Vn.message
+                    : "Action failed";
+              }
+              (u.updateLabelInstance(
+                dn,
+                fn ? "copied" : "error",
+                fn ? void 0 : $i || "Unknown error",
+              ),
+                Jt(dn));
+            } else
+              try {
+                await F();
+              } catch {}
+            Dt ? Qe() : u.unfreeze();
+          },
+          la = () => {
+            setTimeout(() => {
+              u.hideContextMenu();
+            }, 0);
+          },
+          tc = (a) => {
+            let {
+                element: d,
+                filePath: g,
+                lineNumber: _,
+                tagName: P,
+                componentName: F,
+                position: re,
+                performWithFeedbackOptions: ce,
+                shouldDeferHideContextMenu: Le,
+                onBeforeCopy: Ce,
+                onBeforePrompt: We,
+                customEnterPromptMode: nt,
+              } = a,
+              lt = l.frozenElements.length > 0 ? l.frozenElements : [d],
+              Dt = Le ? la : u.hideContextMenu,
+              dn = {
+                element: d,
+                elements: lt,
+                filePath: g,
+                lineNumber: _,
+                componentName: F,
+                tagName: P,
+                enterPromptMode:
+                  nt ??
+                  ((fn) => {
+                    (fn && u.setSelectedAgent(fn),
+                      u.clearLabelInstances(),
+                      We?.(),
+                      Ue(d, re.x, re.y),
+                      u.setPointer({ x: re.x, y: re.y }),
+                      u.setFrozenElement(d),
+                      wt(),
+                      p() || en(),
+                      Dt());
+                  }),
+                copy: () => {
+                  (Ce?.(),
+                    q({
+                      element: d,
+                      positionX: re.x,
+                      elements: lt.length > 1 ? lt : void 0,
+                      shouldDeactivateAfter: l.wasActivatedByToggle,
+                    }),
+                    Dt());
+                },
+                hooks: {
+                  transformHtmlContent: r.hooks.transformHtmlContent,
+                  onOpenFile: r.hooks.onOpenFile,
+                  transformOpenFileUrl: r.hooks.transformOpenFileUrl,
+                },
+                performWithFeedback: $m(d, lt, P, F, ce),
+                hideContextMenu: Dt,
+                cleanup: () => {
+                  l.wasActivatedByToggle ? Qe() : u.unfreeze();
+                },
+              };
+            return r.hooks.transformActionContext(dn);
+          },
+          Hm = se(() => {
+            let a = l.contextMenuElement;
+            if (!a) return;
+            let d = ec(),
+              g = l.contextMenuPosition ?? l.pointer;
+            return tc({
+              element: a,
+              filePath: d?.filePath,
+              lineNumber: d?.lineNumber,
+              tagName: Jl(),
+              componentName: Ql(),
+              position: g,
+              shouldDeferHideContextMenu: true,
+              onBeforeCopy: () => {
+                Gt = null;
+              },
+              customEnterPromptMode: (_) => {
+                (_ && u.setSelectedAgent(_),
+                  u.clearLabelInstances(),
+                  u.clearInputText(),
+                  u.enterPromptMode(g, a),
+                  la());
+              },
+            });
+          }),
+          Bm = () => {
+            setTimeout(() => {
+              (u.hideContextMenu(), Qe());
+            }, 0);
+          },
+          Sn = () => {
+            for (let { boxId: a, labelId: d } of me)
+              (u.removeGrabbedBox(a), d && u.removeLabelInstance(d));
+            me = [];
+          },
+          zm = (a, d, g, _) => {
+            if (d.length === 0) return;
+            let P = a.isComment && a.commentText;
+            for (let [F, re] of d.entries()) {
+              let ce = g[F],
+                Le = `${_}-${a.id}-${F}`;
+              u.addGrabbedBox({
+                id: Le,
+                bounds: re,
+                createdAt: 0,
+                element: ce,
+              });
+              let Ce = null;
+              (F === 0 &&
+                ((Ce = `${_}-label-${a.id}`),
+                u.addLabelInstance({
+                  id: Ce,
+                  bounds: re,
+                  tagName: a.tagName,
+                  componentName: a.componentName,
+                  elementsCount: a.elementsCount,
+                  status: "idle",
+                  isPromptMode: !!P,
+                  inputValue: P ? a.commentText : void 0,
+                  createdAt: 0,
+                  element: ce,
+                  mouseX: re.x + re.width / 2,
+                })),
+                me.push({ boxId: Le, labelId: Ce }));
+            }
+          },
+          nc = (a, d) => {
+            let g = pe(a),
+              _ = g.map((P) => ze(P));
+            zm(a, _, g, d);
+          },
+          _r = () => {
+            W !== null && (Ge(W), (W = null));
+          },
+          ca = (a) => {
+            _r();
+            let d = () => {
+              (a(), (W = Ve(d)));
+            };
+            d();
+          },
+          Vm = (a) => {
+            let d = a.left + a.width / 2,
+              g = a.top + a.height / 2,
+              _ = g,
+              P = window.innerHeight - g,
+              F = d,
+              re = window.innerWidth - d,
+              ce = Math.min(_, P, F, re);
+            return ce === _
+              ? "top"
+              : ce === F
+                ? "left"
+                : ce === re
+                  ? "right"
+                  : "bottom";
+          },
+          ua = () => {
+            if (!N) return null;
+            let a = N.getBoundingClientRect(),
+              d = Vm(a);
+            return d === "left" || d === "right"
+              ? {
+                  x: d === "left" ? a.right : a.left,
+                  y: a.top + a.height / 2,
+                  edge: d,
+                  toolbarWidth: a.width,
+                }
+              : {
+                  x: a.left + a.width / 2,
+                  y: d === "top" ? a.bottom : a.top,
+                  edge: d,
+                  toolbarWidth: a.width,
+                };
+          },
+          tn = () => {
+            (Fi(), Do(), _r(), Sn(), D(null), Ae(false));
+          },
+          oc = () => {
+            (u.hideContextMenu(),
+              lo(),
+              kr(),
+              h(Bl()),
+              de(false),
+              ca(() => {
+                let a = ua();
+                a && D(a);
+              }));
+          },
+          Pr = null,
+          An = null,
+          Fi = () => {
+            Pr !== null && (clearTimeout(Pr), (Pr = null));
+          },
+          Do = () => {
+            An !== null && (clearTimeout(An), (An = null));
+          },
+          lo = () => {
+            (_r(), w(null));
+          },
+          Gm = () => {
+            (tn(),
+              lo(),
+              ca(() => {
+                let a = ua();
+                a && $(a);
+              }));
+          },
+          kr = () => {
+            (_r(), $(null));
+          },
+          rc = () => {
+            (tn(), lo(), kr());
+          },
+          Um = () => {
+            B() !== null
+              ? lo()
+              : (u.hideContextMenu(),
+                tn(),
+                kr(),
+                ca(() => {
+                  let a = ua();
+                  a && w(a);
+                }));
+          },
+          jm = () => {
+            (Fi(),
+              Do(),
+              S() !== null ? (Q() ? (Sn(), Ae(false)) : tn()) : (Sn(), oc()));
+          },
+          ic = (a) => {
+            Xt(a.content, {
+              tagName: a.tagName,
+              componentName: a.componentName ?? a.elementName,
+              commentText: a.commentText,
+            });
+            let d = ke(a);
+            d &&
+              (u.clearLabelInstances(),
+              Ve(() => {
+                if (!et(d)) return;
+                let g = ze(d),
+                  _ = vt(g, a.tagName, a.componentName, "copied", {
+                    element: d,
+                    mouseX: g.x + g.width / 2,
+                  });
+                Jt(_);
+              }));
+          },
+          Wm = (a) => {
+            (Sn(), m() && (u.exitPromptMode(), u.clearInputText()));
+            let d = ke(a);
+            if (a.isComment && a.commentText && d) {
+              let g = ze(d),
+                _ = g.x + g.width / 2,
+                P = g.y + g.height / 2;
+              (u.enterPromptMode({ x: _, y: P }, d),
+                u.setInputText(a.commentText));
+            } else ic(a);
+          },
+          Km = (a) => {
+            (Sn(), V.delete(a.id));
+            let d = zl(a.id);
+            (h(d), d.length === 0 && (de(false), tn()));
+          },
+          sc = () => {
+            Sn();
+            let a = y();
+            if (a.length === 0) return;
+            let d = Hs(a.map((_) => _.content)),
+              g = a[0];
+            (Xt(d, {
+              componentName: g.componentName ?? g.tagName,
+              entries: a.map((_) => ({
+                tagName: _.tagName,
+                componentName: _.componentName ?? _.elementName,
+                content: _.content,
+                commentText: _.commentText,
+              })),
+            }),
+              Gm(),
+              u.clearLabelInstances(),
+              Ve(() => {
+                ji(() => {
+                  for (let _ of a) {
+                    let P = pe(_);
+                    for (let F of P) {
+                      let re = ze(F),
+                        ce = `label-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+                      (u.addLabelInstance({
+                        id: ce,
+                        bounds: re,
+                        tagName: _.tagName,
+                        componentName: _.componentName,
+                        status: "copied",
+                        createdAt: Date.now(),
+                        element: F,
+                        mouseX: re.x + re.width / 2,
+                      }),
+                        Jt(ce));
+                    }
+                  }
+                });
+              }));
+          },
+          Xm = (a) => {
+            if ((Sn(), !a)) return;
+            let d = y().find((g) => g.id === a);
+            d && nc(d, "history-hover");
+          },
+          Ym = (a) => {
+            (Fi(),
+              Sn(),
+              a
+                ? (Do(),
+                  S() === null &&
+                    v() === null &&
+                    (lc(),
+                    (Pr = setTimeout(() => {
+                      ((Pr = null), Ae(true), oc());
+                    }, Gr))))
+                : Q() &&
+                  (An = setTimeout(() => {
+                    ((An = null), tn());
+                  }, Gr)));
+          },
+          qm = (a) => {
+            a
+              ? Do()
+              : Q() &&
+                (An = setTimeout(() => {
+                  ((An = null), tn());
+                }, Gr));
+          },
+          ac = (a) => {
+            (Sn(),
+              a
+                ? (Do(), lc())
+                : Q() &&
+                  (An = setTimeout(() => {
+                    ((An = null), tn());
+                  }, Gr)));
+          },
+          lc = () => {
+            for (let a of y()) nc(a, "history-all-hover");
+          },
+          cc = () => {
+            V.clear();
+            let a = lm();
+            (h(a), de(false), tn());
+          },
+          Zm = (a) => {
+            let d = Ze.sessions().get(a);
+            if (!d) return;
+            let g = Ze.session.getElement(a);
+            g &&
+              et(g) &&
+              setTimeout(() => {
+                (p() || (u.setWasActivatedByToggle(true), en()),
+                  u.setPointer(d.position),
+                  u.setFrozenElement(g),
+                  u.freeze(),
+                  u.showContextMenu(d.position, g));
+              }, 0);
+          },
+          Jm = (a) => {
+            let d = l.labelInstances.find((F) => F.id === a);
+            if (!d?.element || !et(d.element)) return;
+            let g = ze(d.element),
+              _ = { x: d.mouseX ?? g.x + g.width / 2, y: g.y + g.height / 2 },
+              P =
+                d.elements && d.elements.length > 0
+                  ? d.elements.filter((F) => et(F))
+                  : [d.element];
+            setTimeout(() => {
+              (p() || (u.setWasActivatedByToggle(true), en()),
+                u.setPointer(_),
+                u.setFrozenElements(P),
+                P.length > 1 && d.bounds && u.setFrozenDragRect(kl(d.bounds)),
+                u.freeze(),
+                u.showContextMenu(_, d.element));
+            }, 0);
+          };
+        (be(() => {
+          let a = r.store.theme.hue;
+          a !== 0
+            ? (ia.style.filter = `hue-rotate(${a}deg)`)
+            : (ia.style.filter = "");
+        }),
+          r.store.theme.enabled &&
+            Oc(
+              () =>
+                O(Tf, {
+                  get selectionVisible() {
+                    return sa();
+                  },
+                  get selectionBounds() {
+                    return Oe();
+                  },
+                  get selectionBoundsMultiple() {
+                    return kt();
+                  },
+                  get selectionShouldSnap() {
+                    return l.frozenElements.length > 0 || at().length > 0;
+                  },
+                  get selectionElementsCount() {
+                    return je();
+                  },
+                  get selectionFilePath() {
+                    return l.selectionFilePath ?? void 0;
+                  },
+                  get selectionLineNumber() {
+                    return l.selectionLineNumber ?? void 0;
+                  },
+                  get selectionTagName() {
+                    return Mm();
+                  },
+                  get selectionComponentName() {
+                    return wn();
+                  },
+                  get selectionLabelVisible() {
+                    return Rm();
+                  },
+                  selectionLabelStatus: "idle",
+                  get selectionActionCycleState() {
+                    return hm();
+                  },
+                  get selectionArrowNavigationState() {
+                    return ym();
+                  },
+                  onArrowNavigationSelect: mm,
+                  get labelInstances() {
+                    return Im();
+                  },
+                  get dragVisible() {
+                    return aa();
+                  },
+                  get dragBounds() {
+                    return ut();
+                  },
+                  get grabbedBoxes() {
+                    return Nm();
+                  },
+                  labelZIndex: 2147483647,
+                  get mouseX() {
+                    return Be(() => l.frozenElements.length > 1)()
+                      ? void 0
+                      : un().x;
+                  },
+                  get mouseY() {
+                    return un().y;
+                  },
+                  get crosshairVisible() {
+                    return xn();
+                  },
+                  get isFrozen() {
+                    return b() || p() || L();
+                  },
+                  get inputValue() {
+                    return l.inputText;
+                  },
+                  get isPromptMode() {
+                    return m();
+                  },
+                  get hasAgent() {
+                    return Te();
+                  },
+                  get isAgentConnected() {
+                    return l.isAgentConnected;
+                  },
+                  get agentSessions() {
+                    return Ze.sessions();
+                  },
+                  get supportsUndo() {
+                    return l.supportsUndo;
+                  },
+                  get supportsFollowUp() {
+                    return l.supportsFollowUp;
+                  },
+                  get dismissButtonText() {
+                    return l.dismissButtonText;
+                  },
+                  get onDismissSession() {
+                    return Ze.session.dismiss;
+                  },
+                  get onUndoSession() {
+                    return Ze.session.undo;
+                  },
+                  onFollowUpSubmitSession: Ti,
+                  onAcknowledgeSessionError: _i,
+                  get onRetrySession() {
+                    return Ze.session.retry;
+                  },
+                  onShowContextMenuSession: Zm,
+                  onShowContextMenuInstance: Jm,
+                  onLabelInstanceHoverChange: ea,
+                  get onInputChange() {
+                    return u.setInputText;
+                  },
+                  onInputSubmit: () => void Cr(),
+                  onInputCancel: so,
+                  onToggleExpand: Ai,
+                  get isPendingDismiss() {
+                    return T();
+                  },
+                  onConfirmDismiss: Ci,
+                  onCancelDismiss: Ei,
+                  get pendingAbortSessionId() {
+                    return ge();
+                  },
+                  onRequestAbortSession: (a) => u.setPendingAbortSessionId(a),
+                  onAbortSession: Si,
+                  get theme() {
+                    return r.store.theme;
+                  },
+                  get toolbarVisible() {
+                    return r.store.theme.toolbar.enabled;
+                  },
+                  get isActive() {
+                    return p();
+                  },
+                  onToggleActive: Pi,
+                  get enabled() {
+                    return R();
+                  },
+                  onToggleEnabled: Oi,
+                  get shakeCount() {
+                    return fe();
+                  },
+                  onToolbarStateChange: (a) => {
+                    (ue(a), ro.forEach((d) => d(a)));
+                  },
+                  onSubscribeToToolbarStateChanges: (a) => (
+                    ro.add(a),
+                    () => {
+                      ro.delete(a);
+                    }
+                  ),
+                  onToolbarSelectHoverChange: A,
+                  onToolbarRef: (a) => {
+                    N = a;
+                  },
+                  get contextMenuPosition() {
+                    return Fm();
+                  },
+                  get contextMenuBounds() {
+                    return Zl();
+                  },
+                  get contextMenuTagName() {
+                    return Jl();
+                  },
+                  get contextMenuComponentName() {
+                    return Ql();
+                  },
+                  get contextMenuHasFilePath() {
+                    return !!ec()?.filePath;
+                  },
+                  get actions() {
+                    return r.store.actions;
+                  },
+                  get toolbarActions() {
+                    return r.store.toolbarActions;
+                  },
+                  get actionContext() {
+                    return Hm();
+                  },
+                  onContextMenuDismiss: Bm,
+                  onContextMenuHide: la,
+                  get historyItems() {
+                    return y();
+                  },
+                  get historyDisconnectedItemIds() {
+                    return Pe();
+                  },
+                  get historyItemCount() {
+                    return y().length;
+                  },
+                  get clockFlashTrigger() {
+                    return I();
+                  },
+                  get hasUnreadHistoryItems() {
+                    return oe();
+                  },
+                  get historyDropdownPosition() {
+                    return S();
+                  },
+                  get isHistoryPinned() {
+                    return Be(() => S() !== null)() && !Q();
+                  },
+                  onToggleHistory: jm,
+                  onCopyAll: sc,
+                  onCopyAllHover: ac,
+                  onHistoryButtonHover: Ym,
+                  onHistoryItemSelect: Wm,
+                  onHistoryItemRemove: Km,
+                  onHistoryItemCopy: ic,
+                  onHistoryItemHover: Xm,
+                  onHistoryCopyAll: sc,
+                  onHistoryCopyAllHover: ac,
+                  onHistoryClear: cc,
+                  onHistoryDismiss: tn,
+                  onHistoryDropdownHover: qm,
+                  get toolbarMenuPosition() {
+                    return B();
+                  },
+                  onToggleMenu: Um,
+                  onToolbarMenuDismiss: lo,
+                  get clearPromptPosition() {
+                    return v();
+                  },
+                  onClearHistoryConfirm: () => {
+                    (kr(), cc());
+                  },
+                  onClearHistoryCancel: kr,
+                }),
+              ia,
+            ),
+          Te() && Ze.session.tryResume());
+        let Qm = async (a) => {
+            let d = Array.isArray(a) ? a : [a];
+            return d.length === 0 ? false : await xr(d);
+          },
+          uc = () => {
+            let a = Ro();
+            a && Ze._internal.setOptions(a);
+            let d = !!a?.provider;
+            if ((u.setHasAgentProvider(d), d && a?.provider)) {
+              let g = a.provider;
+              (u.setAgentCapabilities({
+                supportsUndo: !!g.undo,
+                supportsFollowUp: !!g.supportsFollowUp,
+                dismissButtonText: g.dismissButtonText,
+                isAgentConnected: false,
+              }),
+                g.checkConnection &&
+                  g
+                    .checkConnection()
+                    .then((_) => {
+                      Ro()?.provider === g &&
+                        u.setAgentCapabilities({
+                          supportsUndo: !!g.undo,
+                          supportsFollowUp: !!g.supportsFollowUp,
+                          dismissButtonText: g.dismissButtonText,
+                          isAgentConnected: _,
+                        });
+                    })
+                    .catch(() => {}),
+                Ze.session.tryResume());
+            } else
+              u.setAgentCapabilities({
+                supportsUndo: false,
+                supportsFollowUp: false,
+                dismissButtonText: void 0,
+                isAgentConnected: false,
+              });
+          },
+          da = {
+            activate: () => {
+              (u.setPendingCommentMode(false), !p() && R() && Z());
+            },
+            deactivate: () => {
+              (p() || M()) && Qe();
+            },
+            toggle: () => {
+              p() ? Qe() : R() && Z();
+            },
+            comment: ki,
+            isActive: () => p(),
+            isEnabled: () => R(),
+            setEnabled: (a) => {
+              a !== R() && (X(a), a || vr());
+            },
+            getToolbarState: () => yo(),
+            setToolbarState: (a) => {
+              let d = yo(),
+                g = {
+                  edge: a.edge ?? d?.edge ?? "bottom",
+                  ratio: a.ratio ?? d?.ratio ?? 0.5,
+                  collapsed: a.collapsed ?? d?.collapsed ?? false,
+                  enabled: a.enabled ?? d?.enabled ?? true,
+                };
+              (Qr(g),
+                ue(g),
+                a.enabled !== void 0 && a.enabled !== R() && X(a.enabled),
+                ro.forEach((_) => _(g)));
+            },
+            onToolbarStateChange: (a) => (
+              ro.add(a),
+              () => {
+                ro.delete(a);
+              }
+            ),
+            dispose: () => {
+              ((Vl = false), Fi(), Do(), _r(), ro.clear(), s());
+            },
+            copyElement: Qm,
+            getSource: async (a) => {
+              let d = await Mn(a),
+                g = nl(d);
+              return g
+                ? {
+                    filePath: g.filePath,
+                    lineNumber: g.lineNumber ?? null,
+                    componentName: g.componentName,
+                  }
+                : null;
+            },
+            getStackContext: ol,
+            getState: () => ({
+              isActive: p(),
+              isDragging: x(),
+              isCopying: M(),
+              isPromptMode: m(),
+              isCrosshairVisible: xn() ?? false,
+              isSelectionBoxVisible: sa() ?? false,
+              isDragBoxVisible: aa() ?? false,
+              targetElement: ee(),
+              dragBounds: ut() ?? null,
+              grabbedBoxes: l.grabbedBoxes.map((a) => ({
+                id: a.id,
+                bounds: a.bounds,
+                createdAt: a.createdAt,
+              })),
+              labelInstances: l.labelInstances.map((a) => ({
+                id: a.id,
+                status: a.status,
+                tagName: a.tagName,
+                componentName: a.componentName,
+                createdAt: a.createdAt,
+              })),
+              selectionFilePath: l.selectionFilePath,
+              toolbarState: le(),
+            }),
+            setOptions: (a) => {
+              r.setOptions(a);
+            },
+            registerPlugin: (a) => {
+              (r.register(a, da), uc());
+            },
+            unregisterPlugin: (a) => {
+              (r.unregister(a), uc());
+            },
+            getPlugins: () => r.getPluginNames(),
+            getDisplayName: Kr,
+          };
+        for (let a of ww) r.register(a, da);
+        return (
+          setTimeout(() => {
+            tr(true);
+          }, wu),
+          da
+        );
+      });
+    };
+  var Ao = null,
+    H5 = () =>
+      typeof window > "u" ? Ao : (window.__REACT_GRAB__ ?? Ao ?? null),
+    B5 = (e) => {
+      ((Ao = e),
+        typeof window < "u" &&
+          (e ? (window.__REACT_GRAB__ = e) : delete window.__REACT_GRAB__));
+    };
+  typeof window < "u" &&
+    (window.__REACT_GRAB__
+      ? (Ao = window.__REACT_GRAB__)
+      : ((Ao = Gl()), (window.__REACT_GRAB__ = Ao)),
+    window.dispatchEvent(new CustomEvent("react-grab:init", { detail: Ao })));
+  /*! Bundled license information:
 
 bippy/dist/rdt-hook-BvBEbB9n.js:
   (**
@@ -115,4 +15527,15 @@ bippy/dist/index.js:
    * This source code is licensed under the MIT license found in the
    * LICENSE file in the root directory of this source tree.
    *)
-*/exports.DEFAULT_THEME=to;exports.commentPlugin=Ll;exports.formatElementInfo=gs;exports.generateSnippet=mr;exports.getGlobalApi=H5;exports.getStack=Mn;exports.init=Gl;exports.isInstrumentationActive=Xn;exports.openPlugin=Dl;exports.setGlobalApi=B5;return exports;})({});
+*/ exports.DEFAULT_THEME = to;
+  exports.commentPlugin = Ll;
+  exports.formatElementInfo = gs;
+  exports.generateSnippet = mr;
+  exports.getGlobalApi = H5;
+  exports.getStack = Mn;
+  exports.init = Gl;
+  exports.isInstrumentationActive = Xn;
+  exports.openPlugin = Dl;
+  exports.setGlobalApi = B5;
+  return exports;
+})({});

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,10 @@
 packages:
-  - "packages/*"
-  - "packages/benchmarks/next-app"
+  - packages/*
+  - packages/benchmarks/next-app
+
+ignoredBuiltDependencies:
+  - "@parcel/watcher"
+  - esbuild
+  - sharp
+  - spawn-sync
+  - unrs-resolver


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add 3 practical demo examples to the Vite playground with intentional, obvious UI bugs to showcase React Grab's workflow.

These examples (User Profile Card, Pricing Cards, Notification Feed) are styled with shadcn/ui CSS variables and each contains multiple glaring bugs (e.g., vanishing hover states, misaligned elements, inconsistent styling, invisible text) that are designed to be easily identifiable and fixable using a coding agent with React Grab.

---
<p><a href="https://cursor.com/agents/bc-ed13a37c-093f-44f4-99a9-70deabb77c44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed13a37c-093f-44f4-99a9-70deabb77c44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three interactive demo examples to the Vite playground to showcase React Grab. Each demo includes obvious UI bugs designed for quick fixing.

- **New Features**
  - Replaced the TodoList with User Profile, Pricing, and Notifications demos in the Vite playground.
  - Updated index.css with shadcn/ui-style CSS variables and @theme inline tokens.
  - Intentional bugs:
    - User Profile: Follow button turns white-on-white on hover; Posts stat is smaller than others.
    - Pricing: Pro card has square corners; Pro checkmarks are blue instead of green.
    - Notifications: Success text is too light on white; no hover transitions; unread dot is clipped.

- **Dependencies**
  - pnpm-workspace.yaml: added ignoredBuiltDependencies for @parcel/watcher, esbuild, sharp, spawn-sync, unrs-resolver.

<sup>Written for commit 552cd7c70dbfd1cf670beba0a9778e1d8837e83e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

