### PR TITLE
Add external communication opt-out for browser runtime

### DIFF
--- a/packages/react-grab/e2e/external-communication.spec.ts
+++ b/packages/react-grab/e2e/external-communication.spec.ts
@@ -1,0 +1,162 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("External Communication", () => {
+  test("should skip external requests during initialization when disabled", async ({
+    page,
+  }) => {
+    const requestedUrls: string[] = [];
+
+    page.on("request", (request) => {
+      const requestUrl = request.url();
+      if (
+        requestUrl.startsWith("https://www.react-grab.com/api/version") ||
+        requestUrl.startsWith("https://fonts.googleapis.com/")
+      ) {
+        requestedUrls.push(requestUrl);
+      }
+    });
+
+    await page.addInitScript(() => {
+      (
+        window as {
+          __REACT_GRAB_OPTIONS__?: {
+            allowExternalCommunication?: boolean;
+          };
+        }
+      ).__REACT_GRAB_OPTIONS__ = {
+        allowExternalCommunication: false,
+      };
+    });
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await page.waitForFunction(
+      () => (window as { __REACT_GRAB__?: unknown }).__REACT_GRAB__ !== undefined,
+      { timeout: 5000 },
+    );
+    await page.waitForTimeout(300);
+
+    expect(requestedUrls).toEqual([]);
+
+    const hasFontLink = await page.evaluate(() => {
+      return document.getElementById("react-grab-fonts") !== null;
+    });
+
+    expect(hasFontLink).toBe(false);
+  });
+
+  test("should not open a remote open-file fallback when disabled", async ({
+    page,
+  }) => {
+    const modifierKey = process.platform === "darwin" ? "Meta" : "Control";
+
+    await page.addInitScript(() => {
+      (
+        window as {
+          __REACT_GRAB_OPTIONS__?: {
+            allowExternalCommunication?: boolean;
+          };
+        }
+      ).__REACT_GRAB_OPTIONS__ = {
+        allowExternalCommunication: false,
+      };
+    });
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await page.waitForFunction(
+      () => (window as { __REACT_GRAB__?: unknown }).__REACT_GRAB__ !== undefined,
+      { timeout: 5000 },
+    );
+
+    await page.evaluate(() => {
+      (window as { __OPEN_FILE_URLS__?: string[] }).__OPEN_FILE_URLS__ = [];
+
+      const originalFetch = window.fetch.bind(window);
+      window.fetch = async (input, init) => {
+        const requestUrl =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        if (
+          requestUrl.includes("/__open-in-editor") ||
+          requestUrl.includes("/__nextjs_launch-editor")
+        ) {
+          return new Response("", { status: 404 });
+        }
+        return originalFetch(input, init);
+      };
+
+      Object.defineProperty(window, "open", {
+        configurable: true,
+        value: (url?: string | URL) => {
+          const openUrls =
+            (window as { __OPEN_FILE_URLS__?: string[] }).__OPEN_FILE_URLS__ ??
+            [];
+          openUrls.push(typeof url === "string" ? url : String(url ?? ""));
+          (window as { __OPEN_FILE_URLS__?: string[] }).__OPEN_FILE_URLS__ =
+            openUrls;
+          return null;
+        },
+      });
+    });
+
+    await page.evaluate(() => {
+      const api = (
+        window as {
+          __REACT_GRAB__?: {
+            activate: () => void;
+          };
+        }
+      ).__REACT_GRAB__;
+      api?.activate();
+    });
+    await page.waitForFunction(
+      () =>
+        (
+          window as {
+            __REACT_GRAB__?: {
+              isActive: () => boolean;
+            };
+          }
+        ).__REACT_GRAB__?.isActive() === true,
+      { timeout: 5000 },
+    );
+
+    const firstListItem = page.locator("li").first();
+    await firstListItem.hover({ force: true });
+
+    await page.waitForFunction(
+      () => {
+        const api = (
+          window as {
+            __REACT_GRAB__?: {
+              getState: () => {
+                isSelectionBoxVisible: boolean;
+                targetElement: unknown;
+                selectionFilePath: string | null;
+              };
+            };
+          }
+        ).__REACT_GRAB__;
+        const state = api?.getState();
+        return Boolean(
+          (state?.isSelectionBoxVisible || state?.targetElement) &&
+            state?.selectionFilePath,
+        );
+      },
+      { timeout: 5000 },
+    );
+
+    await page.keyboard.down(modifierKey);
+    await page.keyboard.press("o");
+    await page.keyboard.up(modifierKey);
+    await page.waitForTimeout(200);
+
+    const openUrls = await page.evaluate(() => {
+      return (window as { __OPEN_FILE_URLS__?: string[] }).__OPEN_FILE_URLS__;
+    });
+
+    expect(openUrls ?? []).toEqual([]);
+  });
+});

