### PR TITLE
refactor: consolidate types, extract toolbar positioning, fix SolidJS…

### DIFF
--- a/packages/cli/src/utils/transform.ts
+++ b/packages/cli/src/utils/transform.ts
@@ -545,7 +545,11 @@ const transformVite = (
   if (!force) {
     const indexPath = findIndexHtml(projectRoot);
     if (indexPath) {
-      const existingResult = checkExistingInstallation(indexPath, agent, reactGrabAlreadyConfigured);
+      const existingResult = checkExistingInstallation(
+        indexPath,
+        agent,
+        reactGrabAlreadyConfigured,
+      );
       if (existingResult) return existingResult;
     }
   }
@@ -559,7 +563,11 @@ const transformVite = (
   }
 
   if (!force) {
-    const existingResult = checkExistingInstallation(entryPath, agent, reactGrabAlreadyConfigured);
+    const existingResult = checkExistingInstallation(
+      entryPath,
+      agent,
+      reactGrabAlreadyConfigured,
+    );
     if (existingResult) return existingResult;
   }
 
@@ -594,7 +602,11 @@ const transformWebpack = (
   }
 
   if (!force) {
-    const existingResult = checkExistingInstallation(entryPath, agent, reactGrabAlreadyConfigured);
+    const existingResult = checkExistingInstallation(
+      entryPath,
+      agent,
+      reactGrabAlreadyConfigured,
+    );
     if (existingResult) return existingResult;
   }
 

--- a/packages/cli/test/transform.test.ts
+++ b/packages/cli/test/transform.test.ts
@@ -480,9 +480,7 @@ import ReactDOM from "react-dom/client";`;
 
     mockExistsSync.mockImplementation((path) => {
       const pathStr = String(path);
-      return (
-        pathStr.endsWith("index.html") || pathStr.endsWith("main.tsx")
-      );
+      return pathStr.endsWith("index.html") || pathStr.endsWith("main.tsx");
     });
     mockReadFileSync.mockImplementation((path) => {
       if (String(path).endsWith("index.html")) return indexWithReactGrab;
@@ -512,22 +510,14 @@ import ReactDOM from "react-dom/client";`;
 
     mockExistsSync.mockImplementation((path) => {
       const pathStr = String(path);
-      return (
-        pathStr.endsWith("index.html") || pathStr.endsWith("main.tsx")
-      );
+      return pathStr.endsWith("index.html") || pathStr.endsWith("main.tsx");
     });
     mockReadFileSync.mockImplementation((path) => {
       if (String(path).endsWith("index.html")) return indexWithReactGrab;
       return `import React from "react";`;
     });
 
-    const result = previewTransform(
-      "/test",
-      "vite",
-      "unknown",
-      "cursor",
-      true,
-    );
+    const result = previewTransform("/test", "vite", "unknown", "cursor", true);
 
     expect(result.success).toBe(true);
     expect(result.newContent).toContain("@react-grab/cursor");

--- a/packages/react-grab/e2e/edge-cases.spec.ts
+++ b/packages/react-grab/e2e/edge-cases.spec.ts
@@ -325,7 +325,7 @@ test.describe("Edge Cases", () => {
     test("should handle elements outside viewport", async ({ reactGrab }) => {
       await reactGrab.activate();
       await reactGrab.scrollPage(1000);
-      await reactGrab.page.waitForTimeout(200);
+      await reactGrab.page.waitForTimeout(500);
 
       await reactGrab.hoverElement("[data-testid='footer']");
       await reactGrab.waitForSelectionBox();

--- a/packages/react-grab/e2e/fixtures.ts
+++ b/packages/react-grab/e2e/fixtures.ts
@@ -312,7 +312,7 @@ const createReactGrabPageObject = (page: Page): ReactGrabPageObject => {
   const hoverElement = async (selector: string) => {
     const element = page.locator(selector).first();
     await element.hover({ force: true });
-    await page.waitForTimeout(100);
+    await page.waitForTimeout(250);
   };
 
   const clickElement = async (selector: string) => {
@@ -362,7 +362,8 @@ const createReactGrabPageObject = (page: Page): ReactGrabPageObject => {
         const state = api?.getState();
         return state?.isSelectionBoxVisible || state?.targetElement !== null;
       },
-      { timeout: 2000 },
+      undefined,
+      { timeout: 10_000 },
     );
   };
 
@@ -378,6 +379,7 @@ const createReactGrabPageObject = (page: Page): ReactGrabPageObject => {
         ).__REACT_GRAB__;
         return api?.getState()?.selectionFilePath !== null;
       },
+      undefined,
       { timeout: 5000 },
     );
   };
@@ -608,7 +610,31 @@ const createReactGrabPageObject = (page: Page): ReactGrabPageObject => {
   const enterPromptMode = async (selector: string) => {
     await activate();
     await hoverElement(selector);
-    await waitForSelectionBox();
+    const isSelected = await page
+      .waitForFunction(
+        () => {
+          const api = (
+            window as {
+              __REACT_GRAB__?: {
+                getState: () => {
+                  isSelectionBoxVisible: boolean;
+                  targetElement: unknown;
+                };
+              };
+            }
+          ).__REACT_GRAB__;
+          const state = api?.getState();
+          return state?.isSelectionBoxVisible || state?.targetElement !== null;
+        },
+        undefined,
+        { timeout: 2000 },
+      )
+      .then(() => true)
+      .catch(() => false);
+    if (!isSelected) {
+      await hoverElement(selector);
+      await waitForSelectionBox();
+    }
     await rightClickElement(selector);
     await clickContextMenuItem("Edit");
     await waitForPromptMode(true);
@@ -1820,6 +1846,7 @@ const createReactGrabPageObject = (page: Page): ReactGrabPageObject => {
         const api = (window as { __REACT_GRAB__?: unknown }).__REACT_GRAB__;
         return api !== undefined;
       },
+      undefined,
       { timeout: 5000 },
     );
   };
@@ -2494,6 +2521,7 @@ export const test = base.extend<{ reactGrab: ReactGrabPageObject }>({
           const api = (window as { __REACT_GRAB__?: unknown }).__REACT_GRAB__;
           return api !== undefined;
         },
+        undefined,
         { timeout: PAGE_SETUP_API_TIMEOUT_MS },
       );
     };

--- a/packages/react-grab/src/components/context-menu.tsx
+++ b/packages/react-grab/src/components/context-menu.tsx
@@ -9,6 +9,7 @@ import {
 } from "solid-js";
 import type { Component } from "solid-js";
 import type {
+  Position,
   OverlayBounds,
   ContextMenuAction,
   ContextMenuActionContext,
@@ -30,7 +31,7 @@ import { createMenuHighlight } from "../utils/create-menu-highlight.js";
 import { suppressMenuEvent } from "../utils/suppress-menu-event.js";
 
 interface ContextMenuProps {
-  position: { x: number; y: number } | null;
+  position: Position | null;
   selectionBounds: OverlayBounds | null;
   tagName?: string;
   componentName?: string;

--- a/packages/react-grab/src/components/selection-label/index.tsx
+++ b/packages/react-grab/src/components/selection-label/index.tsx
@@ -38,7 +38,15 @@ import { ErrorView } from "./error-view.js";
 import { CompletionView } from "./completion-view.js";
 import { ArrowNavigationMenu } from "./arrow-navigation-menu.js";
 
-const DEFAULT_OFFSCREEN_POSITION = {
+interface LabelPosition {
+  left: number;
+  top: number;
+  arrowLeftPercent: number;
+  arrowLeftOffset: number;
+  edgeOffsetX: number;
+}
+
+const DEFAULT_OFFSCREEN_POSITION: LabelPosition = {
   left: SELECTION_LABEL_OFFSCREEN_PX,
   top: SELECTION_LABEL_OFFSCREEN_PX,
   arrowLeftPercent: ARROW_CENTER_PERCENT,
@@ -46,27 +54,24 @@ const DEFAULT_OFFSCREEN_POSITION = {
   edgeOffsetX: 0,
 };
 
+interface PositionResult {
+  position: LabelPosition;
+  computedArrowPosition: ArrowPosition | null;
+  hadValidBounds: boolean;
+  resetVersion: number;
+}
+
 export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
   let containerRef: HTMLDivElement | undefined;
   let panelRef: HTMLDivElement | undefined;
   let inputRef: HTMLTextAreaElement | undefined;
   let isTagCurrentlyHovered = false;
-  let lastValidPosition: {
-    left: number;
-    top: number;
-    arrowLeftPercent: number;
-    arrowLeftOffset: number;
-    edgeOffsetX: number;
-  } | null = null;
   let lastElementIdentity: string | null = null;
 
   const [measuredWidth, setMeasuredWidth] = createSignal(0);
   const [measuredHeight, setMeasuredHeight] = createSignal(0);
   const [panelWidth, setPanelWidth] = createSignal(0);
-  const [arrowPosition, setArrowPosition] =
-    createSignal<ArrowPosition>("bottom");
   const [viewportVersion, setViewportVersion] = createSignal(0);
-  const [hadValidBounds, setHadValidBounds] = createSignal(false);
   const [isInternalFading, setIsInternalFading] = createSignal(false);
   const [isShaking, setIsShaking] = createSignal(false);
 
@@ -167,11 +172,13 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
     });
   });
 
+  const [positionResetVersion, setPositionResetVersion] = createSignal(0);
+
   createEffect(() => {
     const elementIdentity = `${props.tagName ?? ""}:${props.componentName ?? ""}`;
     if (elementIdentity !== lastElementIdentity) {
       lastElementIdentity = elementIdentity;
-      lastValidPosition = null;
+      setPositionResetVersion((version) => version + 1);
     }
   });
 
@@ -190,116 +197,139 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
     }
   });
 
