### PR TITLE
chore: configure dev environment for Cloud Agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,3 +100,36 @@ pnpm lint
 pnpm typecheck # runs type checking
 pnpm format
 ```
+
+## Cursor Cloud specific instructions
+
+This is a pnpm + Turborepo monorepo (19 packages under `packages/`). No external services (databases, Docker, etc.) are required.
+
+### Build before test
+
+`pnpm build` must complete before `pnpm test` or `pnpm lint` — Turborepo `dependsOn` enforces this, but be aware that `pnpm test` will rebuild if the build cache is cold. After modifying source files, always rebuild before running tests.
+
+### Approved build scripts
+
+The root `package.json` has `pnpm.onlyBuiltDependencies` configured for `@parcel/watcher`, `esbuild`, `sharp`, `spawn-sync`, and `unrs-resolver`. Without this, `pnpm install` silently skips their native builds and downstream packages may fail.
+
+### Playwright
+
+E2E tests (`pnpm test` at root) run Playwright against the `e2e-playground` Vite dev server on port 5175 (auto-started by the Playwright config). Chromium must be installed: `npx --prefix packages/react-grab playwright install chromium --with-deps`.
+
+### Known flaky test
+
+`e2e/history-items.spec.ts` > "should reposition when toolbar is dragged to top edge" intermittently times out in headless CI environments. This is a pre-existing issue.
+
+### Key commands reference
+
+See root `package.json` scripts and `CONTRIBUTING.md` for the full list. Quick reference:
+- **Install**: `ni` (or `pnpm install`)
+- **Build**: `nr build` (or `pnpm build`)
+- **Dev watch**: `nr dev` (or `pnpm dev`) — watches core packages
+- **Test**: `pnpm test` — runs Playwright E2E + Vitest CLI tests
+- **Lint**: `pnpm lint` — oxlint on react-grab package
+- **Typecheck**: `pnpm typecheck` — tsc on react-grab package
+- **Format**: `pnpm format` — oxfmt
+- **CLI dev**: `npm_command=exec node packages/cli/dist/cli.js`
+- **E2E playground**: `pnpm --filter @react-grab/e2e-playground dev` (port 5175)

--- a/package.json
+++ b/package.json
@@ -29,5 +29,13 @@
     "pnpm": ">=8"
   },
   "packageManager": "pnpm@10.24.0",
-  "pnpm": {}
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@parcel/watcher",
+      "esbuild",
+      "sharp",
+      "spawn-sync",
+      "unrs-resolver"
+    ]
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,49 +287,6 @@ importers:
         specifier: ^8.4.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
 
-  packages/next-playground:
-    dependencies:
-      next:
-        specifier: 15.3.8
-        version: 15.3.8(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
-      react:
-        specifier: 19.0.1
-        version: 19.0.1
-      react-dom:
-        specifier: 19.0.1
-        version: 19.0.1(react@19.0.1)
-      react-grab:
-        specifier: workspace:*
-        version: link:../react-grab
-    devDependencies:
-      '@eslint/eslintrc':
-        specifier: ^3
-        version: 3.3.1
-      '@tailwindcss/postcss':
-        specifier: ^4
-        version: 4.1.15
-      '@types/node':
-        specifier: ^20
-        version: 20.19.23
-      '@types/react':
-        specifier: ^19
-        version: 19.2.2
-      '@types/react-dom':
-        specifier: ^19
-        version: 19.2.2(@types/react@19.2.2)
-      eslint:
-        specifier: ^9
-        version: 9.37.0(jiti@2.6.1)
-      eslint-config-next:
-        specifier: 15.3.6
-        version: 15.3.6(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
-      tailwindcss:
-        specifier: ^4
-        version: 4.1.15
-      typescript:
-        specifier: ^5
-        version: 5.9.3
-
   packages/provider-amp:
     dependencies:
       '@react-grab/relay':
@@ -606,52 +563,6 @@ importers:
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
-
-  packages/vite-playground:
-    dependencies:
-      '@react-grab/next-playground':
-        specifier: workspace:*
-        version: link:../next-playground
-      '@react-grab/opencode':
-        specifier: workspace:*
-        version: link:../provider-opencode
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
-      react:
-        specifier: 19.1.2
-        version: 19.1.2
-      react-dom:
-        specifier: 19.1.2
-        version: 19.1.2(react@19.1.2)
-      react-grab:
-        specifier: workspace:*
-        version: link:../react-grab
-      tailwind-merge:
-        specifier: ^2.6.0
-        version: 2.6.0
-    devDependencies:
-      '@tailwindcss/vite':
-        specifier: 4.0.0-beta.8
-        version: 4.0.0-beta.8(vite@6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1))
-      '@types/react':
-        specifier: ^19.0.4
-        version: 19.2.2
-      '@types/react-dom':
-        specifier: ^19.0.2
-        version: 19.2.2(@types/react@19.2.2)
-      '@vitejs/plugin-react':
-        specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1))
-      tailwindcss:
-        specifier: 4.0.0-beta.8
-        version: 4.0.0-beta.8
-      typescript:
-        specifier: ^5.7.3
-        version: 5.9.3
-      vite:
-        specifier: ^6.0.2
-        version: 6.4.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.6)(yaml@2.8.1)
 
   packages/web-extension:
     dependencies:
@@ -3070,8 +2981,8 @@ packages:
     resolution: {integrity: sha512-y9/ltK2TY+0HD1H2Sz7MvU3zFh4SjER6eQVNQfBx/0gK9N7S0QwHW6cmhHLx3CP25zN190LKHXPieMGqsVvrOQ==}
     engines: {node: '>=18'}
 
-  '@sourcegraph/amp@0.0.1773636573-gfb5a42':
-    resolution: {integrity: sha512-xjWTKPdTYtBoNciZ9nzPzfiwaTP2Ens2/XnswsiHPHP61Gxgx6X71YoFhqH8HRfUgS9ah7bgkRszqGM7nBqFtg==}
+  '@sourcegraph/amp@0.0.1773792340-gded184':
+    resolution: {integrity: sha512-Kj7jBcX7KbED1fMl+YnrHFOTj89pxIZT8Ipir7sZP2++oQ/IiQnaddv4H3foEYW+UNREWr0sD2tDk7tlB5mBWQ==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -9251,10 +9162,10 @@ snapshots:
 
   '@sourcegraph/amp-sdk@0.1.0-20251210081226-g90e3892':
     dependencies:
-      '@sourcegraph/amp': 0.0.1773636573-gfb5a42
+      '@sourcegraph/amp': 0.0.1773792340-gded184
       zod: 3.25.76
 
-  '@sourcegraph/amp@0.0.1773636573-gfb5a42':
+  '@sourcegraph/amp@0.0.1773792340-gded184':
     dependencies:
       '@napi-rs/keyring': 1.1.9
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Configure the development environment for Cloud Agent compatibility:

- **`package.json`**: Add `pnpm.onlyBuiltDependencies` for `@parcel/watcher`, `esbuild`, `sharp`, `spawn-sync`, and `unrs-resolver` so native build scripts run automatically during `pnpm install` (without needing the interactive `pnpm approve-builds` picker)
- **`AGENTS.md`**: Add `## Cursor Cloud specific instructions` section with:
  - Build-before-test requirement notes
  - Approved build scripts context
  - Playwright/Chromium setup instructions
  - Known flaky test documentation
  - Quick command reference

## Verification

All checks pass:
- `pnpm lint` — 0 warnings, 0 errors
- `pnpm typecheck` — clean
- `pnpm format` — clean
- `pnpm test` — 583/584 E2E tests pass, 167/167 CLI tests pass (1 pre-existing flaky timeout)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abbf524a-8a91-4d86-b624-7fe2781b74d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abbf524a-8a91-4d86-b624-7fe2781b74d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-run native builds during `pnpm install` and add Cursor Cloud setup docs so the monorepo builds and tests reliably in Cloud Agents. Docs cover build-before-test, Playwright setup, and a known flaky test.

- **Dependencies**
  - Set `pnpm.onlyBuiltDependencies` for `@parcel/watcher`, `esbuild`, `sharp`, `spawn-sync`, and `unrs-resolver` so native scripts run automatically (no `pnpm approve-builds` needed).

<sup>Written for commit 3653677f9fc37a99ea457a083045bd6e0bab7cbf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

