### PR TITLE
feat(cli): add Astro framework support

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -81,6 +81,7 @@ const FRAMEWORK_NAMES: Record<Framework, string> = {
   vite: "Vite",
   tanstack: "TanStack Start",
   webpack: "Webpack",
+  astro: "Astro",
   unknown: "Unknown",
 };
 
@@ -96,7 +97,6 @@ const UNSUPPORTED_FRAMEWORK_NAMES: Record<
   string
 > = {
   remix: "Remix",
-  astro: "Astro",
   sveltekit: "SvelteKit",
   gatsby: "Gatsby",
 };
@@ -342,7 +342,10 @@ export const init = new Command()
                 title: "Toggle (press to activate/deactivate)",
                 value: "toggle",
               },
-              { title: "Hold (hold key to keep active)", value: "hold" },
+              {
+                title: "Hold (hold key to keep active)",
+                value: "hold",
+              },
             ],
             initial: 0,
           });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -914,7 +914,7 @@ export const init = new Command()
           frameworkSpinner.fail("Could not detect a supported framework.");
           logger.break();
           logger.log(
-            "React Grab supports Next.js, Vite, TanStack Start, and Webpack projects.",
+            "React Grab supports Next.js, Vite, TanStack Start, Astro, and Webpack projects.",
           );
           logger.log(`Visit ${highlighter.info(DOCS_URL)} for manual setup.`);
           logger.break();

--- a/packages/cli/src/utils/detect.ts
+++ b/packages/cli/src/utils/detect.ts
@@ -69,12 +69,12 @@ export const detectFramework = (projectRoot: string): Framework => {
       return "tanstack";
     }
 
