### PR TITLE
fix: restore toolbar border and shadow styling

### DIFF
--- a/packages/react-grab/src/components/toolbar/toolbar-content.tsx
+++ b/packages/react-grab/src/components/toolbar/toolbar-content.tsx
@@ -88,7 +88,7 @@ export const ToolbarContent: Component<ToolbarContentProps> = (props) => {
   return (
     <div
       class={cn(
-        "flex items-center justify-center rounded-[10px] antialiased relative overflow-visible [font-synthesis:none] shadow-[0px_1px_2px_#51515140] [corner-shape:superellipse(1.25)]",
+        "flex items-center justify-center rounded-[10px] antialiased relative overflow-visible [font-synthesis:none] border border-[#D9D9D9] filter-[drop-shadow(0px_1px_2px_#51515140)] [corner-shape:superellipse(1.25)]",
         isVertical() && "flex-col",
         "bg-white",
         !props.isCollapsed && (isVertical() ? "px-1.5 gap-1 py-2" : "py-1.5 gap-1 px-2"),

--- a/packages/react-grab/src/components/toolbar/toolbar-content.tsx
+++ b/packages/react-grab/src/components/toolbar/toolbar-content.tsx
@@ -88,7 +88,7 @@ export const ToolbarContent: Component<ToolbarContentProps> = (props) => {
   return (
     <div
       class={cn(
-        "flex items-center justify-center rounded-[10px] antialiased relative overflow-visible [font-synthesis:none] border border-[#D9D9D9] filter-[drop-shadow(0px_1px_2px_#51515140)] [corner-shape:superellipse(1.25)]",
+        "flex items-center justify-center rounded-[10px] antialiased relative overflow-visible [font-synthesis:none] border border-[#D9D9D9] filter-[drop-shadow(0px_1px_2px_#51515133)] [corner-shape:superellipse(1.25)]",
         isVertical() && "flex-col",
         "bg-white",
         !props.isCollapsed && (isVertical() ? "px-1.5 gap-1 py-2" : "py-1.5 gap-1 px-2"),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- restore the toolbar panel gray border styling on the toolbar container
- restore toolbar drop shadow rendering using a drop-shadow filter on the same container
- soften the drop shadow opacity slightly for a subtler visual effect
- keep all changes scoped to `packages/react-grab/src/components/toolbar/toolbar-content.tsx`

## Testing
- `nr build`
- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format`

## Notes
- Playwright Chromium was installed earlier in this branch to satisfy e2e runtime requirements
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b2f6df4-4ef4-4174-b44e-aac06b42466d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b2f6df4-4ef4-4174-b44e-aac06b42466d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the toolbar border and drop shadow to fix a visual regression, and softens the shadow opacity. Updates `ToolbarContent` to add a gray `#D9D9D9` border and a `drop-shadow(0px 1px 2px #51515133)` filter, scoped to the toolbar only.

<sup>Written for commit 2dbc6180a555c3e2f59d5efd3940b12a578f0c29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