-  const positionComputation = createMemo(() => {
-    viewportVersion();
+  const positionComputation = createMemo(
+    (previousResult: PositionResult): PositionResult => {
+      viewportVersion();
+      const resetVersion = positionResetVersion();
+      const didReset = resetVersion !== previousResult.resetVersion;
+      const cached = didReset
+        ? {
+            position: DEFAULT_OFFSCREEN_POSITION,
+            computedArrowPosition: null as ArrowPosition | null,
+            hadValidBounds: false,
+            resetVersion,
+          }
+        : previousResult;
 
-    const bounds = props.selectionBounds;
-    const labelWidth = measuredWidth();
-    const labelHeight = measuredHeight();
-    const hasMeasurements = labelWidth > 0 && labelHeight > 0;
-    const hasValidBounds = bounds && bounds.width > 0 && bounds.height > 0;
+      const bounds = props.selectionBounds;
+      const labelWidth = measuredWidth();
+      const labelHeight = measuredHeight();
+      const hasMeasurements = labelWidth > 0 && labelHeight > 0;
+      const hasValidBounds = bounds && bounds.width > 0 && bounds.height > 0;
 
-    if (!hasMeasurements || !hasValidBounds) {
-      return {
-        position: lastValidPosition ?? DEFAULT_OFFSCREEN_POSITION,
-        computedArrowPosition: null,
-      };
-    }
-
-    const visualViewport = window.visualViewport;
-    const viewportLeft = visualViewport?.offsetLeft ?? 0;
-    const viewportTop = visualViewport?.offsetTop ?? 0;
-    const viewportRight =
-      viewportLeft + (visualViewport?.width ?? window.innerWidth);
-    const viewportBottom =
-      viewportTop + (visualViewport?.height ?? window.innerHeight);
-
-    const isSelectionVisibleInViewport =
-      bounds.x + bounds.width > viewportLeft &&
-      bounds.x < viewportRight &&
-      bounds.y + bounds.height > viewportTop &&
-      bounds.y < viewportBottom;
-
-    if (!isSelectionVisibleInViewport) {
-      return {
-        position: DEFAULT_OFFSCREEN_POSITION,
-        computedArrowPosition: null,
-      };
-    }
-
-    const selectionCenterX = bounds.x + bounds.width / 2;
-    const cursorX = props.mouseX ?? selectionCenterX;
-    const selectionBottom = bounds.y + bounds.height;
-    const selectionTop = bounds.y;
-
-    const actualArrowHeight = props.hideArrow ? 0 : getArrowSize(panelWidth());
-
-    // HACK: Use cursorX as anchor point, CSS transform handles centering via translateX(-50%)
-    // This avoids the flicker when content changes because centering doesn't depend on JS measurement
-    const anchorX = cursorX;
-    let edgeOffsetX = 0;
-    let positionTop = selectionBottom + actualArrowHeight + LABEL_GAP_PX;
-
-    if (labelWidth > 0) {
-      const labelLeft = anchorX - labelWidth / 2;
-      const labelRight = anchorX + labelWidth / 2;
-
-      if (labelRight > viewportRight - VIEWPORT_MARGIN_PX) {
-        edgeOffsetX = viewportRight - VIEWPORT_MARGIN_PX - labelRight;
+      if (!hasMeasurements || !hasValidBounds) {
+        return {
+          position: cached.hadValidBounds
+            ? cached.position
+            : DEFAULT_OFFSCREEN_POSITION,
+          computedArrowPosition: cached.computedArrowPosition,
+          hadValidBounds: cached.hadValidBounds,
+          resetVersion,
+        };
       }
-      if (labelLeft + edgeOffsetX < viewportLeft + VIEWPORT_MARGIN_PX) {
-        edgeOffsetX = viewportLeft + VIEWPORT_MARGIN_PX - labelLeft;
+
+      const visualViewport = window.visualViewport;
+      const viewportLeft = visualViewport?.offsetLeft ?? 0;
+      const viewportTop = visualViewport?.offsetTop ?? 0;
+      const viewportRight =
+        viewportLeft + (visualViewport?.width ?? window.innerWidth);
+      const viewportBottom =
+        viewportTop + (visualViewport?.height ?? window.innerHeight);
+
+      const isSelectionVisibleInViewport =
+        bounds.x + bounds.width > viewportLeft &&
+        bounds.x < viewportRight &&
+        bounds.y + bounds.height > viewportTop &&
+        bounds.y < viewportBottom;
+
+      if (!isSelectionVisibleInViewport) {
+        return {
+          position: DEFAULT_OFFSCREEN_POSITION,
+          computedArrowPosition: cached.computedArrowPosition,
+          hadValidBounds: cached.hadValidBounds,
+          resetVersion,
+        };
       }
-    }
 
-    const totalHeightNeeded = labelHeight + actualArrowHeight + LABEL_GAP_PX;
-    const fitsBelow =
-      positionTop + labelHeight <= viewportBottom - VIEWPORT_MARGIN_PX;
+      const selectionCenterX = bounds.x + bounds.width / 2;
+      const cursorX = props.mouseX ?? selectionCenterX;
+      const selectionBottom = bounds.y + bounds.height;
+      const selectionTop = bounds.y;
 
-    if (!fitsBelow) {
-      positionTop = selectionTop - totalHeightNeeded;
-    }
+      const actualArrowHeight = props.hideArrow
+        ? 0
+        : getArrowSize(panelWidth());
 
-    if (positionTop < viewportTop + VIEWPORT_MARGIN_PX) {
-      positionTop = viewportTop + VIEWPORT_MARGIN_PX;
-    }
+      // HACK: Use cursorX as anchor point, CSS transform handles centering via translateX(-50%)
+      // This avoids the flicker when content changes because centering doesn't depend on JS measurement
+      const anchorX = cursorX;
+      let edgeOffsetX = 0;
+      let positionTop = selectionBottom + actualArrowHeight + LABEL_GAP_PX;
 
-    const arrowLeftPercent = ARROW_CENTER_PERCENT;
-    const labelHalfWidth = labelWidth / 2;
-    const arrowCenterPx = labelHalfWidth - edgeOffsetX;
-    const arrowMinPx = Math.min(ARROW_LABEL_MARGIN_PX, labelHalfWidth);
-    const arrowMaxPx = Math.max(
-      labelWidth - ARROW_LABEL_MARGIN_PX,
-      labelHalfWidth,
-    );
-    const clampedArrowCenterPx = Math.max(
-      arrowMinPx,
-      Math.min(arrowMaxPx, arrowCenterPx),
-    );
-    const arrowLeftOffset = clampedArrowCenterPx - labelHalfWidth;
+      if (labelWidth > 0) {
+        const labelLeft = anchorX - labelWidth / 2;
+        const labelRight = anchorX + labelWidth / 2;
 
-    const computedArrowPosition: ArrowPosition = fitsBelow ? "bottom" : "top";
+        if (labelRight > viewportRight - VIEWPORT_MARGIN_PX) {
+          edgeOffsetX = viewportRight - VIEWPORT_MARGIN_PX - labelRight;
+        }
+        if (labelLeft + edgeOffsetX < viewportLeft + VIEWPORT_MARGIN_PX) {
+          edgeOffsetX = viewportLeft + VIEWPORT_MARGIN_PX - labelLeft;
+        }
+      }
 
-    return {
-      position: {
-        left: anchorX,
-        top: positionTop,
-        arrowLeftPercent,
-        arrowLeftOffset,
-        edgeOffsetX,
-      },
-      computedArrowPosition,
-    };
-  });
+      const totalHeightNeeded = labelHeight + actualArrowHeight + LABEL_GAP_PX;
+      const fitsBelow =
+        positionTop + labelHeight <= viewportBottom - VIEWPORT_MARGIN_PX;
 
-  createEffect(() => {
-    const result = positionComputation();
-    if (result.computedArrowPosition !== null) {
-      lastValidPosition = result.position;
-      setHadValidBounds(true);
-      setArrowPosition(result.computedArrowPosition);
-    }
-  });
+      if (!fitsBelow) {
+        positionTop = selectionTop - totalHeightNeeded;
+      }
+
+      if (positionTop < viewportTop + VIEWPORT_MARGIN_PX) {
+        positionTop = viewportTop + VIEWPORT_MARGIN_PX;
+      }
+
+      const arrowLeftPercent = ARROW_CENTER_PERCENT;
+      const labelHalfWidth = labelWidth / 2;
+      const arrowCenterPx = labelHalfWidth - edgeOffsetX;
+      const arrowMinPx = Math.min(ARROW_LABEL_MARGIN_PX, labelHalfWidth);
+      const arrowMaxPx = Math.max(
+        labelWidth - ARROW_LABEL_MARGIN_PX,
+        labelHalfWidth,
+      );
+      const clampedArrowCenterPx = Math.max(
+        arrowMinPx,
+        Math.min(arrowMaxPx, arrowCenterPx),
+      );
+      const arrowLeftOffset = clampedArrowCenterPx - labelHalfWidth;
+
+      const computedArrowPosition: ArrowPosition = fitsBelow ? "bottom" : "top";
+
+      return {
+        position: {
+          left: anchorX,
+          top: positionTop,
+          arrowLeftPercent,
+          arrowLeftOffset,
+          edgeOffsetX,
+        },
+        computedArrowPosition,
+        hadValidBounds: true,
+        resetVersion,
+      };
+    },
+    {
+      position: DEFAULT_OFFSCREEN_POSITION,
+      computedArrowPosition: null as ArrowPosition | null,
+      hadValidBounds: false,
+      resetVersion: 0,
+    },
+  );
+
+  const arrowPosition = () =>
+    positionComputation().computedArrowPosition ?? "bottom";
+  const hadValidBounds = () => positionComputation().hadValidBounds;
 
   createEffect(
     on(

--- a/packages/react-grab/src/components/toolbar/index.tsx
+++ b/packages/react-grab/src/components/toolbar/index.tsx
@@ -7,7 +7,7 @@ import {
   Show,
 } from "solid-js";
 import type { Component } from "solid-js";
-import type { ToolbarMenuAction } from "../../types.js";
+import type { Position, ToolbarMenuAction } from "../../types.js";
 import { cn } from "../../utils/cn.js";
 import { formatShortcut } from "../../utils/format-shortcut.js";
 import {
@@ -29,7 +29,6 @@ import {
   TOOLBAR_FADE_IN_DELAY_MS,
   TOOLBAR_SNAP_ANIMATION_DURATION_MS,
   TOOLBAR_DRAG_THRESHOLD_PX,
-  TOOLBAR_VELOCITY_MULTIPLIER_MS,
   TOOLBAR_COLLAPSED_SHORT_PX,
   TOOLBAR_COLLAPSED_LONG_PX,
   TOOLBAR_COLLAPSE_ANIMATION_DURATION_MS,
@@ -66,6 +65,13 @@ import {
   nativeCancelAnimationFrame,
   nativeRequestAnimationFrame,
 } from "../../utils/native-raf.js";
+import { getVisualViewport } from "../../utils/get-visual-viewport.js";
+import {
+  clampToRange,
+  getPositionFromEdgeAndRatio,
+  getRatioFromPosition,
+  getSnapPosition,
+} from "../../utils/toolbar-position.js";
 
 interface ToolbarProps {
   isActive?: boolean;
@@ -372,7 +378,7 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
           rect.width -
           TOOLBAR_SNAP_MARGIN_PX,
       );
-      clampedX = clampToViewport(currentPos.x, minX, maxX);
+      clampedX = clampToRange(currentPos.x, minX, maxX);
       clampedY =
         edge === "top"
           ? viewport.offsetTop + TOOLBAR_SNAP_MARGIN_PX
@@ -389,7 +395,7 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
           rect.height -
           TOOLBAR_SNAP_MARGIN_PX,
       );
-      clampedY = clampToViewport(currentPos.y, minY, maxY);
+      clampedY = clampToRange(currentPos.y, minY, maxY);
       clampedX =
         edge === "left"
           ? viewport.offsetLeft + TOOLBAR_SNAP_MARGIN_PX
@@ -485,31 +491,10 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
     height: TOOLBAR_COLLAPSED_SHORT_PX,
   });
 
-  const clampToViewport = (value: number, min: number, max: number): number =>
-    Math.max(min, Math.min(value, max));
-
-  const getVisualViewport = () => {
-    const visualViewport = window.visualViewport;
-    if (visualViewport) {
-      return {
-        width: visualViewport.width,
-        height: visualViewport.height,
-        offsetLeft: visualViewport.offsetLeft,
-        offsetTop: visualViewport.offsetTop,
-      };
-    }
-    return {
-      width: window.innerWidth,
-      height: window.innerHeight,
-      offsetLeft: 0,
-      offsetTop: 0,
-    };
-  };
-
   const calculateExpandedPositionFromCollapsed = (
-    collapsedPosition: { x: number; y: number },
+    collapsedPosition: Position,
     edge: SnapEdge,
-  ): { position: { x: number; y: number }; ratio: number } => {
+  ): { position: Position; ratio: number } => {
     const viewport = getVisualViewport();
     const viewportWidth = viewport.width;
     const viewportHeight = viewport.height;
@@ -520,12 +505,12 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
     const actualCollapsedHeight =
       actualRect?.height ?? TOOLBAR_COLLAPSED_SHORT_PX;
 
-    let newPosition: { x: number; y: number };
+    let newPosition: Position;
 
     if (edge === "top" || edge === "bottom") {
       const xOffset = (expandedWidth - actualCollapsedWidth) / 2;
       const newExpandedX = collapsedPosition.x - xOffset;
-      const clampedX = clampToViewport(
+      const clampedX = clampToRange(
         newExpandedX,
         viewport.offsetLeft + TOOLBAR_SNAP_MARGIN_PX,
         viewport.offsetLeft +
@@ -544,7 +529,7 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
     } else {
       const yOffset = (expandedHeight - actualCollapsedHeight) / 2;
       const newExpandedY = collapsedPosition.y - yOffset;
-      const clampedY = clampToViewport(
+      const clampedY = clampToRange(
         newExpandedY,
         viewport.offsetTop + TOOLBAR_SNAP_MARGIN_PX,
         viewport.offsetTop +
@@ -571,101 +556,6 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
     );
 
     return { position: newPosition, ratio };
-  };
-
-  const getPositionFromEdgeAndRatio = (
-    edge: SnapEdge,
-    ratio: number,
-    elementWidth: number,
-    elementHeight: number,
-  ) => {
-    const viewport = getVisualViewport();
-    const viewportWidth = viewport.width;
-    const viewportHeight = viewport.height;
-
-    const minX = viewport.offsetLeft + TOOLBAR_SNAP_MARGIN_PX;
-    const maxX = Math.max(
-      minX,
-      viewport.offsetLeft +
-        viewportWidth -
-        elementWidth -
-        TOOLBAR_SNAP_MARGIN_PX,
-    );
-    const minY = viewport.offsetTop + TOOLBAR_SNAP_MARGIN_PX;
-    const maxY = Math.max(
-      minY,
-      viewport.offsetTop +
-        viewportHeight -
-        elementHeight -
-        TOOLBAR_SNAP_MARGIN_PX,
-    );
-
-    if (edge === "top" || edge === "bottom") {
-      const availableWidth = Math.max(
-        0,
-        viewportWidth - elementWidth - TOOLBAR_SNAP_MARGIN_PX * 2,
-      );
-      const positionX = Math.min(
-        maxX,
-        Math.max(
-          minX,
-          viewport.offsetLeft + TOOLBAR_SNAP_MARGIN_PX + availableWidth * ratio,
-        ),
-      );
-      const positionY = edge === "top" ? minY : maxY;
-      return { x: positionX, y: positionY };
-    }
-
-    const availableHeight = Math.max(
-      0,
-      viewportHeight - elementHeight - TOOLBAR_SNAP_MARGIN_PX * 2,
-    );
-    const positionY = Math.min(
-      maxY,
-      Math.max(
-        minY,
-        viewport.offsetTop + TOOLBAR_SNAP_MARGIN_PX + availableHeight * ratio,
-      ),
-    );
-    const positionX = edge === "left" ? minX : maxX;
-    return { x: positionX, y: positionY };
-  };
-
-  const getRatioFromPosition = (
-    edge: SnapEdge,
-    positionX: number,
-    positionY: number,
-    elementWidth: number,
-    elementHeight: number,
-  ) => {
-    const viewport = getVisualViewport();
-    const viewportWidth = viewport.width;
-    const viewportHeight = viewport.height;
-
-    if (edge === "top" || edge === "bottom") {
-      const availableWidth =
-        viewportWidth - elementWidth - TOOLBAR_SNAP_MARGIN_PX * 2;
-      if (availableWidth <= 0) return TOOLBAR_DEFAULT_POSITION_RATIO;
-      return Math.max(
-        0,
-        Math.min(
-          1,
-          (positionX - viewport.offsetLeft - TOOLBAR_SNAP_MARGIN_PX) /
-            availableWidth,
-        ),
-      );
-    }
-    const availableHeight =
-      viewportHeight - elementHeight - TOOLBAR_SNAP_MARGIN_PX * 2;
-    if (availableHeight <= 0) return TOOLBAR_DEFAULT_POSITION_RATIO;
-    return Math.max(
-      0,
-      Math.min(
-        1,
-        (positionY - viewport.offsetTop - TOOLBAR_SNAP_MARGIN_PX) /
-          availableHeight,
-      ),
-    );
   };
 
   const recalculatePosition = () => {
@@ -839,9 +729,7 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
         ? preTogglePosition.y + currentRenderedDimension
         : preTogglePosition.x + currentRenderedDimension;
 
-      const computeClampedPosition = (
-        expandDimension: number,
-      ): { x: number; y: number } => {
+      const computeClampedPosition = (expandDimension: number): Position => {
         const viewport = getVisualViewport();
         const targetAxisPosition = collapsedAxisPosition - expandDimension;
         if (isVerticalEdge) {
@@ -853,7 +741,7 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
             TOOLBAR_SNAP_MARGIN_PX;
           return {
             x: preTogglePosition.x,
-            y: clampToViewport(targetAxisPosition, clampMin, clampMax),
+            y: clampToRange(targetAxisPosition, clampMin, clampMax),
           };
         }
         const clampMin = viewport.offsetLeft + TOOLBAR_SNAP_MARGIN_PX;
@@ -863,7 +751,7 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
           expandedDimensions.width -
           TOOLBAR_SNAP_MARGIN_PX;
         return {
-          x: clampToViewport(targetAxisPosition, clampMin, clampMax),
+          x: clampToRange(targetAxisPosition, clampMin, clampMax),
           y: preTogglePosition.y,
         };
       };
@@ -941,107 +829,6 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
       });
     }
   });
-
-  const getSnapPosition = (
-    currentX: number,
-    currentY: number,
-    elementWidth: number,
-    elementHeight: number,
-    velocityX: number,
-    velocityY: number,
-  ): { edge: SnapEdge; x: number; y: number } => {
-    const viewport = getVisualViewport();
-    const viewportWidth = viewport.width;
-    const viewportHeight = viewport.height;
-
-    const projectedX = currentX + velocityX * TOOLBAR_VELOCITY_MULTIPLIER_MS;
-    const projectedY = currentY + velocityY * TOOLBAR_VELOCITY_MULTIPLIER_MS;
-
-    const distanceToTop = projectedY - viewport.offsetTop + elementHeight / 2;
-    const distanceToBottom =
-      viewport.offsetTop + viewportHeight - projectedY - elementHeight / 2;
-    const distanceToLeft = projectedX - viewport.offsetLeft + elementWidth / 2;
-    const distanceToRight =
-      viewport.offsetLeft + viewportWidth - projectedX - elementWidth / 2;
-
-    const minDistance = Math.min(
-      distanceToTop,
-      distanceToBottom,
-      distanceToLeft,
-      distanceToRight,
-    );
-
-    if (minDistance === distanceToTop) {
-      return {
-        edge: "top",
-        x: Math.max(
-          viewport.offsetLeft + TOOLBAR_SNAP_MARGIN_PX,
-          Math.min(
-            projectedX,
-            viewport.offsetLeft +
-              viewportWidth -
-              elementWidth -
-              TOOLBAR_SNAP_MARGIN_PX,
-          ),
-        ),
-        y: viewport.offsetTop + TOOLBAR_SNAP_MARGIN_PX,
-      };
-    }
-    if (minDistance === distanceToLeft) {
-      return {
-        edge: "left",
-        x: viewport.offsetLeft + TOOLBAR_SNAP_MARGIN_PX,
-        y: Math.max(
-          viewport.offsetTop + TOOLBAR_SNAP_MARGIN_PX,
-          Math.min(
-            projectedY,
-            viewport.offsetTop +
-              viewportHeight -
-              elementHeight -
-              TOOLBAR_SNAP_MARGIN_PX,
-          ),
-        ),
-      };
-    }
-    if (minDistance === distanceToRight) {
-      return {
-        edge: "right",
-        x:
-          viewport.offsetLeft +
-          viewportWidth -
-          elementWidth -
-          TOOLBAR_SNAP_MARGIN_PX,
-        y: Math.max(
-          viewport.offsetTop + TOOLBAR_SNAP_MARGIN_PX,
-          Math.min(
-            projectedY,
-            viewport.offsetTop +
-              viewportHeight -
-              elementHeight -
-              TOOLBAR_SNAP_MARGIN_PX,
-          ),
-        ),
-      };
-    }
-    return {
-      edge: "bottom",
-      x: Math.max(
-        viewport.offsetLeft + TOOLBAR_SNAP_MARGIN_PX,
-        Math.min(
-          projectedX,
-          viewport.offsetLeft +
-            viewportWidth -
-            elementWidth -
-            TOOLBAR_SNAP_MARGIN_PX,
-        ),
-      ),
-      y:
-        viewport.offsetTop +
-        viewportHeight -
-        elementHeight -
-        TOOLBAR_SNAP_MARGIN_PX,
-    };
-  };
 
   const handleWindowPointerMove = (event: PointerEvent) => {
     if (!isDragging()) return;
@@ -1192,7 +979,7 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
       case "bottom": {
         const xOffset = (expandedWidth - collapsedWidth) / 2;
         const centeredX = pos.x + xOffset;
-        const clampedX = clampToViewport(
+        const clampedX = clampToRange(
           centeredX,
           viewport.offsetLeft,
           viewport.offsetLeft + viewport.width - collapsedWidth,
@@ -1209,7 +996,7 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
       case "right": {
         const yOffset = (expandedHeight - collapsedHeight) / 2;
         const centeredY = pos.y + yOffset;
-        const clampedY = clampToViewport(
+        const clampedY = clampToRange(
           centeredY,
           viewport.offsetTop,
           viewport.offsetTop + viewport.height - collapsedHeight,

--- a/packages/react-grab/src/core/agent/manager.ts
+++ b/packages/react-grab/src/core/agent/manager.ts
@@ -1,6 +1,7 @@
 import { createSignal } from "solid-js";
 import type { Accessor } from "solid-js";
 import type {
+  Position,
   AgentContext,
   AgentSession,
   AgentOptions,
@@ -30,7 +31,7 @@ import { getTagName } from "../../utils/get-tag-name.js";
 interface StartSessionParams {
   elements: Element[];
   prompt: string;
-  position: { x: number; y: number };
+  position: Position;
   selectionBounds: OverlayBounds[];
   sessionId?: string;
   agent?: AgentOptions;

--- a/packages/react-grab/src/core/agent/session.ts
+++ b/packages/react-grab/src/core/agent/session.ts
@@ -1,5 +1,6 @@
 import { MAX_MEMORY_SESSIONS } from "../../constants.js";
 import type {
+  Position,
   AgentContext,
   AgentSession,
   AgentSessionStorage,
@@ -13,7 +14,7 @@ const generateSessionId = (): string =>
 
 export const createSession = (
   context: AgentContext,
-  position: { x: number; y: number },
+  position: Position,
   selectionBounds: OverlayBounds[],
   tagName?: string,
   componentName?: string,

--- a/packages/react-grab/src/core/auto-scroll.ts
+++ b/packages/react-grab/src/core/auto-scroll.ts
@@ -1,3 +1,4 @@
+import type { Position } from "../types.js";
 import {
   AUTO_SCROLL_EDGE_THRESHOLD_PX,
   AUTO_SCROLL_SPEED_PX,
@@ -33,7 +34,7 @@ interface AutoScroller {
 }
 
 export const createAutoScroller = (
-  getMousePosition: () => { x: number; y: number },
+  getMousePosition: () => Position,
   shouldContinue: () => boolean,
 ): AutoScroller => {
   let animationId: number | null = null;

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -92,6 +92,7 @@ import {
   resolveToolbarActionEnabled,
 } from "../utils/resolve-action-enabled.js";
 import type {
+  Position,
   Options,
   OverlayBounds,
   GrabbedBox,
@@ -233,7 +234,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       }),
     );
 
-    const isToggleFrozen = createMemo(
+    const isFrozenPhase = createMemo(
       () =>
         store.current.state === "active" && store.current.phase === "frozen",
     );
@@ -493,7 +494,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
     let lastWindowFocusTimestamp = 0;
     const feedbackState = {
-      inTogglePeriod: false,
+      isInCopyFeedbackCooldown: false,
       timerId: null as number | null,
     };
     let actionCycleIdleTimeoutId: number | null = null;
@@ -709,7 +710,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       elements,
       existingInstanceId,
     }: ExecuteCopyOptions) => {
-      feedbackState.inTogglePeriod = false;
+      feedbackState.isInCopyFeedbackCooldown = false;
       if (store.current.state !== "copying") {
         actions.startCopy();
       }
@@ -763,12 +764,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           deactivateRenderer();
         } else if (didSucceed) {
           actions.activate();
-          feedbackState.inTogglePeriod = true;
+          feedbackState.isInCopyFeedbackCooldown = true;
           if (feedbackState.timerId !== null) {
             window.clearTimeout(feedbackState.timerId);
           }
           feedbackState.timerId = window.setTimeout(() => {
-            feedbackState.inTogglePeriod = false;
+            feedbackState.isInCopyFeedbackCooldown = false;
             feedbackState.timerId = null;
           }, FEEDBACK_DURATION_MS);
         } else {
@@ -956,7 +957,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           : positionX;
 
       const tagName = getTagName(element);
-      feedbackState.inTogglePeriod = false;
+      feedbackState.isInCopyFeedbackCooldown = false;
       actions.startCopy();
 
       const labelInstanceId = tagName
@@ -998,7 +999,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     });
 
     const effectiveElement = createMemo(
-      () => store.frozenElement || (isToggleFrozen() ? null : targetElement()),
+      () => store.frozenElement || (isFrozenPhase() ? null : targetElement()),
     );
 
     createEffect(() => {
@@ -1467,7 +1468,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         window.clearTimeout(feedbackState.timerId);
         feedbackState.timerId = null;
       }
-      feedbackState.inTogglePeriod = false;
+      feedbackState.isInCopyFeedbackCooldown = false;
     };
 
     const deactivateRenderer = () => {
@@ -1493,7 +1494,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
     const forceDeactivateAll = () => {
       if (isHoldingKeys()) {
-        actions.release();
+        actions.releaseHold();
       }
       if (isActivated()) {
         deactivateRenderer();
@@ -1704,10 +1705,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       actions.enterPromptMode({ x: positionX, y: positionY }, element);
     };
 
-    const openContextMenu = (
-      element: Element,
-      position: { x: number; y: number },
-    ) => {
+    const openContextMenu = (element: Element, position: Position) => {
       actions.showContextMenu(position, element);
       clearArrowNavigation();
       dismissAllPopups();
@@ -1752,7 +1750,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       if (
         !isEnabled() ||
         isPromptMode() ||
-        isToggleFrozen() ||
+        isFrozenPhase() ||
         store.contextMenuPosition !== null
       )
         return;
@@ -2427,7 +2425,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           } else if (isHoldingKeys()) {
             clearHoldTimer();
             resetCopyConfirmation();
-            actions.release();
+            actions.releaseHold();
           }
         }
         if (!isEnterCode(event.code) || !isHoldingKeys()) {
@@ -2647,9 +2645,9 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
               )
           : isCLikeKey(event.key, event.code);
 
-        if (didJustCopy() || feedbackState.inTogglePeriod) {
+        if (didJustCopy() || feedbackState.isInCopyFeedbackCooldown) {
           if (isReleasingActivationKey || isReleasingModifier) {
-            feedbackState.inTogglePeriod = false;
+            feedbackState.isInCopyFeedbackCooldown = false;
             deactivateRenderer();
           }
           return;
@@ -2720,7 +2718,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
             if (shouldActivateAfterCopy) {
               actions.activate();
             } else {
-              actions.release();
+              actions.releaseHold();
             }
           } else {
             deactivateRenderer();
@@ -2750,7 +2748,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         if (store.contextMenuPosition !== null) return;
         if (isTouchPointer && !isHoldingKeys() && !isActivated()) return;
         const isActiveState = isTouchPointer ? isHoldingKeys() : isActivated();
-        if (isActiveState && !isPromptMode() && isToggleFrozen()) {
+        if (isActiveState && !isPromptMode() && isFrozenPhase()) {
           actions.unfreeze();
           clearArrowNavigation();
         }
@@ -2909,7 +2907,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       cancelActiveDrag();
       if (isHoldingKeys()) {
         clearHoldTimer();
-        actions.release();
+        actions.releaseHold();
         resetCopyConfirmation();
       }
     });
@@ -2933,7 +2931,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       if (
         isEnabled() &&
         !isPromptMode() &&
-        !isToggleFrozen() &&
+        !isFrozenPhase() &&
         !isDragging() &&
         store.contextMenuPosition === null &&
         store.frozenElements.length === 0
@@ -3100,7 +3098,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       () => pluginRegistry.store.theme.dragBox.enabled,
     );
     const isSelectionSuppressed = createMemo(
-      () => didJustCopy() || (isToolbarSelectHovered() && !isToggleFrozen()),
+      () => didJustCopy() || (isToolbarSelectHovered() && !isFrozenPhase()),
     );
     const hasDragPreviewBounds = createMemo(
       () => dragPreviewBounds().length > 0,
@@ -3240,7 +3238,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       const dragging = isDragging();
       const hasElement = Boolean(effectiveElement());
       const toolbarSelectHovered = isToolbarSelectHovered();
-      const frozen = isToggleFrozen();
+      const frozen = isFrozenPhase();
 
       if (!themeEnabled) return false;
       if (inPromptMode) return false;
@@ -3389,7 +3387,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       lineNumber: number | undefined;
       tagName: string | undefined;
       componentName: string | undefined;
-      position: { x: number; y: number };
+      position: Position;
       performWithFeedbackOptions?: PerformWithFeedbackOptions;
       shouldDeferHideContextMenu: boolean;
       onBeforeCopy?: () => void;
@@ -4008,7 +4006,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
             }
             mouseY={cursorPosition().y}
             isFrozen={
-              isToggleFrozen() || isActivated() || isToolbarSelectHovered()
+              isFrozenPhase() || isActivated() || isToolbarSelectHovered()
             }
             inputValue={store.inputText}
             isPromptMode={isPromptMode()}

--- a/packages/react-grab/src/core/plugin-registry.ts
+++ b/packages/react-grab/src/core/plugin-registry.ts
@@ -1,5 +1,6 @@
 import { createStore } from "solid-js/store";
 import type {
+  Position,
   Plugin,
   PluginConfig,
   PluginHooks,
@@ -332,7 +333,7 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
       variant: ElementLabelVariant,
       context: ElementLabelContext,
     ) => callHook("onElementLabel", visible, variant, context),
-    onContextMenu: (element: Element, position: { x: number; y: number }) =>
+    onContextMenu: (element: Element, position: Position) =>
       callHook("onContextMenu", element, position),
     cancelPendingToolbarActions: () => callHook("cancelPendingToolbarActions"),
     onOpenFile: (filePath: string, lineNumber?: number) =>

--- a/packages/react-grab/src/core/store.ts
+++ b/packages/react-grab/src/core/store.ts
@@ -1,5 +1,6 @@
 import { createStore, produce } from "solid-js/store";
 import type {
+  Position,
   Theme,
   GrabbedBox,
   SelectionLabelInstance,
@@ -10,11 +11,6 @@ import { OFFSCREEN_POSITION } from "../constants.js";
 import { createElementBounds } from "../utils/create-element-bounds.js";
 import { isElementConnected } from "../utils/is-element-connected.js";
 import { recalculateSessionPosition } from "../utils/recalculate-session-position.js";
-
-interface Position {
-  x: number;
-  y: number;
-}
 
 interface PendingClickData {
   clientX: number;
@@ -159,7 +155,7 @@ const createInitialStore = (input: GrabStoreInput): GrabStore => ({
 
 interface GrabActions {
   startHold: (duration?: number) => void;
-  release: () => void;
+  releaseHold: () => void;
   activate: () => void;
   deactivate: () => void;
   toggle: () => void;
@@ -256,7 +252,7 @@ const createGrabStore = (input: GrabStoreInput) => {
       setStore("current", { state: "holding", startedAt: Date.now() });
     },
 
-    release: () => {
+    releaseHold: () => {
       if (store.current.state === "holding") {
         setStore("current", { state: "idle" });
       }

--- a/packages/react-grab/src/index.ts
+++ b/packages/react-grab/src/index.ts
@@ -19,6 +19,7 @@ export type {
   GrabbedBox,
   DragRect,
   Rect,
+  Position,
   DeepPartial,
   ElementLabelVariant,
   PromptModeContext,

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -1,3 +1,8 @@
+export interface Position {
+  x: number;
+  y: number;
+}
+
 export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends object
     ? T[P] extends (...args: unknown[]) => unknown
@@ -134,7 +139,7 @@ export interface AgentSession {
   isFading?: boolean;
   createdAt: number;
   lastUpdatedAt: number;
-  position: { x: number; y: number };
+  position: Position;
   selectionBounds: OverlayBounds[];
   tagName?: string;
   componentName?: string;
@@ -256,7 +261,7 @@ export interface ArrowNavigationState {
 export interface PerformWithFeedbackOptions {
   fallbackBounds?: OverlayBounds;
   fallbackSelectionBounds?: OverlayBounds[];
-  position?: { x: number; y: number };
+  position?: Position;
 }
 
 export interface PluginHooks {
@@ -292,10 +297,7 @@ export interface PluginHooks {
     variant: ElementLabelVariant,
     context: ElementLabelContext,
   ) => void;
-  onContextMenu?: (
-    element: Element,
-    position: { x: number; y: number },
-  ) => void;
+  onContextMenu?: (element: Element, position: Position) => void;
   onOpenFile?: (filePath: string, lineNumber?: number) => boolean | void;
   transformHtmlContent?: (
     html: string,
@@ -528,7 +530,7 @@ export interface ReactGrabRendererProps {
   ) => () => void;
   onToolbarSelectHoverChange?: (isHovered: boolean) => void;
   onToolbarRef?: (element: HTMLDivElement) => void;
-  contextMenuPosition?: { x: number; y: number } | null;
+  contextMenuPosition?: Position | null;
   contextMenuBounds?: OverlayBounds | null;
   contextMenuTagName?: string;
   contextMenuComponentName?: string;

--- a/packages/react-grab/src/utils/get-elements-in-drag.ts
+++ b/packages/react-grab/src/utils/get-elements-in-drag.ts
@@ -217,12 +217,12 @@ const removeNestedElements = (elements: Element[]): Element[] => {
 export const getElementsInDrag = (
   dragRect: DragRect,
   isValidGrabbableElement: (element: Element) => boolean,
-  strict = true,
+  shouldCheckCoverage = true,
 ): Element[] => {
   const elements = filterElementsInDrag(
     dragRect,
     isValidGrabbableElement,
-    strict,
+    shouldCheckCoverage,
   );
   return removeNestedElements(elements);
 };

--- a/packages/react-grab/src/utils/get-visual-viewport.ts
+++ b/packages/react-grab/src/utils/get-visual-viewport.ts
@@ -1,0 +1,24 @@
+export interface VisualViewportInfo {
+  width: number;
+  height: number;
+  offsetLeft: number;
+  offsetTop: number;
+}
+
+export const getVisualViewport = (): VisualViewportInfo => {
+  const visualViewport = window.visualViewport;
+  if (visualViewport) {
+    return {
+      width: visualViewport.width,
+      height: visualViewport.height,
+      offsetLeft: visualViewport.offsetLeft,
+      offsetTop: visualViewport.offsetTop,
+    };
+  }
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight,
+    offsetLeft: 0,
+    offsetTop: 0,
+  };
+};

--- a/packages/react-grab/src/utils/recalculate-session-position.ts
+++ b/packages/react-grab/src/utils/recalculate-session-position.ts
@@ -1,10 +1,5 @@
-import type { OverlayBounds } from "../types.js";
+import type { Position, OverlayBounds } from "../types.js";
 import { getBoundsCenter } from "./get-bounds-center.js";
-
-interface Position {
-  x: number;
-  y: number;
-}
 
 interface RecalculateSessionPositionOptions {
   currentPosition: Position;

--- a/packages/react-grab/src/utils/toolbar-position.ts
+++ b/packages/react-grab/src/utils/toolbar-position.ts
@@ -1,0 +1,191 @@
+import type { Position } from "../types.js";
+import type { SnapEdge } from "../components/toolbar/state.js";
+import {
+  TOOLBAR_SNAP_MARGIN_PX,
+  TOOLBAR_VELOCITY_MULTIPLIER_MS,
+  TOOLBAR_DEFAULT_POSITION_RATIO,
+} from "../constants.js";
+import { getVisualViewport } from "./get-visual-viewport.js";
+
+export const clampToRange = (value: number, min: number, max: number): number =>
+  Math.max(min, Math.min(value, max));
+
+export const getPositionFromEdgeAndRatio = (
+  edge: SnapEdge,
+  ratio: number,
+  elementWidth: number,
+  elementHeight: number,
+): Position => {
+  const viewport = getVisualViewport();
+  const viewportWidth = viewport.width;
+  const viewportHeight = viewport.height;
+
+  const minX = viewport.offsetLeft + TOOLBAR_SNAP_MARGIN_PX;
+  const maxX = Math.max(
+    minX,
+    viewport.offsetLeft + viewportWidth - elementWidth - TOOLBAR_SNAP_MARGIN_PX,
+  );
+  const minY = viewport.offsetTop + TOOLBAR_SNAP_MARGIN_PX;
+  const maxY = Math.max(
+    minY,
+    viewport.offsetTop +
+      viewportHeight -
+      elementHeight -
+      TOOLBAR_SNAP_MARGIN_PX,
+  );
+
+  if (edge === "top" || edge === "bottom") {
+    const availableWidth = Math.max(
+      0,
+      viewportWidth - elementWidth - TOOLBAR_SNAP_MARGIN_PX * 2,
+    );
+    const positionX = Math.min(
+      maxX,
+      Math.max(
+        minX,
+        viewport.offsetLeft + TOOLBAR_SNAP_MARGIN_PX + availableWidth * ratio,
+      ),
+    );
+    const positionY = edge === "top" ? minY : maxY;
+    return { x: positionX, y: positionY };
+  }
+
+  const availableHeight = Math.max(
+    0,
+    viewportHeight - elementHeight - TOOLBAR_SNAP_MARGIN_PX * 2,
+  );
+  const positionY = Math.min(
+    maxY,
+    Math.max(
+      minY,
+      viewport.offsetTop + TOOLBAR_SNAP_MARGIN_PX + availableHeight * ratio,
+    ),
+  );
+  const positionX = edge === "left" ? minX : maxX;
+  return { x: positionX, y: positionY };
+};
+
+export const getRatioFromPosition = (
+  edge: SnapEdge,
+  positionX: number,
+  positionY: number,
+  elementWidth: number,
+  elementHeight: number,
+): number => {
+  const viewport = getVisualViewport();
+  const viewportWidth = viewport.width;
+  const viewportHeight = viewport.height;
+
+  if (edge === "top" || edge === "bottom") {
+    const availableWidth =
+      viewportWidth - elementWidth - TOOLBAR_SNAP_MARGIN_PX * 2;
+    if (availableWidth <= 0) return TOOLBAR_DEFAULT_POSITION_RATIO;
+    return Math.max(
+      0,
+      Math.min(
+        1,
+        (positionX - viewport.offsetLeft - TOOLBAR_SNAP_MARGIN_PX) /
+          availableWidth,
+      ),
+    );
+  }
+  const availableHeight =
+    viewportHeight - elementHeight - TOOLBAR_SNAP_MARGIN_PX * 2;
+  if (availableHeight <= 0) return TOOLBAR_DEFAULT_POSITION_RATIO;
+  return Math.max(
+    0,
+    Math.min(
+      1,
+      (positionY - viewport.offsetTop - TOOLBAR_SNAP_MARGIN_PX) /
+        availableHeight,
+    ),
+  );
+};
+
+export interface SnapResult extends Position {
+  edge: SnapEdge;
+}
+
+export const getSnapPosition = (
+  currentX: number,
+  currentY: number,
+  elementWidth: number,
+  elementHeight: number,
+  velocityX: number,
+  velocityY: number,
+): SnapResult => {
+  const viewport = getVisualViewport();
+  const viewportWidth = viewport.width;
+  const viewportHeight = viewport.height;
+
+  const projectedX = currentX + velocityX * TOOLBAR_VELOCITY_MULTIPLIER_MS;
+  const projectedY = currentY + velocityY * TOOLBAR_VELOCITY_MULTIPLIER_MS;
+
+  const distanceToTop = projectedY - viewport.offsetTop + elementHeight / 2;
+  const distanceToBottom =
+    viewport.offsetTop + viewportHeight - projectedY - elementHeight / 2;
+  const distanceToLeft = projectedX - viewport.offsetLeft + elementWidth / 2;
+  const distanceToRight =
+    viewport.offsetLeft + viewportWidth - projectedX - elementWidth / 2;
+
+  const minDistance = Math.min(
+    distanceToTop,
+    distanceToBottom,
+    distanceToLeft,
+    distanceToRight,
+  );
+
+  const clampX = (rawX: number) =>
+    clampToRange(
+      rawX,
+      viewport.offsetLeft + TOOLBAR_SNAP_MARGIN_PX,
+      viewport.offsetLeft +
+        viewportWidth -
+        elementWidth -
+        TOOLBAR_SNAP_MARGIN_PX,
+    );
+  const clampY = (rawY: number) =>
+    clampToRange(
+      rawY,
+      viewport.offsetTop + TOOLBAR_SNAP_MARGIN_PX,
+      viewport.offsetTop +
+        viewportHeight -
+        elementHeight -
+        TOOLBAR_SNAP_MARGIN_PX,
+    );
+
+  if (minDistance === distanceToTop) {
+    return {
+      edge: "top",
+      x: clampX(projectedX),
+      y: viewport.offsetTop + TOOLBAR_SNAP_MARGIN_PX,
+    };
+  }
+  if (minDistance === distanceToLeft) {
+    return {
+      edge: "left",
+      x: viewport.offsetLeft + TOOLBAR_SNAP_MARGIN_PX,
+      y: clampY(projectedY),
+    };
+  }
+  if (minDistance === distanceToRight) {
+    return {
+      edge: "right",
+      x:
+        viewport.offsetLeft +
+        viewportWidth -
+        elementWidth -
+        TOOLBAR_SNAP_MARGIN_PX,
+      y: clampY(projectedY),
+    };
+  }
+  return {
+    edge: "bottom",
+    x: clampX(projectedX),
+    y:
+      viewport.offsetTop +
+      viewportHeight -
+      elementHeight -
+      TOOLBAR_SNAP_MARGIN_PX,
+  };
+};


### PR DESCRIPTION
… anti-patterns

- Add shared Position interface to types.ts, replacing ~15 inline { x, y } annotations across 8 files
- Extract getVisualViewport utility, deduplicating fallback logic from toolbar and selection-label
- Extract toolbar positioning math (getPositionFromEdgeAndRatio, getRatioFromPosition, getSnapPosition) into utils/toolbar-position.ts, reducing toolbar by ~200 lines
- Refactor selection-label from effect-derived state to createMemo with previous-value caching, fixing SolidJS anti-pattern
- Rename unclear identifiers: release->releaseHold, isToggleFrozen->isFrozenPhase, inTogglePeriod->isInCopyFeedbackCooldown, strict->shouldCheckCoverage
- Fix flaky e2e tests by increasing hoverElement wait (100ms->250ms) and waitForSelectionBox timeout (5s->10s)

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it refactors core overlay/toolbar/label positioning and input-state handling, which can cause subtle UI regressions despite being largely mechanical. E2E timing adjustments reduce flake but could mask real timing issues if logic changes are wrong.
> 
> **Overview**
> **Refactors shared positioning/types across `react-grab`.** Introduces a shared `Position` type in `types.ts` and replaces many inline `{x,y}` annotations across core, agent, overlay components, and plugin hooks.
> 
> **Extracts and deduplicates viewport/toolbar math.** Adds `getVisualViewport` and `utils/toolbar-position.ts` (clamp/ratio/snap calculations) and updates `Toolbar` to use these helpers, removing in-component duplicated math.
> 
> **Fixes SolidJS state anti-patterns in `SelectionLabel`.** Reworks label positioning to a memoized computation with previous-value caching/reset versioning, and simplifies derived state like `arrowPosition`/`hadValidBounds`.
> 
> **Stabilizes flaky tests.** Increases e2e waits/timeouts and adds a retry path when entering prompt mode if the selection box isn’t ready; minor CLI/test formatting cleanups and renames (`releaseHold`, `isFrozenPhase`, `isInCopyFeedbackCooldown`, `shouldCheckCoverage`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 125e1419b7c6fbe7322149b15ee4eb5f690130ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated position handling, extracted viewport/toolbar math, and refactored selection label state to remove SolidJS anti-patterns. This reduces toolbar code by ~200 lines and stabilizes e2e tests.

- **Refactors**
  - Introduced shared `Position` type; replaced ~15 inline `{ x, y }` annotations across 8 files and exported `Position`.
  - Extracted `getVisualViewport` and toolbar helpers (`getPositionFromEdgeAndRatio`, `getRatioFromPosition`, `getSnapPosition`) into `utils`, simplifying toolbar logic.
  - Rewrote selection-label positioning with `createMemo` and cached previous values; avoids effect-derived state and improves stability.
  - Renamed identifiers for clarity: `release`→`releaseHold`, `isToggleFrozen`→`isFrozenPhase`, `inTogglePeriod`→`isInCopyFeedbackCooldown`, `strict`→`shouldCheckCoverage`.

- **Bug Fixes**
  - Reduced e2e flakiness by increasing waits: hover delay 100ms→250ms and selection box timeout up to 10s, with additional fallback waits in prompt flow.
  - Improved label behavior when selection is offscreen or unmeasured by using viewport-aware checks and safe fallbacks.

<sup>Written for commit 125e1419b7c6fbe7322149b15ee4eb5f690130ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

