### PR TITLE
Fix stale element hit-testing cache causing selection to feel stuck

### DIFF
--- a/packages/react-grab/e2e/selection.spec.ts
+++ b/packages/react-grab/e2e/selection.spec.ts
@@ -31,6 +31,23 @@ test.describe("Element Selection", () => {
     expect(clipboardContent.length).toBeGreaterThan(0);
   });
 
+  test("should show selection even when page blocks pointermove bubbling", async ({ reactGrab }) => {
+    await reactGrab.activate();
+
+    await reactGrab.page.evaluate(() => {
+      window.addEventListener(
+        "pointermove",
+        (event) => {
+          event.stopImmediatePropagation();
+        },
+        { capture: false },
+      );
+    });
+
+    await reactGrab.hoverElement("li");
+    await reactGrab.waitForSelectionBox();
+  });
+
   test("should copy heading element to clipboard", async ({ reactGrab }) => {
     await reactGrab.activate();
     await reactGrab.hoverElement("[data-testid='todo-list'] h1");

--- a/packages/react-grab/package.json
+++ b/packages/react-grab/package.json
@@ -102,7 +102,6 @@
   "devDependencies": {
     "@babel/core": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
-    "solid-js": "^1.9.10",
     "@playwright/test": "^1.40.0",
     "@tailwindcss/cli": "^4.1.17",
     "@types/babel__core": "^7.20.5",
@@ -111,6 +110,7 @@
     "babel-preset-solid": "^1.9.10",
     "concurrently": "^9.1.2",
     "expect-sdk": "0.0.0-canary-20260405095424",
+    "solid-js": "^1.9.10",
     "tailwindcss": "^4.1.0",
     "tsx": "^4.21.0"
   },

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -231,7 +231,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     const isDragging = createMemo(
       () =>
         store.current.state === "active" &&
-        (store.current.phase === "dragging-select" || store.current.phase === "dragging-reposition"),
+        (store.current.phase === "dragging-select" ||
+          store.current.phase === "dragging-reposition"),
     );
     const isDragRepositioning = createMemo(
       () => store.current.state === "active" && store.current.phase === "dragging-reposition",
@@ -2569,7 +2570,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         }
         handlePointerMove(event.clientX, event.clientY);
       },
-      { passive: true },
+      { passive: true, capture: true },
     );
 
     eventListenerManager.addWindowListener(

--- a/packages/react-grab/src/core/store.ts
+++ b/packages/react-grab/src/core/store.ts
@@ -12,12 +12,7 @@ interface FrozenDragRect {
   height: number;
 }
 
-type GrabPhase =
-  | "hovering"
-  | "frozen"
-  | "dragging-select"
-  | "dragging-reposition"
-  | "justDragged";
+type GrabPhase = "hovering" | "frozen" | "dragging-select" | "dragging-reposition" | "justDragged";
 
 type GrabState =
   | { state: "idle" }

--- a/packages/react-grab/src/utils/get-element-at-position.ts
+++ b/packages/react-grab/src/utils/get-element-at-position.ts
@@ -59,7 +59,7 @@ export const getElementAtPosition = (clientX: number, clientY: number): Element 
     const isPositionClose = isWithinThreshold(clientX, clientY, cache.clientX, cache.clientY);
     const isWithinThrottle = now - cache.timestamp < ELEMENT_POSITION_THROTTLE_MS;
 
-    if (isPositionClose || isWithinThrottle) {
+    if (isPositionClose && isWithinThrottle) {
       return cache.element;
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What
Fixes hover/selection box not appearing in activation mode on pages that block `pointermove` events in the bubbling phase.

### Why
Some sites attach `pointermove` listeners that call `stopImmediatePropagation()` (bubble). Our `pointermove` listener was registered without capture, so `handlePointerMove` never ran → `detectedElement` stayed null → selection box never appeared.

### How
- Register the `pointermove` listener in capture phase (`capture: true`).
- Add a Playwright regression test that installs a bubbling-phase `pointermove` blocker and asserts the selection box still appears.

### Tests
- `pnpm --filter react-grab test`
- `pnpm test`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-363bb018-eae6-41c3-a7ab-47f6959cdb9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-363bb018-eae6-41c3-a7ab-47f6959cdb9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix hit-testing cache returning stale elements and restore hover selection when pages block `pointermove`. `getElementAtPosition` now reuses cache only when the pointer is close and within the throttle window, and we listen to `pointermove` in capture phase to avoid bubbling blocks.

<sup>Written for commit 9675cc22a16b5e906152b488c2d56c4783713732. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

