### PR TITLE
feat(comments): UAT-friendly long-session QoL — drop 20-item cap, capture page URL

### DIFF
--- a/packages/react-grab/src/components/comments-dropdown.tsx
+++ b/packages/react-grab/src/components/comments-dropdown.tsx
@@ -40,6 +40,21 @@ const getCommentItemDisplayName = (item: CommentItem): string => {
   return item.componentName ?? item.tagName;
 };
 
+const getCommentItemUrlLabel = (item: CommentItem): string | undefined => {
+  if (!item.url) return undefined;
+  try {
+    const parsed = new URL(item.url);
+    const currentHost = typeof window !== "undefined" ? window.location.host : "";
+    const pathAndQuery = `${parsed.pathname}${parsed.search}`;
+    if (parsed.host && parsed.host !== currentHost) {
+      return `${parsed.host}${pathAndQuery}`;
+    }
+    return pathAndQuery || "/";
+  } catch {
+    return item.url;
+  }
+};
+
 export const CommentsDropdown: Component<CommentsDropdownProps> = (props) => {
   let containerRef: HTMLDivElement | undefined;
   const {
@@ -283,6 +298,16 @@ export const CommentsDropdown: Component<CommentsDropdownProps> = (props) => {
                         <span class="text-[11px] leading-3 font-sans text-black/40 truncate mt-0.5">
                           {item.commentText}
                         </span>
+                      </Show>
+                      <Show when={getCommentItemUrlLabel(item)}>
+                        {(urlLabel) => (
+                          <span
+                            class="text-[10px] leading-3 font-sans text-black/30 truncate mt-0.5"
+                            title={item.url}
+                          >
+                            {urlLabel()}
+                          </span>
+                        )}
                       </Show>
                     </span>
                     <span class="shrink-0 text-[10px] font-sans text-black/25 flex items-center justify-end">

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -126,7 +126,6 @@ export const ZOOM_DETECTION_THRESHOLD = 0.01;
 
 export const MOUNT_ROOT_RECHECK_DELAY_MS = 1000;
 
-export const MAX_COMMENT_ITEMS = 20;
 export const MAX_SESSION_STORAGE_SIZE_BYTES = 2 * 1024 * 1024;
 // Must match the CSS exit transition on dropdown components or the DOM
 // unmounts mid-animation.

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -784,6 +784,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         previewBounds: copiedElements.map((copiedElement) => createElementBounds(copiedElement)),
         elementSelectors,
         commentText: extraPrompt,
+        url: typeof window !== "undefined" ? window.location.href : undefined,
         timestamp: Date.now(),
       });
       setCommentItems(updatedCommentItems);
@@ -3341,8 +3342,11 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       }
     };
 
