### PR TITLE
fix: guard sessionStorage access for SSR environments

### DIFF
--- a/packages/react-grab/src/utils/comment-storage.ts
+++ b/packages/react-grab/src/utils/comment-storage.ts
@@ -64,9 +64,14 @@ const persistCommentItems = (nextItems: CommentItem[]): CommentItem[] => {
   return commentItems;
 };
 
-migrateFromLegacyStorage();
-let commentItems: CommentItem[] = loadFromSessionStorage();
-let didConfirmClear = readSessionFlag(CLEAR_CONFIRMED_KEY);
+let commentItems: CommentItem[] = [];
+let didConfirmClear = false;
+
+if (typeof window !== "undefined") {
+  migrateFromLegacyStorage();
+  commentItems = loadFromSessionStorage();
+  didConfirmClear = readSessionFlag(CLEAR_CONFIRMED_KEY);
+}
 
 export const loadComments = (): CommentItem[] => commentItems;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When `react-grab` is used with SSR frameworks (e.g. Next.js), the `comment-storage` module throws a `ReferenceError: sessionStorage is not defined` during server-side evaluation:

```
[react-grab] Failed to load comments from sessionStorage: ReferenceError: sessionStorage is not defined
    at loadFromSessionStorage (…/core-8mQydYp7.js:1836:21)
```

The module-level calls to `migrateFromLegacyStorage()`, `loadFromSessionStorage()`, and `readSessionFlag()` run as an import side effect, even though `init()` in `index.ts` is already gated behind `typeof window !== "undefined"`.

## Fix

Wraps the three module-level initialization calls behind a single `typeof window !== "undefined"` guard — the same convention used throughout the codebase. The variables start with safe defaults (`[]`, `false`) so SSR gets a no-op module, and initialization only runs on the client.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eec00c51-8e78-43ec-8583-abc5c6e0556f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eec00c51-8e78-43ec-8583-abc5c6e0556f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded module-level `sessionStorage` access in `react-grab` for SSR. On the server we skip storage calls and use safe defaults; client behavior is unchanged.

- **Bug Fixes**
  - Wrapped `migrateFromLegacyStorage()`, `loadFromSessionStorage()`, and `readSessionFlag()` behind `typeof window !== "undefined"`.
  - Initialize `commentItems` to `[]` and `didConfirmClear` to `false` on the server; storage functions never run during SSR.
  - Prevents `ReferenceError: sessionStorage is not defined` and noisy SSR logs (e.g., Next.js).

<sup>Written for commit d6989dcfdd6c866fa857de1c3eec13d73081817b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

