### PR TITLE
Update dependencies in pnpm-lock.yaml and refactor context handling in react-grab. Replace 'bippy/source' with 'element-source' for improved source resolution and add new utility functions for better component name checks.

### DIFF
--- a/packages/react-grab/package.json
+++ b/packages/react-grab/package.json
@@ -102,6 +102,7 @@
     "@medv/finder": "^4.0.2",
     "@react-grab/cli": "workspace:*",
     "bippy": "^0.5.32",
+    "element-source": "^0.0.3",
     "solid-js": "^1.9.10"
   },
   "devDependencies": {

--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -1,32 +1,34 @@
 import {
-  isSourceFile,
-  normalizeFileName,
-  getOwnerStack,
-  formatOwnerStack,
-  hasDebugStack,
-  parseStack,
-  StackFrame,
-} from "bippy/source";
-import { isCapitalized } from "../utils/is-capitalized.js";
+  getReactStack,
+  resolveStack,
+  formatStack,
+  checkIsNextProject,
+  isSourceComponentName,
+  resolveComponentName,
+} from "element-source";
 import {
   getFiberFromHostInstance,
   isInstrumentationActive,
   getDisplayName,
   isCompositeFiber,
   traverseFiber,
-  type Fiber,
 } from "bippy";
 import {
   PREVIEW_TEXT_MAX_LENGTH,
   PREVIEW_ATTR_VALUE_MAX_LENGTH,
   PREVIEW_MAX_ATTRS,
   PREVIEW_PRIORITY_ATTRS,
-  SYMBOLICATION_TIMEOUT_MS,
   DEFAULT_MAX_CONTEXT_LINES,
 } from "../constants.js";
 import { getTagName } from "../utils/get-tag-name.js";
 import { truncateString } from "../utils/truncate-string.js";