+    const decorateContentWithUrl = (content: string, url: string | undefined): string =>
+      url ? `${content}\n  at ${url}` : content;
+
     const copyCommentItemContent = (item: CommentItem) => {
-      copyContent(item.content, {
+      copyContent(decorateContentWithUrl(item.content, item.url), {
         tagName: item.tagName,
         componentName: item.componentName ?? item.elementName,
         commentText: item.commentText,
@@ -3386,7 +3390,9 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       if (currentCommentItems.length === 0) return;
 
       const combinedContent = joinSnippets(
-        currentCommentItems.map((commentItem) => commentItem.content),
+        currentCommentItems.map((commentItem) =>
+          decorateContentWithUrl(commentItem.content, commentItem.url),
+        ),
       );
 
       const firstItem = currentCommentItems[0];
@@ -3395,7 +3401,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         entries: currentCommentItems.map((commentItem) => ({
           tagName: commentItem.tagName,
           componentName: commentItem.componentName ?? commentItem.elementName,
-          content: commentItem.content,
+          content: decorateContentWithUrl(commentItem.content, commentItem.url),
           commentText: commentItem.commentText,
         })),
       });

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -344,6 +344,7 @@ export interface CommentItem {
   previewBounds?: OverlayBounds[];
   elementSelectors?: string[];
   commentText?: string;
+  url?: string;
   timestamp: number;
 }
 

--- a/packages/react-grab/src/utils/comment-storage.ts
+++ b/packages/react-grab/src/utils/comment-storage.ts
@@ -1,4 +1,4 @@
-import { MAX_COMMENT_ITEMS, MAX_SESSION_STORAGE_SIZE_BYTES } from "../constants.js";
+import { MAX_SESSION_STORAGE_SIZE_BYTES } from "../constants.js";
 import type { CommentItem } from "../types.js";
 import { generateId } from "./generate-id.js";
 import { logRecoverableError } from "./log-recoverable-error.js";
@@ -76,9 +76,7 @@ if (typeof window !== "undefined") {
 export const loadComments = (): CommentItem[] => commentItems;
 
 export const addCommentItem = (item: Omit<CommentItem, "id">): CommentItem[] =>
-  persistCommentItems(
-    [{ ...item, id: generateId("comment") }, ...commentItems].slice(0, MAX_COMMENT_ITEMS),
-  );
+  persistCommentItems([{ ...item, id: generateId("comment") }, ...commentItems]);
 
 export const removeCommentItem = (itemId: string): void => {
   persistCommentItems(commentItems.filter((innerItem) => innerItem.id !== itemId));


### PR DESCRIPTION
Closes #319.

## Summary

- **Drop the 20-item count cap on comments.** The hard `MAX_COMMENT_ITEMS = 20` in `constants.ts` predates the 2 MB byte-size trim that was later added (in commit `d1877670 fix`) as the principled sessionStorage-quota safeguard. The count cap silently dropped older comments during longer review sessions; the byte trim already handles real storage pressure (~500–2000 typical comments fit under 2 MB).
- **Capture the page URL on each comment.** Multi-page review sessions had no way to tell which page a given comment came from. We now:
  - Store `url?: string` on `CommentItem` (captured from `window.location.href` at creation).
  - Show a third line in the comments dropdown row under the comment text — host is elided when it matches the current page, full URL is shown via `title` on hover.
  - Append `at <url>` to the copied content (single + copy-all) on its own indented line, mirroring the existing `in <Component> (at <file>)` convention from `formatStackContext`. Both the plain-text and rich-MIME (`application/x-react-grab`) entries get the decorated content so paste targets stay consistent.

## Why

From #319: react-grab is being used for long UAT-style review sessions where reviewers comment across many pages. The 20-item silent drop and missing URL context were the two friction points called out.

## Test plan

- [ ] Comment on 25+ different elements in a single session — confirm none silently disappear from the dropdown.
- [ ] Navigate to a second page, comment, open dropdown — confirm the URL line shows the new page's path under the comment.
- [ ] Comment on a cross-host page (e.g. localhost:3000 then localhost:3001) — confirm host appears in the URL label when it differs from the current page.
- [ ] Hover the URL line — confirm the full URL appears in the native tooltip.
- [ ] Use "Copy" on a single comment — confirm pasted content has `at <url>` on its own line.
- [ ] Use "Copy all" — confirm each entry's snippet ends with its own `at <url>` line.
- [ ] Verify `pnpm --filter react-grab typecheck` is clean.
- [ ] Run the existing comments e2e specs (`packages/react-grab/e2e/clear-history-prompt.spec.ts` and friends) — no regressions.

## Notes

- The byte-budget trim is now the only cap. If a single user ever does hit the 2 MB ceiling (well past typical review-session sizes), an IndexedDB-backed storage layer is the natural follow-up — left out of scope here.
- No new e2e coverage for the URL display / 25+ items added in this PR; happy to add it as a follow-up if the maintainers prefer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes comment persistence and clipboard output: comments are no longer capped by count and copied snippets now include a URL line, which could affect consumers expecting the previous format or increase sessionStorage churn (though still size-trimmed).
> 
> **Overview**
> Comments history is now retained beyond the previous 20-item limit by removing the hard count cap and relying solely on the existing sessionStorage byte-size trimming.
> 
> Each `CommentItem` now records `url` (captured at creation), surfaces a compact URL label in the comments dropdown (with full URL on hover), and appends an `at <url>` line when copying single comments or using copy-all (including per-entry payloads).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e33a67a5a16ef475152eaeef83bd39123d3bfe9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->