### PR TITLE
fix: preserve viewport-fit cover during activation

### DIFF
--- a/packages/react-grab/e2e/viewport.spec.ts
+++ b/packages/react-grab/e2e/viewport.spec.ts
@@ -1,6 +1,34 @@
 import { test, expect } from "./fixtures.js";
 
 test.describe("Viewport and Scroll Handling", () => {
+  test("should not mutate viewport meta with viewport-fit cover", async ({ reactGrab }) => {
+    const viewportContent = "width=device-width, initial-scale=1, viewport-fit=cover";
+
+    await reactGrab.page.evaluate((content) => {
+      let meta = document.querySelector<HTMLMetaElement>('meta[name="viewport"]');
+      if (!meta) {
+        meta = document.createElement("meta");
+        meta.name = "viewport";
+        document.head.appendChild(meta);
+      }
+      meta.content = content;
+    }, viewportContent);
+
+    await reactGrab.activate();
+
+    const activeContent = await reactGrab.page.evaluate(() => {
+      return document.querySelector<HTMLMetaElement>('meta[name="viewport"]')?.content ?? null;
+    });
+    expect(activeContent).toBe(viewportContent);
+
+    await reactGrab.deactivate();
+
+    const restoredContent = await reactGrab.page.evaluate(() => {
+      return document.querySelector<HTMLMetaElement>('meta[name="viewport"]')?.content ?? null;
+    });
+    expect(restoredContent).toBe(viewportContent);
+  });
+
   test("should maintain selection after scrolling page", async ({ reactGrab }) => {
     await reactGrab.activate();
     await reactGrab.hoverElement("li:first-child");

--- a/packages/react-grab/src/utils/lock-viewport-zoom.ts
+++ b/packages/react-grab/src/utils/lock-viewport-zoom.ts
@@ -6,7 +6,7 @@ export const lockViewportZoom = (): (() => void) => {
   let meta = document.querySelector<HTMLMetaElement>('meta[name="viewport"]');
   const originalContent = meta?.getAttribute("content") ?? null;
 
-  if (/viewport-fit\s*=\s*cover/.test(originalContent ?? "")) {
+  if (/viewport-fit\s*=\s*cover/i.test(originalContent ?? "")) {
     return () => {};
   }
 

--- a/packages/react-grab/src/utils/lock-viewport-zoom.ts
+++ b/packages/react-grab/src/utils/lock-viewport-zoom.ts
@@ -6,6 +6,10 @@ export const lockViewportZoom = (): (() => void) => {
   let meta = document.querySelector<HTMLMetaElement>('meta[name="viewport"]');
   const originalContent = meta?.getAttribute("content") ?? null;
 
+  if (/viewport-fit\s*=\s*cover/.test(originalContent ?? "")) {
+    return () => {};
+  }
+
   if (!meta) {
     meta = document.createElement("meta");
     meta.name = "viewport";
@@ -13,9 +17,15 @@ export const lockViewportZoom = (): (() => void) => {
   }
 
   const content = originalContent ?? "";
-  meta.content = /maximum-scale/.test(content)
+  const nextContent = /maximum-scale/.test(content)
     ? content.replace(/maximum-scale\s*=\s*[\d.]+/, "maximum-scale=1")
     : `${content}${content ? ", " : ""}maximum-scale=1`;
+
+  if (meta.content === nextContent) {
+    return () => {};
+  }
+
+  meta.content = nextContent;
 
   return () => {
     if (originalContent !== null) {


### PR DESCRIPTION
## Summary
- Skip viewport meta mutation when the page already declares `viewport-fit=cover`, preventing iOS Safari from resetting safe-area behavior during react-grab activation.
- Avoid idempotent viewport content rewrites when the computed value already matches.
- Add E2E coverage that verifies activation and deactivation preserve a `viewport-fit=cover` viewport meta tag unchanged.

## Verification
- `pnpm build`
- `pnpm --filter react-grab exec playwright test e2e/viewport.spec.ts`
- `pnpm typecheck`
- `pnpm lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small conditional change to viewport meta handling plus an added E2E test; impact is limited to activation-time viewport mutation behavior on pages using `viewport-fit=cover`.
> 
> **Overview**
> Prevents `react-grab` activation from rewriting `meta[name="viewport"]` when the page already includes `viewport-fit=cover`, preserving safe-area behavior.
> 
> Also avoids no-op viewport rewrites by computing `nextContent` and early-returning when it would not change the meta tag, and adds an E2E test asserting viewport content remains unchanged across activate/deactivate when `viewport-fit=cover` is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ead67639802caf7151e7333fd6983cb38ed1e5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `react-grab` from mutating the viewport meta when the page uses `viewport-fit=cover` (case-insensitive), preserving iOS safe-area behavior during activation. Also avoids no-op viewport content rewrites to reduce DOM churn.

- **Bug Fixes**
  - Skip updating `meta[name="viewport"]` if content includes `viewport-fit=cover` (case-insensitive).
  - Only set `maximum-scale=1` when the computed value changes.
  - Added E2E to confirm activation/deactivation keep `viewport-fit=cover` unchanged.

<sup>Written for commit 3ead67639802caf7151e7333fd6983cb38ed1e5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

