### PR TITLE
React grab package improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,7 @@ E2E tests (`pnpm test` at root) run Playwright against the `e2e-playground` Vite
 ### Key commands reference
 
 See root `package.json` scripts and `CONTRIBUTING.md` for the full list. Quick reference:
+
 - **Install**: `ni` (or `pnpm install`)
 - **Build**: `nr build` (or `pnpm build`)
 - **Dev watch**: `nr dev` (or `pnpm dev`) — watches core packages

--- a/packages/design-system/src/index.tsx
+++ b/packages/design-system/src/index.tsx
@@ -2572,7 +2572,6 @@ const StateCard = (props: StateCardProps) => {
               visible={true}
               status={currentProps().status}
               hasAgent={currentProps().hasAgent}
-
               isPromptMode={currentProps().isPromptMode}
               inputValue={currentProps().inputValue}
               replyToPrompt={currentProps().replyToPrompt}

--- a/packages/react-grab/e2e/fixtures.ts
+++ b/packages/react-grab/e2e/fixtures.ts
@@ -352,7 +352,10 @@ const createReactGrabPageObject = (page: Page): ReactGrabPageObject => {
       return new Promise<Record<string, string>>((resolve) => {
         const originalSetData = DataTransfer.prototype.setData;
         const clipboardWrites: Record<string, string> = {};
-        DataTransfer.prototype.setData = function (type: string, value: string) {
+        DataTransfer.prototype.setData = function (
+          type: string,
+          value: string,
+        ) {
           clipboardWrites[type] = value;
           return originalSetData.call(this, type, value);
         };

--- a/packages/react-grab/src/components/selection-label/index.tsx
+++ b/packages/react-grab/src/components/selection-label/index.tsx
@@ -192,7 +192,8 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
     (previousResult: PositionResult): PositionResult => {
       viewportVersion();
       const currentElementIdentity = elementIdentity();
-      const didReset = currentElementIdentity !== previousResult.elementIdentity;
+      const didReset =
+        currentElementIdentity !== previousResult.elementIdentity;
       const cached = didReset
         ? {
             position: DEFAULT_OFFSCREEN_POSITION,

--- a/packages/react-grab/src/components/toolbar/index.tsx
+++ b/packages/react-grab/src/components/toolbar/index.tsx
@@ -562,8 +562,10 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
     let newRatio = positionRatio();
 
     if (wasCollapsed) {
-      const { position: newPos, ratio } =
-        getExpandedFromCollapsed(currentPosition(), snapEdge());
+      const { position: newPos, ratio } = getExpandedFromCollapsed(
+        currentPosition(),
+        snapEdge(),
+      );
       newRatio = ratio;
       setPosition(newPos);
       setPositionRatio(newRatio);

--- a/packages/react-grab/src/components/toolbar/toolbar-menu.tsx
+++ b/packages/react-grab/src/components/toolbar/toolbar-menu.tsx
@@ -99,7 +99,8 @@ export const ToolbarMenu: Component<ToolbarMenuProps> = (props) => {
             <For each={props.actions}>
               {(action) => {
                 const isToggleAction = action.isActive !== undefined;
-                const isActionEnabled = () => resolveToolbarActionEnabled(action);
+                const isActionEnabled = () =>
+                  resolveToolbarActionEnabled(action);
                 const isToggleActive = () => {
                   void toggleRefreshCounter();
                   return Boolean(action.isActive?.());

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -236,8 +236,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     const didJustCopy = createMemo(() => store.current.state === "justCopied");
     const isPromptMode = createMemo(
       () =>
-        store.current.state === "active" &&
-        Boolean(store.current.isPromptMode),
+        store.current.state === "active" && Boolean(store.current.isPromptMode),
     );
     const isCommentMode = createMemo(
       () => store.pendingCommentMode || isPromptMode(),
@@ -3143,7 +3142,9 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       if (!isThemeEnabled()) return [];
       if (!pluginRegistry.store.theme.grabbedBoxes.enabled) return [];
       void store.viewportVersion;
-      const currentIds = new Set(store.labelInstances.map((i) => i.id));
+      const currentIds = new Set(
+        store.labelInstances.map((instance) => instance.id),
+      );
       for (const cachedId of labelInstanceCache.keys()) {
         if (!currentIds.has(cachedId)) {
           labelInstanceCache.delete(cachedId);

--- a/packages/react-grab/src/utils/create-anchored-dropdown.ts
+++ b/packages/react-grab/src/utils/create-anchored-dropdown.ts
@@ -54,7 +54,9 @@ export const createAnchoredDropdown = (
   };
 
   const handleViewportChange = () => {
-    setViewportVersion((previousViewportVersion) => previousViewportVersion + 1);
+    setViewportVersion(
+      (previousViewportVersion) => previousViewportVersion + 1,
+    );
     measure();
   };
 
@@ -93,8 +95,14 @@ export const createAnchoredDropdown = (
 
     onCleanup(() => {
       window.removeEventListener("resize", handleViewportChange);
-      window.visualViewport?.removeEventListener("resize", handleViewportChange);
-      window.visualViewport?.removeEventListener("scroll", handleViewportChange);
+      window.visualViewport?.removeEventListener(
+        "resize",
+        handleViewportChange,
+      );
+      window.visualViewport?.removeEventListener(
+        "scroll",
+        handleViewportChange,
+      );
     });
   });
 

--- a/packages/react-grab/src/utils/create-element-bounds.ts
+++ b/packages/react-grab/src/utils/create-element-bounds.ts
@@ -79,20 +79,20 @@ export const createElementBounds = (element: Element): OverlayBounds => {
   let bounds: OverlayBounds;
 
   if (transform !== "none" && element instanceof HTMLElement) {
-    const ow = element.offsetWidth;
-    const oh = element.offsetHeight;
+    const offsetWidth = element.offsetWidth;
+    const offsetHeight = element.offsetHeight;
 
-    if (ow > 0 && oh > 0) {
+    if (offsetWidth > 0 && offsetHeight > 0) {
       const centerX = rect.left + rect.width * 0.5;
       const centerY = rect.top + rect.height * 0.5;
 
       bounds = {
         borderRadius: style.borderRadius || "0px",
-        height: oh,
+        height: offsetHeight,
         transform,
-        width: ow,
-        x: centerX - ow * 0.5,
-        y: centerY - oh * 0.5,
+        width: offsetWidth,
+        x: centerX - offsetWidth * 0.5,
+        y: centerY - offsetHeight * 0.5,
       };
     } else {
       bounds = {

--- a/packages/react-grab/src/utils/create-toolbar-drag.ts
+++ b/packages/react-grab/src/utils/create-toolbar-drag.ts
@@ -33,12 +33,12 @@ interface ToolbarDragResult {
   isDragging: Accessor<boolean>;
   isSnapping: Accessor<boolean>;
   handlePointerDown: (event: PointerEvent) => void;
-  createDragAwareHandler: (
-    callback: () => void,
-  ) => (event: MouseEvent) => void;
+  createDragAwareHandler: (callback: () => void) => (event: MouseEvent) => void;
 }
 
-export const createToolbarDrag = (config: ToolbarDragConfig): ToolbarDragResult => {
+export const createToolbarDrag = (
+  config: ToolbarDragConfig,
+): ToolbarDragResult => {
   const [isDragging, setIsDragging] = createSignal(false);
   const [isSnapping, setIsSnapping] = createSignal(false);
   const [hasDragMoved, setHasDragMoved] = createSignal(false);
@@ -69,10 +69,8 @@ export const createToolbarDrag = (config: ToolbarDragConfig): ToolbarDragResult 
     const deltaTime = now - lastPointerPosition.time;
 
     if (deltaTime > 0) {
-      const newVelocityX =
-        (event.clientX - lastPointerPosition.x) / deltaTime;
-      const newVelocityY =
-        (event.clientY - lastPointerPosition.y) / deltaTime;
+      const newVelocityX = (event.clientX - lastPointerPosition.x) / deltaTime;
+      const newVelocityY = (event.clientY - lastPointerPosition.y) / deltaTime;
       setVelocity({ x: newVelocityX, y: newVelocityY });
     }
 

--- a/packages/react-grab/src/utils/get-elements-in-drag.ts
+++ b/packages/react-grab/src/utils/get-elements-in-drag.ts
@@ -128,10 +128,10 @@ const createSamplePoints = (dragRect: DragRect): SamplePoint[] => {
   addPoint(centerX, centerY);
 
   for (let xIndex = 0; xIndex < scaledXCount; xIndex += 1) {
-    const x = left + ((xIndex + 0.5) / scaledXCount) * dragRect.width;
+    const sampleX = left + ((xIndex + 0.5) / scaledXCount) * dragRect.width;
     for (let yIndex = 0; yIndex < scaledYCount; yIndex += 1) {
-      const y = top + ((yIndex + 0.5) / scaledYCount) * dragRect.height;
-      addPoint(x, y);
+      const sampleY = top + ((yIndex + 0.5) / scaledYCount) * dragRect.height;
+      addPoint(sampleX, sampleY);
     }
   }
 

--- a/packages/react-grab/src/utils/resolve-action-enabled.ts
+++ b/packages/react-grab/src/utils/resolve-action-enabled.ts
@@ -1,4 +1,8 @@
-import type { ActionContext, ContextMenuAction, ToolbarMenuAction } from "../types.js";
+import type {
+  ActionContext,
+  ContextMenuAction,
+  ToolbarMenuAction,
+} from "../types.js";
 
 const resolveBooleanEnabled = (enabled: boolean | undefined): boolean =>
   enabled ?? true;

--- a/packages/react-grab/src/utils/strip-translate-from-transform.ts
+++ b/packages/react-grab/src/utils/strip-translate-from-transform.ts
@@ -78,13 +78,13 @@ export const stripTranslateFromTransformString = (
       const values = parseMatrixValues(transform.slice(start, end), 6);
 
       if (values) {
-        const a = values[0];
-        const b = values[1];
-        const c = values[2];
-        const d = values[3];
+        const scaleX = values[0];
+        const skewY = values[1];
+        const skewX = values[2];
+        const scaleY = values[3];
 
-        if (isIdentityMatrix2d(a, b, c, d)) return "none";
-        return `matrix(${a}, ${b}, ${c}, ${d}, 0, 0)`;
+        if (isIdentityMatrix2d(scaleX, skewY, skewX, scaleY)) return "none";
+        return `matrix(${scaleX}, ${skewY}, ${skewX}, ${scaleY}, 0, 0)`;
       }
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
refactor: rename short variable names to be descriptive

Renames 5 short/ambiguous variable names across 4 files to improve code readability and adhere to AGENTS.md refactoring guidelines. The codebase was found to be very clean otherwise.

<div><a href="https://cursor.com/agents/bc-823a5118-3108-4bd8-9731-fe8f6bc687b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-823a5118-3108-4bd8-9731-fe8f6bc687b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed short, ambiguous variables across `packages/react-grab` to make the code clearer without changing behavior. Also tightened up formatting and standardized a few handler signatures.

- **Refactors**
  - Replaced terse vars with descriptive names in utils/components (e.g., `create-element-bounds`, `strip-translate-from-transform`, `create-toolbar-drag`, `get-elements-in-drag`, toolbar components).
  - Broke long calls and listeners into multiple lines and aligned type imports; no logic changes.
  - Minor cleanup: adjusted `DataTransfer.setData` formatting in e2e fixtures, removed an extra newline in `packages/design-system`, and added spacing in `AGENTS.md`.

<sup>Written for commit 618e5c41a9d65dfb9d3aa61d13ad8181e927f748. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

