### PR TITLE
feat: include page URL in copied context

### DIFF
--- a/packages/react-grab/e2e/copy-url.spec.ts
+++ b/packages/react-grab/e2e/copy-url.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from "./fixtures.js";
+
+test.describe("Copy URL Inclusion", () => {
+  test("should include page URL in copied clipboard content", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.activate();
+    await reactGrab.hoverElement("[data-testid='main-title']");
+    await reactGrab.waitForSelectionBox();
+    await reactGrab.clickElement("[data-testid='main-title']");
+
+    const pageUrl = reactGrab.page.url();
+    await expect
+      .poll(() => reactGrab.getClipboardContent(), { timeout: 5000 })
+      .toContain(`URL: ${pageUrl}`);
+  });
+
+  test("should place URL after element snippet content", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.activate();
+    await reactGrab.hoverElement("[data-testid='main-title']");
+    await reactGrab.waitForSelectionBox();
+    await reactGrab.clickElement("[data-testid='main-title']");
+
+    await expect
+      .poll(() => reactGrab.getClipboardContent(), { timeout: 5000 })
+      .toContain("React Grab");
+
+    const content = await reactGrab.getClipboardContent();
+    const urlIndex = content.indexOf("URL:");
+    const snippetIndex = content.indexOf("React Grab");
+    expect(urlIndex).toBeGreaterThan(snippetIndex);
+  });
+
+  test("should include URL in clipboard metadata but not in metadata content", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.activate();
+    await reactGrab.hoverElement("[data-testid='todo-list'] h1");
+    await reactGrab.waitForSelectionBox();
+
+    const copyPayloadPromise = reactGrab.captureNextClipboardWrites();
+    await reactGrab.clickElement("[data-testid='todo-list'] h1");
+    const copyPayload = await copyPayloadPromise;
+    const metadataText = copyPayload["application/x-react-grab"];
+    if (!metadataText) {
+      throw new Error("Missing React Grab clipboard metadata");
+    }
+
+    const pageUrl = reactGrab.page.url();
+    const metadata = JSON.parse(metadataText);
+    expect(metadata.url).toBe(pageUrl);
+    expect(metadata.content).toContain("Todo List");
+    expect(metadata.content).not.toContain("URL:");
+  });
+
+  test("should include URL when copying with comment", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.registerCommentAction();
+    await reactGrab.enterPromptMode("li:first-child");
+    await reactGrab.typeInInput("Fix this item");
+    await reactGrab.submitInput();
+
+    const pageUrl = reactGrab.page.url();
+    await expect
+      .poll(() => reactGrab.getClipboardContent(), { timeout: 5000 })
+      .toContain("Fix this item");
+
+    const content = await reactGrab.getClipboardContent();
+    expect(content).toContain(`URL: ${pageUrl}`);
+
+    // Comment should come before snippet, URL should come last
+    const commentIndex = content.indexOf("Fix this item");
+    const urlIndex = content.indexOf("URL:");
+    expect(commentIndex).toBeLessThan(urlIndex);
+  });
+
+  test("should include URL when copying multiple elements via drag", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.activate();
+    await reactGrab.dragSelect("li:first-child", "li:nth-child(3)");
+
+    const pageUrl = reactGrab.page.url();
+    await expect
+      .poll(() => reactGrab.getClipboardContent(), { timeout: 5000 })
+      .toContain(`URL: ${pageUrl}`);
+  });
+});

--- a/packages/react-grab/e2e/element-context.spec.ts
+++ b/packages/react-grab/e2e/element-context.spec.ts
@@ -116,7 +116,8 @@ test.describe("Element Context Fallback", () => {
 
       const clipboard = await reactGrab.getClipboardContent();
       expect(clipboard).toContain("long-dom-element");
-      expect(clipboard.length).toBeLessThanOrEqual(510);
+      const snippetPortion = clipboard.split("\n\nURL:")[0];
+      expect(snippetPortion.length).toBeLessThanOrEqual(510);
     });
   });
 });

--- a/packages/react-grab/src/core/copy.ts
+++ b/packages/react-grab/src/core/copy.ts
@@ -69,6 +69,8 @@ export const tryCopyWithFallback = async (
         elements,
       );
 
