### PR TITLE
Prevent selection changes while grabbing

### DIFF
--- a/packages/react-grab/e2e/selection.spec.ts
+++ b/packages/react-grab/e2e/selection.spec.ts
@@ -59,6 +59,60 @@ test.describe("Element Selection", () => {
     expect(clipboardMetadata.entries[0].content).toContain("Todo List");
   });
 
+  test("should block page text selection while grabbing", async ({ reactGrab }) => {
+    await reactGrab.page.evaluate(() => {
+      const api = (
+        window as {
+          __REACT_GRAB__?: {
+            unregisterPlugin: (name: string) => void;
+            registerPlugin: (plugin: Record<string, unknown>) => void;
+          };
+        }
+      ).__REACT_GRAB__;
+      api?.unregisterPlugin("slow-copy-hook");
+      api?.registerPlugin({
+        name: "slow-copy-hook",
+        hooks: {
+          onBeforeCopy: async () => {
+            await new Promise((resolve) => setTimeout(resolve, 600));
+          },
+        },
+      });
+    });
+
+    await reactGrab.activate();
+    await reactGrab.hoverElement("[data-testid='main-description']");
+    await reactGrab.waitForSelectionBox();
+    await reactGrab.clickElement("[data-testid='main-description']");
+
+    await expect
+      .poll(async () => {
+        const state = await reactGrab.getState();
+        return state.isCopying;
+      })
+      .toBe(true);
+
+    const description = reactGrab.page.locator("[data-testid='main-description']");
+    const descriptionBounds = await description.boundingBox();
+    if (!descriptionBounds) {
+      throw new Error("Could not get main description bounds");
+    }
+
+    await reactGrab.page.mouse.move(descriptionBounds.x + 5, descriptionBounds.y + descriptionBounds.height / 2);
+    await reactGrab.page.mouse.down();
+    await reactGrab.page.mouse.move(
+      descriptionBounds.x + descriptionBounds.width - 5,
+      descriptionBounds.y + descriptionBounds.height / 2,
+      { steps: 8 },
+    );
+    await reactGrab.page.mouse.up();
+
+    const selectedText = await reactGrab.page.evaluate(() => {
+      return window.getSelection()?.toString().trim() ?? "";
+    });
+    expect(selectedText).toBe("");
+  });
+
   test("should highlight different elements when hovering", async ({ reactGrab }) => {
     await reactGrab.activate();
 

--- a/packages/react-grab/e2e/selection.spec.ts
+++ b/packages/react-grab/e2e/selection.spec.ts
@@ -98,7 +98,10 @@ test.describe("Element Selection", () => {
       throw new Error("Could not get main description bounds");
     }
 
-    await reactGrab.page.mouse.move(descriptionBounds.x + 5, descriptionBounds.y + descriptionBounds.height / 2);
+    await reactGrab.page.mouse.move(
+      descriptionBounds.x + 5,
+      descriptionBounds.y + descriptionBounds.height / 2,
+    );
     await reactGrab.page.mouse.down();
     await reactGrab.page.mouse.move(
       descriptionBounds.x + descriptionBounds.width - 5,

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -240,9 +240,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       () => store.current.state === "active" && store.current.phase === "justDragged",
     );
     const isCopying = createMemo(() => store.current.state === "copying");
-    const [selectionInteractionLockDepth, setSelectionInteractionLockDepth] = createSignal(0);
     const isSelectionInteractionLocked = createMemo(
-      () => isCopying() || selectionInteractionLockDepth() > 0,
+      () => isCopying() || store.selectionInteractionLockDepth > 0,
     );
     const didJustCopy = createMemo(() => store.current.state === "justCopied");
     const isPromptMode = createMemo(
@@ -3106,11 +3105,11 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     );
 
     const withSelectionInteractionLock = async <T,>(operation: () => Promise<T>): Promise<T> => {
-      setSelectionInteractionLockDepth((currentLockDepth) => currentLockDepth + 1);
+      actions.incrementSelectionInteractionLockDepth();
       try {
         return await operation();
       } finally {
-        setSelectionInteractionLockDepth((currentLockDepth) => Math.max(0, currentLockDepth - 1));
+        actions.decrementSelectionInteractionLockDepth();
       }
     };
 

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -240,10 +240,9 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       () => store.current.state === "active" && store.current.phase === "justDragged",
     );
     const isCopying = createMemo(() => store.current.state === "copying");
+    const [selectionInteractionLockDepth, setSelectionInteractionLockDepth] = createSignal(0);
     const isSelectionInteractionLocked = createMemo(
-      () =>
-        isCopying() ||
-        store.labelInstances.some((labelInstance) => labelInstance.status === "copying"),
+      () => isCopying() || selectionInteractionLockDepth() > 0,
     );
     const didJustCopy = createMemo(() => store.current.state === "justCopied");
     const isPromptMode = createMemo(
@@ -3106,6 +3105,15 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       },
     );
 
+    const withSelectionInteractionLock = async <T,>(operation: () => Promise<T>): Promise<T> => {
+      setSelectionInteractionLockDepth((currentLockDepth) => currentLockDepth + 1);
+      try {
+        return await operation();
+      } finally {
+        setSelectionInteractionLockDepth((currentLockDepth) => Math.max(0, currentLockDepth - 1));
+      }
+    };
+
     const createPerformWithFeedback = (
       element: Element,
       elements: Element[],
@@ -3114,73 +3122,75 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       options?: PerformWithFeedbackOptions,
     ) => {
       return async (action: () => Promise<boolean>): Promise<void> => {
-        const fallbackBounds = options?.fallbackBounds ?? null;
-        const fallbackSelectionBounds = options?.fallbackSelectionBounds ?? [];
-        const position = options?.position ?? store.contextMenuPosition ?? store.pointer;
-        const frozenBounds = frozenElementsBounds();
-        const singleElementBounds = contextMenuBounds() ?? fallbackBounds;
-        const hasMultipleElements = elements.length > 1;
+        await withSelectionInteractionLock(async () => {
+          const fallbackBounds = options?.fallbackBounds ?? null;
+          const fallbackSelectionBounds = options?.fallbackSelectionBounds ?? [];
+          const position = options?.position ?? store.contextMenuPosition ?? store.pointer;
+          const frozenBounds = frozenElementsBounds();
+          const singleElementBounds = contextMenuBounds() ?? fallbackBounds;
+          const hasMultipleElements = elements.length > 1;
 
-        const labelBounds = hasMultipleElements
-          ? createFlatOverlayBounds(combineBounds(frozenBounds))
-          : singleElementBounds;
+          const labelBounds = hasMultipleElements
+            ? createFlatOverlayBounds(combineBounds(frozenBounds))
+            : singleElementBounds;
 
-        const shouldDeactivateAfter = store.wasActivatedByToggle;
-        let selectionBoundsForLabel: OverlayBounds[];
-        if (hasMultipleElements) {
-          selectionBoundsForLabel = frozenBounds;
-        } else if (singleElementBounds) {
-          selectionBoundsForLabel = [singleElementBounds];
-        } else {
-          selectionBoundsForLabel = fallbackSelectionBounds;
-        }
+          const shouldDeactivateAfter = store.wasActivatedByToggle;
+          let selectionBoundsForLabel: OverlayBounds[];
+          if (hasMultipleElements) {
+            selectionBoundsForLabel = frozenBounds;
+          } else if (singleElementBounds) {
+            selectionBoundsForLabel = [singleElementBounds];
+          } else {
+            selectionBoundsForLabel = fallbackSelectionBounds;
+          }
 
-        actions.hideContextMenu();
+          actions.hideContextMenu();
 
-        if (labelBounds) {
-          const labelCursorX = hasMultipleElements
-            ? labelBounds.x + labelBounds.width / 2
-            : position.x;
+          if (labelBounds) {
+            const labelCursorX = hasMultipleElements
+              ? labelBounds.x + labelBounds.width / 2
+              : position.x;
 
-          const labelInstanceId = createLabelInstance(
-            labelBounds,
-            tagName || "element",
-            componentName,
-            "copying",
-            {
-              element,
-              mouseX: labelCursorX,
-              elements: hasMultipleElements ? elements : undefined,
-              boundsMultiple: selectionBoundsForLabel,
-            },
-          );
+            const labelInstanceId = createLabelInstance(
+              labelBounds,
+              tagName || "element",
+              componentName,
+              "copying",
+              {
+                element,
+                mouseX: labelCursorX,
+                elements: hasMultipleElements ? elements : undefined,
+                boundsMultiple: selectionBoundsForLabel,
+              },
+            );
 
-          let didSucceed = false;
-          let errorMessage: string | undefined;
+            let didSucceed = false;
+            let errorMessage: string | undefined;
 
-          try {
-            didSucceed = await action();
-            if (!didSucceed) {
-              errorMessage = "Failed to copy";
+            try {
+              didSucceed = await action();
+              if (!didSucceed) {
+                errorMessage = "Failed to copy";
+              }
+            } catch (error) {
+              errorMessage = normalizeErrorMessage(error, "Action failed");
             }
-          } catch (error) {
-            errorMessage = normalizeErrorMessage(error, "Action failed");
+
+            updateLabelAfterCopy(labelInstanceId, didSucceed, errorMessage);
+          } else {
+            try {
+              await action();
+            } catch (error) {
+              logRecoverableError("Action failed without feedback bounds", error);
+            }
           }
 
-          updateLabelAfterCopy(labelInstanceId, didSucceed, errorMessage);
-        } else {
-          try {
-            await action();
-          } catch (error) {
-            logRecoverableError("Action failed without feedback bounds", error);
+          if (shouldDeactivateAfter) {
+            deactivateRenderer();
+          } else {
+            actions.unfreeze();
           }
-        }
-
-        if (shouldDeactivateAfter) {
-          deactivateRenderer();
-        } else {
-          actions.unfreeze();
-        }
+        });
       };
     };
 

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -240,6 +240,10 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       () => store.current.state === "active" && store.current.phase === "justDragged",
     );
     const isCopying = createMemo(() => store.current.state === "copying");
+    const isSelectionInteractionLocked = createMemo(
+      () =>
+        isCopying() || store.labelInstances.some((labelInstance) => labelInstance.status === "copying"),
+    );
     const didJustCopy = createMemo(() => store.current.state === "justCopied");
     const isPromptMode = createMemo(
       () => store.current.state === "active" && Boolean(store.current.isPromptMode),
@@ -952,7 +956,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
     const targetElement = createMemo(() => {
       void store.viewportVersion;
-      if (!isRendererActive() || isDragging()) return null;
+      if (!isRendererActive() || isDragging() || isSelectionInteractionLocked()) return null;
       const element = store.detectedElement;
       if (!isElementConnected(element)) return null;
       return element;
@@ -1598,8 +1602,15 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
 
     const handlePointerMove = (clientX: number, clientY: number) => {
-      if (!isEnabled() || isPromptMode() || isFrozenPhase() || store.contextMenuPosition !== null)
+      if (
+        !isEnabled() ||
+        isPromptMode() ||
+        isFrozenPhase() ||
+        isSelectionInteractionLocked() ||
+        store.contextMenuPosition !== null
+      ) {
         return;
+      }
 
       actions.setPointer({ x: clientX, y: clientY });
 
@@ -1654,7 +1665,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
 
     const handlePointerDown = (clientX: number, clientY: number) => {
-      if (!isRendererActive() || isCopying()) return false;
+      if (!isRendererActive() || isSelectionInteractionLocked()) return false;
 
       actions.startDrag({ x: clientX, y: clientY });
       actions.setPointer({ x: clientX, y: clientY });
@@ -1957,6 +1968,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     const handleEnterKeyActivation = (event: KeyboardEvent): boolean => {
       if (!isEnterCode(event.code)) return false;
       if (isKeyboardEventTriggeredByInput(event)) return false;
+      if (isSelectionInteractionLocked()) return false;
 
       const copiedElement = store.lastCopiedElement;
       const canActivateFromCopied =
@@ -2055,6 +2067,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       return (
         Boolean(element) &&
         isRendererActive() &&
+        !isSelectionInteractionLocked() &&
         !isPromptMode() &&
         !isDragging() &&
         store.contextMenuPosition === null
@@ -2553,6 +2566,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         actions.setTouchMode(isTouchPointer);
         if (isEventFromOverlay(event, "data-react-grab-ignore-events")) return;
         if (store.contextMenuPosition !== null) return;
+        if (isSelectionInteractionLocked()) return;
         if (isTouchPointer && !isHoldingKeys() && !isActivated()) return;
         const isActiveState = isTouchPointer ? isHoldingKeys() : isActivated();
         if (isActiveState && !isPromptMode() && isFrozenPhase()) {
@@ -2591,6 +2605,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           return;
         }
 
+        if (isSelectionInteractionLocked()) {
+          event.preventDefault();
+          event.stopImmediatePropagation();
+          return;
+        }
+
         const didHandle = handlePointerDown(event.clientX, event.clientY);
         if (didHandle) {
           if (event.pointerId !== undefined) {
@@ -2610,7 +2630,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         if (!event.isPrimary) return;
         if (isEventFromOverlay(event, "data-react-grab-ignore-events")) return;
         if (store.contextMenuPosition !== null) return;
-        const isActive = isRendererActive() || isCopying() || isDragging();
+        const isActive = isRendererActive() || isSelectionInteractionLocked() || isDragging();
         const hasModifierKeyHeld = event.metaKey || event.ctrlKey;
         handlePointerUp(event.clientX, event.clientY, hasModifierKeyHeld);
         if (isActive) {
@@ -2736,6 +2756,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       if (
         isEnabled() &&
         !isPromptMode() &&
+        !isSelectionInteractionLocked() &&
         !isFrozenPhase() &&
         !isDragging() &&
         store.contextMenuPosition === null &&

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -242,7 +242,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     const isCopying = createMemo(() => store.current.state === "copying");
     const isSelectionInteractionLocked = createMemo(
       () =>
-        isCopying() || store.labelInstances.some((labelInstance) => labelInstance.status === "copying"),
+        isCopying() ||
+        store.labelInstances.some((labelInstance) => labelInstance.status === "copying"),
     );
     const didJustCopy = createMemo(() => store.current.state === "justCopied");
     const isPromptMode = createMemo(

--- a/packages/react-grab/src/core/store.ts
+++ b/packages/react-grab/src/core/store.ts
@@ -28,6 +28,7 @@ type GrabState =
 
 interface GrabStore {
   current: GrabState;
+  selectionInteractionLockDepth: number;
 
   wasActivatedByToggle: boolean;
   pendingCommentMode: boolean;
@@ -73,6 +74,7 @@ interface GrabStoreInput {
 
 const createInitialStore = (input: GrabStoreInput): GrabStore => ({
   current: { state: "idle" },
+  selectionInteractionLockDepth: 0,
 
   wasActivatedByToggle: false,
   pendingCommentMode: false,
@@ -145,6 +147,8 @@ interface GrabActions {
   setWasActivatedByToggle: (value: boolean) => void;
   setPendingCommentMode: (value: boolean) => void;
   setTouchMode: (value: boolean) => void;
+  incrementSelectionInteractionLockDepth: () => void;
+  decrementSelectionInteractionLockDepth: () => void;
   setSelectionSource: (filePath: string | null, lineNumber: number | null) => void;
   incrementViewportVersion: () => void;
   addGrabbedBox: (box: GrabbedBox) => void;
@@ -488,6 +492,16 @@ const createGrabStore = (input: GrabStoreInput) => {
 
     setTouchMode: (value: boolean) => {
       setStore("isTouchMode", value);
+    },
+
+    incrementSelectionInteractionLockDepth: () => {
+      setStore("selectionInteractionLockDepth", (currentLockDepth) => currentLockDepth + 1);
+    },
+
+    decrementSelectionInteractionLockDepth: () => {
+      setStore("selectionInteractionLockDepth", (currentLockDepth) =>
+        Math.max(0, currentLockDepth - 1),
+      );
     },
 
     setSelectionSource: (filePath: string | null, lineNumber: number | null) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace UI-coupled grabbing lock logic with a dedicated interaction lock primitive
- move `selectionInteractionLockDepth` into the central grab store with explicit store actions to increment/decrement lock depth
- keep `isSelectionInteractionLocked` as the single guard consumed by pointer/keyboard/retarget paths while grabbing is active
- retain the grabbing regression e2e test that verifies page text cannot be selected during grab operations

## Testing
- `pnpm build`
- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format`
- `pnpm --filter react-grab exec playwright test --grep "should block page text selection while grabbing"`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a3144b7-6162-4fb5-80a8-9a62350daff8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a3144b7-6162-4fb5-80a8-9a62350daff8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks selection interactions during grabbing and copy to stop page text selection and retargeting. Centralizes a depth-based lock in the shared store and applies it across mouse, touch, keyboard, and overlay handlers.

- **Bug Fixes**
  - Move lock state into the store via `selectionInteractionLockDepth` with `incrementSelectionInteractionLockDepth`/`decrementSelectionInteractionLockDepth`; `isSelectionInteractionLocked` is `isCopying || depth > 0`.
  - Add `withSelectionInteractionLock()` to hold the lock during async copy/feedback.
  - Guard target detection, hover/retarget, pointer move/down/up, Enter activation, and overlay/touch events; when locked, overlay `pointerdown` prevents default and stops immediate propagation. Added an e2e test with a slow copy hook to confirm no text becomes selectable while grabbing.

<sup>Written for commit 55cb5d0f11c620e16b65948d6f51e5c73cbaf71b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