-import { getNextBasePath } from "../utils/get-next-base-path.js";
+
+export {
+  checkIsNextProject,
+  isSourceComponentName as checkIsSourceComponentName,
+  getReactStack as getStack,
+  resolveComponentName as getNearestComponentName,
+};
 
 const NON_COMPONENT_PREFIXES = new Set([
   "_",
@@ -75,222 +77,15 @@ const REACT_INTERNAL_COMPONENT_NAMES = new Set([
   "SuspenseList",
 ]);
 
-let cachedIsNextProject: boolean | undefined;
-
-export const checkIsNextProject = (revalidate?: boolean): boolean => {
-  if (revalidate) {
-    cachedIsNextProject = undefined;
-  }
-  cachedIsNextProject ??=
-    typeof document !== "undefined" &&
-    Boolean(
-      document.getElementById("__NEXT_DATA__") ||
-      document.querySelector("nextjs-portal"),
-    );
-  return cachedIsNextProject;
-};
-
-const checkIsInternalComponentName = (name: string): boolean => {
-  if (NEXT_INTERNAL_COMPONENT_NAMES.has(name)) return true;
-  if (REACT_INTERNAL_COMPONENT_NAMES.has(name)) return true;
+const isUsefulComponentName = (name: string): boolean => {
+  if (!name) return false;
+  if (NEXT_INTERNAL_COMPONENT_NAMES.has(name)) return false;
+  if (REACT_INTERNAL_COMPONENT_NAMES.has(name)) return false;
   for (const prefix of NON_COMPONENT_PREFIXES) {
-    if (name.startsWith(prefix)) return true;
+    if (name.startsWith(prefix)) return false;
   }
-  return false;
-};
-
-export const checkIsSourceComponentName = (name: string): boolean => {
-  if (name.length <= 1) return false;
-  if (checkIsInternalComponentName(name)) return false;
-  if (!isCapitalized(name)) return false;
-  if (name.endsWith("Provider") || name.endsWith("Context")) return false;
+  if (name === "SlotClone" || name === "Slot") return false;
   return true;
-};
-
-const SERVER_COMPONENT_URL_PREFIXES = ["about://React/", "rsc://React/"];
-
-const isServerComponentUrl = (url: string): boolean =>
-  SERVER_COMPONENT_URL_PREFIXES.some((prefix) => url.startsWith(prefix));
-
-const devirtualizeServerUrl = (url: string): string => {
-  for (const prefix of SERVER_COMPONENT_URL_PREFIXES) {
-    if (!url.startsWith(prefix)) continue;
-    const environmentEndIndex = url.indexOf("/", prefix.length);
-    const querySuffixIndex = url.lastIndexOf("?");
-    if (environmentEndIndex > -1 && querySuffixIndex > -1) {
-      return decodeURI(url.slice(environmentEndIndex + 1, querySuffixIndex));
-    }
-  }
-  return url;
-};
-
-interface NextJsOriginalFrame {
-  file: string | null;
-  line1: number | null;
-  column1: number | null;
-  ignored: boolean;
-}
-
-interface NextJsFrameResult {
-  status: string;
-  value?: { originalStackFrame: NextJsOriginalFrame | null };
-}
-
-interface NextJsRequestFrame {
-  file: string;
-  methodName: string;
-  line1: number | null;
-  column1: number | null;
-  arguments: string[];
-}
-
-const symbolicateServerFrames = async (
-  frames: StackFrame[],
-): Promise<StackFrame[]> => {
-  const serverFrameIndices: number[] = [];
-  const requestFrames: NextJsRequestFrame[] = [];
-
-  for (let frameIndex = 0; frameIndex < frames.length; frameIndex++) {
-    const frame = frames[frameIndex];
-    if (!frame.isServer || !frame.fileName) continue;
-
-    serverFrameIndices.push(frameIndex);
-    requestFrames.push({
-      file: devirtualizeServerUrl(frame.fileName),
-      methodName: frame.functionName ?? "<unknown>",
-      line1: frame.lineNumber ?? null,
-      column1: frame.columnNumber ?? null,
-      arguments: [],
-    });
-  }
-
-  if (requestFrames.length === 0) return frames;
-
-  const controller = new AbortController();
-  const timeout = setTimeout(
-    () => controller.abort(),
-    SYMBOLICATION_TIMEOUT_MS,
-  );
-
-  try {
-    // Next.js dev server (>=15.2) exposes a batched symbolication endpoint that resolves
-    // bundled/virtual stack frames back to original source locations via source maps.
-    //
-    // Server components produce virtual URLs like "rsc://React/Server/webpack-internal:///..."
-    // that have no real file on disk. The dev server reads the bundler's source maps
-    // (webpack or turbopack) and returns the original file path, line, and column for each frame.
-    //
-    // We POST an array of frames and get back PromiseSettledResult<OriginalStackFrameResponse>[]:
-    //
-    //   POST /__nextjs_original-stack-frames
-    //   { frames: [{ file, methodName, lineNumber, column, arguments }],
-    //     isServer: true, isEdgeServer: false, isAppDirectory: true }
-    //
-    //   Response: [{ status: "fulfilled",
-    //     value: { originalStackFrame: { file, lineNumber, column, ignored } } }]
-    //
-    // Introduced by vercel/next.js#75557 (batched POST, replaces legacy per-frame GET).
-    // Handler: packages/next/src/client/components/react-dev-overlay/server/middleware-webpack.ts
-    // Types:   packages/next/src/client/components/react-dev-overlay/server/shared.ts
-    const response = await fetch(
-      `${getNextBasePath()}/__nextjs_original-stack-frames`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          frames: requestFrames,
-          isServer: true,
-          isEdgeServer: false,
-          isAppDirectory: true,
-        }),
-        signal: controller.signal,
-      },
-    );
-
-    if (!response.ok) return frames;
-
-    const results = (await response.json()) as NextJsFrameResult[];
-    const resolvedFrames = [...frames];
-
-    for (let i = 0; i < serverFrameIndices.length; i++) {
-      const result = results[i];
-      if (result?.status !== "fulfilled") continue;
-
-      const resolved = result.value?.originalStackFrame;
-      if (!resolved?.file || resolved.ignored) continue;
-
-      const originalFrameIndex = serverFrameIndices[i];
-      resolvedFrames[originalFrameIndex] = {
-        ...frames[originalFrameIndex],
-        fileName: resolved.file,
-        lineNumber: resolved.line1 ?? undefined,
-        columnNumber: resolved.column1 ?? undefined,
-        isSymbolicated: true,
-      };
-    }
-
-    return resolvedFrames;
-  } catch {
-    return frames;
-  } finally {
-    clearTimeout(timeout);
-  }
-};
-
-const extractServerFramesFromDebugStack = (
-  rootFiber: Fiber,
-): Map<string, StackFrame> => {
-  const serverFramesByName = new Map<string, StackFrame>();
-
-  traverseFiber(
-    rootFiber,
-    (currentFiber) => {
-      if (!hasDebugStack(currentFiber)) return false;
-
-      const ownerStack = formatOwnerStack(currentFiber._debugStack.stack);
-      if (!ownerStack) return false;
-
-      for (const frame of parseStack(ownerStack)) {
-        if (!frame.functionName || !frame.fileName) continue;
-        if (!isServerComponentUrl(frame.fileName)) continue;
-        if (serverFramesByName.has(frame.functionName)) continue;
-
-        serverFramesByName.set(frame.functionName, {
-          ...frame,
-          isServer: true,
-        });
-      }
-      return false;
-    },
-    true,
-  );
-
-  return serverFramesByName;
-};
-
-const enrichServerFrameLocations = (
-  rootFiber: Fiber,
-  frames: StackFrame[],
-): StackFrame[] => {
-  const hasUnresolvedServerFrames = frames.some(
-    (frame) => frame.isServer && !frame.fileName && frame.functionName,
-  );
-  if (!hasUnresolvedServerFrames) return frames;
-
-  const serverFramesByName = extractServerFramesFromDebugStack(rootFiber);
-  if (serverFramesByName.size === 0) return frames;
-
-  return frames.map((frame) => {
-    if (!frame.isServer || frame.fileName || !frame.functionName) return frame;
-    const resolved = serverFramesByName.get(frame.functionName);
-    if (!resolved) return frame;
-    return {
-      ...frame,
-      fileName: resolved.fileName,
-      lineNumber: resolved.lineNumber,
-      columnNumber: resolved.columnNumber,
-    };
-  });
 };
 
 const findNearestFiberElement = (element: Element): Element => {
@@ -301,95 +96,6 @@ const findNearestFiberElement = (element: Element): Element => {
     current = current.parentElement;
   }
   return element;
-};
-
-const stackCache = new WeakMap<Element, Promise<StackFrame[] | null>>();
-
-const fetchStackForElement = async (
-  element: Element,
-): Promise<StackFrame[] | null> => {
-  try {
-    const fiber = getFiberFromHostInstance(element);
-    if (!fiber) return null;
-
-    const frames = await getOwnerStack(fiber);
-
-    if (checkIsNextProject()) {
-      const enrichedFrames = enrichServerFrameLocations(fiber, frames);
-      return await symbolicateServerFrames(enrichedFrames);
-    }
-
-    return frames;
-  } catch {
-    return null;
-  }
-};
-
-export const getStack = (element: Element): Promise<StackFrame[] | null> => {
-  if (!isInstrumentationActive()) return Promise.resolve([]);
-
-  const resolvedElement = findNearestFiberElement(element);
-  const cached = stackCache.get(resolvedElement);
-  if (cached) return cached;
-
-  const promise = fetchStackForElement(resolvedElement);
-  stackCache.set(resolvedElement, promise);
-  return promise;
-};
-
-export const getNearestComponentName = async (
-  element: Element,
-): Promise<string | null> => {
-  if (!isInstrumentationActive()) return null;
-  const stack = await getStack(element);
-  if (!stack) return null;
-
-  for (const frame of stack) {
-    if (frame.functionName && checkIsSourceComponentName(frame.functionName)) {
-      return frame.functionName;
-    }
-  }
-
-  return null;
-};
-
-export const resolveSourceFromStack = (
-  stack: StackFrame[] | null,
-): {
-  filePath: string;
-  lineNumber: number | undefined;
-  componentName: string | null;
-} | null => {
-  if (!stack || stack.length === 0) return null;
-
-  const sourceFrames = stack.filter(
-    (frame) => frame.fileName && isSourceFile(frame.fileName),
-  );
-
-  const namedFrame = sourceFrames.find(
-    (frame) =>
-      frame.functionName && checkIsSourceComponentName(frame.functionName),
-  );
-
-  const resolvedFrame = namedFrame ?? sourceFrames[0];
-  if (!resolvedFrame?.fileName) return null;
-
-  return {
-    filePath: normalizeFileName(resolvedFrame.fileName),
-    lineNumber: resolvedFrame.lineNumber,
-    componentName:
-      resolvedFrame.functionName &&
-      checkIsSourceComponentName(resolvedFrame.functionName)
-        ? resolvedFrame.functionName
-        : null,
-  };
-};
-
-const isUsefulComponentName = (name: string): boolean => {
-  if (!name) return false;
-  if (checkIsInternalComponentName(name)) return false;
-  if (name === "SlotClone" || name === "Slot") return false;
-  return true;
 };
 
 export const getComponentDisplayName = (element: Element): string | null => {
@@ -415,14 +121,6 @@ export const getComponentDisplayName = (element: Element): string | null => {
 interface StackContextOptions {
   maxLines?: number;
 }
-
-const hasSourceFiles = (stack: StackFrame[] | null): boolean => {
-  if (!stack) return false;
-  return stack.some(
-    (frame) =>
-      frame.isServer || (frame.fileName && isSourceFile(frame.fileName)),
-  );
-};
 
 const getComponentNamesFromFiber = (
   element: Element,
@@ -450,66 +148,15 @@ const getComponentNamesFromFiber = (
   return componentNames;
 };
 
-export const formatStackContext = (
-  stack: StackFrame[],
-  options: StackContextOptions = {},
-): string => {
-  const { maxLines = DEFAULT_MAX_CONTEXT_LINES } = options;
-  const isNextProject = checkIsNextProject();
-  const stackContext: string[] = [];
-
-  for (const frame of stack) {
-    if (stackContext.length >= maxLines) break;
-
-    const hasResolvedSource = frame.fileName && isSourceFile(frame.fileName);
-
-    if (
-      frame.isServer &&
-      !hasResolvedSource &&
-      (!frame.functionName || checkIsSourceComponentName(frame.functionName))
-    ) {
-      stackContext.push(
-        `\n  in ${frame.functionName || "<anonymous>"} (at Server)`,
-      );
-      continue;
-    }
-
-    if (hasResolvedSource) {
-      let line = "\n  in ";
-      const hasComponentName =
-        frame.functionName && checkIsSourceComponentName(frame.functionName);
-
-      if (hasComponentName) {
-        line += `${frame.functionName} (at `;
-      }
-
-      line += normalizeFileName(frame.fileName!);
-
-      // HACK: bundlers like vite mess up the line/column numbers, so we don't show them
-      if (isNextProject && frame.lineNumber && frame.columnNumber) {
-        line += `:${frame.lineNumber}:${frame.columnNumber}`;
-      }
-
-      if (hasComponentName) {
-        line += `)`;
-      }
-
-      stackContext.push(line);
-    }
-  }
-
-  return stackContext.join("");
-};
-
 export const getStackContext = async (
   element: Element,
   options: StackContextOptions = {},
 ): Promise<string> => {
   const maxLines = options.maxLines ?? DEFAULT_MAX_CONTEXT_LINES;
-  const stack = await getStack(element);
+  const stack = await resolveStack(element);
 
-  if (stack && hasSourceFiles(stack)) {
-    return formatStackContext(stack, options);
+  if (stack.length > 0) {
+    return formatStack(stack, maxLines);
   }
 
   const componentNames = getComponentNamesFromFiber(element, maxLines);

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -25,15 +25,12 @@ import {
 } from "../utils/native-raf.js";
 import { ReactGrabRenderer } from "../components/renderer.js";
 import {
-  getStack,
   getStackContext,
   getNearestComponentName,
-  checkIsSourceComponentName,
   getComponentDisplayName,
-  resolveSourceFromStack,
   checkIsNextProject,
 } from "./context.js";
-import { isSourceFile, normalizeFileName } from "bippy/source";
+import { resolveSource } from "element-source";
 import { createNoopApi } from "./noop-api.js";
 import { createEventListenerManager } from "./events.js";
 import { tryCopyWithFallback } from "./copy.js";
@@ -573,34 +570,11 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     ): Promise<void> => {
       const elementsPayload = await Promise.all(
         elements.map(async (element) => {
-          const stack = await getStack(element);
-
-          let componentName: string | null = null;
-          let filePath: string | undefined;
-          let lineNumber: number | undefined;
-          let columnNumber: number | undefined;
-
-          if (stack && stack.length > 0) {
-            for (const frame of stack) {
-              const hasSourceComponentName =
-                frame.functionName &&
-                checkIsSourceComponentName(frame.functionName);
-              const hasSourceFile =
-                frame.fileName && isSourceFile(frame.fileName);
-
-              if (hasSourceComponentName && !componentName) {
-                componentName = frame.functionName!;
-              }
-
-              if (hasSourceFile && !filePath) {
-                filePath = normalizeFileName(frame.fileName!);
-                lineNumber = frame.lineNumber || undefined;
-                columnNumber = frame.columnNumber || undefined;
-              }
-
-              if (componentName && filePath) break;
-            }
-          }
+          const source = await resolveSource(element);
+          let componentName = source?.componentName ?? null;
+          const filePath = source?.filePath;
+          const lineNumber = source?.lineNumber ?? undefined;
+          const columnNumber = source?.columnNumber ?? undefined;
 
           if (!componentName) {
             componentName = getComponentDisplayName(element);
@@ -1292,20 +1266,17 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
             return;
           }
 
-          getStack(element)
-            .then((stack) => {
+          resolveSource(element)
+            .then((source) => {
               if (selectionSourceRequestVersion !== currentVersion) return;
-              if (!stack) return;
-              for (const frame of stack) {
-                if (frame.fileName && isSourceFile(frame.fileName)) {
-                  actions.setSelectionSource(
-                    normalizeFileName(frame.fileName),
-                    frame.lineNumber ?? null,
-                  );
-                  return;
-                }
+              if (!source) {
+                clearSource();
+                return;
               }
-              clearSource();
+              actions.setSelectionSource(
+                source.filePath,
+                source.lineNumber,
+              );
             })
             .catch(() => {
               if (selectionSourceRequestVersion === currentVersion) {
@@ -3332,8 +3303,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       () => store.contextMenuElement,
       async (element) => {
         if (!element) return null;
-        const stack = await getStack(element);
-        return resolveSourceFromStack(stack);
+        return resolveSource(element);
       },
     );
 
@@ -3539,7 +3509,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         return buildActionContext({
           element,
           filePath: fileInfo?.filePath,
-          lineNumber: fileInfo?.lineNumber,
+          lineNumber: fileInfo?.lineNumber ?? undefined,
           tagName: contextMenuTagName(),
           componentName: contextMenuComponentName(),
           position,
@@ -4276,12 +4246,11 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       },
       copyElement: copyElementAPI,
       getSource: async (element: Element): Promise<SourceInfo | null> => {
-        const stack = await getStack(element);
-        const source = resolveSourceFromStack(stack);
+        const source = await resolveSource(element);
         if (!source) return null;
         return {
           filePath: source.filePath,
-          lineNumber: source.lineNumber ?? null,
+          lineNumber: source.lineNumber,
           componentName: source.componentName,
         };
       },

--- a/packages/react-grab/src/utils/is-capitalized.ts
+++ b/packages/react-grab/src/utils/is-capitalized.ts
@@ -1,2 +1,0 @@
-export const isCapitalized = (value: string): boolean =>
-  value.length > 0 && /^[A-Z]/.test(value);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,67 +61,6 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
 
-  packages/demo:
-    dependencies:
-      '@number-flow/react':
-        specifier: ^0.6.0
-        version: 0.6.0(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
-      '@radix-ui/react-select':
-        specifier: ^2.1.6
-        version: 2.2.6(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
-      '@radix-ui/react-separator':
-        specifier: ^1.1.1
-        version: 1.1.8(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
-      '@radix-ui/react-slot':
-        specifier: ^1.1.1
-        version: 1.2.4(@types/react@19.2.11)(react@19.0.1)
-      class-variance-authority:
-        specifier: ^0.7.1
-        version: 0.7.1
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
-      lucide-react:
-        specifier: ^0.553.0
-        version: 0.553.0(react@19.0.1)
-      next:
-        specifier: 15.3.8
-        version: 15.3.8(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
-      react:
-        specifier: 19.0.1
-        version: 19.0.1
-      react-dom:
-        specifier: 19.0.1
-        version: 19.0.1(react@19.0.1)
-      react-grab:
-        specifier: workspace:*
-        version: link:../react-grab
-      tailwind-merge:
-        specifier: ^2.6.0
-        version: 2.6.0
-      tw-animate-css:
-        specifier: ^1.4.0
-        version: 1.4.0
-    devDependencies:
-      '@tailwindcss/postcss':
-        specifier: ^4
-        version: 4.1.15
-      '@types/node':
-        specifier: ^20
-        version: 20.19.23
-      '@types/react':
-        specifier: ^19
-        version: 19.2.11
-      '@types/react-dom':
-        specifier: ^19
-        version: 19.2.2(@types/react@19.2.11)
-      tailwindcss:
-        specifier: ^4
-        version: 4.1.17
-      typescript:
-        specifier: ^5
-        version: 5.9.3
-
   packages/design-system:
     dependencies:
       react-grab:
@@ -403,19 +342,6 @@ importers:
         specifier: ^5
         version: 5.9.3
 
-  packages/provider-ami:
-    dependencies:
-      react-grab:
-        specifier: workspace:*
-        version: link:../react-grab
-    devDependencies:
-      '@types/node':
-        specifier: ^22.10.7
-        version: 22.19.2
-      tsup:
-        specifier: ^8.4.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
-
   packages/provider-amp:
     dependencies:
       '@react-grab/relay':
@@ -609,6 +535,9 @@ importers:
       bippy:
         specifier: ^0.5.32
         version: 0.5.32(@types/react@19.2.11)(react@19.2.3)
+      element-source:
+        specifier: ^0.0.3
+        version: 0.0.3(@types/react@19.2.11)(react@19.2.3)
       react:
         specifier: '>=17.0.0'
         version: 19.2.3
@@ -2337,12 +2266,6 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
-  '@number-flow/react@0.6.0':
-    resolution: {integrity: sha512-77Yfc9+zkV2UDSP8phhZzxJGuwxi/Tt1TikmipL+1r3e9GFKEYDZ1XwInj67NoSt3OnOB0KLvvcl3lfPZgBHVQ==}
-    peerDependencies:
-      react: ^18 || ^19
-      react-dom: ^18 || ^19
-
   '@openai/codex-sdk@0.66.0':
     resolution: {integrity: sha512-mJSSMNsZ2YaxexnaETCO3gz3yvxUrSypv4gXMrWX639SGr5la5vz+hN9goXkDvHRwVPNlgxI+MOVoJpFjIjRLA==}
     engines: {node: '>=18'}
@@ -3167,8 +3090,8 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
-  '@sourcegraph/amp@0.0.1773043670-gfff8f2':
-    resolution: {integrity: sha512-RR24DuAqKtLtFMwhK5r3MlmflwIIy4S/9cgYjSsJSKMKN7+3vwtDBTJI0xgXMavf8jE2JjGpIvnJovpElGmjNg==}
+  '@sourcegraph/amp@0.0.1773219707-g14bcca':
+    resolution: {integrity: sha512-Y0Syc2sEco9J0J/L3baFsWV3FRnlsF941MEmb1PDk2fM/OH76B8FOE1+G4LFe1v1NMHIOv/aSS01NdY6sZ2Nfg==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -4473,6 +4396,9 @@ packages:
   electron-to-chromium@1.5.237:
     resolution: {integrity: sha512-icUt1NvfhGLar5lSWH3tHNzablaA5js3HVHacQimfP8ViEBOQv+L7DKEuHdbTZ0SKCO1ogTJTIL1Gwk9S6Qvcg==}
 
+  element-source@0.0.3:
+    resolution: {integrity: sha512-o3VMv2BIfY/axhIBKlE9HrR5rNqnhjHN2PEAKxG65O0VCSfONoMi9QMQjY12XVVvMuTzr1cAg/4xLMkvh+/Wlg==}
+
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
 
@@ -4704,9 +4630,6 @@ packages:
     peerDependenciesMeta:
       jiti:
         optional: true
-
-  esm-env@1.2.2:
-    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
@@ -5875,9 +5798,6 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
-
-  number-flow@0.6.0:
-    resolution: {integrity: sha512-K8flNq2Wqus53vjp/btVo3qXFkagF8dIdYavreBfE7hlvFFG/b1HMGEH6nZL+mlrJ+4lbLP9OmPv3t2rmRkpSQ==}
 
   nuqs@2.8.1:
     resolution: {integrity: sha512-kIw8UW5KXXfVla6B9h0EKzSH/YDpee6lojniQoMyul8wq9brwV0kElE2Jzg4NSCLBo7n2E3wc1J3o7IyPYVlqQ==}
@@ -8658,13 +8578,6 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@number-flow/react@0.6.0(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
-    dependencies:
-      esm-env: 1.2.2
-      number-flow: 0.6.0
-      react: 19.0.1
-      react-dom: 19.0.1(react@19.0.1)
-
   '@openai/codex-sdk@0.66.0': {}
 
   '@opencode-ai/sdk@1.0.132': {}
@@ -8802,15 +8715,6 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
-  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
-      react: 19.0.1
-      react-dom: 19.0.1(react@19.0.1)
-    optionalDependencies:
-      '@types/react': 19.2.11
-      '@types/react-dom': 19.2.2(@types/react@19.2.11)
-
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.2(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.2(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
@@ -8865,18 +8769,6 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.2(@types/react@19.2.7)
 
-  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.11)(react@19.0.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.11)(react@19.0.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.11)(react@19.0.1)
-      react: 19.0.1
-      react-dom: 19.0.1(react@19.0.1)
-    optionalDependencies:
-      '@types/react': 19.2.11
-      '@types/react-dom': 19.2.2(@types/react@19.2.11)
-
   '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.2(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.0.1)
@@ -8889,23 +8781,11 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.2(@types/react@19.2.7)
 
-  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.11)(react@19.0.1)':
-    dependencies:
-      react: 19.0.1
-    optionalDependencies:
-      '@types/react': 19.2.11
-
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.7)(react@19.0.1)':
     dependencies:
       react: 19.0.1
     optionalDependencies:
       '@types/react': 19.2.7
-
-  '@radix-ui/react-context@1.1.2(@types/react@19.2.11)(react@19.0.1)':
-    dependencies:
-      react: 19.0.1
-    optionalDependencies:
-      '@types/react': 19.2.11
 
   '@radix-ui/react-context@1.1.2(@types/react@19.2.7)(react@19.0.1)':
     dependencies:
@@ -8941,30 +8821,11 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.2(@types/react@19.2.7)
 
-  '@radix-ui/react-direction@1.1.1(@types/react@19.2.11)(react@19.0.1)':
-    dependencies:
-      react: 19.0.1
-    optionalDependencies:
-      '@types/react': 19.2.11
-
   '@radix-ui/react-direction@1.1.1(@types/react@19.2.7)(react@19.0.1)':
     dependencies:
       react: 19.0.1
     optionalDependencies:
       '@types/react': 19.2.7
-
-  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.11)(react@19.0.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.11)(react@19.0.1)
-      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.11)(react@19.0.1)
-      react: 19.0.1
-      react-dom: 19.0.1(react@19.0.1)
-    optionalDependencies:
-      '@types/react': 19.2.11
-      '@types/react-dom': 19.2.2(@types/react@19.2.11)
 
   '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.2(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
     dependencies:
@@ -8994,28 +8855,11 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.2(@types/react@19.2.7)
 
-  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.11)(react@19.0.1)':
-    dependencies:
-      react: 19.0.1
-    optionalDependencies:
-      '@types/react': 19.2.11
-
   '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.7)(react@19.0.1)':
     dependencies:
       react: 19.0.1
     optionalDependencies:
       '@types/react': 19.2.7
-
-  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.11)(react@19.0.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.11)(react@19.0.1)
-      react: 19.0.1
-      react-dom: 19.0.1(react@19.0.1)
-    optionalDependencies:
-      '@types/react': 19.2.11
-      '@types/react-dom': 19.2.2(@types/react@19.2.11)
 
   '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.2(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
     dependencies:
@@ -9027,13 +8871,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.2(@types/react@19.2.7)
-
-  '@radix-ui/react-id@1.1.1(@types/react@19.2.11)(react@19.0.1)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.11)(react@19.0.1)
-      react: 19.0.1
-    optionalDependencies:
-      '@types/react': 19.2.11
 
   '@radix-ui/react-id@1.1.1(@types/react@19.2.7)(react@19.0.1)':
     dependencies:
@@ -9077,24 +8914,6 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.2(@types/react@19.2.7)
 
-  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
-    dependencies:
-      '@floating-ui/react-dom': 2.1.6(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
-      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.11)(react@19.0.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.11)(react@19.0.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.11)(react@19.0.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.11)(react@19.0.1)
-      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.11)(react@19.0.1)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.11)(react@19.0.1)
-      '@radix-ui/rect': 1.1.1
-      react: 19.0.1
-      react-dom: 19.0.1(react@19.0.1)
-    optionalDependencies:
-      '@types/react': 19.2.11
-      '@types/react-dom': 19.2.2(@types/react@19.2.11)
-
   '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.2(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
     dependencies:
       '@floating-ui/react-dom': 2.1.6(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
@@ -9112,16 +8931,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.2(@types/react@19.2.7)
-
-  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.11)(react@19.0.1)
-      react: 19.0.1
-      react-dom: 19.0.1(react@19.0.1)
-    optionalDependencies:
-      '@types/react': 19.2.11
-      '@types/react-dom': 19.2.2(@types/react@19.2.11)
 
   '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.2(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
     dependencies:
@@ -9143,15 +8952,6 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.2(@types/react@19.2.7)
 
-  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
-    dependencies:
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.11)(react@19.0.1)
-      react: 19.0.1
-      react-dom: 19.0.1(react@19.0.1)
-    optionalDependencies:
-      '@types/react': 19.2.11
-      '@types/react-dom': 19.2.2(@types/react@19.2.11)
-
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.2(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.7)(react@19.0.1)
@@ -9160,15 +8960,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.2(@types/react@19.2.7)
-
-  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
-    dependencies:
-      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.11)(react@19.0.1)
-      react: 19.0.1
-      react-dom: 19.0.1(react@19.0.1)
-    optionalDependencies:
-      '@types/react': 19.2.11
-      '@types/react-dom': 19.2.2(@types/react@19.2.11)
 
   '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.2(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
     dependencies:
@@ -9195,35 +8986,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.2(@types/react@19.2.7)
-
-  '@radix-ui/react-select@2.2.6(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
-    dependencies:
-      '@radix-ui/number': 1.1.1
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.11)(react@19.0.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.11)(react@19.0.1)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.11)(react@19.0.1)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.11)(react@19.0.1)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.11)(react@19.0.1)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.11)(react@19.0.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.11)(react@19.0.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.11)(react@19.0.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.11)(react@19.0.1)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.11)(react@19.0.1)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
-      aria-hidden: 1.2.6
-      react: 19.0.1
-      react-dom: 19.0.1(react@19.0.1)
-      react-remove-scroll: 2.7.2(@types/react@19.2.11)(react@19.0.1)
-    optionalDependencies:
-      '@types/react': 19.2.11
-      '@types/react-dom': 19.2.2(@types/react@19.2.11)
 
   '@radix-ui/react-select@2.2.6(@types/react-dom@19.2.2(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
     dependencies:
@@ -9254,15 +9016,6 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.2(@types/react@19.2.7)
 
-  '@radix-ui/react-separator@1.1.8(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
-      react: 19.0.1
-      react-dom: 19.0.1(react@19.0.1)
-    optionalDependencies:
-      '@types/react': 19.2.11
-      '@types/react-dom': 19.2.2(@types/react@19.2.11)
-
   '@radix-ui/react-separator@1.1.8(@types/react-dom@19.2.2(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.2(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
@@ -9272,26 +9025,12 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.2(@types/react@19.2.7)
 
-  '@radix-ui/react-slot@1.2.3(@types/react@19.2.11)(react@19.0.1)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.11)(react@19.0.1)
-      react: 19.0.1
-    optionalDependencies:
-      '@types/react': 19.2.11
-
   '@radix-ui/react-slot@1.2.3(@types/react@19.2.7)(react@19.0.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.0.1)
       react: 19.0.1
     optionalDependencies:
       '@types/react': 19.2.7
-
-  '@radix-ui/react-slot@1.2.4(@types/react@19.2.11)(react@19.0.1)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.11)(react@19.0.1)
-      react: 19.0.1
-    optionalDependencies:
-      '@types/react': 19.2.11
 
   '@radix-ui/react-slot@1.2.4(@types/react@19.2.7)(react@19.0.1)':
     dependencies:
@@ -9362,25 +9101,11 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.2(@types/react@19.2.7)
 
-  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.11)(react@19.0.1)':
-    dependencies:
-      react: 19.0.1
-    optionalDependencies:
-      '@types/react': 19.2.11
-
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.7)(react@19.0.1)':
     dependencies:
       react: 19.0.1
     optionalDependencies:
       '@types/react': 19.2.7
-
-  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.11)(react@19.0.1)':
-    dependencies:
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.11)(react@19.0.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.11)(react@19.0.1)
-      react: 19.0.1
-    optionalDependencies:
-      '@types/react': 19.2.11
 
   '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.7)(react@19.0.1)':
     dependencies:
@@ -9390,26 +9115,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
-  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.11)(react@19.0.1)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.11)(react@19.0.1)
-      react: 19.0.1
-    optionalDependencies:
-      '@types/react': 19.2.11
-
   '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.7)(react@19.0.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.7)(react@19.0.1)
       react: 19.0.1
     optionalDependencies:
       '@types/react': 19.2.7
