### PR TITLE
feat: add skipVersionCheck option to silence outdated warning

### DIFF
--- a/.changeset/skip-version-check.md
+++ b/.changeset/skip-version-check.md
@@ -1,0 +1,5 @@
+---
+"react-grab": minor
+---
+
+Add `skipVersionCheck` option to opt out of the npm version check and silence the "outdated" console warning.

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -203,7 +203,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
   }
   hasInited = true;
 
-  logIntro();
+  logIntro({ skipVersionCheck: initialOptions.skipVersionCheck });
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- need to omit enabled from settableOptions to avoid circular dependency
   const { enabled: _enabled, ...settableOptions } = initialOptions;

--- a/packages/react-grab/src/core/log-intro.ts
+++ b/packages/react-grab/src/core/log-intro.ts
@@ -1,7 +1,7 @@
 import { LOGO_SVG } from "./logo-svg.js";
 import { isExtensionContext } from "../utils/is-extension-context.js";
 
-export const logIntro = () => {
+export const logIntro = (options?: { skipVersionCheck?: boolean }) => {
   try {
     const version = process.env.VERSION;
     const logoDataUri = `data:image/svg+xml;base64,${btoa(LOGO_SVG)}`;
@@ -10,6 +10,7 @@ export const logIntro = () => {
       `background: #330039; color: #ffffff; border: 1px solid #d75fcb; padding: 4px 4px 4px 24px; border-radius: 4px; background-image: url("${logoDataUri}"); background-size: 16px 16px; background-repeat: no-repeat; background-position: 4px center; display: inline-block; margin-bottom: 4px;`,
       "",
     );
+    if (options?.skipVersionCheck) return;
     if (navigator.onLine && version && !isExtensionContext()) {
       fetch(`https://www.react-grab.com/api/version?source=browser&v=${version}&t=${Date.now()}`, {
         referrerPolicy: "origin",

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -252,6 +252,12 @@ export interface Options {
    * @default true
    */
   freezeReactUpdates?: boolean;
+  /**
+   * Whether to skip the version check that logs a warning when a newer
+   * version of React Grab is available on npm.
+   * @default false
+   */
+  skipVersionCheck?: boolean;
 }
 
 export interface SettableOptions extends Options {

--- a/packages/react-grab/src/utils/get-script-options.ts
+++ b/packages/react-grab/src/utils/get-script-options.ts
@@ -30,6 +30,9 @@ const parseOptionsFromJson = (rawValue: unknown): Partial<Options> | null => {
   if (typeof rawValue.freezeReactUpdates === "boolean") {
     parsedOptions.freezeReactUpdates = rawValue.freezeReactUpdates;
   }
+  if (typeof rawValue.skipVersionCheck === "boolean") {
+    parsedOptions.skipVersionCheck = rawValue.skipVersionCheck;
+  }
 
   if (Object.keys(parsedOptions).length === 0) return null;
   return parsedOptions;


### PR DESCRIPTION
Closes #293.

## Summary

Adds a `skipVersionCheck` option so consumers can opt out of the npm version check in `logIntro` (and the associated `[React Grab] vX is outdated ...` console warning). Useful for projects that pin versions intentionally, run in environments where the network request is undesirable, or simply want a quiet console.

## Changes

- `Options.skipVersionCheck?: boolean` (defaults to `false`) in `packages/react-grab/src/types.ts`
- `logIntro` accepts `{ skipVersionCheck }` and short-circuits before the `fetch` when true
- `init()` forwards the option to `logIntro`
- `getScriptOptions()` parses `data-options='{"skipVersionCheck": true}'` from the script tag
- Changeset added (minor)

The intro banner still logs as before — only the network check + warning are gated.

## Usage

```ts
import { init } from "react-grab";

init({ skipVersionCheck: true });
```

Or via the script tag:

```html
<script src="..." data-options='{"skipVersionCheck": true}'></script>
```

## Checks

- `pnpm --filter react-grab typecheck` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional flag that only short-circuits the startup version-check fetch and related warning, without changing core grabbing/overlay behavior.
> 
> **Overview**
> Adds a new `Options.skipVersionCheck` flag that lets consumers opt out of React Grab’s startup npm version check (and the associated “outdated” console warning) while keeping the intro banner log unchanged.
> 
> `init()` now forwards the option into `logIntro`, `logIntro` returns early before performing the network `fetch` when enabled, and `getScriptOptions()` supports parsing `skipVersionCheck` from the script tag’s `data-options` JSON. Includes a changeset for a minor `react-grab` release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 723cfae53baed33b204e4fd1fb544af93635f8a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `skipVersionCheck` option to `react-grab` to bypass the npm version check in `logIntro` and silence the outdated-version warning. Default is false; the intro banner still logs.

- **New Features**
  - Added `Options.skipVersionCheck?: boolean`, including `data-options` script-tag support.
  - `init()` forwards the option to `logIntro`, which short-circuits the network request and warning when true.

<sup>Written for commit 723cfae53baed33b204e4fd1fb544af93635f8a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

