### PR TITLE
Fix toolbar disappearing after delayed startup re-append

### DIFF
--- a/packages/react-grab/e2e/toolbar.spec.ts
+++ b/packages/react-grab/e2e/toolbar.spec.ts
@@ -42,7 +42,7 @@ test.describe("Toolbar", () => {
         originalBody.parentNode.replaceChild(replacementBody, originalBody);
       });
 
-      await expect.poll(() => reactGrab.isToolbarVisible(), { timeout: 4000 }).toBe(true);
+      await expect.poll(() => reactGrab.isToolbarVisible(), { timeout: 6000 }).toBe(true);
     });
   });
 

--- a/packages/react-grab/e2e/toolbar.spec.ts
+++ b/packages/react-grab/e2e/toolbar.spec.ts
@@ -33,6 +33,17 @@ test.describe("Toolbar", () => {
       await reactGrab.setViewportSize(1280, 720);
       await expect.poll(() => reactGrab.isToolbarVisible(), { timeout: 2000 }).toBe(true);
     });
+
+    test("toolbar should recover after body replacement during startup", async ({ reactGrab }) => {
+      await reactGrab.page.evaluate(() => {
+        const originalBody = document.body;
+        if (!originalBody || !originalBody.parentNode) return;
+        const replacementBody = originalBody.cloneNode(true);
+        originalBody.parentNode.replaceChild(replacementBody, originalBody);
+      });
+
+      await expect.poll(() => reactGrab.isToolbarVisible(), { timeout: 4000 }).toBe(true);
+    });
   });
 
   test.describe("Toggle Activation", () => {

--- a/packages/react-grab/src/utils/mount-root.ts
+++ b/packages/react-grab/src/utils/mount-root.ts
@@ -8,25 +8,12 @@ const FONT_IMPORT =
   '@import url("https://fonts.googleapis.com/css2?family=Geist:wght@500&display=swap");';
 
 export const mountRoot = (cssText?: string) => {
-  const getMountTarget = (): HTMLElement => document.body ?? document.documentElement;
-
-  const pruneAndGetMountedRoot = (activeHost?: HTMLElement): HTMLDivElement | null => {
-    let existingRoot: HTMLDivElement | null = null;
-    const mountedHosts = document.querySelectorAll<HTMLElement>(`[${ATTRIBUTE_NAME}]`);
-    for (const mountedHost of mountedHosts) {
-      if (mountedHost === activeHost) continue;
-      const mountedRoot = mountedHost.shadowRoot?.querySelector(`[${ATTRIBUTE_NAME}]`);
-      if (mountedRoot instanceof HTMLDivElement && !existingRoot) {
-        existingRoot = mountedRoot;
-        continue;
-      }
-      mountedHost.remove();
-    }
-    return existingRoot;
-  };
-
-  const mountedRoot = pruneAndGetMountedRoot();
-  if (mountedRoot) return mountedRoot;
+  const mountedHosts = document.querySelectorAll<HTMLElement>(`[${ATTRIBUTE_NAME}]`);
+  for (const mountedHost of mountedHosts) {
+    const mountedRoot = mountedHost.shadowRoot?.querySelector(`[${ATTRIBUTE_NAME}]`);
+    if (mountedRoot instanceof HTMLDivElement) return mountedRoot;
+    mountedHost.remove();
+  }
 
   const host = document.createElement("div");
 
@@ -51,49 +38,11 @@ export const mountRoot = (cssText?: string) => {
 
   shadowRoot.appendChild(root);
 
-  const ensureHostMounted = () => {
-    pruneAndGetMountedRoot(host);
-    const mountTarget = getMountTarget();
-    if (host.parentNode === mountTarget && host.isConnected) return;
+  const mountTarget = document.documentElement;
+  mountTarget.appendChild(host);
+  setTimeout(() => {
     mountTarget.appendChild(host);
-  };
-
-  ensureHostMounted();
-
-  const delayedRecheckTimeoutId = setTimeout(() => {
-    ensureHostMounted();
   }, MOUNT_ROOT_RECHECK_DELAY_MS);
-
-  let observedBody: HTMLElement | null = null;
-  const bodyObserver = new MutationObserver(() => {
-    ensureHostMounted();
-  });
-
-  const attachBodyObserver = () => {
-    const currentBody = document.body;
-    if (currentBody === observedBody) return;
-    bodyObserver.disconnect();
-    observedBody = currentBody;
-    if (currentBody) bodyObserver.observe(currentBody, { childList: true });
-  };
-
-  const rootObserver = new MutationObserver(() => {
-    attachBodyObserver();
-    ensureHostMounted();
-  });
-
-  rootObserver.observe(document.documentElement, { childList: true });
-  attachBodyObserver();
-
-  window.addEventListener(
-    "beforeunload",
-    () => {
-      clearTimeout(delayedRecheckTimeoutId);
-      rootObserver.disconnect();
-      bodyObserver.disconnect();
-    },
-    { once: true },
-  );
 
   return root;
 };

--- a/packages/react-grab/src/utils/mount-root.ts
+++ b/packages/react-grab/src/utils/mount-root.ts
@@ -12,10 +12,23 @@ export const mountRoot = (cssText?: string) => {
     return document.body ?? document.documentElement;
   };
 
-  const mountedHost = document.querySelector(`[${ATTRIBUTE_NAME}]`);
-  if (mountedHost) {
+  const removeBrokenHosts = (activeHost?: HTMLElement): void => {
+    const mountedHosts = document.querySelectorAll<HTMLElement>(`[${ATTRIBUTE_NAME}]`);
+    for (const mountedHost of mountedHosts) {
+      if (mountedHost === activeHost) continue;
+      const mountedRoot = mountedHost.shadowRoot?.querySelector(`[${ATTRIBUTE_NAME}]`);
+      if (!(mountedRoot instanceof HTMLDivElement)) {
+        mountedHost.remove();
+      }
+    }
+  };
+
+  removeBrokenHosts();
+
+  const mountedHosts = document.querySelectorAll<HTMLElement>(`[${ATTRIBUTE_NAME}]`);
+  for (const mountedHost of mountedHosts) {
     const mountedRoot = mountedHost.shadowRoot?.querySelector(`[${ATTRIBUTE_NAME}]`);
-    if (mountedRoot instanceof HTMLDivElement && mountedHost.shadowRoot) {
+    if (mountedRoot instanceof HTMLDivElement) {
       return mountedRoot;
     }
   }
@@ -44,6 +57,7 @@ export const mountRoot = (cssText?: string) => {
   shadowRoot.appendChild(root);
 
   const appendHostToMountTarget = () => {
+    removeBrokenHosts(host);
     const mountTarget = getMountTarget();
     if (host.parentNode !== mountTarget || !host.isConnected) {
       mountTarget.appendChild(host);
@@ -60,6 +74,15 @@ export const mountRoot = (cssText?: string) => {
   setTimeout(() => {
     appendHostToMountTarget();
   }, MOUNT_ROOT_RECHECK_DELAY_MS);
+
+  const mountObserver = new MutationObserver(() => {
+    if (host.isConnected && host.parentNode === getMountTarget()) {
+      return;
+    }
+    appendHostToMountTarget();
+  });
+  mountObserver.observe(document.documentElement, { childList: true, subtree: true });
+  window.addEventListener("beforeunload", () => mountObserver.disconnect(), { once: true });
 
   return root;
 };

--- a/packages/react-grab/src/utils/mount-root.ts
+++ b/packages/react-grab/src/utils/mount-root.ts
@@ -70,7 +70,7 @@ export const mountRoot = (cssText?: string) => {
 
   // Observe only direct child list changes on <html> and <body> to detect
   // host removal and body replacement without paying subtree-wide costs.
-  let observedBody: HTMLBodyElement | null = null;
+  let observedBody: HTMLElement | null = null;
   const bodyObserver = new MutationObserver(() => {
     if (host.isConnected && host.parentNode === getMountTarget()) return;
     appendHostToMountTarget();

--- a/packages/react-grab/src/utils/mount-root.ts
+++ b/packages/react-grab/src/utils/mount-root.ts
@@ -10,22 +10,23 @@ const FONT_IMPORT =
 export const mountRoot = (cssText?: string) => {
   const getMountTarget = (): HTMLElement => document.body ?? document.documentElement;
 
-  const removeBrokenHosts = (activeHost?: HTMLElement): void => {
+  const pruneAndGetMountedRoot = (activeHost?: HTMLElement): HTMLDivElement | null => {
+    let existingRoot: HTMLDivElement | null = null;
     const mountedHosts = document.querySelectorAll<HTMLElement>(`[${ATTRIBUTE_NAME}]`);
     for (const mountedHost of mountedHosts) {
       if (mountedHost === activeHost) continue;
       const mountedRoot = mountedHost.shadowRoot?.querySelector(`[${ATTRIBUTE_NAME}]`);
-      if (!(mountedRoot instanceof HTMLDivElement)) mountedHost.remove();
+      if (mountedRoot instanceof HTMLDivElement && !existingRoot) {
+        existingRoot = mountedRoot;
+        continue;
+      }
+      mountedHost.remove();
     }
+    return existingRoot;
   };
 
-  removeBrokenHosts();
-
-  const mountedHosts = document.querySelectorAll<HTMLElement>(`[${ATTRIBUTE_NAME}]`);
-  for (const mountedHost of mountedHosts) {
-    const mountedRoot = mountedHost.shadowRoot?.querySelector(`[${ATTRIBUTE_NAME}]`);
-    if (mountedRoot instanceof HTMLDivElement) return mountedRoot;
-  }
+  const mountedRoot = pruneAndGetMountedRoot();
+  if (mountedRoot) return mountedRoot;
 
   const host = document.createElement("div");
 
@@ -50,30 +51,22 @@ export const mountRoot = (cssText?: string) => {
 
   shadowRoot.appendChild(root);
 
-  const appendHostToMountTarget = () => {
+  const ensureHostMounted = () => {
+    pruneAndGetMountedRoot(host);
     const mountTarget = getMountTarget();
     if (host.parentNode === mountTarget && host.isConnected) return;
     mountTarget.appendChild(host);
   };
 
-  appendHostToMountTarget();
+  ensureHostMounted();
 
-  // Re-appending after a delay handles two cases: framework hydration
-  // (React/Next.js) may blow away the DOM and remove our host, and another
-  // tool (e.g. react-scan) may have appended at the same z-index where last
-  // DOM child wins the stacking tiebreaker. Moving an already-attached node
-  // via appendChild is atomic with no flash or reflow.
   const delayedRecheckTimeoutId = setTimeout(() => {
-    removeBrokenHosts(host);
-    appendHostToMountTarget();
+    ensureHostMounted();
   }, MOUNT_ROOT_RECHECK_DELAY_MS);
 
-  // Observe only direct child list changes on <html> and <body> to detect
-  // host removal and body replacement without paying subtree-wide costs.
   let observedBody: HTMLElement | null = null;
   const bodyObserver = new MutationObserver(() => {
-    if (host.isConnected && host.parentNode === getMountTarget()) return;
-    appendHostToMountTarget();
+    ensureHostMounted();
   });
 
   const attachBodyObserver = () => {
@@ -85,9 +78,8 @@ export const mountRoot = (cssText?: string) => {
   };
 
   const rootObserver = new MutationObserver(() => {
-    removeBrokenHosts(host);
     attachBodyObserver();
-    appendHostToMountTarget();
+    ensureHostMounted();
   });
 
   rootObserver.observe(document.documentElement, { childList: true });

--- a/packages/react-grab/src/utils/mount-root.ts
+++ b/packages/react-grab/src/utils/mount-root.ts
@@ -40,6 +40,11 @@ export const mountRoot = (cssText?: string) => {
 
   const mountTarget = document.documentElement;
   mountTarget.appendChild(host);
+  // Re-appending after a delay handles two cases: framework hydration
+  // (React/Next.js) may blow away the DOM and remove our host, and another
+  // tool (e.g. react-scan) may have appended at the same z-index where last
+  // DOM child wins the stacking tiebreaker. Moving an already-attached node
+  // via appendChild is atomic with no flash or reflow.
   setTimeout(() => {
     mountTarget.appendChild(host);
   }, MOUNT_ROOT_RECHECK_DELAY_MS);

--- a/packages/react-grab/src/utils/mount-root.ts
+++ b/packages/react-grab/src/utils/mount-root.ts
@@ -8,18 +8,14 @@ const FONT_IMPORT =
   '@import url("https://fonts.googleapis.com/css2?family=Geist:wght@500&display=swap");';
 
 export const mountRoot = (cssText?: string) => {
-  const getMountTarget = (): HTMLElement => {
-    return document.body ?? document.documentElement;
-  };
+  const getMountTarget = (): HTMLElement => document.body ?? document.documentElement;
 
   const removeBrokenHosts = (activeHost?: HTMLElement): void => {
     const mountedHosts = document.querySelectorAll<HTMLElement>(`[${ATTRIBUTE_NAME}]`);
     for (const mountedHost of mountedHosts) {
       if (mountedHost === activeHost) continue;
       const mountedRoot = mountedHost.shadowRoot?.querySelector(`[${ATTRIBUTE_NAME}]`);
-      if (!(mountedRoot instanceof HTMLDivElement)) {
-        mountedHost.remove();
-      }
+      if (!(mountedRoot instanceof HTMLDivElement)) mountedHost.remove();
     }
   };
 
@@ -28,9 +24,7 @@ export const mountRoot = (cssText?: string) => {
   const mountedHosts = document.querySelectorAll<HTMLElement>(`[${ATTRIBUTE_NAME}]`);
   for (const mountedHost of mountedHosts) {
     const mountedRoot = mountedHost.shadowRoot?.querySelector(`[${ATTRIBUTE_NAME}]`);
-    if (mountedRoot instanceof HTMLDivElement) {
-      return mountedRoot;
-    }
+    if (mountedRoot instanceof HTMLDivElement) return mountedRoot;
   }
 
   const host = document.createElement("div");
@@ -57,11 +51,9 @@ export const mountRoot = (cssText?: string) => {
   shadowRoot.appendChild(root);
 
   const appendHostToMountTarget = () => {
-    removeBrokenHosts(host);
     const mountTarget = getMountTarget();
-    if (host.parentNode !== mountTarget || !host.isConnected) {
-      mountTarget.appendChild(host);
-    }
+    if (host.parentNode === mountTarget && host.isConnected) return;
+    mountTarget.appendChild(host);
   };
 
   appendHostToMountTarget();
@@ -71,18 +63,45 @@ export const mountRoot = (cssText?: string) => {
   // tool (e.g. react-scan) may have appended at the same z-index where last
   // DOM child wins the stacking tiebreaker. Moving an already-attached node
   // via appendChild is atomic with no flash or reflow.
-  setTimeout(() => {
+  const delayedRecheckTimeoutId = setTimeout(() => {
+    removeBrokenHosts(host);
     appendHostToMountTarget();
   }, MOUNT_ROOT_RECHECK_DELAY_MS);
 
-  const mountObserver = new MutationObserver(() => {
-    if (host.isConnected && host.parentNode === getMountTarget()) {
-      return;
-    }
+  // Observe only direct child list changes on <html> and <body> to detect
+  // host removal and body replacement without paying subtree-wide costs.
+  let observedBody: HTMLBodyElement | null = null;
+  const bodyObserver = new MutationObserver(() => {
+    if (host.isConnected && host.parentNode === getMountTarget()) return;
     appendHostToMountTarget();
   });
-  mountObserver.observe(document.documentElement, { childList: true, subtree: true });
-  window.addEventListener("beforeunload", () => mountObserver.disconnect(), { once: true });
+
+  const attachBodyObserver = () => {
+    const currentBody = document.body;
+    if (currentBody === observedBody) return;
+    bodyObserver.disconnect();
+    observedBody = currentBody;
+    if (currentBody) bodyObserver.observe(currentBody, { childList: true });
+  };
+
+  const rootObserver = new MutationObserver(() => {
+    removeBrokenHosts(host);
+    attachBodyObserver();
+    appendHostToMountTarget();
+  });
+
+  rootObserver.observe(document.documentElement, { childList: true });
+  attachBodyObserver();
+
+  window.addEventListener(
+    "beforeunload",
+    () => {
+      clearTimeout(delayedRecheckTimeoutId);
+      rootObserver.disconnect();
+      bodyObserver.disconnect();
+    },
+    { once: true },
+  );
 
   return root;
 };

--- a/packages/react-grab/src/utils/mount-root.ts
+++ b/packages/react-grab/src/utils/mount-root.ts
@@ -8,6 +8,10 @@ const FONT_IMPORT =
   '@import url("https://fonts.googleapis.com/css2?family=Geist:wght@500&display=swap");';
 
 export const mountRoot = (cssText?: string) => {
+  const getMountTarget = (): HTMLElement => {
+    return document.body ?? document.documentElement;
+  };
+
   const mountedHost = document.querySelector(`[${ATTRIBUTE_NAME}]`);
   if (mountedHost) {
     const mountedRoot = mountedHost.shadowRoot?.querySelector(`[${ATTRIBUTE_NAME}]`);
@@ -39,8 +43,14 @@ export const mountRoot = (cssText?: string) => {
 
   shadowRoot.appendChild(root);
 
-  const doc = document.body ?? document.documentElement;
-  doc.appendChild(host);
+  const appendHostToMountTarget = () => {
+    const mountTarget = getMountTarget();
+    if (host.parentNode !== mountTarget || !host.isConnected) {
+      mountTarget.appendChild(host);
+    }
+  };
+
+  appendHostToMountTarget();
 
   // Re-appending after a delay handles two cases: framework hydration
   // (React/Next.js) may blow away the DOM and remove our host, and another
@@ -48,7 +58,7 @@ export const mountRoot = (cssText?: string) => {
   // DOM child wins the stacking tiebreaker. Moving an already-attached node
   // via appendChild is atomic with no flash or reflow.
   setTimeout(() => {
-    doc.appendChild(host);
+    appendHostToMountTarget();
   }, MOUNT_ROOT_RECHECK_DELAY_MS);
 
   return root;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- simplify toolbar-host recovery to a minimal approach:
  - append host to `document.documentElement` once on mount
  - append it again after `MOUNT_ROOT_RECHECK_DELAY_MS` to recover from hydration/removal and win stacking-order ties
- keep existing mounted-host reuse and cleanup of broken hosts
- restore rationale comment explaining why delayed re-append exists
- slightly increase startup body-replacement regression timeout to reduce CI flake risk

## Testing
- `pnpm typecheck`
- `pnpm --filter react-grab test e2e/toolbar.spec.ts --grep "recover after body replacement during startup"`
- `pnpm build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de2c8241-6fd9-4099-b5eb-1a6855b5da77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de2c8241-6fd9-4099-b5eb-1a6855b5da77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the toolbar disappearing when apps replace the `<body>` or rebuild the DOM. We now always mount to `<html>` and re-append after a short delay so the toolbar stays visible after hydration or DOM swaps.

- **Bug Fixes**
  - Simplified recovery: mount to `document.documentElement` and re-append after a short delay to handle hydration and z-index ties.
  - Deduplicate hosts: reuse an existing valid root; remove broken hosts.
  - Add regression e2e for startup body replacement; increase timeout to 6s to cover slow hydration.

<sup>Written for commit 9940a542d26f936a3a823eb3dcb0a119fc29c1eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