+      const url = window.location.href;
+
       copiedContent = extraPrompt
         ? `${extraPrompt}\n\n${transformedContent}`
         : transformedContent;
@@ -76,6 +78,7 @@ export const tryCopyWithFallback = async (
       didCopy = copyContent(copiedContent, {
         componentName: options.componentName,
         entries,
+        url,
       });
     }
   } catch (error) {

--- a/packages/react-grab/src/core/copy.ts
+++ b/packages/react-grab/src/core/copy.ts
@@ -1,4 +1,8 @@
-import { copyContent, type ReactGrabEntry } from "../utils/copy-content.js";
+import {
+  buildClipboardText,
+  copyContent,
+  type ReactGrabEntry,
+} from "../utils/copy-content.js";
 import { generateSnippet } from "../utils/generate-snippet.js";
 import { joinSnippets } from "../utils/join-snippets.js";
 import { normalizeError } from "../utils/normalize-error.js";
@@ -17,7 +21,11 @@ interface CopyHooks {
     elements: Element[],
   ) => Promise<string>;
   onAfterCopy: (elements: Element[], success: boolean) => void;
-  onCopySuccess: (elements: Element[], content: string) => void;
+  onCopySuccess: (
+    elements: Element[],
+    content: string,
+    clipboardText: string,
+  ) => void;
   onCopyError: (error: Error) => void;
 }
 