-
-  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.11)(react@19.0.1)':
-    dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.11)(react@19.0.1)
-      react: 19.0.1
-    optionalDependencies:
-      '@types/react': 19.2.11
 
   '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.7)(react@19.0.1)':
     dependencies:
@@ -9425,36 +9136,17 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
-  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.11)(react@19.0.1)':
-    dependencies:
-      react: 19.0.1
-    optionalDependencies:
-      '@types/react': 19.2.11
-
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.7)(react@19.0.1)':
     dependencies:
       react: 19.0.1
     optionalDependencies:
       '@types/react': 19.2.7
 
-  '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.11)(react@19.0.1)':
-    dependencies:
-      react: 19.0.1
-    optionalDependencies:
-      '@types/react': 19.2.11
-
   '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.7)(react@19.0.1)':
     dependencies:
       react: 19.0.1
     optionalDependencies:
       '@types/react': 19.2.7
-
-  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.11)(react@19.0.1)':
-    dependencies:
-      '@radix-ui/rect': 1.1.1
-      react: 19.0.1
-    optionalDependencies:
-      '@types/react': 19.2.11
 
   '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.7)(react@19.0.1)':
     dependencies:
@@ -9463,28 +9155,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
-  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.11)(react@19.0.1)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.11)(react@19.0.1)
-      react: 19.0.1
-    optionalDependencies:
-      '@types/react': 19.2.11
-
   '@radix-ui/react-use-size@1.1.1(@types/react@19.2.7)(react@19.0.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.7)(react@19.0.1)
       react: 19.0.1
     optionalDependencies:
       '@types/react': 19.2.7
