### PR TITLE
fix: support 'mcp' as command-line argument

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -82,8 +82,7 @@ export const add = new Command()
 
       if (availableAgents.length === 0 && isNonInteractive && !agentArg) {
         logger.break();
-        logger.success("All legacy agents are already installed.");
-        logger.log("Run without -y to add MCP.");
+        logger.success("All agents are already installed.");
         logger.break();
         process.exit(0);
       }
@@ -110,6 +109,25 @@ export const add = new Command()
         }
 
         agentIntegration = validAgent;
+
+        // Handle MCP specially - it needs server configuration, not package installation
+        if (validAgent === "mcp") {
+          const mcpSpinner = spinner("Installing MCP server.").start();
+          const didInstall = await promptMcpInstall();
+          if (!didInstall) {
+            mcpSpinner.fail();
+            logger.break();
+            process.exit(1);
+          }
+          mcpSpinner.succeed();
+          logger.break();
+          logger.log(
+            `${highlighter.success("Success!")} MCP server has been configured.`,
+          );
+          logger.log("Restart your agents to activate.");
+          logger.break();
+          projectInfo.installedAgents = [...projectInfo.installedAgents, "mcp"];
+        }
 
         if (projectInfo.installedAgents.length > 0 && !isNonInteractive) {
           const installedNames = formatInstalledAgentNames(

--- a/packages/cli/src/utils/templates.ts
+++ b/packages/cli/src/utils/templates.ts
@@ -8,11 +8,12 @@ export const AGENTS = [
   "ami",
   "droid",
   "copilot",
+  "mcp",
 ] as const;
 
 export type Agent = (typeof AGENTS)[number];
 
-export type AgentIntegration = Agent | "mcp" | "none";
+export type AgentIntegration = Agent | "none";
 
 export const AGENT_NAMES: Record<Agent, string> = {
   "claude-code": "Claude Code",
@@ -24,17 +25,17 @@ export const AGENT_NAMES: Record<Agent, string> = {
   ami: "Ami",
   droid: "Droid",
   copilot: "Copilot",
+  mcp: "MCP",
 };
 
 export const getAgentDisplayName = (agent: string): string => {
-  if (agent === "mcp") return "MCP";
   if (agent in AGENT_NAMES) {
     return AGENT_NAMES[agent as Agent];
   }
   return agent;
 };
 
-export const PROVIDERS = AGENTS.filter((agent) => agent !== "ami").map(
+export const PROVIDERS = AGENTS.filter((agent) => agent !== "ami" && agent !== "mcp").map(
   (agent) => `@react-grab/${agent}` as const,
 );
 
@@ -49,7 +50,7 @@ export const NEXT_APP_ROUTER_SCRIPT = `{process.env.NODE_ENV === "development" &
 export const NEXT_APP_ROUTER_SCRIPT_WITH_AGENT = (
   agent: AgentIntegration,
 ): string => {
-  if (agent === "none") return NEXT_APP_ROUTER_SCRIPT;
+  if (agent === "none" || agent === "mcp") return NEXT_APP_ROUTER_SCRIPT;
 
   return `{process.env.NODE_ENV === "development" && (
           <Script
@@ -77,7 +78,7 @@ export const NEXT_PAGES_ROUTER_SCRIPT = `{process.env.NODE_ENV === "development"
 export const NEXT_PAGES_ROUTER_SCRIPT_WITH_AGENT = (
   agent: AgentIntegration,
 ): string => {
-  if (agent === "none") return NEXT_PAGES_ROUTER_SCRIPT;
+  if (agent === "none" || agent === "mcp") return NEXT_PAGES_ROUTER_SCRIPT;
 
   return `{process.env.NODE_ENV === "development" && (
           <Script
@@ -101,7 +102,7 @@ export const VITE_SCRIPT = `<script type="module">
     </script>`;
 
 export const VITE_SCRIPT_WITH_AGENT = (agent: AgentIntegration): string => {
-  if (agent === "none") return VITE_SCRIPT;
+  if (agent === "none" || agent === "mcp") return VITE_SCRIPT;
 
   return `<script type="module">
       if (import.meta.env.DEV) {
@@ -116,7 +117,7 @@ export const WEBPACK_IMPORT = `if (process.env.NODE_ENV === "development") {
 }`;
 
 export const WEBPACK_IMPORT_WITH_AGENT = (agent: AgentIntegration): string => {
-  if (agent === "none") return WEBPACK_IMPORT;
+  if (agent === "none" || agent === "mcp") return WEBPACK_IMPORT;
 
   return `if (process.env.NODE_ENV === "development") {
   import("react-grab");
@@ -131,7 +132,7 @@ export const TANSTACK_EFFECT = `useEffect(() => {
   }, []);`;
 
 export const TANSTACK_EFFECT_WITH_AGENT = (agent: AgentIntegration): string => {
-  if (agent === "none") return TANSTACK_EFFECT;
+  if (agent === "none" || agent === "mcp") return TANSTACK_EFFECT;
 
   return `useEffect(() => {
     if (import.meta.env.DEV) {


### PR DESCRIPTION
## Summary
This PR fixes issue #240 where running `npx -y grab@latest add mcp` fails with "Invalid agent: mcp".

## Changes
- Add 'mcp' to AGENTS array in templates.ts so it passes the argument validation
- Add 'mcp' to AGENT_NAMES for display purposes
- Simplify AgentIntegration type (mcp is now part of Agent)
- Add MCP handling in add.ts when passed as argument - calls promptMcpInstall() similar to interactive mode
- Update script template functions (NEXT_APP_ROUTER_SCRIPT_WITH_AGENT, etc.) to handle 'mcp' specially - returns base script without agent-specific package
- Filter 'mcp' from PROVIDERS (no npm package needed, similar to 'ami')
- Update success message for non-interactive mode

## Testing
The fix allows users to run:
```bash
npx -y grab@latest add mcp
```
to install MCP server for React Grab.

Fixes #240

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: scoped to CLI validation/template generation and adds a special-case MCP install path, with no changes to core runtime or security-sensitive logic.
> 
> **Overview**
> Fixes `grab add mcp` by treating `mcp` as a first-class agent in `AGENTS`/`AGENT_NAMES` and validating it like other integrations.
> 
> Updates `add` to special-case `mcp` in non-interactive/arg-driven flows by running `promptMcpInstall()` (server configuration only) and marking it installed, while excluding `mcp` from `PROVIDERS` and ensuring script/template helpers don’t emit agent-specific client imports for `mcp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5aec9eebbd7077a4e0e7537230bad884ee85eeac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow `mcp` as a `grab add` argument and set up the MCP server in non-interactive mode, fixing the “Invalid agent: mcp” error. Templates and providers treat MCP as server-only (no client package).

- **Bug Fixes**
  - Accept `mcp` in `AGENTS`/`AGENT_NAMES`; simplify `AgentIntegration`.
  - In `add.ts`, run `promptMcpInstall()` when `mcp` is passed and record it as installed.
  - Exclude `mcp` from `PROVIDERS` (`@react-grab/<agent>`) and skip agent imports in all script/template helpers.
  - `npx -y grab@latest add mcp` now works. Fixes #240.

<sup>Written for commit 5aec9eebbd7077a4e0e7537230bad884ee85eeac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

