### PR TITLE
feat(react-grab): add `silent` option to suppress intro log

### DIFF
--- a/.changeset/silent-intro-option.md
+++ b/.changeset/silent-intro-option.md
@@ -1,0 +1,7 @@
+---
+"react-grab": minor
+"grab": minor
+"@react-grab/cli": minor
+---
+
+Add `silent` option to suppress the React Grab intro banner and version-check log. Useful when console output is forwarded to error tracking services like Sentry.

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -201,8 +201,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     logIntro();
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- need to omit enabled from settableOptions to avoid circular dependency
-  const { enabled: _enabled, ...settableOptions } = initialOptions;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- need to omit init-only options from settableOptions to avoid circular dependency
+  const { enabled: _enabled, silent: _silent, ...settableOptions } = initialOptions;
 
   return createRoot((dispose) => {
     let disposed = false;

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -197,7 +197,9 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
   }
   hasInited = true;
 
-  logIntro();
+  if (!initialOptions.silent) {
+    logIntro();
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- need to omit enabled from settableOptions to avoid circular dependency
   const { enabled: _enabled, ...settableOptions } = initialOptions;

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -252,6 +252,13 @@ export interface Options {
    * @default true
    */
   freezeReactUpdates?: boolean;
+  /**
+   * Suppress the React Grab intro banner and version-check log.
+   * Useful when console output is forwarded to error tracking
+   * services like Sentry.
+   * @default false
+   */
+  silent?: boolean;
 }
 
 export interface SettableOptions extends Options {

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -263,6 +263,7 @@ export interface Options {
 
 export interface SettableOptions extends Options {
   enabled?: never;
+  silent?: never;
 }
 
 export interface SourceInfo {

--- a/packages/react-grab/src/utils/get-script-options.ts
+++ b/packages/react-grab/src/utils/get-script-options.ts
@@ -30,6 +30,9 @@ const parseOptionsFromJson = (rawValue: unknown): Partial<Options> | null => {
   if (typeof rawValue.freezeReactUpdates === "boolean") {
     parsedOptions.freezeReactUpdates = rawValue.freezeReactUpdates;
   }
+  if (typeof rawValue.silent === "boolean") {
+    parsedOptions.silent = rawValue.silent;
+  }
 
   if (Object.keys(parsedOptions).length === 0) return null;
   return parsedOptions;


### PR DESCRIPTION
Our sentry sends logs and it would be nice to silence the intro - Elmin

## Summary
- Adds a `silent?: boolean` option to `init()` that gates the `logIntro()` call in `packages/react-grab/src/core/index.tsx`.
- Parses the same key from the `data-options` JSON attribute in `get-script-options.ts` so it works for the script-tag install path too.
- Documented on the `Options` interface in `types.ts`.

## Why
When react-grab is initialized in an app that forwards `console` output to an error tracker (e.g. Sentry breadcrumbs), the intro banner and the follow-up version-check log get pushed upstream every page load. There's currently no way to opt out without monkey-patching `console.log`. This adds a single, explicit knob.

## Usage
```ts
import { init } from "react-grab";
init({ silent: true });
```

Or via script tag:
```html
<script src="..." data-options='{"silent":true}'></script>
```

Default is `false`, so existing consumers see no change.

## Test plan
- [x] `pnpm --filter react-grab typecheck`
- [x] `pnpm lint`
- [ ] Manually verify that `init({ silent: true })` produces no console output, and `init()` (or `init({ silent: false })`) still logs the banner + performs the version check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an opt-in flag that only gates console/banner output and the version-check log, with no functional changes to selection/copy behavior.
> 
> **Overview**
> Adds a new `silent?: boolean` init-only option to suppress React Grab’s startup banner and version-check logging (including when configured via script tag `data-options`).
> 
> Updates public types so `silent` cannot be changed via `setOptions`, and ships a minor version bump via a changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17ad71007d9fe91ffaca612040a183fbc5604f08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->