### PR TITLE
Opencode jsonc resolution

### DIFF
--- a/packages/cli/src/utils/install-mcp.ts
+++ b/packages/cli/src/utils/install-mcp.ts
@@ -48,6 +48,16 @@ const getZedConfigPath = (): string => {
   return path.join(os.homedir(), ".config", "zed", "settings.json");
 };
 
+export const getOpenCodeConfigPath = (): string => {
+  const configDir = path.join(getXdgConfigHome(), "opencode");
+  const jsoncPath = path.join(configDir, "opencode.jsonc");
+  const jsonPath = path.join(configDir, "opencode.json");
+
+  if (fs.existsSync(jsoncPath)) return jsoncPath;
+  if (fs.existsSync(jsonPath)) return jsonPath;
+  return jsoncPath;
+};
+
 const getClients = (): ClientDefinition[] => {
   const homeDir = os.homedir();
   const baseDir = getBaseDir();
@@ -84,7 +94,7 @@ const getClients = (): ClientDefinition[] => {
     },
     {
       name: "OpenCode",
-      configPath: path.join(getXdgConfigHome(), "opencode", "opencode.json"),
+      configPath: getOpenCodeConfigPath(),
       configKey: "mcp",
       format: "json",
       serverConfig: {

--- a/packages/cli/test/install-mcp.test.ts
+++ b/packages/cli/test/install-mcp.test.ts
@@ -8,6 +8,7 @@ import {
   installJsonClient,
   installTomlClient,
   getMcpClientNames,
+  getOpenCodeConfigPath,
 } from "../src/utils/install-mcp.js";
 
 let tempDir: string;
@@ -182,6 +183,50 @@ describe("upsertIntoJsonc", () => {
     const result = fs.readFileSync(filePath, "utf8");
     expect(result).toContain('"command": "new"');
     expect(result).not.toContain('"old"');
+  });
+});
+
+describe("getOpenCodeConfigPath", () => {
+  let originalXdgConfigHome: string | undefined;
+
+  beforeEach(() => {
+    originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = tempDir;
+  });
+
+  afterEach(() => {
+    if (originalXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+    }
+  });
+
+  it("should prefer opencode.jsonc when both files exist", () => {
+    const opencodeDir = path.join(tempDir, "opencode");
+    fs.mkdirSync(opencodeDir, { recursive: true });
+    fs.writeFileSync(path.join(opencodeDir, "opencode.json"), "{}");
+    fs.writeFileSync(path.join(opencodeDir, "opencode.jsonc"), "{}");
+
+    const result = getOpenCodeConfigPath();
+
+    expect(result).toBe(path.join(opencodeDir, "opencode.jsonc"));
+  });
+
+  it("should use opencode.json when only it exists", () => {
+    const opencodeDir = path.join(tempDir, "opencode");
+    fs.mkdirSync(opencodeDir, { recursive: true });
+    fs.writeFileSync(path.join(opencodeDir, "opencode.json"), "{}");
+
+    const result = getOpenCodeConfigPath();
+
+    expect(result).toBe(path.join(opencodeDir, "opencode.json"));
+  });
+
+  it("should default to opencode.jsonc when neither file exists", () => {
+    const result = getOpenCodeConfigPath();
+
+    expect(result).toBe(path.join(tempDir, "opencode", "opencode.jsonc"));
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Resolve `opencode.json` and `opencode.jsonc` paths to ensure the CLI writes to the correct OpenCode configuration file.

The CLI previously hardcoded `opencode.json` as the configuration file path, even though OpenCode itself prefers `opencode.jsonc`. This led to scenarios where users with an existing `opencode.jsonc` would still have `opencode.json` created or written to, causing confusion and incorrect behavior. This PR introduces a resolver to correctly prioritize `opencode.jsonc` if it exists, falls back to `opencode.json`, and defaults to `opencode.jsonc` for new installations.

---
<p><a href="https://cursor.com/agents/bc-385c7366-1e83-4b24-8613-f245d871b6e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-385c7366-1e83-4b24-8613-f245d871b6e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the CLI so it writes to the correct OpenCode config file. It now prefers `opencode.jsonc`, falls back to `opencode.json`, and defaults to JSONC for new installs.

- **Bug Fixes**
  - Introduced `getOpenCodeConfigPath()` to resolve the OpenCode config path.
  - Updated the OpenCode client `configPath` to use the resolver.
  - Added tests for JSONC preferred, JSON fallback, and default behavior.

<sup>Written for commit 7fdb4a5eb13cb044b37270131539c7a526e6e5e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