--- a/packages/react-grab/e2e/external-communication.spec.ts
+++ b/packages/react-grab/e2e/external-communication.spec.ts
@@ -146,15 +146,11 @@ test.describe("External Communication", () => {
       { timeout: 5000 },
     );
 
-    await page.evaluate(() => {
-      const host = document.querySelector("[data-react-grab]");
-      const shadowRoot = host?.shadowRoot;
-      const root = shadowRoot?.querySelector("[data-react-grab]");
-      const clickableTagBadge = root?.querySelector<HTMLDivElement>(
-        "[data-react-grab-selection-label] .cursor-pointer",
-      );
-      clickableTagBadge?.click();
-    });
+    const selectionLabelOpenButton = page.locator(
+      "[data-react-grab-selection-label] .cursor-pointer",
+    );
+    await expect(selectionLabelOpenButton).toBeVisible();
+    await selectionLabelOpenButton.click({ force: true });
     await page.waitForTimeout(200);
 
     const openUrls = await page.evaluate(() => {

--- a/packages/react-grab/e2e/external-communication.spec.ts
+++ b/packages/react-grab/e2e/external-communication.spec.ts
@@ -44,11 +44,9 @@ test.describe("External Communication", () => {
     expect(hasFontLink).toBe(false);
   });
 
-  test("should not open a remote open-file fallback when disabled", async ({
+  test("should not open a remote open-file fallback from the selection label when disabled", async ({
     page,
   }) => {
-    const modifierKey = process.platform === "darwin" ? "Meta" : "Control";
-
     await page.addInitScript(() => {
       (
         window as {
@@ -148,9 +146,15 @@ test.describe("External Communication", () => {
       { timeout: 5000 },
     );
 
-    await page.keyboard.down(modifierKey);
-    await page.keyboard.press("o");
-    await page.keyboard.up(modifierKey);
+    await page.evaluate(() => {
+      const host = document.querySelector("[data-react-grab]");
+      const shadowRoot = host?.shadowRoot;
+      const root = shadowRoot?.querySelector("[data-react-grab]");
+      const clickableTagBadge = root?.querySelector<HTMLDivElement>(
+        "[data-react-grab-selection-label] .cursor-pointer",
+      );
+      clickableTagBadge?.click();
+    });
     await page.waitForTimeout(200);
 
     const openUrls = await page.evaluate(() => {

--- a/packages/react-grab/src/components/renderer.tsx
+++ b/packages/react-grab/src/components/renderer.tsx
@@ -6,7 +6,6 @@ import {
   FROZEN_GLOW_EDGE_PX,
   Z_INDEX_OVERLAY_CANVAS,
 } from "../constants.js";
-import { openFile } from "../utils/open-file.js";
 import { isElementConnected } from "../utils/is-element-connected.js";
 import { OverlayCanvas } from "./overlay-canvas.js";
 import { SelectionLabel } from "./selection-label/index.js";
@@ -143,11 +142,7 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
           isPendingDismiss={props.isPendingDismiss}
           onConfirmDismiss={props.onConfirmDismiss}
           onCancelDismiss={props.onCancelDismiss}
-          onOpen={() => {
-            if (props.selectionFilePath) {
-              openFile(props.selectionFilePath, props.selectionLineNumber);
-            }
-          }}
+          onOpen={props.onOpenSelectionFile}
           isContextMenuOpen={props.contextMenuPosition !== null}
         />
       </Show>

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -182,6 +182,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     activationMode: "toggle",
     keyHoldDuration: DEFAULT_KEY_HOLD_DURATION_MS,
     allowActivationInsideInput: true,
+    allowExternalCommunication: true,
     maxContextLines: DEFAULT_MAX_CONTEXT_LINES,
     ...scriptOptions,
     ...rawOptions,
@@ -192,7 +193,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
   }
   hasInited = true;
 
-  logIntro();
+  logIntro(initialOptions.allowExternalCommunication ?? true);
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- need to omit enabled from settableOptions to avoid circular dependency
   const { enabled: _enabled, ...settableOptions } = initialOptions;
@@ -2297,6 +2298,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           filePath,
           lineNumber ?? undefined,
           pluginRegistry.hooks.transformOpenFileUrl,
+          pluginRegistry.store.options.allowExternalCommunication,
         );
       }
       return true;
@@ -3131,7 +3133,10 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     });
 
     const resolvedCssText = typeof cssText === "string" ? cssText : "";
-    const rendererRoot = mountRoot(resolvedCssText);
+    const rendererRoot = mountRoot(
+      resolvedCssText,
+      pluginRegistry.store.options.allowExternalCommunication,
+    );
 
     const isThemeEnabled = createMemo(() => pluginRegistry.store.theme.enabled);
     const isSelectionBoxThemeEnabled = createMemo(
@@ -3504,6 +3509,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         copy: copyAction,
         hooks: {
           transformHtmlContent: pluginRegistry.hooks.transformHtmlContent,
+          allowExternalCommunication:
+            pluginRegistry.store.options.allowExternalCommunication,
           onOpenFile: pluginRegistry.hooks.onOpenFile,
           transformOpenFileUrl: pluginRegistry.hooks.transformOpenFileUrl,
         },

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -2278,29 +2278,35 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       return false;
     };
 
-    const handleOpenFileShortcut = (event: KeyboardEvent): boolean => {
-      if (event.key?.toLowerCase() !== "o" || isPromptMode()) return false;
-      if (!isActivated() || !(event.metaKey || event.ctrlKey)) return false;
-
+    const openSelectionFile = (): boolean => {
       const filePath = store.selectionFilePath;
       const lineNumber = store.selectionLineNumber;
       if (!filePath) return false;
-
-      event.preventDefault();
-      event.stopPropagation();
 
       const wasHandled = pluginRegistry.hooks.onOpenFile(
         filePath,
         lineNumber ?? undefined,
       );
       if (!wasHandled) {
-        openFile(
+        void openFile(
           filePath,
           lineNumber ?? undefined,
           pluginRegistry.hooks.transformOpenFileUrl,
           pluginRegistry.store.options.allowExternalCommunication,
         );
       }
+      return true;
+    };
+
+    const handleOpenFileShortcut = (event: KeyboardEvent): boolean => {
+      if (event.key?.toLowerCase() !== "o" || isPromptMode()) return false;
+      if (!isActivated() || !(event.metaKey || event.ctrlKey)) return false;
+
+      const didOpenSelectionFile = openSelectionFile();
+      if (!didOpenSelectionFile) return false;
+
+      event.preventDefault();
+      event.stopPropagation();
       return true;
     };
 
@@ -3505,12 +3511,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         lineNumber,
         componentName,
         tagName,
+        allowExternalCommunication:
+          pluginRegistry.store.options.allowExternalCommunication,
         enterPromptMode: customEnterPromptMode ?? defaultEnterPromptMode,
         copy: copyAction,
         hooks: {
           transformHtmlContent: pluginRegistry.hooks.transformHtmlContent,
-          allowExternalCommunication:
-            pluginRegistry.store.options.allowExternalCommunication,
           onOpenFile: pluginRegistry.hooks.onOpenFile,
           transformOpenFileUrl: pluginRegistry.hooks.transformOpenFileUrl,
         },
@@ -4043,6 +4049,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
             selectionElementsCount={frozenElementsCount()}
             selectionFilePath={store.selectionFilePath ?? undefined}
             selectionLineNumber={store.selectionLineNumber ?? undefined}
+            onOpenSelectionFile={openSelectionFile}
             selectionTagName={selectionTagName()}
             selectionComponentName={resolvedComponentName()}
             selectionLabelVisible={selectionLabelVisible()}

--- a/packages/react-grab/src/core/log-intro.ts
+++ b/packages/react-grab/src/core/log-intro.ts
@@ -1,7 +1,7 @@
 import { LOGO_SVG } from "../constants.js";
 import { isExtensionContext } from "../utils/is-extension-context.js";
 
-export const logIntro = () => {
+export const logIntro = (allowExternalCommunication: boolean) => {
   try {
     const version = process.env.VERSION;
     const logoDataUri = `data:image/svg+xml;base64,${btoa(LOGO_SVG)}`;
@@ -10,7 +10,12 @@ export const logIntro = () => {
       `background: #330039; color: #ffffff; border: 1px solid #d75fcb; padding: 4px 4px 4px 24px; border-radius: 4px; background-image: url("${logoDataUri}"); background-size: 16px 16px; background-repeat: no-repeat; background-position: 4px center; display: inline-block; margin-bottom: 4px;`,
       "",
     );
-    if (navigator.onLine && version && !isExtensionContext()) {
+    if (
+      allowExternalCommunication &&
+      navigator.onLine &&
+      version &&
+      !isExtensionContext()
+    ) {
       fetch(
         `https://www.react-grab.com/api/version?source=browser&t=${Date.now()}`,
         {

--- a/packages/react-grab/src/core/plugin-registry.ts
+++ b/packages/react-grab/src/core/plugin-registry.ts
@@ -36,6 +36,7 @@ interface OptionsState {
   activationMode: ActivationMode;
   keyHoldDuration: number;
   allowActivationInsideInput: boolean;
+  allowExternalCommunication: boolean;
   maxContextLines: number;
   activationKey: ActivationKey | undefined;
   getContent: ((elements: Element[]) => Promise<string> | string) | undefined;
@@ -46,6 +47,7 @@ const DEFAULT_OPTIONS: OptionsState = {
   activationMode: "toggle",
   keyHoldDuration: DEFAULT_KEY_HOLD_DURATION_MS,
   allowActivationInsideInput: true,
+  allowExternalCommunication: true,
   maxContextLines: DEFAULT_MAX_CONTEXT_LINES,
   activationKey: undefined,
   getContent: undefined,
@@ -128,6 +130,7 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     "activationMode",
     "keyHoldDuration",
     "allowActivationInsideInput",
+    "allowExternalCommunication",
     "maxContextLines",
     "activationKey",
     "getContent",

--- a/packages/react-grab/src/core/plugins/open.ts
+++ b/packages/react-grab/src/core/plugins/open.ts
@@ -18,7 +18,7 @@ export const openPlugin: Plugin = {
         );
 
         if (!wasHandled) {
-          openFile(
+          void openFile(
             context.filePath,
             context.lineNumber,
             context.hooks.transformOpenFileUrl,

--- a/packages/react-grab/src/core/plugins/open.ts
+++ b/packages/react-grab/src/core/plugins/open.ts
@@ -22,6 +22,7 @@ export const openPlugin: Plugin = {
             context.filePath,
             context.lineNumber,
             context.hooks.transformOpenFileUrl,
+            context.hooks.allowExternalCommunication ?? true,
           );
         }
 

--- a/packages/react-grab/src/core/plugins/open.ts
+++ b/packages/react-grab/src/core/plugins/open.ts
@@ -22,7 +22,7 @@ export const openPlugin: Plugin = {
             context.filePath,
             context.lineNumber,
             context.hooks.transformOpenFileUrl,
-            context.hooks.allowExternalCommunication ?? true,
+            context.allowExternalCommunication,
           );
         }
 

--- a/packages/react-grab/src/index.ts
+++ b/packages/react-grab/src/index.ts
@@ -44,12 +44,13 @@ export type {
 } from "./types.js";
 
 import { init } from "./core/index.js";
-import type { Plugin, ReactGrabAPI } from "./types.js";
+import type { Options, Plugin, ReactGrabAPI } from "./types.js";
 
 declare global {
   interface Window {
     __REACT_GRAB__?: ReactGrabAPI;
     __REACT_GRAB_DISABLED__?: boolean;
+    __REACT_GRAB_OPTIONS__?: Options;
   }
 }
 
@@ -109,7 +110,7 @@ if (typeof window !== "undefined" && !window.__REACT_GRAB_DISABLED__) {
   if (window.__REACT_GRAB__) {
     globalApi = window.__REACT_GRAB__;
   } else {
-    globalApi = init();
+    globalApi = init(window.__REACT_GRAB_OPTIONS__);
     window.__REACT_GRAB__ = globalApi;
   }
   flushPendingPlugins(globalApi);

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -210,6 +210,7 @@ export type ActivationMode = "toggle" | "hold";
 
 export interface ActionContextHooks {
   transformHtmlContent: (html: string, elements: Element[]) => Promise<string>;
+  allowExternalCommunication?: boolean;
   onOpenFile: (filePath: string, lineNumber?: number) => boolean | void;
   transformOpenFileUrl: (
     url: string,
@@ -368,6 +369,13 @@ export interface Options {
   activationMode?: ActivationMode;
   keyHoldDuration?: number;
   allowActivationInsideInput?: boolean;
+  /**
+   * Whether React Grab can make remote network requests or load remote assets.
+   * When disabled, React Grab skips version checks, remote font loading, and
+   * remote open-file fallbacks.
+   * @default true
+   */
+  allowExternalCommunication?: boolean;
   maxContextLines?: number;
   activationKey?: ActivationKey;
   getContent?: (elements: Element[]) => Promise<string> | string;

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -210,7 +210,6 @@ export type ActivationMode = "toggle" | "hold";
 
 export interface ActionContextHooks {
   transformHtmlContent: (html: string, elements: Element[]) => Promise<string>;
-  allowExternalCommunication?: boolean;
   onOpenFile: (filePath: string, lineNumber?: number) => boolean | void;
   transformOpenFileUrl: (
     url: string,
@@ -226,6 +225,7 @@ export interface ActionContext {
   lineNumber?: number;
   componentName?: string;
   tagName?: string;
+  allowExternalCommunication: boolean;
   enterPromptMode?: (agent?: AgentOptions) => void;
   hooks: ActionContextHooks;
   performWithFeedback: (action: () => Promise<boolean>) => Promise<void>;
@@ -493,6 +493,7 @@ export interface ReactGrabRendererProps {
   selectionElementsCount?: number;
   selectionFilePath?: string;
   selectionLineNumber?: number;
+  onOpenSelectionFile?: () => void;
   selectionTagName?: string;
   selectionComponentName?: string;
   selectionLabelVisible?: boolean;

--- a/packages/react-grab/src/utils/get-script-options.ts
+++ b/packages/react-grab/src/utils/get-script-options.ts
@@ -28,6 +28,10 @@ const parseOptionsFromJson = (rawValue: unknown): Partial<Options> | null => {
     parsedOptions.allowActivationInsideInput =
       rawValue.allowActivationInsideInput;
   }
+  if (typeof rawValue.allowExternalCommunication === "boolean") {
+    parsedOptions.allowExternalCommunication =
+      rawValue.allowExternalCommunication;
+  }
   if (
     typeof rawValue.maxContextLines === "number" &&
     Number.isFinite(rawValue.maxContextLines)

--- a/packages/react-grab/src/utils/mount-root.ts
+++ b/packages/react-grab/src/utils/mount-root.ts
@@ -18,8 +18,13 @@ const loadFonts = () => {
   document.head.appendChild(link);
 };
 
-export const mountRoot = (cssText?: string) => {
-  loadFonts();
+export const mountRoot = (
+  cssText?: string,
+  allowExternalCommunication = true,
+) => {
+  if (allowExternalCommunication) {
+    loadFonts();
+  }
 
   const mountedHost = document.querySelector(`[${ATTRIBUTE_NAME}]`);
   if (mountedHost) {

--- a/packages/react-grab/src/utils/open-file.ts
+++ b/packages/react-grab/src/utils/open-file.ts
@@ -26,6 +26,7 @@ export const openFile = async (
   filePath: string,
   lineNumber: number | undefined,
   transformUrl?: (url: string, filePath: string, lineNumber?: number) => string,
+  allowExternalCommunication = true,
 ): Promise<void> => {
   filePath = normalizeFileName(filePath);
 
@@ -39,5 +40,18 @@ export const openFile = async (
   const url = transformUrl
     ? transformUrl(rawUrl, filePath, lineNumber)
     : rawUrl;
+  if (!allowExternalCommunication) {
+    let targetUrl: URL;
+    try {
+      targetUrl = new URL(url, window.location.href);
+    } catch {
+      return;
+    }
+    const isHttpProtocol =
+      targetUrl.protocol === "http:" || targetUrl.protocol === "https:";
+    if (isHttpProtocol && targetUrl.origin !== window.location.origin) {
+      return;
+    }
+  }
   window.open(url, "_blank", "noopener,noreferrer");
 };


### PR DESCRIPTION
## Summary
- add an \ option to the browser runtime
- disable the version check, remote font load, and remote open-file fallback when the option is false
- support the option through auto-init via \ and add focused Playwright coverage

## Testing
- pnpm typecheck
- pnpm lint
- pnpm exec playwright test e2e/external-communication.spec.ts --project=chromium

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new runtime option that gates network requests, asset loading, and open-file fallbacks; mistakes could silently break expected UX (fonts/version check/open in editor) or regress plugin behavior.
> 
> **Overview**
> Adds an `allowExternalCommunication` option (default `true`) that can be provided via script `data-options` and via auto-init through `window.__REACT_GRAB_OPTIONS__`.
> 
> When disabled, the browser runtime now skips the intro version-check request (`logIntro`), avoids loading remote Google Fonts (`mountRoot`), and prevents cross-origin HTTP(S) open-file fallbacks by plumbing the flag through the plugin registry/action context and centralizing selection-label + keyboard shortcut open behavior.
> 
> Includes new Playwright e2e coverage ensuring no external requests/fonts on init and no remote `window.open` fallback when the option is off.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4c9aabc5da08520d15eb36bcde37a712928d8e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `allowExternalCommunication` opt-out to the browser runtime. When disabled, it skips the version check, does not load Google Fonts, and blocks cross-origin HTTP(S) open-file fallbacks from both the keyboard shortcut and the selection label.

- **New Features**
  - New option: `allowExternalCommunication` (default `true`), set via `window.__REACT_GRAB_OPTIONS__` and script `data-options`; auto-init reads and passes it to `init`.
  - Gates version check (`logIntro`), Google Fonts (`mountRoot`), and open-file fallbacks via centralized open logic; plumbed through the plugin registry, action context, renderer, and plugins.
  - Hardened Playwright e2e tests to ensure no version check/fonts on init and no remote open-file fallback by stubbing local editor endpoints and capturing `window.open`.

- **Bug Fixes**
  - Selection label "Open" now uses the centralized open flow and respects `allowExternalCommunication`.
  - Open-file calls now use `void` for fire-and-forget to avoid dangling promises in UI paths.

<sup>Written for commit c4c9aabc5da08520d15eb36bcde37a712928d8e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

