### PR TITLE
fix(web-extension): initialize on localhost when page has no react-grab

### DIFF
--- a/apps/web-extension/src/content/react-grab.ts
+++ b/apps/web-extension/src/content/react-grab.ts
@@ -90,7 +90,11 @@ const initializeReactGrab = (): Promise<ReactGrabAPI | null> => {
           resolve(delayedApi);
           return;
         }
-        resolve(null);
+        // Fall back to creating our own API if the page never announced one.
+        // Preserves the race window for pages that do install react-grab
+        // themselves, while keeping the extension functional on dev servers
+        // that don't.
+        resolve(createExtensionApi());
       }, LOCALHOST_INIT_DELAY_MS);
     });
   }


### PR DESCRIPTION
## Problem

On `localhost`, `initializeReactGrab` in `apps/web-extension/src/content/react-grab.ts` waits `LOCALHOST_INIT_DELAY_MS` (500 ms) for the page to announce its own react-grab via the `react-grab:init` event or `window.__REACT_GRAB__`, then resolves with `null` if neither appeared:

```ts
if (isLocalhost) {
  return new Promise((resolve) => {
    setTimeout(() => {
      const delayedApi = getActiveApi();
      if (delayedApi) {
        extensionApi = delayedApi;
        resolve(delayedApi);
        return;
      }
      resolve(null);              // ← extension is now inert on this tab
    }, LOCALHOST_INIT_DELAY_MS);
  });
}
```

That leaves the extension completely inert on dev servers that don't bundle `react-grab` as a dependency — which is the common case for apps where you install the extension specifically because you don't want to touch the app's source. On any non-localhost site the code path falls through to `createExtensionApi()`, so it works; on localhost it silently does nothing and users report "the extension doesn't work on my dev server".

## Fix

Fall back to `createExtensionApi()` after the race window elapses. The prefer-the-page-copy behavior is fully preserved — the 500 ms delay still runs first and adopts a page-provided API if one arrives via `react-grab:init`, so projects that install react-grab themselves get the exact same behavior they had before. Only the "nothing arrived" branch changes.

```ts
if (isLocalhost) {
  return new Promise((resolve) => {
    setTimeout(() => {
      const delayedApi = getActiveApi();
      if (delayedApi) {
        extensionApi = delayedApi;
        resolve(delayedApi);
        return;
      }
      // Fall back to creating our own API if the page never announced one.
      // Preserves the race window for pages that do install react-grab
      // themselves, while keeping the extension functional on dev servers
      // that don't.
      resolve(createExtensionApi());
    }, LOCALHOST_INIT_DELAY_MS);
  });
}
```

## Scope

One file, +5 / -1. No behavior change for non-localhost pages, no behavior change for localhost pages that do install react-grab (they still win the 500 ms race), only a fallback added for the previously-inert case.

## Verification

Tested locally on two localhost dev servers — a vanilla React 19 Vite app and a Next.js app that does not depend on `react-grab`. Before: extension icon does nothing, `window.__REACT_GRAB__` is undefined after DOMContentLoaded + 500 ms. After: extension creates its own API, overlay activates, component selection works. Pages that do import react-grab themselves continue to be adopted via the existing `react-grab:init` handshake.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to localhost-only initialization that adds a fallback to `createExtensionApi()`; low risk aside from potentially changing behavior on dev pages that intentionally rely on no API being created.
>
> **Overview**
> Fixes the web extension becoming inert on `localhost` when the page never provides a `react-grab` instance.
>
> After waiting `LOCALHOST_INIT_DELAY_MS` for a page-announced API, `initializeReactGrab` now falls back to `createExtensionApi()` instead of resolving `null`, while keeping the existing "prefer page-provided API" race window intact.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4c02940f1ed81ca8d23f267b5988cab32263ca4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
On localhost, the extension now initializes even if the page doesn't include `react-grab` by creating its own API after the 500 ms race window. Behavior is unchanged for non-localhost pages and for pages that provide an API via `react-grab:init` or `window.__REACT_GRAB__`.

<sup>Written for commit b4c02940f1ed81ca8d23f267b5988cab32263ca4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->