-    if (allDependencies["vite"]) {
-      return "vite";
-    }
-
     if (allDependencies["astro"]) {
       return "astro";
+    }
+
+    if (allDependencies["vite"]) {
+      return "vite";
     }
 
     if (allDependencies["webpack"]) {

--- a/packages/cli/src/utils/detect.ts
+++ b/packages/cli/src/utils/detect.ts
@@ -5,14 +5,15 @@ import { detect } from "@antfu/ni";
 import ignore from "ignore";
 
 export type PackageManager = "npm" | "yarn" | "pnpm" | "bun";
-export type Framework = "next" | "vite" | "tanstack" | "webpack" | "unknown";
-export type NextRouterType = "app" | "pages" | "unknown";
-export type UnsupportedFramework =
-  | "remix"
+export type Framework =
+  | "next"
+  | "vite"
+  | "tanstack"
+  | "webpack"
   | "astro"
-  | "sveltekit"
-  | "gatsby"
-  | null;
+  | "unknown";
+export type NextRouterType = "app" | "pages" | "unknown";
+export type UnsupportedFramework = "remix" | "sveltekit" | "gatsby" | null;
 
 export interface ProjectInfo {
   packageManager: PackageManager;
@@ -70,6 +71,10 @@ export const detectFramework = (projectRoot: string): Framework => {
 
     if (allDependencies["vite"]) {
       return "vite";
+    }
+
+    if (allDependencies["astro"]) {
+      return "astro";
     }
 
     if (allDependencies["webpack"]) {
@@ -413,6 +418,19 @@ export const detectReactGrab = (projectRoot: string): boolean => {
     join(projectRoot, "src", "routes", "__root.jsx"),
     join(projectRoot, "app", "routes", "__root.tsx"),
     join(projectRoot, "app", "routes", "__root.jsx"),
+    join(projectRoot, "src", "layouts", "Layout.astro"),
+    join(projectRoot, "src", "layouts", "_BaseLayout.astro"),
+    join(projectRoot, "src", "layouts", "_Layout.astro"),
+    join(projectRoot, "src", "layouts", "BaseLayout.astro"),
+    join(projectRoot, "layouts", "Layout.astro"),
+    join(projectRoot, "layouts", "_BaseLayout.astro"),
+    join(projectRoot, "layouts", "_Layout.astro"),
+    join(projectRoot, "layouts", "BaseLayout.astro"),
+    join(projectRoot, "src", "pages", "index.astro"),
+    join(projectRoot, "src", "pages", "_layout.astro"),
+    join(projectRoot, "pages", "index.astro"),
+    join(projectRoot, "Layout.astro"),
+    join(projectRoot, "index.astro"),
   ];
 
   return filesToCheck.some(hasReactGrabInFile);
@@ -448,10 +466,6 @@ export const detectUnsupportedFramework = (
 
     if (allDependencies["@remix-run/react"] || allDependencies["remix"]) {
       return "remix";
-    }
-
-    if (allDependencies["astro"]) {
-      return "astro";
     }
 
     if (allDependencies["@sveltejs/kit"]) {

--- a/packages/cli/src/utils/templates.ts
+++ b/packages/cli/src/utils/templates.ts
@@ -141,4 +141,25 @@ export const TANSTACK_EFFECT_WITH_AGENT = (agent: AgentIntegration): string => {
   }, []);`;
 };
 
+export const ASTRO_EFFECT = `{import.meta.env.DEV && (
+\t\t\t<script>
+\t\t\t\tif (import.meta.env.DEV) {
+\t\t\t\t\timport("react-grab");
+\t\t\t\t}
+\t\t\t</script>
+\t\t)}`;
+
+export const ASTRO_EFFECT_WITH_AGENT = (agent: AgentIntegration): string => {
+  if (agent === "none") return ASTRO_EFFECT;
+
+  return `{import.meta.env.DEV && (
+\t\t\t<script>
+\t\t\t\tif (import.meta.env.DEV) {
+\t\t\t\t\timport("react-grab");
+\t\t\t\t\timport("@react-grab/${agent}/client");
+\t\t\t\t}
+\t\t\t</script>
+\t\t)}`;
+};
+
 export const SCRIPT_IMPORT = 'import Script from "next/script";';

--- a/packages/cli/src/utils/templates.ts
+++ b/packages/cli/src/utils/templates.ts
@@ -142,24 +142,24 @@ export const TANSTACK_EFFECT_WITH_AGENT = (agent: AgentIntegration): string => {
 };
 
 export const ASTRO_EFFECT = `{import.meta.env.DEV && (
-\t\t\t<script>
-\t\t\t\tif (import.meta.env.DEV) {
-\t\t\t\t\timport("react-grab");
-\t\t\t\t}
-\t\t\t</script>
-\t\t)}`;
+        <script>
+          if (import.meta.env.DEV) {
+            import("react-grab");
+          }
+        </script>
+)}`;
 
 export const ASTRO_EFFECT_WITH_AGENT = (agent: AgentIntegration): string => {
   if (agent === "none") return ASTRO_EFFECT;
 
   return `{import.meta.env.DEV && (
-\t\t\t<script>
-\t\t\t\tif (import.meta.env.DEV) {
-\t\t\t\t\timport("react-grab");
-\t\t\t\t\timport("@react-grab/${agent}/client");
-\t\t\t\t}
-\t\t\t</script>
-\t\t)}`;
+        <script>
+          if (import.meta.env.DEV) {
+            import("react-grab");
+            import("@react-grab/${agent}/client");
+          }
+        </script>
+)}`;
 };
 
 export const SCRIPT_IMPORT = 'import Script from "next/script";';

--- a/packages/cli/src/utils/transform.ts
+++ b/packages/cli/src/utils/transform.ts
@@ -1682,7 +1682,7 @@ const removeAgentFromAstro = (
   }
 
   const agentImportPattern = new RegExp(
-    `\\s*import\\s*\\(\\s*["']${agentPackage}/client["']\\s*\\);?`,
+    `\\s*import\\s*\\(\\s*["']${agentPackage.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/client["']\\s*\\);?`,
     "g",
   );
 

--- a/packages/cli/src/utils/transform.ts
+++ b/packages/cli/src/utils/transform.ts
@@ -14,6 +14,7 @@ import {
   TANSTACK_EFFECT_WITH_AGENT,
   VITE_SCRIPT_WITH_AGENT,
   WEBPACK_IMPORT_WITH_AGENT,
+  ASTRO_EFFECT_WITH_AGENT,
   type AgentIntegration,
 } from "./templates.js";
 
@@ -168,6 +169,26 @@ const findTanStackRootFile = (projectRoot: string): string | null => {
   }
 
   return null;
+};
+
+const findAllAstroLayoutFiles = (projectRoot: string): string[] => {
+  const possiblePaths = [
+    join(projectRoot, "src", "layouts", "Layout.astro"),
+    join(projectRoot, "src", "layouts", "_BaseLayout.astro"),
+    join(projectRoot, "src", "layouts", "_Layout.astro"),
+    join(projectRoot, "src", "layouts", "BaseLayout.astro"),
+    join(projectRoot, "src", "pages", "index.astro"),
+    join(projectRoot, "src", "pages", "_layout.astro"),
+    join(projectRoot, "layouts", "Layout.astro"),
+    join(projectRoot, "layouts", "_BaseLayout.astro"),
+    join(projectRoot, "layouts", "_Layout.astro"),
+    join(projectRoot, "layouts", "BaseLayout.astro"),
+    join(projectRoot, "pages", "index.astro"),
+    join(projectRoot, "Layout.astro"),
+    join(projectRoot, "index.astro"),
+  ];
+
+  return possiblePaths.filter((filePath) => existsSync(filePath));
 };
 
 const addAgentToExistingNextApp = (
@@ -761,6 +782,127 @@ const transformTanStack = (
   };
 };
 
+const addAgentToExistingAstro = (
+  originalContent: string,
+  agent: AgentIntegration,
+  filePath: string,
+): TransformResult => {
+  if (agent === "none") {
+    return {
+      success: true,
+      filePath,
+      message: "React Grab is already configured",
+      noChanges: true,
+    };
+  }
+
+  const agentPackage = `@react-grab/${agent}`;
+  if (originalContent.includes(agentPackage)) {
+    return {
+      success: true,
+      filePath,
+      message: `Agent ${agent} is already configured`,
+      noChanges: true,
+    };
+  }
+
+  const scriptBlock = ASTRO_EFFECT_WITH_AGENT(agent);
+  const headMatch = originalContent.match(/<head[^>]*>/i);
+
+  if (!headMatch) {
+    return {
+      success: false,
+      filePath,
+      message: "Could not find <head> tag in the Astro file",
+    };
+  }
+
+  const indentation = "        ";
+
+  const newContent = originalContent.replace(
+    headMatch[0],
+    `${headMatch[0]}\n${indentation}${scriptBlock}`,
+  );
+
+  return {
+    success: true,
+    filePath,
+    message: `Add ${agent} agent to existing React Grab configuration`,
+    originalContent,
+    newContent,
+  };
+};
+
+const transformAstro = (
+  projectRoot: string,
+  agent: AgentIntegration,
+  reactGrabAlreadyConfigured: boolean,
+  force: boolean = false,
+): TransformResult => {
+  const layoutFiles = findAllAstroLayoutFiles(projectRoot);
+
+  if (layoutFiles.length === 0) {
+    return {
+      success: false,
+      filePath: "",
+      message:
+        "Could not find an Astro layout file.\n\n" +
+        "To set up React Grab with Astro, add this to your Layout.astro <head>:\n\n" +
+        '  {import.meta.env.DEV && (\n    <script>\n      if (import.meta.env.DEV) {\n        import("react-grab");\n      }\n    </script>\n  )}',
+    };
+  }
+
+  for (const layoutPath of layoutFiles) {
+    const originalContent = readFileSync(layoutPath, "utf-8");
+    const headMatch = originalContent.match(/<head[^>]*>/i);
+    if (!headMatch) {
+      continue;
+    }
+
+    let newContent = originalContent;
+    const hasReactGrabInFile = hasReactGrabCode(originalContent);
+
+    if (!force && hasReactGrabInFile && reactGrabAlreadyConfigured) {
+      return addAgentToExistingAstro(originalContent, agent, layoutPath);
+    }
+
+    if (!force && hasReactGrabInFile) {
+      return {
+        success: true,
+        filePath: layoutPath,
+        message: "React Grab is already installed in this file",
+        noChanges: true,
+      };
+    }
+
+    const scriptBlock = ASTRO_EFFECT_WITH_AGENT(agent);
+    const indentation = "        ";
+
+    newContent = originalContent.replace(
+      headMatch[0],
+      `${headMatch[0]}\n${indentation}${scriptBlock}`,
+    );
+
+    return {
+      success: true,
+      filePath: layoutPath,
+      message:
+        "Add React Grab" + (agent !== "none" ? ` with ${agent} agent` : ""),
+      originalContent,
+      newContent,
+    };
+  }
+
+  return {
+    success: false,
+    filePath: "",
+    message:
+      "Could not find an Astro layout file with a <head> tag.\n\n" +
+      "To set up React Grab with Astro, add this to your Layout.astro <head>:\n\n" +
+      '  {import.meta.env.DEV && (\n    <script>\n      if (import.meta.env.DEV) {\n        import("react-grab");\n      }\n    </script>\n  )}',
+  };
+};
+
 export const previewTransform = (
   projectRoot: string,
   framework: Framework,
@@ -804,6 +946,14 @@ export const previewTransform = (
 
     case "webpack":
       return transformWebpack(
+        projectRoot,
+        agent,
+        reactGrabAlreadyConfigured,
+        force,
+      );
+
+    case "astro":
+      return transformAstro(
         projectRoot,
         agent,
         reactGrabAlreadyConfigured,
@@ -1132,6 +1282,9 @@ const findReactGrabFile = (
       return findTanStackRootFile(projectRoot);
     case "webpack":
       return findEntryFile(projectRoot);
+    case "astro":
+      const astroFiles = findAllAstroLayoutFiles(projectRoot);
+      return astroFiles.length > 0 ? astroFiles[0] : null;
     default:
       return null;
   }
@@ -1287,6 +1440,39 @@ const addOptionsToTanStackImport = (
   };
 };
 
+const addOptionsToAstroScript = (
+  originalContent: string,
+  options: ReactGrabOptions,
+  filePath: string,
+): TransformResult => {
+  const optionsJson = formatOptionsAsJson(options);
+  const reactGrabImportMatch = originalContent.match(
+    /import\s*\(\s*["']react-grab["']\s*\)(?:\s*\.\s*then\s*\(\s*\([^)]*\)\s*=>[^}]*\}\s*\))?/,
+  );
+
+  if (!reactGrabImportMatch) {
+    return {
+      success: false,
+      filePath,
+      message: "Could not find React Grab import",
+    };
+  }
+
+  const newImport = `import("react-grab").then((m) => m.init(${optionsJson}))`;
+  const newContent = originalContent.replace(
+    reactGrabImportMatch[0],
+    newImport,
+  );
+
+  return {
+    success: true,
+    filePath,
+    message: "Update React Grab options",
+    originalContent,
+    newContent,
+  };
+};
+
 export const previewOptionsTransform = (
   projectRoot: string,
   framework: Framework,
@@ -1322,6 +1508,8 @@ export const previewOptionsTransform = (
       return addOptionsToTanStackImport(originalContent, options, filePath);
     case "webpack":
       return addOptionsToWebpackImport(originalContent, options, filePath);
+    case "astro":
+      return addOptionsToAstroScript(originalContent, options, filePath);
     default:
       return {
         success: false,
@@ -1466,6 +1654,46 @@ const removeAgentFromWebpack = (
   };
 };
 
+const removeAgentFromAstro = (
+  originalContent: string,
+  agent: string,
+  filePath: string,
+): TransformResult => {
+  const agentPackage = `@react-grab/${agent}`;
+
+  if (!originalContent.includes(agentPackage)) {
+    return {
+      success: true,
+      filePath,
+      message: `Agent ${agent} is not configured in this file`,
+      noChanges: true,
+    };
+  }
+
+  const agentImportPattern = new RegExp(
+    `\\s*import\\s*\\(\\s*["']${agentPackage}/client["']\\s*\\);?`,
+    "g",
+  );
+
+  const newContent = originalContent.replace(agentImportPattern, "");
+
+  if (newContent === originalContent) {
+    return {
+      success: false,
+      filePath,
+      message: `Could not find agent ${agent} import to remove`,
+    };
+  }
+
+  return {
+    success: true,
+    filePath,
+    message: `Remove ${agent} agent`,
+    originalContent,
+    newContent,
+  };
+};
+
 const removeAgentFromTanStack = (
   originalContent: string,
   agent: string,
@@ -1534,6 +1762,8 @@ export const previewAgentRemoval = (
       return removeAgentFromTanStack(originalContent, agent, filePath);
     case "webpack":
       return removeAgentFromWebpack(originalContent, agent, filePath);
+    case "astro":
+      return removeAgentFromAstro(originalContent, agent, filePath);
     default:
       return {
         success: false,

--- a/packages/cli/src/utils/transform.ts
+++ b/packages/cli/src/utils/transform.ts
@@ -816,7 +816,8 @@ const addAgentToExistingAstro = (
     const hasSemicolon = matchedText.endsWith(";");
     const newContent = originalContent.replace(
       matchedText,
-      `${hasSemicolon ? matchedText.slice(0, -1) : matchedText};\n        ${agentImport}`,
+      `${hasSemicolon ? matchedText.slice(0, -1) : matchedText};
+        ${agentImport}`,
     );
     return {
       success: true,
@@ -876,7 +877,7 @@ const transformAstro = (
       };
     }
 
-    if (reactGrabAlreadyConfigured) {
+    if (!force && reactGrabAlreadyConfigured) {
       continue;
     }
 

--- a/packages/cli/src/utils/transform.ts
+++ b/packages/cli/src/utils/transform.ts
@@ -806,30 +806,31 @@ const addAgentToExistingAstro = (
     };
   }
 
-  const scriptBlock = ASTRO_EFFECT_WITH_AGENT(agent);
-  const headMatch = originalContent.match(/<head[^>]*>/i);
+  const agentImport = `import("@react-grab/${agent}/client");`;
+  const reactGrabImportMatch = originalContent.match(
+    /import\s*\(\s*["']react-grab["']\s*\);?/,
+  );
 
-  if (!headMatch) {
+  if (reactGrabImportMatch) {
+    const matchedText = reactGrabImportMatch[0];
+    const hasSemicolon = matchedText.endsWith(";");
+    const newContent = originalContent.replace(
+      matchedText,
+      `${hasSemicolon ? matchedText.slice(0, -1) : matchedText};\n        ${agentImport}`,
+    );
     return {
-      success: false,
+      success: true,
       filePath,
-      message: "Could not find <head> tag in the Astro file",
+      message: `Add ${agent} agent`,
+      originalContent,
+      newContent,
     };
   }
 
-  const indentation = "        ";
-
-  const newContent = originalContent.replace(
-    headMatch[0],
-    `${headMatch[0]}\n${indentation}${scriptBlock}`,
-  );
-
   return {
-    success: true,
+    success: false,
     filePath,
-    message: `Add ${agent} agent to existing React Grab configuration`,
-    originalContent,
-    newContent,
+    message: "Could not find React Grab import in the Astro file",
   };
 };
 
@@ -873,6 +874,10 @@ const transformAstro = (
         message: "React Grab is already installed in this file",
         noChanges: true,
       };
+    }
+
+    if (reactGrabAlreadyConfigured) {
+      continue;
     }
 
     const scriptBlock = ASTRO_EFFECT_WITH_AGENT(agent);
@@ -1284,6 +1289,12 @@ const findReactGrabFile = (
       return findEntryFile(projectRoot);
     case "astro":
       const astroFiles = findAllAstroLayoutFiles(projectRoot);
+      for (const file of astroFiles) {
+        const content = readFileSync(file, "utf-8");
+        if (hasReactGrabCode(content)) {
+          return file;
+        }
+      }
       return astroFiles.length > 0 ? astroFiles[0] : null;
     default:
       return null;
@@ -1445,12 +1456,11 @@ const addOptionsToAstroScript = (
   options: ReactGrabOptions,
   filePath: string,
 ): TransformResult => {
-  const optionsJson = formatOptionsAsJson(options);
-  const reactGrabImportMatch = originalContent.match(
-    /import\s*\(\s*["']react-grab["']\s*\)(?:\s*\.\s*then\s*\(\s*\([^)]*\)\s*=>[^}]*\}\s*\))?/,
+  const reactGrabImportWithInitMatch = originalContent.match(
+    /import\s*\(\s*["']react-grab["']\s*\)(?:\.then\s*\(\s*\(m\)\s*=>\s*m\.init\s*\([^)]*\)\s*\))?/,
   );
 
-  if (!reactGrabImportMatch) {
+  if (!reactGrabImportWithInitMatch) {
     return {
       success: false,
       filePath,
@@ -1458,9 +1468,10 @@ const addOptionsToAstroScript = (
     };
   }
 
+  const optionsJson = formatOptionsAsJson(options);
   const newImport = `import("react-grab").then((m) => m.init(${optionsJson}))`;
   const newContent = originalContent.replace(
-    reactGrabImportMatch[0],
+    reactGrabImportWithInitMatch[0],
     newImport,
   );
 

--- a/packages/cli/test/detect.test.ts
+++ b/packages/cli/test/detect.test.ts
@@ -33,7 +33,9 @@ describe("detectFramework", () => {
   it("should detect Next.js", () => {
     mockExistsSync.mockReturnValue(true);
     mockReadFileSync.mockReturnValue(
-      JSON.stringify({ dependencies: { next: "14.0.0", react: "18.0.0" } }),
+      JSON.stringify({
+        dependencies: { next: "14.0.0", react: "18.0.0" },
+      }),
     );
 
     expect(detectFramework("/test")).toBe("next");
@@ -46,6 +48,15 @@ describe("detectFramework", () => {
     );
 
     expect(detectFramework("/test")).toBe("vite");
+  });
+
+  it("should detect Astro", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ devDependencies: { astro: "4.0.0" } }),
+    );
+
+    expect(detectFramework("/test")).toBe("astro");
   });
 
   it("should detect Webpack", () => {
@@ -297,15 +308,6 @@ describe("detectUnsupportedFramework", () => {
     );
 
     expect(detectUnsupportedFramework("/test")).toBe("remix");
-  });
-
-  it("should detect Astro", () => {
-    mockExistsSync.mockReturnValue(true);
-    mockReadFileSync.mockReturnValue(
-      JSON.stringify({ devDependencies: { astro: "4.0.0" } }),
-    );
-
-    expect(detectUnsupportedFramework("/test")).toBe("astro");
   });
 
   it("should detect SvelteKit", () => {

--- a/packages/cli/test/detect.test.ts
+++ b/packages/cli/test/detect.test.ts
@@ -59,6 +59,15 @@ describe("detectFramework", () => {
     expect(detectFramework("/test")).toBe("astro");
   });
 
+  it("should prioritize Astro over Vite when both are present", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ devDependencies: { astro: "4.0.0", vite: "5.0.0" } }),
+    );
+
+    expect(detectFramework("/test")).toBe("astro");
+  });
+
   it("should detect Webpack", () => {
     mockExistsSync.mockReturnValue(true);
     mockReadFileSync.mockReturnValue(


### PR DESCRIPTION
## Summary

Add full Astro framework support to React Grab's init command. Closes #224

### Features Implemented

- **Astro Detection**: Automatically detects Astro projects by checking for the `astro` package in `devDependencies`
- **Layout File Discovery**: Finds Astro layout files in common locations (`src/layouts/`, `layouts/`, `src/pages/`)
- **Code Injection**: Injects React Grab initialization code into the `<head>` tag of Astro layout files
- **Agent Support**: Full support for adding and removing AI agents (MCP, Claude Code, Cursor, etc.)
- **Options Configuration**: Support for configuring React Grab options in Astro projects
- **Existing Configuration Detection**: Detects if React Grab is already installed in Astro projects

### How It Works

For Astro projects, React Grab is initialized using dynamic imports that only run in development mode:

```astro
{import.meta.env.DEV && (
  <script>
    if (import.meta.env.DEV) {
      import("react-grab");
      import("@react-grab/mcp/client");
    }
  </script>
)}
```

### Usage

```bash
# Initialize in an Astro project
npx -y grab@latest init

# Add a specific agent
npx -y grab@latest init --agent mcp
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new supported framework path that detects Astro projects and rewrites `.astro` layout/page files to inject/remove scripts and update options; mistakes could lead to incorrect code injection or missed configs in user projects.
> 
> **Overview**
> Adds **Astro** as a first-class supported framework in the CLI `init` flow, including updated user-facing messaging and removal of Astro from the unsupported-framework list.
> 
> Extends project detection and React Grab presence checks to recognize Astro projects (including prioritizing `astro` over `vite`) and to scan common `.astro` layout/page locations.
> 
> Implements Astro-specific transforms to inject a dev-only `<script>` into an `.astro` file’s `<head>`, plus support for **adding/removing agents** and **updating options** by rewriting the dynamic `import("react-grab")` block; includes new tests covering Astro detection and precedence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84d719535d6380576c110fee8892eaa0f0b1741b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Astro support to the CLI init flow so `astro` projects auto-detect, inject a dev-only setup, and manage agents/options. Also fixes detection precedence and improves Astro transforms, including `--force` handling and consistent indentation.

- **New Features**
  - Detects `astro` projects and treats Astro as a supported framework in `init`.
  - Injects a dev-only `<script>` into `<head>` of common `.astro` layout files to load `react-grab` (and `@react-grab/<agent>/client` when selected).
  - Adds/removes agents and updates options in `.astro` files; detects existing setup to avoid duplicates.
  - Updates templates/transforms/tests and removes Astro from the unsupported list.

- **Bug Fixes**
  - Prioritizes `astro` over `vite` in detection to avoid misidentification (with a test to prevent regression).
  - Places agent import next to the existing `react-grab` import; escapes regex for agent package during removal.
  - Updates options by matching the full `.then((m) => m.init(...))` block.
  - Finds the `.astro` file that contains `react-grab` and continues scanning files if already configured.
  - Adds Astro to the supported frameworks message when detection fails.
  - Fixes `--force` guard behavior and ensures consistent indentation when injecting Astro script.

<sup>Written for commit 84d719535d6380576c110fee8892eaa0f0b1741b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

