### PR TITLE
fix(toolbar): drop the 1px outer border

### DIFF
--- a/packages/react-grab/src/components/toolbar/toolbar-content.tsx
+++ b/packages/react-grab/src/components/toolbar/toolbar-content.tsx
@@ -115,7 +115,7 @@ export const ToolbarContent: Component<ToolbarContentProps> = (props) => {
     <div
       data-react-grab-toolbar-panel
       class={cn(
-        "flex items-center justify-center rounded-[10px] antialiased relative overflow-visible [font-synthesis:none] border border-[#D9D9D9] filter-[drop-shadow(0px_1px_2px_#51515133)] [corner-shape:superellipse(1.25)]",
+        "flex items-center justify-center rounded-[10px] antialiased relative overflow-visible [font-synthesis:none] filter-[drop-shadow(0px_1px_2px_#51515133)] [corner-shape:superellipse(1.25)]",
         outerTransitionClass(),
         isVertical() && "flex-col",
         "bg-white",


### PR DESCRIPTION
## Summary

Already removed on the `permissionless-clipboard-mcp` branch (#311); porting the visual change to `main` so it doesn't have to wait for that PR.

The drop-shadow alone gives enough visual separation; the explicit `border border-[#D9D9D9]` stacked on top of the shadow read as a hairline ring against light backgrounds.

## Diff

Single-line change in `packages/react-grab/src/components/toolbar/toolbar-content.tsx`:

\`\`\`diff
-  "flex items-center justify-center rounded-[10px] antialiased relative overflow-visible [font-synthesis:none] border border-[#D9D9D9] filter-[drop-shadow(0px_1px_2px_#51515133)] [corner-shape:superellipse(1.25)]",
+  "flex items-center justify-center rounded-[10px] antialiased relative overflow-visible [font-synthesis:none] filter-[drop-shadow(0px_1px_2px_#51515133)] [corner-shape:superellipse(1.25)]",
\`\`\`

## Test plan

- [ ] Open a page with the toolbar and confirm the panel no longer has a visible 1px hairline ring around it
- [ ] Confirm the drop-shadow still renders correctly
- [ ] CI: lint, typecheck, e2e all pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS class removal affecting only toolbar visuals; no behavioral or data-flow changes.
> 
> **Overview**
> Removes the 1px outer border from the toolbar panel container in `ToolbarContent`, leaving the drop-shadow as the only visual separation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78fcd967c9f9eb90bd0aaac16d3b80dd64f8ed30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the 1px outer border from the toolbar panel in `react-grab` to eliminate the hairline ring on light backgrounds. The drop-shadow remains to provide sufficient visual separation.

<sup>Written for commit 78fcd967c9f9eb90bd0aaac16d3b80dd64f8ed30. Summary will update on new commits. <a href="https://cubic.dev/pr/aidenybai/react-grab/pull/316?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

