### PR TITLE
feat: box model overlay for inspect mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ playwright-report
 meta.json
 .agents/skills
 .claude.expect
+.mcp.json

--- a/apps/website/public/r/index.json
+++ b/apps/website/public/r/index.json
@@ -8,9 +8,7 @@
       "type": "registry:component",
       "title": "React Grab",
       "description": "Loads React Grab as early as possible — select context for coding agents directly from your website.",
-      "dependencies": [
-        "react-grab"
-      ],
+      "dependencies": ["react-grab"],
       "files": [
         {
           "path": "react-grab.tsx",

--- a/apps/website/public/r/react-grab.json
+++ b/apps/website/public/r/react-grab.json
@@ -4,9 +4,7 @@
   "type": "registry:component",
   "title": "React Grab",
   "description": "Loads React Grab as early as possible — select context for coding agents directly from your website.",
-  "dependencies": [
-    "react-grab"
-  ],
+  "dependencies": ["react-grab"],
   "files": [
     {
       "path": "components/react-grab.tsx",

--- a/packages/react-grab/e2e/drag-selection.spec.ts
+++ b/packages/react-grab/e2e/drag-selection.spec.ts
@@ -306,6 +306,49 @@ test.describe("Drag Selection with Scroll", () => {
     await reactGrab.page.mouse.up();
   });
 
+  test("drag bounds height should grow by exactly the scroll delta during auto-scroll", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.activate();
+
+    const viewport = await reactGrab.getViewportSize();
+
+    // Start drag from the top of the page
+    const startX = 100;
+    const startY = 100;
+    await reactGrab.page.mouse.move(startX, startY);
+    await reactGrab.page.mouse.down();
+
+    // Move near the bottom edge to trigger auto-scroll (threshold is 25px)
+    const nearBottomY = viewport.height - 10;
+    await reactGrab.page.mouse.move(startX, nearBottomY, { steps: 5 });
+    await reactGrab.page.waitForTimeout(200);
+
+    // Capture initial state after auto-scroll has started
+    const scrollBefore = await reactGrab.page.evaluate(() => window.scrollY);
+    const boundsBefore = await reactGrab.getDragBoxBounds();
+    expect(boundsBefore).not.toBeNull();
+
+    // Wait for auto-scroll to advance several frames
+    await reactGrab.page.waitForTimeout(800);
+
+    const scrollAfter = await reactGrab.page.evaluate(() => window.scrollY);
+    const boundsAfter = await reactGrab.getDragBoxBounds();
+    expect(boundsAfter).not.toBeNull();
+
+    const scrollDelta = scrollAfter - scrollBefore;
+    // Auto-scroll should have moved the page
+    expect(scrollDelta).toBeGreaterThan(0);
+
+    // The drag height growth should match the scroll delta (not double-counted).
+    // Allow a small tolerance for RAF timing between reading scroll and bounds.
+    const heightGrowth = boundsAfter!.height - boundsBefore!.height;
+    const drift = Math.abs(heightGrowth - scrollDelta);
+    expect(drift).toBeLessThanOrEqual(20);
+
+    await reactGrab.page.mouse.up();
+  });
+
   test("drag selection should work in scrollable container", async ({ reactGrab }) => {
     await reactGrab.activate();
 

--- a/packages/react-grab/package.json
+++ b/packages/react-grab/package.json
@@ -102,7 +102,6 @@
   "devDependencies": {
     "@babel/core": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
-    "solid-js": "^1.9.10",
     "@playwright/test": "^1.40.0",
     "@tailwindcss/cli": "^4.1.17",
     "@types/babel__core": "^7.20.5",
@@ -111,6 +110,7 @@
     "babel-preset-solid": "^1.9.10",
     "concurrently": "^9.1.2",
     "expect-sdk": "0.0.0-canary-20260405095424",
+    "solid-js": "^1.9.10",
     "tailwindcss": "^4.1.0",
     "tsx": "^4.21.0"
   },

--- a/packages/react-grab/src/components/overlay-canvas.tsx
+++ b/packages/react-grab/src/components/overlay-canvas.tsx
@@ -56,7 +56,7 @@ interface AnimatedBounds {
   id: string;
   current: { x: number; y: number; width: number; height: number };
   target: { x: number; y: number; width: number; height: number };
-  borderRadius: number;
+  borderRadii: number[];
   opacity: number;
   targetOpacity: number;
   createdAt?: number;
@@ -143,10 +143,12 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
     }
   };
 
-  const parseBorderRadiusValue = (borderRadius: string): number => {
-    if (!borderRadius) return 0;
-    const match = borderRadius.match(/^(\d+(?:\.\d+)?)/);
-    return match ? parseFloat(match[1]) : 0;
+  const parseBorderRadii = (borderRadius: string): number[] => {
+    if (!borderRadius) return [0, 0, 0, 0];
+    const radiusString = borderRadius.split("/")[0].trim();
+    const values = radiusString.split(/\s+/).map((value) => parseFloat(value) || 0);
+    const [topLeft = 0, topRight = topLeft, bottomRight = topLeft, bottomLeft = topRight] = values;
+    return [topLeft, topRight, bottomRight, bottomLeft];
   };
 
   const createAnimatedBounds = (
@@ -167,7 +169,7 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
       width: bounds.width,
       height: bounds.height,
     },
-    borderRadius: parseBorderRadiusValue(bounds.borderRadius),
+    borderRadii: parseBorderRadii(bounds.borderRadius),
     opacity: options?.opacity ?? 1,
     targetOpacity: options?.targetOpacity ?? options?.opacity ?? 1,
     createdAt: options?.createdAt,
@@ -185,7 +187,7 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
       width: bounds.width,
       height: bounds.height,
     };
-    animation.borderRadius = parseBorderRadiusValue(bounds.borderRadius);
+    animation.borderRadii = parseBorderRadii(bounds.borderRadius);
     if (targetOpacity !== undefined) {
       animation.targetOpacity = targetOpacity;
     }
@@ -194,26 +196,28 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
   const resolveBoundsArray = (instance: SelectionLabelInstance): OverlayBounds[] =>
     instance.boundsMultiple ?? [instance.bounds];
 
+  const clampRadii = (radii: number[], halfWidth: number, halfHeight: number): number[] =>
+    radii.map((radius) => Math.min(radius, halfWidth, halfHeight));
+
   const drawRoundedRectangle = (
     context: OffscreenCanvasRenderingContext2D,
     rectX: number,
     rectY: number,
     rectWidth: number,
     rectHeight: number,
-    cornerRadius: number,
+    cornerRadii: number[],
     fillColor: string,
     strokeColor: string,
     opacity: number = 1,
   ) => {
     if (rectWidth <= 0 || rectHeight <= 0) return;
 
-    const maxCornerRadius = Math.min(rectWidth / 2, rectHeight / 2);
-    const clampedCornerRadius = Math.min(cornerRadius, maxCornerRadius);
+    const clamped = clampRadii(cornerRadii, rectWidth / 2, rectHeight / 2);
 
     context.globalAlpha = opacity;
     context.beginPath();
-    if (clampedCornerRadius > 0) {
-      context.roundRect(rectX, rectY, rectWidth, rectHeight, clampedCornerRadius);
+    if (clamped.some((radius) => radius > 0)) {
+      context.roundRect(rectX, rectY, rectWidth, rectHeight, clamped);
     } else {
       context.rect(rectX, rectY, rectWidth, rectHeight);
     }
@@ -241,7 +245,7 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
       dragAnimation.current.y,
       dragAnimation.current.width,
       dragAnimation.current.height,
-      dragAnimation.borderRadius,
+      dragAnimation.borderRadii,
       style.fillColor,
       style.borderColor,
     );
@@ -266,7 +270,7 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
         animation.current.y,
         animation.current.width,
         animation.current.height,
-        animation.borderRadius,
+        animation.borderRadii,
         style.fillColor,
         style.borderColor,
         effectiveOpacity,
@@ -293,7 +297,7 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
         animation.current.y,
         animation.current.width,
         animation.current.height,
-        animation.borderRadius,
+        animation.borderRadii,
         style.fillColor,
         style.borderColor,
         animation.opacity,
@@ -335,9 +339,9 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
   const appendBoundsToPath = (path: Path2D, animation: AnimatedBounds) => {
     const { x, y, width, height } = animation.current;
     if (width <= 0 || height <= 0) return;
-    const clampedRadius = Math.min(animation.borderRadius, width / 2, height / 2);
-    if (clampedRadius > 0) {
-      path.roundRect(x, y, width, height, clampedRadius);
+    const clamped = clampRadii(animation.borderRadii, width / 2, height / 2);
+    if (clamped.some((radius) => radius > 0)) {
+      path.roundRect(x, y, width, height, clamped);
     } else {
       path.rect(x, y, width, height);
     }

--- a/packages/react-grab/src/components/overlay-canvas.tsx
+++ b/packages/react-grab/src/components/overlay-canvas.tsx
@@ -329,23 +329,30 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
     return pattern;
   };
 
-  const buildBoundsPath = (animation: AnimatedBounds): Path2D => {
+  // Chromium bug: combining a roundRect sub-path via addPath() breaks the
+  // "evenodd" fill rule, rendering the ring as empty. We must draw both
+  // sub-paths directly on the same Path2D instead of using addPath().
+  const appendBoundsToPath = (path: Path2D, animation: AnimatedBounds) => {
     const { x, y, width, height } = animation.current;
-    const path = new Path2D();
-    if (width <= 0 || height <= 0) return path;
+    if (width <= 0 || height <= 0) return;
     const clampedRadius = Math.min(animation.borderRadius, width / 2, height / 2);
     if (clampedRadius > 0) {
       path.roundRect(x, y, width, height, clampedRadius);
     } else {
       path.rect(x, y, width, height);
     }
+  };
+
+  const buildBoundsPath = (animation: AnimatedBounds): Path2D => {
+    const path = new Path2D();
+    appendBoundsToPath(path, animation);
     return path;
   };
 
   const buildRingPath = (outer: AnimatedBounds, inner: AnimatedBounds): Path2D => {
     const path = new Path2D();
-    path.addPath(buildBoundsPath(outer));
-    path.addPath(buildBoundsPath(inner));
+    appendBoundsToPath(path, outer);
+    appendBoundsToPath(path, inner);
     return path;
   };
 

--- a/packages/react-grab/src/components/overlay-canvas.tsx
+++ b/packages/react-grab/src/components/overlay-canvas.tsx
@@ -323,7 +323,7 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
 
     const pattern = context.createPattern(patternCanvas, "repeat");
     if (pattern) {
-      pattern.setTransform(new DOMMatrix().rotate(0, 0, HATCH_ROTATION_DEG));
+      pattern.setTransform(new DOMMatrix().rotate(HATCH_ROTATION_DEG));
       hatchPatternCache.set(color, pattern);
     }
     return pattern;

--- a/packages/react-grab/src/components/overlay-canvas.tsx
+++ b/packages/react-grab/src/components/overlay-canvas.tsx
@@ -45,6 +45,7 @@ const LAYER_STYLES = {
 } as const;
 
 type LayerName = "drag" | "selection" | "grabbed" | "inspect";
+type BoxModelLayerName = "margin" | "border" | "padding" | "content";
 
 interface OffscreenLayer {
   canvas: OffscreenCanvas | null;
@@ -103,7 +104,6 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
   let selectionAnimations: AnimatedBounds[] = [];
   let dragAnimation: AnimatedBounds | null = null;
   let grabbedAnimations: AnimatedBounds[] = [];
-  type BoxModelLayerName = "margin" | "border" | "padding" | "content";
   let boxModelAnimations: Partial<Record<BoxModelLayerName, AnimatedBounds>> = {};
 
   const canvasColorSpace: PredefinedColorSpace = supportsDisplayP3() ? "display-p3" : "srgb";

--- a/packages/react-grab/src/components/overlay-canvas.tsx
+++ b/packages/react-grab/src/components/overlay-canvas.tsx
@@ -1,6 +1,6 @@
 import { createEffect, onCleanup, onMount, on } from "solid-js";
 import type { Component } from "solid-js";
-import type { OverlayBounds, SelectionLabelInstance } from "../types.js";
+import type { BoxModelBounds, OverlayBounds, SelectionLabelInstance } from "../types.js";
 import { lerp } from "../utils/lerp.js";
 import {
   SELECTION_LERP_FACTOR,
@@ -15,8 +15,15 @@ import {
   OPACITY_CONVERGENCE_THRESHOLD,
   OVERLAY_BORDER_COLOR_DEFAULT,
   OVERLAY_FILL_COLOR_DEFAULT,
-  OVERLAY_BORDER_COLOR_INSPECT,
-  OVERLAY_FILL_COLOR_INSPECT,
+  BOX_MODEL_MARGIN_HATCH_COLOR,
+  BOX_MODEL_PADDING_FILL_COLOR,
+  BOX_MODEL_CONTENT_FILL_COLOR,
+  BOX_MODEL_GAP_HATCH_COLOR,
+  HATCH_PATTERN_WIDTH_PX,
+  HATCH_DASH_LENGTH_PX,
+  HATCH_DASH_GAP_PX,
+  HATCH_LINE_WIDTH_PX,
+  HATCH_ROTATION_DEG,
 } from "../constants.js";
 import { nativeCancelAnimationFrame, nativeRequestAnimationFrame } from "../utils/native-raf.js";
 import { supportsDisplayP3 } from "../utils/supports-display-p3.js";
@@ -24,12 +31,6 @@ import { supportsDisplayP3 } from "../utils/supports-display-p3.js";
 const DEFAULT_LAYER_STYLE = {
   borderColor: OVERLAY_BORDER_COLOR_DEFAULT,
   fillColor: OVERLAY_FILL_COLOR_DEFAULT,
-  lerpFactor: SELECTION_LERP_FACTOR,
-} as const;
-
-const INSPECT_LAYER_STYLE = {
-  borderColor: OVERLAY_BORDER_COLOR_INSPECT,
-  fillColor: OVERLAY_FILL_COLOR_INSPECT,
   lerpFactor: SELECTION_LERP_FACTOR,
 } as const;
 
@@ -41,7 +42,6 @@ const LAYER_STYLES = {
   },
   selection: DEFAULT_LAYER_STYLE,
   grabbed: DEFAULT_LAYER_STYLE,
-  inspect: INSPECT_LAYER_STYLE,
 } as const;
 
 type LayerName = "drag" | "selection" | "grabbed" | "inspect";
@@ -71,6 +71,7 @@ interface OverlayCanvasProps {
 
   inspectVisible?: boolean;
   inspectBounds?: OverlayBounds[];
+  inspectBoxModel?: BoxModelBounds;
 
   dragVisible?: boolean;
   dragBounds?: OverlayBounds;
@@ -102,7 +103,8 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
   let selectionAnimations: AnimatedBounds[] = [];
   let dragAnimation: AnimatedBounds | null = null;
   let grabbedAnimations: AnimatedBounds[] = [];
-  let inspectAnimations: AnimatedBounds[] = [];
+  type BoxModelLayerName = "margin" | "border" | "padding" | "content";
+  let boxModelAnimations: Partial<Record<BoxModelLayerName, AnimatedBounds>> = {};
 
   const canvasColorSpace: PredefinedColorSpace = supportsDisplayP3() ? "display-p3" : "srgb";
 
@@ -299,6 +301,98 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
     }
   };
 
+  const hatchPatternCache = new Map<string, CanvasPattern>();
+
+  const getOrCreateHatchPattern = (
+    context: OffscreenCanvasRenderingContext2D,
+    color: string,
+  ): CanvasPattern | null => {
+    const cached = hatchPatternCache.get(color);
+    if (cached) return cached;
+
+    const patternCanvas = new OffscreenCanvas(
+      HATCH_PATTERN_WIDTH_PX,
+      HATCH_DASH_LENGTH_PX + HATCH_DASH_GAP_PX,
+    );
+    const patternContext = patternCanvas.getContext("2d");
+    if (!patternContext) return null;
+
+    patternContext.clearRect(0, 0, patternCanvas.width, patternCanvas.height);
+    patternContext.fillStyle = color;
+    patternContext.fillRect(0, 0, HATCH_LINE_WIDTH_PX, HATCH_DASH_LENGTH_PX);
+
+    const pattern = context.createPattern(patternCanvas, "repeat");
+    if (pattern) {
+      pattern.setTransform(new DOMMatrix().rotate(0, 0, HATCH_ROTATION_DEG));
+      hatchPatternCache.set(color, pattern);
+    }
+    return pattern;
+  };
+
+  const buildBoundsPath = (animation: AnimatedBounds): Path2D => {
+    const { x, y, width, height } = animation.current;
+    const path = new Path2D();
+    if (width <= 0 || height <= 0) return path;
+    const clampedRadius = Math.min(animation.borderRadius, width / 2, height / 2);
+    if (clampedRadius > 0) {
+      path.roundRect(x, y, width, height, clampedRadius);
+    } else {
+      path.rect(x, y, width, height);
+    }
+    return path;
+  };
+
+  const buildRingPath = (outer: AnimatedBounds, inner: AnimatedBounds): Path2D => {
+    const path = new Path2D();
+    path.addPath(buildBoundsPath(outer));
+    path.addPath(buildBoundsPath(inner));
+    return path;
+  };
+
+  const fillWithHatch = (
+    context: OffscreenCanvasRenderingContext2D,
+    path: Path2D,
+    color: string,
+  ) => {
+    const pattern = getOrCreateHatchPattern(context, color);
+    if (!pattern) return;
+    context.fillStyle = pattern;
+    context.fill(path, "evenodd");
+  };
+
+  const renderInspectLayer = () => {
+    const layer = layers.inspect;
+    if (!layer.context) return;
+
+    const context = layer.context;
+    context.clearRect(0, 0, canvasWidth, canvasHeight);
+
+    if (!props.inspectVisible) return;
+
+    const { margin, border, padding, content } = boxModelAnimations;
+    if (!margin || !border || !padding || !content) return;
+
+    fillWithHatch(context, buildRingPath(margin, border), BOX_MODEL_MARGIN_HATCH_COLOR);
+
+    context.fillStyle = BOX_MODEL_PADDING_FILL_COLOR;
+    context.fill(buildRingPath(padding, content), "evenodd");
+
+    const contentPath = buildBoundsPath(content);
+    context.fillStyle = BOX_MODEL_CONTENT_FILL_COLOR;
+    context.fill(contentPath);
+
+    const gapRects = props.inspectBoxModel?.gaps;
+    if (gapRects && gapRects.length > 0) {
+      const gapPath = new Path2D();
+      for (const gapRect of gapRects) {
+        if (gapRect.width > 0 && gapRect.height > 0) {
+          gapPath.rect(gapRect.x, gapRect.y, gapRect.width, gapRect.height);
+        }
+      }
+      fillWithHatch(context, gapPath, BOX_MODEL_GAP_HATCH_COLOR);
+    }
+  };
+
   const compositeAllLayers = () => {
     if (!mainContext || !canvasRef) return;
 
@@ -309,7 +403,7 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
     renderDragLayer();
     renderSelectionLayer();
     renderBoundsLayer("grabbed", grabbedAnimations);
-    renderBoundsLayer("inspect", inspectAnimations);
+    renderInspectLayer();
 
     const layerRenderOrder: LayerName[] = ["inspect", "drag", "selection", "grabbed"];
     for (const layerName of layerRenderOrder) {
@@ -411,9 +505,9 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
       return animation.opacity > 0;
     });
 
-    for (const animation of inspectAnimations) {
+    for (const animation of Object.values(boxModelAnimations)) {
       if (animation.isInitialized) {
-        if (interpolateBounds(animation, LAYER_STYLES.inspect.lerpFactor)) {
+        if (interpolateBounds(animation, SELECTION_LERP_FACTOR)) {
           shouldContinueAnimating = true;
         }
       }
@@ -580,27 +674,24 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
 
   createEffect(
     on(
-      () => [props.inspectVisible, props.inspectBounds] as const,
-      ([isVisible, bounds]) => {
-        if (!isVisible || !bounds || bounds.length === 0) {
-          inspectAnimations = [];
+      () => [props.inspectVisible, props.inspectBoxModel] as const,
+      ([isVisible, boxModel]) => {
+        if (!isVisible || !boxModel) {
+          boxModelAnimations = {};
           scheduleAnimationFrame();
           return;
         }
 
-        inspectAnimations = bounds.map((ancestorBounds, index) => {
-          const animationId = `inspect-${index}`;
-          const existingAnimation = inspectAnimations.find(
-            (animation) => animation.id === animationId,
-          );
-
-          if (existingAnimation) {
-            updateAnimationTarget(existingAnimation, ancestorBounds);
-            return existingAnimation;
+        const layers = ["margin", "border", "padding", "content"] as const;
+        for (const layer of layers) {
+          const bounds = boxModel[layer];
+          const existing = boxModelAnimations[layer];
+          if (existing) {
+            updateAnimationTarget(existing, bounds);
+          } else {
+            boxModelAnimations[layer] = createAnimatedBounds(`boxmodel-${layer}`, bounds);
           }
-
-          return createAnimatedBounds(animationId, ancestorBounds);
-        });
+        }
 
         scheduleAnimationFrame();
       },

--- a/packages/react-grab/src/components/overlay-canvas.tsx
+++ b/packages/react-grab/src/components/overlay-canvas.tsx
@@ -216,11 +216,7 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
 
     context.globalAlpha = opacity;
     context.beginPath();
-    if (clamped.some((radius) => radius > 0)) {
-      context.roundRect(rectX, rectY, rectWidth, rectHeight, clamped);
-    } else {
-      context.rect(rectX, rectY, rectWidth, rectHeight);
-    }
+    context.roundRect(rectX, rectY, rectWidth, rectHeight, clamped);
     context.fillStyle = fillColor;
     context.fill();
     context.strokeStyle = strokeColor;
@@ -333,18 +329,15 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
     return pattern;
   };
 
-  // Chromium bug: combining a roundRect sub-path via addPath() breaks the
-  // "evenodd" fill rule, rendering the ring as empty. We must draw both
-  // sub-paths directly on the same Path2D instead of using addPath().
+  // Chromium bug: mixing roundRect and rect sub-paths on the same Path2D
+  // breaks the "evenodd" fill rule, clipping the top-left of the ring.
+  // Always use roundRect (even with [0,0,0,0] radii) to keep both
+  // sub-paths using the same drawing primitive.
   const appendBoundsToPath = (path: Path2D, animation: AnimatedBounds) => {
     const { x, y, width, height } = animation.current;
     if (width <= 0 || height <= 0) return;
     const clamped = clampRadii(animation.borderRadii, width / 2, height / 2);
-    if (clamped.some((radius) => radius > 0)) {
-      path.roundRect(x, y, width, height, clamped);
-    } else {
-      path.rect(x, y, width, height);
-    }
+    path.roundRect(x, y, width, height, clamped);
   };
 
   const buildBoundsPath = (animation: AnimatedBounds): Path2D => {

--- a/packages/react-grab/src/components/renderer.tsx
+++ b/packages/react-grab/src/components/renderer.tsx
@@ -29,6 +29,7 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
         selectionIsFading={props.selectionLabelStatus === "fading"}
         inspectVisible={props.inspectVisible}
         inspectBounds={props.inspectBounds}
+        inspectBoxModel={props.inspectBoxModel}
         dragVisible={props.dragVisible}
         dragBounds={props.dragBounds}
         grabbedBoxes={props.grabbedBoxes}

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -54,6 +54,22 @@ export const OVERLAY_FILL_COLOR_DEFAULT = overlayColor(0.08);
 export const OVERLAY_BORDER_COLOR_INSPECT = overlayColor(0.3);
 export const OVERLAY_FILL_COLOR_INSPECT = overlayColor(0.04);
 export const FROZEN_GLOW_COLOR = overlayColor(0.15);
+
+// Box model overlay colors
+export const BOX_MODEL_MARGIN_HATCH_COLOR = overlayColor(0.6);
+export const BOX_MODEL_PADDING_FILL_COLOR = overlayColor(0.15);
+export const BOX_MODEL_CONTENT_FILL_COLOR = overlayColor(0.04);
+export const BOX_MODEL_GAP_HATCH_COLOR = overlayColor(0.45);
+
+// Box model hatch pattern dimensions (matches Chrome DevTools)
+export const HATCH_PATTERN_WIDTH_PX = 10;
+export const HATCH_DASH_LENGTH_PX = 5;
+export const HATCH_DASH_GAP_PX = 3;
+export const HATCH_LINE_WIDTH_PX = 1;
+export const HATCH_ROTATION_DEG = -45;
+
+// Minimum gap size to consider visible
+export const BOX_MODEL_GAP_THRESHOLD_PX = 0.5;
 export const FROZEN_GLOW_EDGE_PX = 50;
 
 export const ARROW_HEIGHT_PX = 8;

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -40,6 +40,7 @@ import { isElementConnected } from "../utils/is-element-connected.js";
 import { getElementsInDrag } from "../utils/get-elements-in-drag.js";
 import { getAncestorElements } from "../utils/get-ancestor-elements.js";
 import { createElementBounds } from "../utils/create-element-bounds.js";
+import { createBoxModelBounds } from "../utils/create-box-model-bounds.js";
 import { createElementSelector } from "../utils/create-element-selector.js";
 import { getVisibleBoundsCenter } from "../utils/get-visible-bounds-center.js";
 import { invalidateInteractionCaches } from "../utils/invalidate-interaction-caches.js";
@@ -2125,6 +2126,19 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       };
     });
 
+    const inspectBoxModel = createMemo(() => {
+      if (!isInspectMode()) return undefined;
+      const ancestors = inspectAncestorElements();
+      const activeIdx = inspectActiveIndex();
+      const element =
+        activeIdx >= 0 && activeIdx < ancestors.length
+          ? ancestors[activeIdx]
+          : effectiveElement();
+      if (!element) return undefined;
+      void store.viewportVersion;
+      return createBoxModelBounds(element);
+    });
+
     const handleInspectSelect = (index: number) => {
       setInspectActiveIndex(index);
     };
@@ -3702,6 +3716,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
                 }
                 inspectVisible={isInspectMode() && inspectBounds().length > 0}
                 inspectBounds={inspectBounds()}
+                inspectBoxModel={inspectBoxModel()}
                 selectionElementsCount={store.frozenElements.length}
                 selectionFilePath={store.selectionFilePath ?? undefined}
                 selectionLineNumber={store.selectionLineNumber ?? undefined}
@@ -3712,7 +3727,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
                 selectionActionCycleState={actionCycleState()}
                 selectionArrowNavigationState={arrowNavigationState()}
                 onArrowNavigationSelect={handleArrowNavigationSelect}
-                inspectNavigationState={inspectNavigationState()}
                 onInspectSelect={handleInspectSelect}
                 labelInstances={computedLabelInstances()}
                 dragVisible={dragVisible()}

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -3727,6 +3727,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
                 selectionActionCycleState={actionCycleState()}
                 selectionArrowNavigationState={arrowNavigationState()}
                 onArrowNavigationSelect={handleArrowNavigationSelect}
+                inspectNavigationState={inspectNavigationState()}
                 onInspectSelect={handleInspectSelect}
                 labelInstances={computedLabelInstances()}
                 dragVisible={dragVisible()}

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -232,7 +232,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     const isDragging = createMemo(
       () =>
         store.current.state === "active" &&
-        (store.current.phase === "dragging-select" || store.current.phase === "dragging-reposition"),
+        (store.current.phase === "dragging-select" ||
+          store.current.phase === "dragging-reposition"),
     );
     const isDragRepositioning = createMemo(
       () => store.current.state === "active" && store.current.phase === "dragging-reposition",
@@ -2131,9 +2132,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       const ancestors = inspectAncestorElements();
       const activeIdx = inspectActiveIndex();
       const element =
-        activeIdx >= 0 && activeIdx < ancestors.length
-          ? ancestors[activeIdx]
-          : effectiveElement();
+        activeIdx >= 0 && activeIdx < ancestors.length ? ancestors[activeIdx] : effectiveElement();
       if (!element) return undefined;
       void store.viewportVersion;
       return createBoxModelBounds(element);

--- a/packages/react-grab/src/core/store.ts
+++ b/packages/react-grab/src/core/store.ts
@@ -12,12 +12,7 @@ interface FrozenDragRect {
   height: number;
 }
 
-type GrabPhase =
-  | "hovering"
-  | "frozen"
-  | "dragging-select"
-  | "dragging-reposition"
-  | "justDragged";
+type GrabPhase = "hovering" | "frozen" | "dragging-select" | "dragging-reposition" | "justDragged";
 
 type GrabState =
   | { state: "idle" }

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -323,6 +323,21 @@ export interface OverlayBounds {
   y: number;
 }
 
+export interface GapRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface BoxModelBounds {
+  margin: OverlayBounds;
+  border: OverlayBounds;
+  padding: OverlayBounds;
+  content: OverlayBounds;
+  gaps: GapRect[];
+}
+
 export type SelectionLabelStatus = "idle" | "copying" | "copied" | "fading" | "error";
 
 export interface SelectionLabelInstance {
@@ -366,6 +381,7 @@ export interface ReactGrabRendererProps {
   selectionShouldSnap?: boolean;
   inspectVisible?: boolean;
   inspectBounds?: OverlayBounds[];
+  inspectBoxModel?: BoxModelBounds;
   selectionElementsCount?: number;
   selectionFilePath?: string;
   selectionLineNumber?: number;

--- a/packages/react-grab/src/utils/create-box-model-bounds.ts
+++ b/packages/react-grab/src/utils/create-box-model-bounds.ts
@@ -11,6 +11,7 @@ interface BoxSides {
 
 const GRID_DISPLAYS = new Set(["grid", "inline-grid"]);
 const LAYOUT_DISPLAYS = new Set(["flex", "inline-flex", "grid", "inline-grid"]);
+const OUT_OF_FLOW_POSITIONS = new Set(["absolute", "fixed"]);
 
 const parseSides = (style: CSSStyleDeclaration, property: string): BoxSides => ({
   top: parseFloat(style.getPropertyValue(`${property}-top`)) || 0,
@@ -86,7 +87,18 @@ const computeChildGaps = (
     return [];
   }
 
-  const childRects = Array.from(element.children).map((child) => child.getBoundingClientRect());
+  const childRects: DOMRect[] = [];
+  for (const child of element.children) {
+    const childStyle = window.getComputedStyle(child);
+    if (childStyle.display === "none" || OUT_OF_FLOW_POSITIONS.has(childStyle.position)) {
+      continue;
+    }
+    const rect = child.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) continue;
+    childRects.push(rect);
+  }
+
+  if (childRects.length < 2) return [];
 
   if (GRID_DISPLAYS.has(style.display)) {
     return [

--- a/packages/react-grab/src/utils/create-box-model-bounds.ts
+++ b/packages/react-grab/src/utils/create-box-model-bounds.ts
@@ -1,0 +1,105 @@
+import type { BoxModelBounds, GapRect, OverlayBounds } from "../types.js";
+import { createElementBounds } from "./create-element-bounds.js";
+import { BOX_MODEL_GAP_THRESHOLD_PX } from "../constants.js";
+
+interface BoxSides {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}
+
+const FLEX_DISPLAYS = new Set(["flex", "inline-flex"]);
+const LAYOUT_DISPLAYS = new Set(["flex", "inline-flex", "grid", "inline-grid"]);
+
+const parseSides = (style: CSSStyleDeclaration, property: string): BoxSides => ({
+  top: parseFloat(style.getPropertyValue(`${property}-top`)) || 0,
+  right: parseFloat(style.getPropertyValue(`${property}-right`)) || 0,
+  bottom: parseFloat(style.getPropertyValue(`${property}-bottom`)) || 0,
+  left: parseFloat(style.getPropertyValue(`${property}-left`)) || 0,
+});
+
+const insetBounds = (
+  bounds: OverlayBounds,
+  inset: BoxSides,
+  borderRadius: string,
+): OverlayBounds => ({
+  ...bounds,
+  x: bounds.x + inset.left,
+  y: bounds.y + inset.top,
+  width: bounds.width - inset.left - inset.right,
+  height: bounds.height - inset.top - inset.bottom,
+  borderRadius,
+});
+
+const outsetBounds = (
+  bounds: OverlayBounds,
+  outset: BoxSides,
+  borderRadius: string,
+): OverlayBounds => ({
+  ...bounds,
+  x: bounds.x - outset.left,
+  y: bounds.y - outset.top,
+  width: bounds.width + outset.left + outset.right,
+  height: bounds.height + outset.top + outset.bottom,
+  borderRadius,
+});
+
+const maxSide = (sides: BoxSides): number =>
+  Math.max(sides.top, sides.right, sides.bottom, sides.left);
+
+const computeChildGaps = (
+  element: Element,
+  style: CSSStyleDeclaration,
+  contentBounds: OverlayBounds,
+): GapRect[] => {
+  if (!LAYOUT_DISPLAYS.has(style.display) || element.children.length < 2) {
+    return [];
+  }
+
+  const isColumn = FLEX_DISPLAYS.has(style.display)
+    && (style.flexDirection === "column" || style.flexDirection === "column-reverse");
+
+  const childRects = Array.from(element.children).map((child) =>
+    child.getBoundingClientRect(),
+  );
+
+  const gaps: GapRect[] = [];
+  for (let childIndex = 0; childIndex < childRects.length - 1; childIndex++) {
+    const currentRect = childRects[childIndex];
+    const nextRect = childRects[childIndex + 1];
+    const gapStart = isColumn ? currentRect.bottom : currentRect.right;
+    const gapEnd = isColumn ? nextRect.top : nextRect.left;
+    const gapSize = gapEnd - gapStart;
+
+    if (gapSize > BOX_MODEL_GAP_THRESHOLD_PX) {
+      gaps.push(
+        isColumn
+          ? { x: contentBounds.x, y: gapStart, width: contentBounds.width, height: gapSize }
+          : { x: gapStart, y: contentBounds.y, width: gapSize, height: contentBounds.height },
+      );
+    }
+  }
+
+  return gaps;
+};
+
+export const createBoxModelBounds = (element: Element): BoxModelBounds => {
+  const borderBounds = createElementBounds(element);
+  const style = window.getComputedStyle(element);
+
+  const marginSides = parseSides(style, "margin");
+  const paddingSides = parseSides(style, "padding");
+  const borderSides = parseSides(style, "border-width");
+
+  const outerRadius = parseFloat(style.borderRadius) || 0;
+  const paddingRadius = Math.max(0, outerRadius - maxSide(borderSides));
+  const contentRadius = Math.max(0, paddingRadius - maxSide(paddingSides));
+
+  const margin = outsetBounds(borderBounds, marginSides, "0px");
+  const padding = insetBounds(borderBounds, borderSides, `${paddingRadius}px`);
+  const content = insetBounds(padding, paddingSides, `${contentRadius}px`);
+  const gaps = computeChildGaps(element, style, content);
+
+  return { margin, border: borderBounds, padding, content, gaps };
+};

--- a/packages/react-grab/src/utils/create-box-model-bounds.ts
+++ b/packages/react-grab/src/utils/create-box-model-bounds.ts
@@ -53,14 +53,16 @@ const computeAxisGaps = (
   contentBounds: OverlayBounds,
   axis: "row" | "column",
 ): GapRect[] => {
-  const sorted = [...childRects].sort((a, b) =>
+  const sortedRects = [...childRects].sort((a, b) =>
     axis === "column" ? a.top - b.top : a.left - b.left,
   );
 
   const gaps: GapRect[] = [];
-  for (let i = 0; i < sorted.length - 1; i++) {
-    const gapStart = axis === "column" ? sorted[i].bottom : sorted[i].right;
-    const gapEnd = axis === "column" ? sorted[i + 1].top : sorted[i + 1].left;
+  for (let childIndex = 0; childIndex < sortedRects.length - 1; childIndex++) {
+    const gapStart =
+      axis === "column" ? sortedRects[childIndex].bottom : sortedRects[childIndex].right;
+    const gapEnd =
+      axis === "column" ? sortedRects[childIndex + 1].top : sortedRects[childIndex + 1].left;
     const gapSize = gapEnd - gapStart;
 
     if (gapSize > BOX_MODEL_GAP_THRESHOLD_PX) {
@@ -84,9 +86,7 @@ const computeChildGaps = (
     return [];
   }
 
-  const childRects = Array.from(element.children).map((child) =>
-    child.getBoundingClientRect(),
-  );
+  const childRects = Array.from(element.children).map((child) => child.getBoundingClientRect());
 
   if (GRID_DISPLAYS.has(style.display)) {
     return [

--- a/packages/react-grab/src/utils/create-box-model-bounds.ts
+++ b/packages/react-grab/src/utils/create-box-model-bounds.ts
@@ -9,7 +9,7 @@ interface BoxSides {
   left: number;
 }
 
-const FLEX_DISPLAYS = new Set(["flex", "inline-flex"]);
+const GRID_DISPLAYS = new Set(["grid", "inline-grid"]);
 const LAYOUT_DISPLAYS = new Set(["flex", "inline-flex", "grid", "inline-grid"]);
 
 const parseSides = (style: CSSStyleDeclaration, property: string): BoxSides => ({
@@ -48,33 +48,24 @@ const outsetBounds = (
 const maxSide = (sides: BoxSides): number =>
   Math.max(sides.top, sides.right, sides.bottom, sides.left);
 
-const computeChildGaps = (
-  element: Element,
-  style: CSSStyleDeclaration,
+const computeAxisGaps = (
+  childRects: DOMRect[],
   contentBounds: OverlayBounds,
+  axis: "row" | "column",
 ): GapRect[] => {
-  if (!LAYOUT_DISPLAYS.has(style.display) || element.children.length < 2) {
-    return [];
-  }
-
-  const isColumn = FLEX_DISPLAYS.has(style.display)
-    && (style.flexDirection === "column" || style.flexDirection === "column-reverse");
-
-  const childRects = Array.from(element.children).map((child) =>
-    child.getBoundingClientRect(),
+  const sorted = [...childRects].sort((a, b) =>
+    axis === "column" ? a.top - b.top : a.left - b.left,
   );
 
   const gaps: GapRect[] = [];
-  for (let childIndex = 0; childIndex < childRects.length - 1; childIndex++) {
-    const currentRect = childRects[childIndex];
-    const nextRect = childRects[childIndex + 1];
-    const gapStart = isColumn ? currentRect.bottom : currentRect.right;
-    const gapEnd = isColumn ? nextRect.top : nextRect.left;
+  for (let i = 0; i < sorted.length - 1; i++) {
+    const gapStart = axis === "column" ? sorted[i].bottom : sorted[i].right;
+    const gapEnd = axis === "column" ? sorted[i + 1].top : sorted[i + 1].left;
     const gapSize = gapEnd - gapStart;
 
     if (gapSize > BOX_MODEL_GAP_THRESHOLD_PX) {
       gaps.push(
-        isColumn
+        axis === "column"
           ? { x: contentBounds.x, y: gapStart, width: contentBounds.width, height: gapSize }
           : { x: gapStart, y: contentBounds.y, width: gapSize, height: contentBounds.height },
       );
@@ -84,13 +75,42 @@ const computeChildGaps = (
   return gaps;
 };
 
+const computeChildGaps = (
+  element: Element,
+  style: CSSStyleDeclaration,
+  contentBounds: OverlayBounds,
+): GapRect[] => {
+  if (!LAYOUT_DISPLAYS.has(style.display) || element.children.length < 2) {
+    return [];
+  }
+
+  const childRects = Array.from(element.children).map((child) =>
+    child.getBoundingClientRect(),
+  );
+
+  if (GRID_DISPLAYS.has(style.display)) {
+    return [
+      ...computeAxisGaps(childRects, contentBounds, "row"),
+      ...computeAxisGaps(childRects, contentBounds, "column"),
+    ];
+  }
+
+  const isColumn = style.flexDirection === "column" || style.flexDirection === "column-reverse";
+  return computeAxisGaps(childRects, contentBounds, isColumn ? "column" : "row");
+};
+
 export const createBoxModelBounds = (element: Element): BoxModelBounds => {
   const borderBounds = createElementBounds(element);
   const style = window.getComputedStyle(element);
 
   const marginSides = parseSides(style, "margin");
   const paddingSides = parseSides(style, "padding");
-  const borderSides = parseSides(style, "border-width");
+  const borderSides: BoxSides = {
+    top: parseFloat(style.borderTopWidth) || 0,
+    right: parseFloat(style.borderRightWidth) || 0,
+    bottom: parseFloat(style.borderBottomWidth) || 0,
+    left: parseFloat(style.borderLeftWidth) || 0,
+  };
 
   const outerRadius = parseFloat(style.borderRadius) || 0;
   const paddingRadius = Math.max(0, outerRadius - maxSide(borderSides));

--- a/packages/react-grab/src/utils/create-box-model-bounds.ts
+++ b/packages/react-grab/src/utils/create-box-model-bounds.ts
@@ -46,8 +46,29 @@ const outsetBounds = (
   borderRadius,
 });
 
-const maxSide = (sides: BoxSides): number =>
-  Math.max(sides.top, sides.right, sides.bottom, sides.left);
+interface CornerRadii {
+  topLeft: number;
+  topRight: number;
+  bottomRight: number;
+  bottomLeft: number;
+}
+
+const parseCornerRadii = (style: CSSStyleDeclaration): CornerRadii => ({
+  topLeft: parseFloat(style.borderTopLeftRadius) || 0,
+  topRight: parseFloat(style.borderTopRightRadius) || 0,
+  bottomRight: parseFloat(style.borderBottomRightRadius) || 0,
+  bottomLeft: parseFloat(style.borderBottomLeftRadius) || 0,
+});
+
+const insetCornerRadii = (radii: CornerRadii, sides: BoxSides): CornerRadii => ({
+  topLeft: Math.max(0, radii.topLeft - Math.max(sides.top, sides.left)),
+  topRight: Math.max(0, radii.topRight - Math.max(sides.top, sides.right)),
+  bottomRight: Math.max(0, radii.bottomRight - Math.max(sides.bottom, sides.right)),
+  bottomLeft: Math.max(0, radii.bottomLeft - Math.max(sides.bottom, sides.left)),
+});
+
+const formatCornerRadii = (radii: CornerRadii): string =>
+  `${radii.topLeft}px ${radii.topRight}px ${radii.bottomRight}px ${radii.bottomLeft}px`;
 
 const isInFlowChild = (child: Element): boolean => {
   const childStyle = window.getComputedStyle(child);
@@ -127,13 +148,13 @@ export const createBoxModelBounds = (element: Element): BoxModelBounds => {
     left: parseFloat(style.borderLeftWidth) || 0,
   };
 
-  const outerRadius = parseFloat(style.borderRadius) || 0;
-  const paddingRadius = Math.max(0, outerRadius - maxSide(borderSides));
-  const contentRadius = Math.max(0, paddingRadius - maxSide(paddingSides));
+  const outerRadii = parseCornerRadii(style);
+  const paddingRadii = insetCornerRadii(outerRadii, borderSides);
+  const contentRadii = insetCornerRadii(paddingRadii, paddingSides);
 
   const margin = outsetBounds(borderBounds, marginSides, "0px");
-  const padding = insetBounds(borderBounds, borderSides, `${paddingRadius}px`);
-  const content = insetBounds(padding, paddingSides, `${contentRadius}px`);
+  const padding = insetBounds(borderBounds, borderSides, formatCornerRadii(paddingRadii));
+  const content = insetBounds(padding, paddingSides, formatCornerRadii(contentRadii));
   const gaps = computeChildGaps(element, style, content);
 
   return { margin, border: borderBounds, padding, content, gaps };

--- a/packages/react-grab/src/utils/create-box-model-bounds.ts
+++ b/packages/react-grab/src/utils/create-box-model-bounds.ts
@@ -49,26 +49,35 @@ const outsetBounds = (
 const maxSide = (sides: BoxSides): number =>
   Math.max(sides.top, sides.right, sides.bottom, sides.left);
 
+const isInFlowChild = (child: Element): boolean => {
+  const childStyle = window.getComputedStyle(child);
+  return childStyle.display !== "none" && !OUT_OF_FLOW_POSITIONS.has(childStyle.position);
+};
+
+const hasVisibleSize = (rect: DOMRect): boolean => rect.width > 0 || rect.height > 0;
+
 const computeAxisGaps = (
   childRects: DOMRect[],
   contentBounds: OverlayBounds,
   axis: "row" | "column",
 ): GapRect[] => {
+  const isColumnAxis = axis === "column";
+
   const sortedRects = [...childRects].sort((a, b) =>
-    axis === "column" ? a.top - b.top : a.left - b.left,
+    isColumnAxis ? a.top - b.top : a.left - b.left,
   );
 
   const gaps: GapRect[] = [];
   for (let childIndex = 0; childIndex < sortedRects.length - 1; childIndex++) {
-    const gapStart =
-      axis === "column" ? sortedRects[childIndex].bottom : sortedRects[childIndex].right;
-    const gapEnd =
-      axis === "column" ? sortedRects[childIndex + 1].top : sortedRects[childIndex + 1].left;
+    const currentRect = sortedRects[childIndex];
+    const nextRect = sortedRects[childIndex + 1];
+    const gapStart = isColumnAxis ? currentRect.bottom : currentRect.right;
+    const gapEnd = isColumnAxis ? nextRect.top : nextRect.left;
     const gapSize = gapEnd - gapStart;
 
     if (gapSize > BOX_MODEL_GAP_THRESHOLD_PX) {
       gaps.push(
-        axis === "column"
+        isColumnAxis
           ? { x: contentBounds.x, y: gapStart, width: contentBounds.width, height: gapSize }
           : { x: gapStart, y: contentBounds.y, width: gapSize, height: contentBounds.height },
       );
@@ -87,16 +96,10 @@ const computeChildGaps = (
     return [];
   }
 
-  const childRects: DOMRect[] = [];
-  for (const child of element.children) {
-    const childStyle = window.getComputedStyle(child);
-    if (childStyle.display === "none" || OUT_OF_FLOW_POSITIONS.has(childStyle.position)) {
-      continue;
-    }
-    const rect = child.getBoundingClientRect();
-    if (rect.width === 0 && rect.height === 0) continue;
-    childRects.push(rect);
-  }
+  const childRects = Array.from(element.children)
+    .filter(isInFlowChild)
+    .map((child) => child.getBoundingClientRect())
+    .filter(hasVisibleSize);
 
   if (childRects.length < 2) return [];
 


### PR DESCRIPTION
## Summary
- Replace ancestor highlight boxes in inspect mode (Shift-hold) with a DevTools-style box model overlay showing margin, padding, content, and flex/grid gap regions
- Margin and gap regions use hatched diagonal line patterns (matching Chrome DevTools hatch style); padding and content use solid fills
- Border radius is respected and shrinks inward across layers (border → padding → content)
- Prevent default browser behavior (e.g. space-to-scroll) for non-modifier keys while activated

## Test plan
- [ ] Activate selection mode, hover element, hold Shift — verify margin (hatched), padding (solid), content (light fill) regions render correctly
- [ ] Test on elements with border-radius — verify rounded corners shrink inward per layer
- [ ] Test on flex-col/flex-row containers — verify gap hatching appears between children
- [ ] Test on elements with no padding/margin — verify no spurious regions appear
- [ ] Verify space key no longer scrolls page while in selection mode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: replaces inspect-mode rendering with new canvas Path2D/hatch logic and adds DOM/CSS-dependent box-model calculations that could affect overlay correctness/perf across browsers.
> 
> **Overview**
> **Inspect mode overlay is replaced with a DevTools-style box model view.** The overlay now renders animated `margin`, `padding`, and `content` regions (with hatched patterns for margin and layout gaps) and respects *per-corner* border radii.
> 
> This threads a new `inspectBoxModel` shape from core → renderer → `OverlayCanvas`, adds `createBoxModelBounds` (including flex/grid gap detection), and updates the canvas renderer to use `Path2D` ring fills plus cached hatch patterns. An additional Playwright e2e test asserts drag-box height growth matches auto-scroll delta; minor housekeeping updates `.gitignore` and registry JSON formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d82e2fbd4f86763502e56aa263c3557388500e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces inspect-mode ancestor boxes with a DevTools-style box model overlay. Shows margin (hatched), padding/content (solid), and flex/grid gaps with smooth animation and correct per-corner border radii.

- New Features
  - Added `createBoxModelBounds` to compute `margin`, `border`, `padding`, `content`, and `gaps`, and threaded `inspectBoxModel` from core → renderer → canvas.
  - Rendered rings using `Path2D.roundRect`, cached hatch patterns via `OffscreenCanvas`, introduced overlay colors, and enabled independent corner radii across selection/drag/grab/inspect.

- Bug Fixes
  - Read `border-*-width` longhands to avoid 0px borders.
  - Gap detection: sort by visual order, detect both axes for grid, and skip hidden, out-of-flow, and zero-size children.
  - Worked around Chromium evenodd clipping by always using `roundRect` and building ring subpaths on the same `Path2D`.
  - Added an e2e asserting drag-box height grows exactly by the auto-scroll delta.

<sup>Written for commit 6d82e2fbd4f86763502e56aa263c3557388500e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

