### PR TITLE
feat: add bookmarklet for using React Grab on any site

### DIFF
--- a/bookmarklet.html
+++ b/bookmarklet.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>React Grab Bookmarklet</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600&family=Geist+Mono:wght@400&display=swap" rel="stylesheet">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: 'Geist', system-ui, -apple-system, sans-serif;
+    max-width: 672px;
+    margin: 0 auto;
+    padding: 48px 32px;
+    background: #000;
+    color: #fff;
+  }
+  h1 {
+    font-size: 24px;
+    font-weight: 600;
+    letter-spacing: -0.5px;
+    margin-bottom: 8px;
+  }
+  .shimmer {
+    background: linear-gradient(90deg, #f973ff, #ffb3ff, #ffe6ff, #f973ff);
+    background-size: 200% 100%;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    animation: shimmer 2.5s linear infinite;
+  }
+  @keyframes shimmer {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+  }
+  .subtitle {
+    color: #8f8f8f;
+    font-size: 16px;
+    line-height: 1.6;
+    margin-bottom: 32px;
+  }
+  a.bookmarklet {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 24px;
+    background: #292929;
+    color: #fff;
+    text-decoration: none;
+    border-radius: 10px;
+    font-family: 'Geist', system-ui, sans-serif;
+    font-size: 15px;
+    font-weight: 500;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    transition: all 0.3s;
+    cursor: grab;
+  }
+  a.bookmarklet:hover {
+    border-color: rgba(252, 78, 253, 0.5);
+    box-shadow: 0 0 20px rgba(252, 78, 253, 0.15);
+  }
+  a.bookmarklet:active { cursor: grabbing; }
+  .bookmarklet-icon {
+    width: 18px;
+    height: 18px;
+    border-radius: 4px;
+    background: #fc4efd;
+    flex-shrink: 0;
+  }
+  .instructions {
+    margin-top: 32px;
+    padding: 16px 20px;
+    background: #292929;
+    border-radius: 10px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+  }
+  .instructions p {
+    color: #8f8f8f;
+    font-size: 14px;
+    line-height: 1.7;
+  }
+  .instructions p + p { margin-top: 8px; }
+  code {
+    font-family: 'Geist Mono', ui-monospace, monospace;
+    font-size: 13px;
+    color: #ff4fff;
+    background: rgba(252, 78, 253, 0.1);
+    padding: 2px 6px;
+    border-radius: 4px;
+  }
+  .step {
+    color: #5b5b5b;
+    font-family: 'Geist Mono', ui-monospace, monospace;
+    font-size: 13px;
+    margin-right: 8px;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .shimmer { animation: none; }
+  }
+</style>
+</head>
+<body>
+  <h1><span class="shimmer">React Grab</span> Bookmarklet</h1>
+  <p class="subtitle">Drag this to your bookmarks bar to use React Grab on any site.</p>
+  <a class="bookmarklet" href="javascript:void((function(){var s=document.createElement('script');s.src='https://unpkg.com/react-grab/dist/index.global.js';s.crossOrigin='anonymous';document.head.appendChild(s);})())"><span class="bookmarklet-icon"></span>React Grab</a>
+  <div class="instructions">
+    <p><span class="step">1.</span> Drag the button above into your bookmarks bar</p>
+    <p><span class="step">2.</span> Visit any React site and click the bookmarklet</p>
+    <p><span class="step">3.</span> Hover over an element and press <code>&#x2318;C</code> to copy its component context</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds a `bookmarklet.html` page that lets users drag a bookmarklet to their bookmarks bar
- Clicking it injects `react-grab/dist/index.global.js` into any page — no install or build step needed
- Styled to match the existing site aesthetic (Geist font, dark theme, magenta accents)

## Use case

Useful for quickly trying React Grab on any React site without modifying the project. Also handy for inspecting third-party React apps you don't control.

## Test plan

- [ ] Open `bookmarklet.html` in a browser
- [ ] Drag the button to bookmarks bar
- [ ] Visit a React site, click the bookmarklet, hover + ⌘C to verify it works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Injects a third-party script from `unpkg.com` into arbitrary pages via `javascript:` bookmarklet, which has security/trust and CSP compatibility implications despite being isolated to an optional static page.
> 
> **Overview**
> Adds a standalone `bookmarklet.html` page that users can open to drag a **React Grab** bookmarklet into their bookmarks bar.
> 
> The bookmarklet injects `https://unpkg.com/react-grab/dist/index.global.js` into the current page, and the page includes brief usage instructions plus inline styling for a dark, branded look.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d58655e7fffd6bf345c182875edbf291a64adff0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bookmarklet page to inject React Grab into any site, so you can try it without installing or changing the project. Helps quickly inspect third‑party React apps.

- **New Features**
  - Added bookmarklet.html with a simple drag-to-bookmarks UI (Geist, dark theme, magenta accents).
  - Bookmarklet loads react-grab/dist/index.global.js from unpkg and runs in the current page.
  - Usage: drag to bookmarks bar, click on a React site, then hover + ⌘C to copy component context.

<sup>Written for commit d58655e7fffd6bf345c182875edbf291a64adff0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