-
-  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.2(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
-      react: 19.0.1
-      react-dom: 19.0.1(react@19.0.1)
-    optionalDependencies:
-      '@types/react': 19.2.11
-      '@types/react-dom': 19.2.2(@types/react@19.2.11)
 
   '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.2(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
     dependencies:
@@ -9610,14 +9286,14 @@ snapshots:
 
   '@sourcegraph/amp-sdk@0.1.0-20251210081226-g90e3892':
     dependencies:
-      '@sourcegraph/amp': 0.0.1773043670-gfff8f2
+      '@sourcegraph/amp': 0.0.1773219707-g14bcca
       zod: 3.25.76
 
   '@sourcegraph/amp@0.0.1767830505-ga62310':
     dependencies:
       '@napi-rs/keyring': 1.1.9
 
-  '@sourcegraph/amp@0.0.1773043670-gfff8f2':
+  '@sourcegraph/amp@0.0.1773219707-g14bcca':
     dependencies:
       '@napi-rs/keyring': 1.1.9
 
@@ -9950,10 +9626,6 @@ snapshots:
     dependencies:
       '@types/node': 20.19.23
       kleur: 3.0.3
-
-  '@types/react-dom@19.2.2(@types/react@19.2.11)':
-    dependencies:
-      '@types/react': 19.2.11
 
   '@types/react-dom@19.2.2(@types/react@19.2.2)':
     dependencies:
@@ -10867,6 +10539,13 @@ snapshots:
 
   electron-to-chromium@1.5.237: {}
 
+  element-source@0.0.3(@types/react@19.2.11)(react@19.2.3):
+    dependencies:
+      bippy: 0.5.32(@types/react@19.2.11)(react@19.2.3)
+    transitivePeerDependencies:
+      - '@types/react'
+      - react
+
   emoji-regex-xs@1.0.0: {}
 
   emoji-regex@10.6.0: {}
@@ -11344,8 +11023,6 @@ snapshots:
       jiti: 2.6.1
     transitivePeerDependencies:
       - supports-color
-
-  esm-env@1.2.2: {}
 
   espree@10.4.0:
     dependencies:
@@ -12515,10 +12192,6 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  number-flow@0.6.0:
-    dependencies:
-      esm-env: 1.2.2
-
   nuqs@2.8.1(next@16.0.10(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1):
     dependencies:
       '@standard-schema/spec': 1.0.0
@@ -12912,14 +12585,6 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
-  react-remove-scroll-bar@2.3.8(@types/react@19.2.11)(react@19.0.1):
-    dependencies:
-      react: 19.0.1
-      react-style-singleton: 2.2.3(@types/react@19.2.11)(react@19.0.1)
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.11
-
   react-remove-scroll-bar@2.3.8(@types/react@19.2.7)(react@19.0.1):
     dependencies:
       react: 19.0.1
@@ -12927,17 +12592,6 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.7
-
-  react-remove-scroll@2.7.2(@types/react@19.2.11)(react@19.0.1):
-    dependencies:
-      react: 19.0.1
-      react-remove-scroll-bar: 2.3.8(@types/react@19.2.11)(react@19.0.1)
-      react-style-singleton: 2.2.3(@types/react@19.2.11)(react@19.0.1)
-      tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.2.11)(react@19.0.1)
-      use-sidecar: 1.1.3(@types/react@19.2.11)(react@19.0.1)
-    optionalDependencies:
-      '@types/react': 19.2.11
 
   react-remove-scroll@2.7.2(@types/react@19.2.7)(react@19.0.1):
     dependencies:
@@ -12965,14 +12619,6 @@ snapshots:
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
       react-transition-group: 4.4.5(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-
-  react-style-singleton@2.2.3(@types/react@19.2.11)(react@19.0.1):
-    dependencies:
-      get-nonce: 1.0.1
-      react: 19.0.1
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.11
 
   react-style-singleton@2.2.3(@types/react@19.2.7)(react@19.0.1):
     dependencies:
@@ -13934,27 +13580,12 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  use-callback-ref@1.3.3(@types/react@19.2.11)(react@19.0.1):
-    dependencies:
-      react: 19.0.1
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.11
-
   use-callback-ref@1.3.3(@types/react@19.2.7)(react@19.0.1):
     dependencies:
       react: 19.0.1
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.7
-
-  use-sidecar@1.1.3(@types/react@19.2.11)(react@19.0.1):
-    dependencies:
-      detect-node-es: 1.1.0
-      react: 19.0.1
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.11
 
   use-sidecar@1.1.3(@types/react@19.2.7)(react@19.0.1):
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because this rewires how `react-grab` resolves component names and source file/line info (including Next.js handling), which can affect selection metadata, stack context output, and editor-open behavior across frameworks.
> 
> **Overview**
> `react-grab` now delegates React stack/source resolution to the new `element-source` dependency, removing the in-repo logic for stack parsing, Next.js server-frame symbolication, and source-frame selection.
> 
> Core selection flows (`element-selected` event payloads, selection source updates, context menu file info, and `ReactGrabAPI.getSource`) are updated to use `resolveSource`/`resolveStack`/`formatStack`, and component-name filtering is simplified; the old `is-capitalized` helper is removed. Lockfile changes primarily reflect the new dependency and related dependency graph updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39c546567ccca4c747b67dd678849b910939f5ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor react-grab to use `element-source` for stack and source resolution, replacing `bippy/source`. This improves file/line/component detection (incl. Next.js), reduces code, and simplifies the API.

- **Refactors**
  - Swapped custom stack parsing/symbolication and cache with `element-source` (`resolveSource`, `resolveStack`, `formatStack`, `getReactStack`, `resolveComponentName`).
  - Updated context and UI flows to use `resolveSource` for file/line/component and `formatStack` for stack context.
  - Re-exported helpers to keep API stable: `checkIsNextProject`, `checkIsSourceComponentName`, `getStack`, `getNearestComponentName`; removed `is-capitalized`.
  - Removed Next.js server-frame symbolication and debug stack traversal (large code cleanup).

- **Dependencies**
  - Added `element-source@^0.0.3` to `packages/react-grab`; continued using `bippy`.
  - Updated `pnpm-lock.yaml`.

<sup>Written for commit 39c546567ccca4c747b67dd678849b910939f5ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

