### PR TITLE
Fix Provider/Context filter to use OR instead of AND

### DIFF
--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -102,7 +102,7 @@ export const checkIsSourceComponentName = (name: string): boolean => {
   if (checkIsInternalComponentName(name)) return false;
   if (!isCapitalized(name)) return false;
   if (name.startsWith("Primitive.")) return false;
-  if (name.includes("Provider") && name.includes("Context")) return false;
+  if (name.includes("Provider") || name.includes("Context")) return false;
   return true;
 };
 


### PR DESCRIPTION
Fixes #122. The condition used AND which required both Provider and Context to be present. This caused common wrapper components like ThemeProvider, StyleCacheProvider, IntlProvider, ReduxProvider, ApolloProvider, and QueryClientProvider to not be filtered out as intended. Changed to OR so that any component containing Provider or Context is filtered.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single boolean-condition change in component-name filtering; impact is limited to which component names are considered “source” in stack/context output.
> 
> **Overview**
> Updates `checkIsSourceComponentName` in `packages/react-grab/src/core/context.ts` to **exclude any component name containing either `Provider` or `Context`** (OR), instead of only excluding names containing both (AND), so common wrapper/provider components no longer show up as “source” components.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 582817326d04a896d894b88e27a18be77b648037. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the Provider/Context name filter to OR so any component with “Provider” or “Context” in its name is excluded. Fixes #122 by filtering common wrappers (e.g., ThemeProvider, IntlProvider, ReduxProvider, ApolloProvider, QueryClientProvider) so only likely user components are considered.

<sup>Written for commit 582817326d04a896d894b88e27a18be77b648037. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