@@ -29,6 +37,7 @@ export const tryCopyWithFallback = async (
 ): Promise<boolean> => {
   let didCopy = false;
   let copiedContent = "";
+  let url = "";
 
   await hooks.onBeforeCopy(elements);
 
@@ -69,7 +78,7 @@ export const tryCopyWithFallback = async (
         elements,
       );
 
-      const url = window.location.href;
+      url = window.location.href;
 
       copiedContent = extraPrompt
         ? `${extraPrompt}\n\n${transformedContent}`
@@ -86,7 +95,11 @@ export const tryCopyWithFallback = async (
   }
 
   if (didCopy) {
-    hooks.onCopySuccess(elements, copiedContent);
+    hooks.onCopySuccess(
+      elements,
+      copiedContent,
+      buildClipboardText(copiedContent, url),
+    );
   }
   hooks.onAfterCopy(elements, didCopy);
 

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -827,6 +827,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     const handleCopySuccessWithComments = (options: {
       copiedElements: Element[];
       content: string;
+      clipboardText: string;
       extraPrompt: string | undefined;
       elementName: string | undefined;
       tagName: string | null;
@@ -835,12 +836,13 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       const {
         copiedElements,
         content,
+        clipboardText,
         extraPrompt,
         elementName,
         tagName,
         componentName,
       } = options;
-      pluginRegistry.hooks.onCopySuccess(copiedElements, content);
+      pluginRegistry.hooks.onCopySuccess(copiedElements, clipboardText);
 
       if (!extraPrompt) return;
 
@@ -928,10 +930,15 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           transformSnippet: pluginRegistry.hooks.transformSnippet,
           transformCopyContent: pluginRegistry.hooks.transformCopyContent,
           onAfterCopy: pluginRegistry.hooks.onAfterCopy,
-          onCopySuccess: (copiedElements: Element[], content: string) => {
+          onCopySuccess: (
+            copiedElements: Element[],
+            content: string,
+            clipboardText: string,
+          ) => {
             handleCopySuccessWithComments({
               copiedElements,
               content,
+              clipboardText,
               extraPrompt,
               elementName,
               tagName,

--- a/packages/react-grab/src/utils/copy-content.ts
+++ b/packages/react-grab/src/utils/copy-content.ts
@@ -33,6 +33,11 @@ const escapeHtml = (text: string): string =>
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;");
 
+export const buildClipboardText = (
+  content: string,
+  url?: string,
+): string => (url != null ? `${content}\n\nURL: ${url}` : content);
+
 export const copyContent = (
   content: string,
   options?: CopyContentOptions,
@@ -47,9 +52,7 @@ export const copyContent = (
     },
   ];
   const url = options?.url ?? window.location.href;
-  const clipboardText = options?.url != null
-    ? `${content}\n\nURL: ${url}`
-    : content;
+  const clipboardText = buildClipboardText(content, options?.url != null ? url : undefined);
   const reactGrabMetadata: ReactGrabMetadata = {
     version: VERSION,
     url,

--- a/packages/react-grab/src/utils/copy-content.ts
+++ b/packages/react-grab/src/utils/copy-content.ts
@@ -15,10 +15,12 @@ interface CopyContentOptions {
   tagName?: string;
   commentText?: string;
   entries?: ReactGrabEntry[];
+  url?: string;
 }
 
 interface ReactGrabMetadata {
   version: string;
+  url: string;
   content: string;
   entries: ReactGrabEntry[];
   timestamp: number;
@@ -44,8 +46,13 @@ export const copyContent = (
       commentText: options?.commentText,
     },
   ];
+  const url = options?.url ?? window.location.href;
+  const clipboardText = options?.url != null
+    ? `${content}\n\nURL: ${url}`
+    : content;
   const reactGrabMetadata: ReactGrabMetadata = {
     version: VERSION,
+    url,
     content,
     entries,
     timestamp: Date.now(),
@@ -53,10 +60,10 @@ export const copyContent = (
 
   const copyHandler = (event: ClipboardEvent) => {
     event.preventDefault();
-    event.clipboardData?.setData("text/plain", content);
+    event.clipboardData?.setData("text/plain", clipboardText);
     event.clipboardData?.setData(
       "text/html",
-      `<meta charset='utf-8'><pre><code>${escapeHtml(content)}</code></pre>`,
+      `<meta charset='utf-8'><pre><code>${escapeHtml(clipboardText)}</code></pre>`,
     );
     event.clipboardData?.setData(
       REACT_GRAB_MIME_TYPE,
@@ -67,7 +74,7 @@ export const copyContent = (
   document.addEventListener("copy", copyHandler);
 
   const textarea = document.createElement("textarea");
-  textarea.value = content;
+  textarea.value = clipboardText;
   textarea.style.position = "fixed";
   textarea.style.left = "-9999px";
   textarea.ariaHidden = "true";


### PR DESCRIPTION
## Summary

- Appends the current page URL as a `URL: <href>` footer in `text/plain` and `text/html` clipboard output when grabbing elements, giving AI tools immediate context about where the element was found
- Adds a structured `url` field to the `application/x-react-grab` clipboard metadata for programmatic access
- Only the primary grab path appends the URL text footer; comment re-copy and plugin copies (styles, HTML) omit it but still record the URL in metadata

## Design decisions

- **URL footer is opt-in via `copyContent()` options** — only callers that pass `url` get the text footer appended. This keeps copy-styles (CSS) and copy-html (raw HTML) output clean.
- **`metadata.content` stays clean** — no URL text embedded. Consumers use `metadata.url` for structured access, avoiding redundancy.
- **URL is read once per copy operation** in `copy.ts` and passed through to `copyContent()`, with a `window.location.href` fallback in `copyContent()` for paths that don't pass it explicitly (ensuring `metadata.url` is always populated).

## Test plan

- [x] New `copy-url.spec.ts` with 5 tests: single element, URL ordering, metadata structure, copy with comment, multi-element drag
- [x] Updated `element-context.spec.ts` truncation test to assert on snippet portion only (before URL footer)
- [x] All 584 existing e2e tests pass
- [x] TypeScript typecheck passes
- [x] Linter passes (0 warnings, 0 errors)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include the current page URL in copied content so snippets carry their source. Adds a structured URL field to clipboard metadata and appends a text footer for primary and comment copies.

- **New Features**
  - Appends "URL: <href>" to `text/plain` and `text/html` for primary and comment copies; plugin copies (styles, HTML) omit the footer.
  - Adds `url` to `application/x-react-grab` metadata; `metadata.content` stays unchanged.
  - Footer is opt-in via `copyContent({ url })`; metadata always includes a URL via `window.location.href` fallback.

- **Bug Fixes**
  - Aligned `onCopySuccess` to pass the actual clipboard text (including the URL footer) to plugins.

<sup>Written for commit ed1ed8fecdf21918ef7c03c3b9bd8a0958270e6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

