### PR TITLE
feat: replace inspect stack with element properties panel

### DIFF
--- a/packages/react-grab/e2e/fixtures.ts
+++ b/packages/react-grab/e2e/fixtures.ts
@@ -1008,9 +1008,7 @@ const createReactGrabPageObject = (page: Page): ReactGrabPageObject => {
         const items = dropdown.querySelectorAll<HTMLButtonElement>(
           "[data-react-grab-menu-item]",
         );
-        return Array.from(items).map(
-          (item) => item.textContent?.trim() ?? "",
-        );
+        return Array.from(items).map((item) => item.textContent?.trim() ?? "");
       }
       return [];
     }, ATTRIBUTE_NAME);
@@ -1682,9 +1680,7 @@ const createReactGrabPageObject = (page: Page): ReactGrabPageObject => {
             id: "comment-action",
             label: "Edit",
             shortcut: "Enter",
-            onAction: (context: {
-              enterPromptMode?: () => void;
-            }) => {
+            onAction: (context: { enterPromptMode?: () => void }) => {
               context.enterPromptMode?.();
             },
           },

--- a/packages/react-grab/src/components/overlay-canvas.tsx
+++ b/packages/react-grab/src/components/overlay-canvas.tsx
@@ -4,6 +4,7 @@ import type {
   OverlayBounds,
   SelectionLabelInstance,
   AgentSession,
+  InspectBoxModel,
 } from "../types.js";
 import { lerp } from "../utils/lerp.js";
 import {
@@ -19,8 +20,8 @@ import {
   OPACITY_CONVERGENCE_THRESHOLD,
   OVERLAY_BORDER_COLOR_DEFAULT,
   OVERLAY_FILL_COLOR_DEFAULT,
-  OVERLAY_BORDER_COLOR_INSPECT,
-  OVERLAY_FILL_COLOR_INSPECT,
+  OVERLAY_FILL_COLOR_MARGIN,
+  OVERLAY_FILL_COLOR_PADDING,
 } from "../constants.js";
 import {
   nativeCancelAnimationFrame,
@@ -34,12 +35,6 @@ const DEFAULT_LAYER_STYLE = {
   lerpFactor: SELECTION_LERP_FACTOR,
 } as const;
 
-const INSPECT_LAYER_STYLE = {
-  borderColor: OVERLAY_BORDER_COLOR_INSPECT,
-  fillColor: OVERLAY_FILL_COLOR_INSPECT,
-  lerpFactor: SELECTION_LERP_FACTOR,
-} as const;
-
 const LAYER_STYLES = {
   drag: {
     borderColor: OVERLAY_BORDER_COLOR_DRAG,
@@ -49,10 +44,9 @@ const LAYER_STYLES = {
   selection: DEFAULT_LAYER_STYLE,
   grabbed: DEFAULT_LAYER_STYLE,
   processing: DEFAULT_LAYER_STYLE,
-  inspect: INSPECT_LAYER_STYLE,
 } as const;
 
-type LayerName = "drag" | "selection" | "grabbed" | "processing" | "inspect";
+type LayerName = "drag" | "selection" | "grabbed" | "processing";
 
 interface OffscreenLayer {
   canvas: OffscreenCanvas | null;
@@ -77,9 +71,6 @@ export interface OverlayCanvasProps {
   selectionIsFading?: boolean;
   selectionShouldSnap?: boolean;
 
-  inspectVisible?: boolean;
-  inspectBounds?: OverlayBounds[];
-
   dragVisible?: boolean;
   dragBounds?: OverlayBounds;
 
@@ -88,6 +79,8 @@ export interface OverlayCanvasProps {
     bounds: OverlayBounds;
     createdAt: number;
   }>;
+
+  inspectBoxModel?: InspectBoxModel;
 
   agentSessions?: Map<string, AgentSession>;
 
@@ -107,14 +100,12 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
     selection: { canvas: null, context: null },
     grabbed: { canvas: null, context: null },
     processing: { canvas: null, context: null },
-    inspect: { canvas: null, context: null },
   };
 
   let selectionAnimations: AnimatedBounds[] = [];
   let dragAnimation: AnimatedBounds | null = null;
   let grabbedAnimations: AnimatedBounds[] = [];
   let processingAnimations: AnimatedBounds[] = [];
-  let inspectAnimations: AnimatedBounds[] = [];
 
   const canvasColorSpace: PredefinedColorSpace = supportsDisplayP3()
     ? "display-p3"
@@ -276,6 +267,30 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
     );
   };
 
+  const drawBoxModelZone = (
+    context: OffscreenCanvasRenderingContext2D,
+    outerX: number,
+    outerY: number,
+    outerWidth: number,
+    outerHeight: number,
+    innerX: number,
+    innerY: number,
+    innerWidth: number,
+    innerHeight: number,
+    fillColor: string,
+    opacity: number,
+  ) => {
+    if (outerWidth <= 0 || outerHeight <= 0) return;
+
+    context.globalAlpha = opacity;
+    context.beginPath();
+    context.rect(outerX, outerY, outerWidth, outerHeight);
+    context.rect(innerX, innerY, innerWidth, innerHeight);
+    context.fillStyle = fillColor;
+    context.fill("evenodd");
+    context.globalAlpha = 1;
+  };
+
   const renderSelectionLayer = () => {
     const layer = layers.selection;
     if (!layer.context) return;
@@ -286,15 +301,64 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
     if (!props.selectionVisible) return;
 
     const style = LAYER_STYLES.selection;
+    const boxModel = props.inspectBoxModel;
 
     for (const animation of selectionAnimations) {
       const effectiveOpacity = props.selectionIsFading ? 0 : animation.opacity;
+      const { x, y, width, height } = animation.current;
+
+      if (boxModel) {
+        const hasMargin =
+          boxModel.marginTop > 0 ||
+          boxModel.marginRight > 0 ||
+          boxModel.marginBottom > 0 ||
+          boxModel.marginLeft > 0;
+
+        if (hasMargin) {
+          drawBoxModelZone(
+            context,
+            x - boxModel.marginLeft,
+            y - boxModel.marginTop,
+            width + boxModel.marginLeft + boxModel.marginRight,
+            height + boxModel.marginTop + boxModel.marginBottom,
+            x,
+            y,
+            width,
+            height,
+            OVERLAY_FILL_COLOR_MARGIN,
+            effectiveOpacity,
+          );
+        }
+
+        const hasPadding =
+          boxModel.paddingTop > 0 ||
+          boxModel.paddingRight > 0 ||
+          boxModel.paddingBottom > 0 ||
+          boxModel.paddingLeft > 0;
+
+        if (hasPadding) {
+          drawBoxModelZone(
+            context,
+            x,
+            y,
+            width,
+            height,
+            x + boxModel.paddingLeft,
+            y + boxModel.paddingTop,
+            width - boxModel.paddingLeft - boxModel.paddingRight,
+            height - boxModel.paddingTop - boxModel.paddingBottom,
+            OVERLAY_FILL_COLOR_PADDING,
+            effectiveOpacity,
+          );
+        }
+      }
+
       drawRoundedRectangle(
         context,
-        animation.current.x,
-        animation.current.y,
-        animation.current.width,
-        animation.current.height,
+        x,
+        y,
+        width,
+        height,
         animation.borderRadius,
         style.fillColor,
         style.borderColor,
@@ -341,10 +405,8 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
     renderSelectionLayer();
     renderBoundsLayer("grabbed", grabbedAnimations);
     renderBoundsLayer("processing", processingAnimations);
-    renderBoundsLayer("inspect", inspectAnimations);
 
     const layerRenderOrder: LayerName[] = [
-      "inspect",
       "drag",
       "selection",
       "grabbed",
@@ -477,14 +539,6 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
     for (const animation of processingAnimations) {
       if (animation.isInitialized) {
         if (interpolateBounds(animation, LAYER_STYLES.processing.lerpFactor)) {
-          shouldContinueAnimating = true;
-        }
-      }
-    }
-
-    for (const animation of inspectAnimations) {
-      if (animation.isInitialized) {
-        if (interpolateBounds(animation, LAYER_STYLES.inspect.lerpFactor)) {
           shouldContinueAnimating = true;
         }
       }
@@ -686,35 +740,6 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
         }
 
         processingAnimations = updatedAnimations;
-        scheduleAnimationFrame();
-      },
-    ),
-  );
-
-  createEffect(
-    on(
-      () => [props.inspectVisible, props.inspectBounds] as const,
-      ([isVisible, bounds]) => {
-        if (!isVisible || !bounds || bounds.length === 0) {
-          inspectAnimations = [];
-          scheduleAnimationFrame();
-          return;
-        }
-
-        inspectAnimations = bounds.map((ancestorBounds, index) => {
-          const animationId = `inspect-${index}`;
-          const existingAnimation = inspectAnimations.find(
-            (animation) => animation.id === animationId,
-          );
-
-          if (existingAnimation) {
-            updateAnimationTarget(existingAnimation, ancestorBounds);
-            return existingAnimation;
-          }
-
-          return createAnimatedBounds(animationId, ancestorBounds);
-        });
-
         scheduleAnimationFrame();
       },
     ),

--- a/packages/react-grab/src/components/renderer.tsx
+++ b/packages/react-grab/src/components/renderer.tsx
@@ -41,11 +41,10 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
         selectionBoundsMultiple={props.selectionBoundsMultiple}
         selectionShouldSnap={props.selectionShouldSnap}
         selectionIsFading={props.selectionLabelStatus === "fading"}
-        inspectVisible={props.inspectVisible}
-        inspectBounds={props.inspectBounds}
         dragVisible={props.dragVisible}
         dragBounds={props.dragBounds}
         grabbedBoxes={props.grabbedBoxes}
+        inspectBoxModel={props.inspectPropertiesState?.boxModel}
         agentSessions={props.agentSessions}
         labelInstances={props.labelInstances}
       />
@@ -138,8 +137,7 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
           actionCycleState={props.selectionActionCycleState}
           arrowNavigationState={props.selectionArrowNavigationState}
           onArrowNavigationSelect={props.onArrowNavigationSelect}
-          inspectNavigationState={props.inspectNavigationState}
-          onInspectSelect={props.onInspectSelect}
+          inspectPropertiesState={props.inspectPropertiesState}
           filePath={props.selectionFilePath}
           onInputChange={props.onInputChange}
           onSubmit={props.onInputSubmit}

--- a/packages/react-grab/src/components/selection-label/element-properties-panel.tsx
+++ b/packages/react-grab/src/components/selection-label/element-properties-panel.tsx
@@ -1,0 +1,186 @@
+import { Show, For } from "solid-js";
+import type { Component } from "solid-js";
+import type {
+  InspectPropertiesState,
+  InspectPropertyRow,
+} from "../../types.js";
+import { BottomSection } from "./bottom-section.js";
+
+interface ElementPropertiesPanelProps {
+  state: InspectPropertiesState;
+}
+
+const ColorSwatch: Component<{ color: string }> = (props) => (
+  <span
+    class="inline-block size-[10px] shrink-0 rounded-[2px] border border-black/15 align-middle"
+    style={{ "background-color": props.color }}
+  />
+);
+
+const PropertyRow: Component<{
+  label: string;
+  value: string;
+  colorHex?: string;
+}> = (props) => (
+  <div class="flex items-center justify-between gap-3 min-w-0">
+    <span class="text-[12px] leading-4 text-black/50 shrink-0">
+      {props.label}
+    </span>
+    <span class="text-[12px] leading-4 text-black font-medium break-all min-w-0 text-right flex items-center gap-1 justify-end">
+      <Show when={props.colorHex}>
+        <ColorSwatch color={props.colorHex!} />
+      </Show>
+      {props.value || "\u2014"}
+    </span>
+  </div>
+);
+
+const PropertyRows: Component<{ rows: InspectPropertyRow[] }> = (props) => (
+  <For each={props.rows}>
+    {(row) => (
+      <PropertyRow
+        label={row.label}
+        value={row.value}
+        colorHex={row.colorHex}
+      />
+    )}
+  </For>
+);
+
+const SectionDivider: Component<{ label: string }> = (props) => (
+  <div class="flex flex-col mt-1 pt-1 [border-top-width:0.5px] border-t-solid border-t-[#D9D9D9]">
+    <span class="text-[10px] leading-3 font-semibold tracking-wider text-black/40 uppercase">
+      {props.label}
+    </span>
+  </div>
+);
+
+const ContrastBadge: Component<{
+  ratio: number;
+  aa: boolean;
+  aaa: boolean;
+}> = (props) => (
+  <div class="flex items-center gap-1.5 min-w-0">
+    <span class="text-[12px] leading-4 text-black/50 shrink-0">Contrast</span>
+    <span class="flex items-center gap-1 ml-auto">
+      <span
+        class="text-[11px] leading-none font-semibold px-1 py-0.5 rounded-[3px]"
+        classList={{
+          "bg-[#0f9d58]/15 text-[#0f9d58]": props.aa,
+          "bg-[#db4437]/15 text-[#db4437]": !props.aa,
+        }}
+      >
+        AA
+      </span>
+      <span class="text-[12px] leading-4 text-black font-medium tabular-nums">
+        {props.ratio}
+      </span>
+      <Show when={props.aaa}>
+        <span class="text-[11px] leading-none font-semibold px-1 py-0.5 rounded-[3px] bg-[#0f9d58]/15 text-[#0f9d58]">
+          AAA
+        </span>
+      </Show>
+    </span>
+  </div>
+);
+
+const FocusableIndicator: Component<{ focusable: boolean }> = (props) => (
+  <div class="flex items-center justify-between gap-3 min-w-0">
+    <span class="text-[12px] leading-4 text-black/50 shrink-0">
+      Keyboard-focusable
+    </span>
+    <Show
+      when={props.focusable}
+      fallback={
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 16 16"
+          fill="none"
+          class="text-black/25 shrink-0"
+        >
+          <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.5" />
+          <line x1="4.5" y1="11.5" x2="11.5" y2="4.5" stroke="currentColor" stroke-width="1.5" />
+        </svg>
+      }
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 16 16"
+        fill="none"
+        class="text-[#0f9d58] shrink-0"
+      >
+        <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.5" />
+        <path
+          d="M5 8.5L7 10.5L11 5.5"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+    </Show>
+  </div>
+);
+
+export const ElementPropertiesPanel: Component<ElementPropertiesPanelProps> = (
+  props,
+) => (
+  <BottomSection>
+    <div
+      class="flex flex-col w-full max-w-[280px] gap-0.5 cursor-text select-text"
+      onPointerDown={(event) => event.stopPropagation()}
+    >
+      <div class="flex items-center justify-between gap-3 min-w-0">
+        <span class="text-[12px] leading-4 text-black/50 shrink-0">Size</span>
+        <span class="text-[12px] leading-4 text-black font-medium tabular-nums whitespace-nowrap">
+          {Math.round(props.state.width)} × {Math.round(props.state.height)}
+        </span>
+      </div>
+
+      <PropertyRows rows={props.state.properties} />
+
+      <Show when={props.state.className}>
+        <div class="flex items-start gap-1.5 min-w-0 mt-0.5">
+          <span class="text-[12px] leading-4 text-black/50 shrink-0">
+            class
+          </span>
+          <span class="text-[12px] leading-4 text-[#8B2BB9]/70 font-mono break-all min-w-0 line-clamp-3">
+            {props.state.className}
+          </span>
+        </div>
+      </Show>
+
+      <Show when={props.state.reactProps.length > 0}>
+        <SectionDivider label="Props" />
+        <PropertyRows rows={props.state.reactProps} />
+      </Show>
+
+      <Show when={props.state.accessibility.length > 0}>
+        <SectionDivider label="Accessibility" />
+        <Show when={props.state.contrast}>
+          {(contrastInfo) => (
+            <ContrastBadge
+              ratio={contrastInfo().ratio}
+              aa={contrastInfo().aa}
+              aaa={contrastInfo().aaa}
+            />
+          )}
+        </Show>
+        <For each={props.state.accessibility}>
+          {(row) => (
+            <Show
+              when={row.label !== "Keyboard-focusable"}
+              fallback={
+                <FocusableIndicator focusable={row.value === "Yes"} />
+              }
+            >
+              <PropertyRow label={row.label} value={row.value} />
+            </Show>
+          )}
+        </For>
+      </Show>
+    </div>
+  </BottomSection>
+);

--- a/packages/react-grab/src/components/selection-label/index.tsx
+++ b/packages/react-grab/src/components/selection-label/index.tsx
@@ -36,6 +36,7 @@ import { DiscardPrompt } from "./discard-prompt.js";
 import { ErrorView } from "./error-view.js";
 import { CompletionView } from "./completion-view.js";
 import { ArrowNavigationMenu } from "./arrow-navigation-menu.js";
+import { ElementPropertiesPanel } from "./element-properties-panel.js";
 
 interface LabelPosition {
   left: number;
@@ -95,7 +96,7 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
       return true;
     }
     if (props.arrowNavigationState?.isVisible) return true;
-    if (props.inspectNavigationState?.isVisible) return true;
+    if (props.inspectPropertiesState?.isVisible) return true;
     return false;
   };
 
@@ -356,7 +357,7 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
     Boolean(props.arrowNavigationState?.isVisible);
 
   const isInspectNavigationVisible = () =>
-    Boolean(props.inspectNavigationState?.isVisible);
+    Boolean(props.inspectPropertiesState?.isVisible);
 
   const handleTagClick = (event: MouseEvent) => {
     event.stopImmediatePropagation();
@@ -548,16 +549,10 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
                 when={
                   !isArrowNavigationVisible() &&
                   isInspectNavigationVisible() &&
-                  props.inspectNavigationState
+                  props.inspectPropertiesState
                 }
               >
-                {(state) => (
-                  <ArrowNavigationMenu
-                    items={state().items}
-                    activeIndex={state().activeIndex}
-                    onSelect={(index) => props.onInspectSelect?.(index)}
-                  />
-                )}
+                {(state) => <ElementPropertiesPanel state={state()} />}
               </Show>
               <Show
                 when={

--- a/packages/react-grab/src/components/toolbar/index.tsx
+++ b/packages/react-grab/src/components/toolbar/index.tsx
@@ -1299,24 +1299,14 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
             </span>
           </Show>
           <Show when={selectionHintIndex() === 1}>
-            <span
-              class={cn(
-                "flex items-center gap-1",
-                HINT_FLIP_IN_ANIMATION,
-              )}
-            >
+            <span class={cn("flex items-center gap-1", HINT_FLIP_IN_ANIMATION)}>
               <Kbd>↑</Kbd>
               <Kbd>↓</Kbd>
               to fine-tune target
             </span>
           </Show>
           <Show when={selectionHintIndex() === 2}>
-            <span
-              class={cn(
-                "flex items-center gap-1",
-                HINT_FLIP_IN_ANIMATION,
-              )}
-            >
+            <span class={cn("flex items-center gap-1", HINT_FLIP_IN_ANIMATION)}>
               <Kbd>esc</Kbd>
               to cancel
             </span>

--- a/packages/react-grab/src/components/toolbar/toolbar-content.tsx
+++ b/packages/react-grab/src/components/toolbar/toolbar-content.tsx
@@ -216,10 +216,12 @@ export const ToolbarContent: Component<ToolbarContentProps> = (props) => {
           "grid relative overflow-visible",
           gridSizeTransitionClass(),
           props.isCollapsed
-            ? (isVertical()
-                ? "grid-rows-[0fr] pointer-events-none"
-                : "grid-cols-[0fr] pointer-events-none")
-            : (isVertical() ? "grid-rows-[1fr]" : "grid-cols-[1fr]"),
+            ? isVertical()
+              ? "grid-rows-[0fr] pointer-events-none"
+              : "grid-cols-[0fr] pointer-events-none"
+            : isVertical()
+              ? "grid-rows-[1fr]"
+              : "grid-cols-[1fr]",
         )}
       >
         <div

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -51,8 +51,8 @@ export const OVERLAY_BORDER_COLOR_DRAG = overlayColor(0.4);
 export const OVERLAY_FILL_COLOR_DRAG = overlayColor(0.05);
 export const OVERLAY_BORDER_COLOR_DEFAULT = overlayColor(0.5);
 export const OVERLAY_FILL_COLOR_DEFAULT = overlayColor(0.08);
-export const OVERLAY_BORDER_COLOR_INSPECT = overlayColor(0.3);
-export const OVERLAY_FILL_COLOR_INSPECT = overlayColor(0.04);
+export const OVERLAY_FILL_COLOR_MARGIN = overlayColor(0.06);
+export const OVERLAY_FILL_COLOR_PADDING = overlayColor(0.12);
 export const FROZEN_GLOW_COLOR = overlayColor(0.15);
 export const FROZEN_GLOW_EDGE_PX = 50;
 
@@ -172,6 +172,12 @@ export const TEXTAREA_MAX_HEIGHT_PX = 95;
 
 export const IME_COMPOSING_KEY_CODE = 229;
 export const SELECTION_LABEL_OFFSCREEN_PX = -9999;
+
+export const INSPECT_MAX_PROP_VALUE_LENGTH = 40;
+export const INSPECT_MAX_REACT_PROPS = 6;
+export const INSPECT_MAX_STRING_TRUNCATE_LENGTH = 30;
+export const WCAG_AA_CONTRAST_THRESHOLD = 4.5;
+export const WCAG_AAA_CONTRAST_THRESHOLD = 7;
 
 export const RELEVANT_CSS_PROPERTIES = new Set([
   "display",

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -41,7 +41,7 @@ import { isValidGrabbableElement } from "../utils/is-valid-grabbable-element.js"
 import { isRootElement } from "../utils/is-root-element.js";
 import { isElementConnected } from "../utils/is-element-connected.js";
 import { getElementsInDrag } from "../utils/get-elements-in-drag.js";
-import { getAncestorElements } from "../utils/get-ancestor-elements.js";
+import { getElementInspectProperties } from "../utils/get-element-inspect-properties.js";
 import { createElementBounds } from "../utils/create-element-bounds.js";
 import { createElementSelector } from "../utils/create-element-selector.js";
 import { getVisibleBoundsCenter } from "../utils/get-visible-bounds-center.js";
@@ -109,6 +109,7 @@ import type {
   ActionCycleItem,
   ActionCycleState,
   ArrowNavigationState,
+  InspectPropertiesState,
   PerformWithFeedbackOptions,
   SettableOptions,
   SourceInfo,
@@ -1269,19 +1270,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       return frozenElementsBounds();
     });
 
-    const inspectBounds = createMemo((): OverlayBounds[] => {
-      if (!isInspectMode()) return [];
-
-      const element = effectiveElement();
-      if (!element) return [];
-
-      void store.viewportVersion;
-
-      return [...getAncestorElements(element), element].map((ancestor) =>
-        createElementBounds(ancestor),
-      );
-    });
-
     const cursorPosition = createMemo(() => {
       if (isCopying() || isPromptMode()) {
         void store.viewportVersion;
@@ -1850,6 +1838,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       if (
         !isEnabled() ||
         isPromptMode() ||
+        isInspectMode() ||
         isFrozenPhase() ||
         store.contextMenuPosition !== null
       )
@@ -1903,7 +1892,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
 
     const handlePointerDown = (clientX: number, clientY: number) => {
-      if (!isRendererActive() || isCopying()) return false;
+      if (!isRendererActive() || isCopying() || isInspectMode()) return false;
 
       actions.startDrag({ x: clientX, y: clientY });
       actions.setPointer({ x: clientX, y: clientY });
@@ -2405,40 +2394,44 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       isVisible: arrowNavigationElements().length > 0,
     }));
 
-    const inspectAncestorElements = createMemo((): Element[] => {
-      if (!isInspectMode()) return [];
+    const EMPTY_INSPECT_STATE: InspectPropertiesState = {
+      width: 0,
+      height: 0,
+      className: "",
+      properties: [],
+      reactProps: [],
+      accessibility: [],
+      isVisible: false,
+    };
+
+    const inspectPropertiesState = createMemo<InspectPropertiesState>(() => {
+      if (!isInspectMode()) return EMPTY_INSPECT_STATE;
+
       const element = effectiveElement();
-      if (!element) return [];
-      return [...getAncestorElements(element).reverse(), element];
-    });
+      if (!element) return EMPTY_INSPECT_STATE;
 
-    const inspectNavigationItems = createMemo(() =>
-      inspectAncestorElements().map((element) => ({
-        tagName: getTagName(element) || "element",
-        componentName: getComponentDisplayName(element) ?? undefined,
-      })),
-    );
+      const rect = element.getBoundingClientRect();
+      const {
+        className,
+        properties,
+        reactProps,
+        accessibility,
+        contrast,
+        boxModel,
+      } = getElementInspectProperties(element);
 
-    const [inspectActiveIndex, setInspectActiveIndex] = createSignal(-1);
-
-    createEffect(
-      on(inspectAncestorElements, (elements) => {
-        setInspectActiveIndex(elements.length - 1);
-      }),
-    );
-
-    const inspectNavigationState = createMemo<ArrowNavigationState>(() => {
-      const elements = inspectAncestorElements();
       return {
-        items: inspectNavigationItems(),
-        activeIndex: inspectActiveIndex(),
-        isVisible: isInspectMode() && elements.length > 0,
+        width: rect.width,
+        height: rect.height,
+        className,
+        properties,
+        reactProps,
+        accessibility,
+        contrast,
+        boxModel,
+        isVisible: true,
       };
     });
-
-    const handleInspectSelect = (index: number) => {
-      setInspectActiveIndex(index);
-    };
 
     createEffect(
       on(selectionElement, () => {
@@ -2892,7 +2885,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         if (store.contextMenuPosition !== null) return;
         if (isTouchPointer && !isHoldingKeys() && !isActivated()) return;
         const isActiveState = isTouchPointer ? isHoldingKeys() : isActivated();
-        if (isActiveState && !isPromptMode() && isFrozenPhase()) {
+        if (
+          isActiveState &&
+          !isPromptMode() &&
+          !isInspectMode() &&
+          isFrozenPhase()
+        ) {
           actions.unfreeze();
           clearArrowNavigation();
         }
@@ -4085,8 +4083,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
                   store.frozenElements.length > 0 ||
                   dragPreviewBounds().length > 0
                 }
-                inspectVisible={isInspectMode() && inspectBounds().length > 0}
-                inspectBounds={inspectBounds()}
                 selectionElementsCount={store.frozenElements.length}
                 selectionFilePath={store.selectionFilePath ?? undefined}
                 selectionLineNumber={store.selectionLineNumber ?? undefined}
@@ -4097,8 +4093,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
                 selectionActionCycleState={actionCycleState()}
                 selectionArrowNavigationState={arrowNavigationState()}
                 onArrowNavigationSelect={handleArrowNavigationSelect}
-                inspectNavigationState={inspectNavigationState()}
-                onInspectSelect={handleInspectSelect}
+                inspectPropertiesState={inspectPropertiesState()}
                 labelInstances={computedLabelInstances()}
                 dragVisible={dragVisible()}
                 dragBounds={dragBounds()}

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -258,6 +258,41 @@ export interface ArrowNavigationState {
   isVisible: boolean;
 }
 
+export interface InspectPropertyRow {
+  label: string;
+  value: string;
+  colorHex?: string;
+}
+
+export interface InspectContrastInfo {
+  ratio: number;
+  aa: boolean;
+  aaa: boolean;
+}
+
+export interface InspectPropertiesState {
+  width: number;
+  height: number;
+  className: string;
+  properties: InspectPropertyRow[];
+  reactProps: InspectPropertyRow[];
+  accessibility: InspectPropertyRow[];
+  contrast?: InspectContrastInfo;
+  boxModel?: InspectBoxModel;
+  isVisible: boolean;
+}
+
+export interface InspectBoxModel {
+  paddingTop: number;
+  paddingRight: number;
+  paddingBottom: number;
+  paddingLeft: number;
+  marginTop: number;
+  marginRight: number;
+  marginBottom: number;
+  marginLeft: number;
+}
+
 export interface PerformWithFeedbackOptions {
   fallbackBounds?: OverlayBounds;
   fallbackSelectionBounds?: OverlayBounds[];
@@ -454,8 +489,6 @@ export interface ReactGrabRendererProps {
   selectionBounds?: OverlayBounds;
   selectionBoundsMultiple?: OverlayBounds[];
   selectionShouldSnap?: boolean;
-  inspectVisible?: boolean;
-  inspectBounds?: OverlayBounds[];
   selectionElementsCount?: number;
   selectionFilePath?: string;
   selectionLineNumber?: number;
@@ -466,8 +499,7 @@ export interface ReactGrabRendererProps {
   selectionActionCycleState?: ActionCycleState;
   selectionArrowNavigationState?: ArrowNavigationState;
   onArrowNavigationSelect?: (index: number) => void;
-  inspectNavigationState?: ArrowNavigationState;
-  onInspectSelect?: (index: number) => void;
+  inspectPropertiesState?: InspectPropertiesState;
   labelInstances?: SelectionLabelInstance[];
   dragVisible?: boolean;
   dragBounds?: OverlayBounds;
@@ -645,8 +677,7 @@ export interface SelectionLabelProps {
   actionCycleState?: ActionCycleState;
   arrowNavigationState?: ArrowNavigationState;
   onArrowNavigationSelect?: (index: number) => void;
-  inspectNavigationState?: ArrowNavigationState;
-  onInspectSelect?: (index: number) => void;
+  inspectPropertiesState?: InspectPropertiesState;
   onInputChange?: (value: string) => void;
   onSubmit?: () => void;
   onToggleExpand?: () => void;

--- a/packages/react-grab/src/utils/comment-storage.ts
+++ b/packages/react-grab/src/utils/comment-storage.ts
@@ -76,9 +76,7 @@ let didConfirmClear = readSessionFlag(CLEAR_CONFIRMED_KEY);
 
 export const loadComments = (): CommentItem[] => commentItems;
 
-export const addCommentItem = (
-  item: Omit<CommentItem, "id">,
-): CommentItem[] =>
+export const addCommentItem = (item: Omit<CommentItem, "id">): CommentItem[] =>
   persistCommentItems(
     [{ ...item, id: generateId("comment") }, ...commentItems].slice(
       0,
@@ -101,6 +99,9 @@ export const confirmClear = (): void => {
     sessionStorage.setItem(CLEAR_CONFIRMED_KEY, "1");
   } catch (error) {
     // HACK: sessionStorage can throw in private browsing or when quota is exceeded
-    logRecoverableError("Failed to save clear preference to sessionStorage", error);
+    logRecoverableError(
+      "Failed to save clear preference to sessionStorage",
+      error,
+    );
   }
 };

--- a/packages/react-grab/src/utils/get-element-inspect-properties.ts
+++ b/packages/react-grab/src/utils/get-element-inspect-properties.ts
@@ -1,0 +1,370 @@
+import type {
+  InspectPropertyRow,
+  InspectContrastInfo,
+  InspectBoxModel,
+} from "../types.js";
+import { getFiberFromHostInstance, isCompositeFiber } from "bippy";
+import {
+  INSPECT_MAX_PROP_VALUE_LENGTH,
+  INSPECT_MAX_REACT_PROPS,
+  INSPECT_MAX_STRING_TRUNCATE_LENGTH,
+  WCAG_AA_CONTRAST_THRESHOLD,
+  WCAG_AAA_CONTRAST_THRESHOLD,
+} from "../constants.js";
+
+const NATIVELY_FOCUSABLE_TAGS = new Set([
+  "a",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  "details",
+  "summary",
+]);
+
+const IMPLICIT_ROLES: Record<string, string> = {
+  a: "link",
+  article: "article",
+  aside: "complementary",
+  button: "button",
+  details: "group",
+  dialog: "dialog",
+  footer: "contentinfo",
+  form: "form",
+  h1: "heading",
+  h2: "heading",
+  h3: "heading",
+  h4: "heading",
+  h5: "heading",
+  h6: "heading",
+  header: "banner",
+  hr: "separator",
+  img: "img",
+  input: "textbox",
+  li: "listitem",
+  main: "main",
+  nav: "navigation",
+  ol: "list",
+  option: "option",
+  p: "paragraph",
+  progress: "progressbar",
+  section: "region",
+  select: "combobox",
+  summary: "button",
+  table: "table",
+  td: "cell",
+  textarea: "textbox",
+  th: "columnheader",
+  tr: "row",
+  ul: "list",
+};
+
+const HIDDEN_PROP_KEYS = new Set([
+  "children",
+  "key",
+  "ref",
+  "__self",
+  "__source",
+  "dangerouslySetInnerHTML",
+]);
+
+const SENSITIVE_PROP_PATTERN =
+  /secret|token|password|apiKey|auth|credential/i;
+
+interface ParsedColor {
+  red: number;
+  green: number;
+  blue: number;
+  hex: string;
+}
+
+const parseRgb = (rgb: string): ParsedColor | null => {
+  const match = rgb.match(
+    /rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)(?:\s*,\s*[\d.]+)?\s*\)/,
+  );
+  if (!match) return null;
+
+  const red = Number(match[1]);
+  const green = Number(match[2]);
+  const blue = Number(match[3]);
+  const hex = `#${((1 << 24) | (red << 16) | (green << 8) | blue).toString(16).slice(1).toUpperCase()}`;
+
+  return { red, green, blue, hex };
+};
+
+const srgbChannelToLinear = (channel: number): number => {
+  const normalized = channel / 255;
+  return normalized <= 0.04045
+    ? normalized / 12.92
+    : Math.pow((normalized + 0.055) / 1.055, 2.4);
+};
+
+const relativeLuminance = (red: number, green: number, blue: number): number =>
+  0.2126 * srgbChannelToLinear(red) +
+  0.7152 * srgbChannelToLinear(green) +
+  0.0722 * srgbChannelToLinear(blue);
+
+const computeContrast = (
+  foreground: ParsedColor,
+  background: ParsedColor,
+): InspectContrastInfo => {
+  const foregroundLuminance = relativeLuminance(
+    foreground.red,
+    foreground.green,
+    foreground.blue,
+  );
+  const backgroundLuminance = relativeLuminance(
+    background.red,
+    background.green,
+    background.blue,
+  );
+  const lighter = Math.max(foregroundLuminance, backgroundLuminance);
+  const darker = Math.min(foregroundLuminance, backgroundLuminance);
+  const ratio = (lighter + 0.05) / (darker + 0.05);
+
+  return {
+    ratio: Math.round(ratio * 100) / 100,
+    aa: ratio >= WCAG_AA_CONTRAST_THRESHOLD,
+    aaa: ratio >= WCAG_AAA_CONTRAST_THRESHOLD,
+  };
+};
+
+const buildSpacingShorthand = (
+  top: string,
+  right: string,
+  bottom: string,
+  left: string,
+): string | null => {
+  if (top === "0px" && right === "0px" && bottom === "0px" && left === "0px") {
+    return null;
+  }
+
+  if (top === right && right === bottom && bottom === left) return top;
+  if (top === bottom && right === left) return `${top} ${right}`;
+  if (right === left) return `${top} ${right} ${bottom}`;
+  return `${top} ${right} ${bottom} ${left}`;
+};
+
+const getAccessibleName = (element: Element): string => {
+  const ariaLabel = element.getAttribute("aria-label");
+  if (ariaLabel) return ariaLabel;
+
+  const labelledBy = element.getAttribute("aria-labelledby");
+  if (labelledBy) {
+    const labelParts = labelledBy
+      .split(/\s+/)
+      .map((labelId) => document.getElementById(labelId)?.textContent?.trim())
+      .filter(Boolean);
+    if (labelParts.length > 0) return labelParts.join(" ");
+  }
+
+  if (element instanceof HTMLImageElement) {
+    return element.alt || "";
+  }
+
+  return "";
+};
+
+const formatPropValue = (value: unknown): string => {
+  if (value === null || value === undefined) return String(value);
+  if (typeof value === "string") return `"${value}"`;
+  if (typeof value === "boolean" || typeof value === "number") {
+    return String(value);
+  }
+  if (typeof value === "function") return "fn()";
+  if (Array.isArray(value)) return `[${value.length}]`;
+  if (typeof value === "object") {
+    const keys = Object.keys(value);
+    return `{${keys.length}}`;
+  }
+  return String(value);
+};
+
+const getReactProps = (element: Element): InspectPropertyRow[] => {
+  const fiber = getFiberFromHostInstance(element);
+  if (!fiber) return [];
+
+  let compositeFiber = fiber.return;
+  while (compositeFiber) {
+    if (isCompositeFiber(compositeFiber)) break;
+    compositeFiber = compositeFiber.return;
+  }
+  if (!compositeFiber) return [];
+
+  const fiberProps = compositeFiber.memoizedProps;
+  if (!fiberProps || typeof fiberProps !== "object") return [];
+
+  const propEntries = Object.entries(fiberProps);
+  const rows: InspectPropertyRow[] = [];
+
+  for (const [propKey, propValue] of propEntries) {
+    if (HIDDEN_PROP_KEYS.has(propKey)) continue;
+    if (propKey.startsWith("__")) continue;
+    if (SENSITIVE_PROP_PATTERN.test(propKey)) continue;
+
+    let formatted = formatPropValue(propValue);
+    if (formatted.length > INSPECT_MAX_PROP_VALUE_LENGTH) {
+      formatted = `${formatted.slice(0, INSPECT_MAX_PROP_VALUE_LENGTH - 1)}…`;
+    }
+    rows.push({ label: propKey, value: formatted });
+
+    if (rows.length >= INSPECT_MAX_REACT_PROPS) break;
+  }
+
+  return rows;
+};
+
+const parsePx = (value: string): number => parseFloat(value) || 0;
+
+interface ElementInspectProperties {
+  className: string;
+  properties: InspectPropertyRow[];
+  reactProps: InspectPropertyRow[];
+  accessibility: InspectPropertyRow[];
+  contrast?: InspectContrastInfo;
+  boxModel: InspectBoxModel;
+}
+
+export const getElementInspectProperties = (
+  element: Element,
+): ElementInspectProperties => {
+  const computedStyle = getComputedStyle(element);
+  const properties: InspectPropertyRow[] = [];
+
+  const foregroundColor = parseRgb(computedStyle.color);
+  if (foregroundColor) {
+    properties.push({
+      label: "Color",
+      value: foregroundColor.hex,
+      colorHex: foregroundColor.hex,
+    });
+  }
+
+  const rawBackgroundColor = computedStyle.backgroundColor;
+  const isTransparentBackground =
+    rawBackgroundColor === "rgba(0, 0, 0, 0)" ||
+    rawBackgroundColor === "transparent";
+  const backgroundColorParsed = isTransparentBackground
+    ? null
+    : parseRgb(rawBackgroundColor);
+  if (backgroundColorParsed) {
+    properties.push({
+      label: "Background",
+      value: backgroundColorParsed.hex,
+      colorHex: backgroundColorParsed.hex,
+    });
+  }
+
+  const fontSize = computedStyle.fontSize;
+  const fontFamily = computedStyle.fontFamily;
+  if (fontSize && fontFamily) {
+    const truncatedFamily =
+      fontFamily.length > INSPECT_MAX_STRING_TRUNCATE_LENGTH
+        ? `${fontFamily.slice(0, INSPECT_MAX_STRING_TRUNCATE_LENGTH)}…`
+        : fontFamily;
+    properties.push({ label: "Font", value: `${fontSize} ${truncatedFamily}` });
+  }
+
+  const marginShorthand = buildSpacingShorthand(
+    computedStyle.marginTop,
+    computedStyle.marginRight,
+    computedStyle.marginBottom,
+    computedStyle.marginLeft,
+  );
+  if (marginShorthand) {
+    properties.push({ label: "Margin", value: marginShorthand });
+  }
+
+  const paddingShorthand = buildSpacingShorthand(
+    computedStyle.paddingTop,
+    computedStyle.paddingRight,
+    computedStyle.paddingBottom,
+    computedStyle.paddingLeft,
+  );
+  if (paddingShorthand) {
+    properties.push({ label: "Padding", value: paddingShorthand });
+  }
+
+  const display = computedStyle.display;
+  if (display && display !== "block" && display !== "inline") {
+    properties.push({ label: "Display", value: display });
+  }
+
+  if (display === "flex" || display === "inline-flex") {
+    const flexDirection = computedStyle.flexDirection;
+    if (flexDirection && flexDirection !== "row") {
+      properties.push({ label: "Direction", value: flexDirection });
+    }
+    const gap = computedStyle.gap;
+    if (gap && gap !== "normal") {
+      properties.push({ label: "Gap", value: gap });
+    }
+  }
+
+  if (display === "grid" || display === "inline-grid") {
+    const gridCols = computedStyle.gridTemplateColumns;
+    if (gridCols && gridCols !== "none") {
+      const truncatedCols =
+        gridCols.length > INSPECT_MAX_STRING_TRUNCATE_LENGTH
+          ? `${gridCols.slice(0, INSPECT_MAX_STRING_TRUNCATE_LENGTH)}…`
+          : gridCols;
+      properties.push({ label: "Columns", value: truncatedCols });
+    }
+  }
+
+  const position = computedStyle.position;
+  if (position && position !== "static") {
+    properties.push({ label: "Position", value: position });
+  }
+
+  const overflow = computedStyle.overflow;
+  if (overflow && overflow !== "visible" && overflow !== "visible visible") {
+    properties.push({ label: "Overflow", value: overflow });
+  }
+
+  const className = element.getAttribute("class")?.trim() || "";
+
+  const tagName = element.tagName.toLowerCase();
+  const accessibility: InspectPropertyRow[] = [];
+
+  const accessibleName = getAccessibleName(element);
+  accessibility.push({ label: "Name", value: accessibleName });
+
+  const explicitRole = element.getAttribute("role");
+  const implicitRole = IMPLICIT_ROLES[tagName];
+  accessibility.push({
+    label: "Role",
+    value: explicitRole || implicitRole || "",
+  });
+
+  const htmlElement = element as HTMLElement;
+  const isDisabled =
+    "disabled" in htmlElement && Boolean(htmlElement.disabled);
+  const isNativelyFocusable =
+    NATIVELY_FOCUSABLE_TAGS.has(tagName) && !isDisabled;
+  const isKeyboardFocusable = isNativelyFocusable || htmlElement.tabIndex >= 0;
+  accessibility.push({
+    label: "Keyboard-focusable",
+    value: isKeyboardFocusable ? "Yes" : "No",
+  });
+
+  const reactProps = getReactProps(element);
+
+  let contrast: InspectContrastInfo | undefined;
+  if (foregroundColor && backgroundColorParsed) {
+    contrast = computeContrast(foregroundColor, backgroundColorParsed);
+  }
+
+  const boxModel: InspectBoxModel = {
+    paddingTop: parsePx(computedStyle.paddingTop),
+    paddingRight: parsePx(computedStyle.paddingRight),
+    paddingBottom: parsePx(computedStyle.paddingBottom),
+    paddingLeft: parsePx(computedStyle.paddingLeft),
+    marginTop: parsePx(computedStyle.marginTop),
+    marginRight: parsePx(computedStyle.marginRight),
+    marginBottom: parsePx(computedStyle.marginBottom),
+    marginLeft: parsePx(computedStyle.marginLeft),
+  };
+
+  return { className, properties, reactProps, accessibility, contrast, boxModel };
+};

--- a/packages/website/next.config.ts
+++ b/packages/website/next.config.ts
@@ -5,7 +5,9 @@ const nextConfig: NextConfig = {
   // HACK: disable react compiler to avoid issues with source mangling
   reactCompiler: false,
   productionBrowserSourceMaps: true,
-  turbopack: {},
+  turbopack: {
+    root: "../..",
+  },
   experimental: {
     optimizeCss: true,
     inlineCss: true,


### PR DESCRIPTION
## Summary

- Replaces the inspect mode (Shift) ancestor stack list with a Chrome DevTools-style element properties panel
- Shows computed styles (color, background, font, margin, padding, display, position, flex/grid), className, React component props, and accessibility info (contrast ratio with AA/AAA badges, accessible name, role, keyboard-focusable)
- Draws box model overlay on the canvas with padding and margin zones in pink
- Freezes element detection and blocks selection during inspect mode so the panel is stable and interactive
- Allows text selection within the properties panel

## Test plan

- [ ] Activate react-grab, hover an element, hold Shift to enter inspect mode
- [ ] Verify the properties panel appears with correct computed styles and dimensions
- [ ] Verify color and background swatches render with correct colors
- [ ] Verify contrast ratio badge shows correct AA/AAA pass/fail
- [ ] Verify className is shown and clamps at 3 lines
- [ ] Verify React props section shows parent component props (filtered)
- [ ] Verify accessibility section shows name, role, and focusable icon
- [ ] Verify padding/margin zones render on the canvas overlay
- [ ] Verify element detection freezes while Shift is held
- [ ] Verify text in the panel is selectable without affecting the page
- [ ] Verify releasing Shift returns to normal selection behavior

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/interaction refactor of inspect mode, including new runtime style/React-props introspection and changes that block hover/drag during inspect, which could affect selection behavior. Adds new overlay rendering for margin/padding zones that may have visual edge cases on complex layouts.
> 
> **Overview**
> **Inspect mode UI is redesigned**: the prior ancestor-stack navigation is removed and replaced with an `ElementPropertiesPanel` that displays element size, computed style highlights, class name, selected React props, and accessibility/contrast info.
> 
> **Overlay rendering changes**: the dedicated inspect canvas layer is removed; selection rendering can now optionally draw margin/padding zones (new `OVERLAY_FILL_COLOR_MARGIN/PADDING`) based on computed `boxModel` data.
> 
> **Core interaction updates**: inspect state is now computed via new `getElementInspectProperties` (including filtering/truncation and sensitive-prop avoidance) and passed through `inspectPropertiesState`; pointer move/drag/unfreeze are suppressed while inspecting to keep the panel stable. Also updates website `turbopack` config to set `root`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b31444805e66183dd4383a2a0d3562407cf57880. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the inspect-mode ancestor stack with a Chrome DevTools-style Properties panel and a box-model overlay for padding and margin. Inspect is now stable (freezes detection) and the panel supports text selection.

- **New Features**
  - Properties panel shows size, class, and computed styles: color/background (with swatches), font, margin/padding, display/position/overflow, and flex/grid.
  - React props are shown (filtered, truncated, capped at 6).
  - Accessibility: accessible name, role, keyboard-focusable, and contrast ratio with AA/AAA badges.
  - Canvas overlay shades margin and padding around the selection.
  - Panel stays interactive while inspecting; element detection is frozen.

- **Refactors**
  - Removed ancestor overlay boxes and the inspect canvas layer; selection overlay now renders with box-model data.
  - Added a utility to compute properties, contrast, and box model; introduced new types and constants.
  - Blocked drag/selection in inspect mode and wired a new inspect properties state through the renderer.

<sup>Written for commit af140c767e293d9922bd4631005262715544e5fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

