### PR TITLE
feat(react-grab): inline source snippets, fiber props, and stack-tail collapse

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,21 @@
 [![version](https://img.shields.io/npm/v/react-grab?style=flat&colorA=000000&colorB=000000)](https://npmjs.com/package/react-grab)
 [![downloads](https://img.shields.io/npm/dt/react-grab.svg?style=flat&colorA=000000&colorB=000000)](https://npmjs.com/package/react-grab)
 
-Select context for coding agents directly from your website
+Copy any UI element for your agent.
 
-How? Point at any element and press **⌘C** (Mac) or **Ctrl+C** (Windows/Linux) to copy the file name, React component, and HTML source code.
-
-It makes tools like Cursor, Claude Code, Copilot run up to [**3× faster**](https://react-grab.com/blog/intro) and more accurate.
+React Grab points agents to the actual source behind each selection, so edits are [**2× faster**](https://github.com/aidenybai/react-grab-bench) and more accurate.
 
 ### [Try out a demo! →](https://react-grab.com)
 
-## Install
+## Quick Start
 
-Run this command at your project root (where `next.config.ts` or `vite.config.ts` is located):
+Run this at your project root:
 
 ```bash
 npx grab@latest init
 ```
 
-## Connect to MCP
+Optional: connect React Grab to your agents with MCP:
 
 ```bash
 npx grab@latest add mcp
@@ -27,27 +25,46 @@ npx grab@latest add mcp
 
 ## Usage
 
-Once installed, hover over any UI element in your browser and press:
+Start your dev server, open your app, then hover any UI element and press:
 
 - **⌘C** (Cmd+C) on Mac
 - **Ctrl+C** on Windows/Linux
 
-This copies the element's context (file name, React component, and HTML source code) to your clipboard ready to paste into your coding agent. For example:
+React Grab copies that context to your clipboard, ready to paste into your agent.
 
-```js
+## What Agents Get
+
+React Grab includes the details agents need to edit the right file:
+
+- the rendered HTML for the element
+- the React component name
+- the source file and line number
+- the nearby source code, when available
+- the component stack
+
+Example:
+
+```txt
 <a class="ml-auto inline-block text-sm" href="#">
   Forgot your password?
 </a>
-in LoginForm at components/login-form.tsx:46:19
+
+// components/login-form.tsx:46
+  45| <div className="flex items-center">
+> 46|   <a className="ml-auto inline-block text-sm" href="#">
+  47|     Forgot your password?
+  48|   </a>
+
+  in LoginForm (at components/login-form.tsx:46:19)
 ```
 
 ## Manual Installation
 
-If you're using a React framework or build tool, view instructions below:
+If you cannot use the CLI, install React Grab manually for your framework:
 
 #### Next.js (App router)
 
-Add this inside of your `app/layout.tsx`:
+Add this inside your `app/layout.tsx`:
 
 ```jsx
 import Script from "next/script";
@@ -190,19 +207,13 @@ actions: [
 
 See [`packages/react-grab/src/types.ts`](https://github.com/aidenybai/react-grab/blob/main/packages/react-grab/src/types.ts) for the full `Plugin`, `PluginHooks`, and `PluginConfig` interfaces.
 
-## Resources & Contributing Back
+## Links
 
-Want to try it out? Check out [our demo](https://react-grab.com).
-
-Looking to contribute back? Check out the [Contributing Guide](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md).
-
-Want to talk to the community? Hop in our [Discord](https://discord.com/invite/G7zxfUzkm7) and share your ideas and what you've built with React Grab.
-
-Find a bug? Head over to our [issue tracker](https://github.com/aidenybai/react-grab/issues) and we'll do our best to help. We love pull requests, too!
-
-We expect all contributors to abide by the terms of our [Code of Conduct](https://github.com/aidenybai/react-grab/blob/main/.github/CODE_OF_CONDUCT.md).
-
-[**→ Start contributing on GitHub**](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md)
+- [Demo](https://react-grab.com)
+- [Contributing Guide](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md)
+- [Discord](https://discord.com/invite/G7zxfUzkm7)
+- [Issue tracker](https://github.com/aidenybai/react-grab/issues)
+- [Code of Conduct](https://github.com/aidenybai/react-grab/blob/main/.github/CODE_OF_CONDUCT.md)
 
 ### License
 

--- a/apps/storybook/README.md
+++ b/apps/storybook/README.md
@@ -1,6 +1,8 @@
 # @react-grab/storybook
 
-Visual playground for React Grab's overlay system - renders the full `ReactGrabRenderer` on a sample page with Storybook controls for every user-facing state.
+Internal playground for React Grab's overlay UI.
+
+Storybook renders the full `ReactGrabRenderer` against mocked states and realistic playground pages, so overlay states can be inspected without running the e2e app.
 
 Uses [Storybook 10](https://storybook.js.org/) with [`storybook-solidjs-vite`](https://github.com/nicolo-ribaudo/storybook-solidjs-vite).
 
@@ -29,13 +31,13 @@ Static build output is written to `storybook-static/`.
 ```
 apps/storybook/
 ├── .storybook/
-│   ├── main.ts                 ← Storybook config
-│   └── preview.tsx             ← global parameters & CSS import
+│   ├── main.ts                 Storybook config
+│   └── preview.tsx             global parameters and CSS import
 └── stories/
-    ├── fixtures.ts             ← preset comment items + menu actions
-    ├── noop.ts                 ← no-op callback for handlers
-    ├── *.stories.tsx           ← Component stories (mock renderer states)
-    └── playground/             ← Ad-hoc scenarios with real init() running
+    ├── fixtures.ts             preset comment items and menu actions
+    ├── noop.ts                 no-op callback for handlers
+    ├── *.stories.tsx           component stories with mocked renderer states
+    └── playground/             scenarios with real init() running
         ├── composite-dashboard.stories.tsx
         ├── freeze-demo.stories.tsx
         └── live-updates.stories.tsx
@@ -43,9 +45,9 @@ apps/storybook/
 
 ## Two kinds of stories
 
-**Component stories** (toolbar, selection-label, context-menu, comments-dropdown, renderer) render the overlay with mocked props. They're single sources of truth for every user-facing state: idle, context menu, comment input, pending dismiss, etc.
+**Component stories** render toolbar, selection label, context menu, comments dropdown, and renderer states with mocked props. Use these to inspect specific UI states such as idle, context menu, comment input, and pending dismiss.
 
-**Playground stories** import `react-grab` for its side effect, so `init()` actually runs and hooks into the story DOM. They replace the former `apps/gym` and exist for ad-hoc hover/grab testing against realistic fixtures:
+**Playground stories** import `react-grab` for its side effect, so `init()` runs against the story DOM. Use these for ad-hoc hover and grab testing against realistic fixtures:
 
 - **Composite Dashboard** - sidebar, metric cards, chart, and data table for dense-DOM selection testing
 - **Freeze Demo** - bouncing animated timer for verifying freeze-animations + freeze-updates

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,8 @@
 # @react-grab/cli
 
-Interactive CLI to install and configure React Grab in your project.
+CLI for installing React Grab, configuring its activation behavior, and connecting agents through MCP.
+
+The CLI detects supported React projects, applies the dev-only setup, and can reconfigure an existing installation without hand-editing framework files.
 
 ## Quick Start
 
@@ -12,7 +14,7 @@ npx grab@latest init
 
 ### `grab init`
 
-Initialize React Grab in your project. Auto-detects your framework and applies the necessary changes.
+Install React Grab in the current project. The CLI auto-detects the framework and applies the required development-only integration.
 
 ```bash
 npx grab@latest init
@@ -29,7 +31,7 @@ npx grab@latest init
 
 ### `grab add`
 
-Connect React Grab to your coding agent via MCP.
+Configure the React Grab MCP server for your agent.
 
 ```bash
 npx grab@latest add mcp
@@ -42,7 +44,7 @@ npx grab@latest add mcp
 
 ### `grab remove`
 
-Disconnect React Grab from your coding agent.
+Remove the MCP connection from your agent.
 
 ```bash
 npx grab@latest remove mcp
@@ -55,7 +57,7 @@ npx grab@latest remove mcp
 
 ### `grab configure`
 
-Configure React Grab options. Runs an interactive wizard when called without flags.
+Update React Grab options. Runs an interactive wizard when called without flags.
 
 ```bash
 npx grab@latest configure
@@ -96,9 +98,10 @@ npx grab@latest configure
 
 ## Supported Frameworks
 
-| Framework              | Detection                             |
-| ---------------------- | ------------------------------------- |
-| Next.js (App Router)   | `next.config.ts` + `app/` directory   |
-| Next.js (Pages Router) | `next.config.ts` + `pages/` directory |
-| Vite                   | `vite.config.ts`                      |
-| Webpack                | `webpack.config.*`                    |
+The CLI currently configures:
+
+- Next.js App Router
+- Next.js Pages Router
+- Vite
+- TanStack Start
+- Webpack

--- a/packages/grab/README.md
+++ b/packages/grab/README.md
@@ -3,23 +3,21 @@
 [![version](https://img.shields.io/npm/v/grab?style=flat&colorA=000000&colorB=000000)](https://npmjs.com/package/grab)
 [![downloads](https://img.shields.io/npm/dt/grab.svg?style=flat&colorA=000000&colorB=000000)](https://npmjs.com/package/grab)
 
-Select context for coding agents directly from your website
+Copy any UI element for your agent.
 
-How? Point at any element and press **⌘C** (Mac) or **Ctrl+C** (Windows/Linux) to copy the file name, React component, and HTML source code.
-
-It makes tools like Cursor, Claude Code, Copilot run up to [**3× faster**](https://react-grab.com/blog/intro) and more accurate.
+React Grab points agents to the actual source behind each selection, so edits are [**2× faster**](https://github.com/aidenybai/react-grab-bench) and more accurate.
 
 ### [Try out a demo! →](https://react-grab.com)
 
-## Install
+## Quick Start
 
-Run this command at your project root (where `next.config.ts` or `vite.config.ts` is located):
+Run this at your project root:
 
 ```bash
 npx grab@latest init
 ```
 
-## Connect to MCP
+Optional: connect React Grab to your agents with MCP:
 
 ```bash
 npx grab@latest add mcp
@@ -27,27 +25,46 @@ npx grab@latest add mcp
 
 ## Usage
 
-Once installed, hover over any UI element in your browser and press:
+Start your dev server, open your app, then hover any UI element and press:
 
 - **⌘C** (Cmd+C) on Mac
 - **Ctrl+C** on Windows/Linux
 
-This copies the element's context (file name, React component, and HTML source code) to your clipboard ready to paste into your coding agent. For example:
+React Grab copies that context to your clipboard, ready to paste into your agent.
 
-```js
+## What Agents Get
+
+React Grab includes the details agents need to edit the right file:
+
+- the rendered HTML for the element
+- the React component name
+- the source file and line number
+- the nearby source code, when available
+- the component stack
+
+Example:
+
+```txt
 <a class="ml-auto inline-block text-sm" href="#">
   Forgot your password?
 </a>
-in LoginForm at components/login-form.tsx:46:19
+
+// components/login-form.tsx:46
+  45| <div className="flex items-center">
+> 46|   <a className="ml-auto inline-block text-sm" href="#">
+  47|     Forgot your password?
+  48|   </a>
+
+  in LoginForm (at components/login-form.tsx:46:19)
 ```
 
 ## Manual Installation
 
-If you're using a React framework or build tool, view instructions below:
+If you cannot use the CLI, install React Grab manually for your framework:
 
 #### Next.js (App router)
 
-Add this inside of your `app/layout.tsx`:
+Add this inside your `app/layout.tsx`:
 
 ```jsx
 import Script from "next/script";
@@ -190,19 +207,13 @@ actions: [
 
 See [`packages/react-grab/src/types.ts`](https://github.com/aidenybai/react-grab/blob/main/packages/react-grab/src/types.ts) for the full `Plugin`, `PluginHooks`, and `PluginConfig` interfaces.
 
-## Resources & Contributing Back
+## Links
 
-Want to try it out? Check out [our demo](https://react-grab.com).
-
-Looking to contribute back? Check out the [Contributing Guide](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md).
-
-Want to talk to the community? Hop in our [Discord](https://discord.com/invite/G7zxfUzkm7) and share your ideas and what you've built with React Grab.
-
-Find a bug? Head over to our [issue tracker](https://github.com/aidenybai/react-grab/issues) and we'll do our best to help. We love pull requests, too!
-
-We expect all contributors to abide by the terms of our [Code of Conduct](https://github.com/aidenybai/react-grab/blob/main/.github/CODE_OF_CONDUCT.md).
-
-[**→ Start contributing on GitHub**](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md)
+- [Demo](https://react-grab.com)
+- [Contributing Guide](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md)
+- [Discord](https://discord.com/invite/G7zxfUzkm7)
+- [Issue tracker](https://github.com/aidenybai/react-grab/issues)
+- [Code of Conduct](https://github.com/aidenybai/react-grab/blob/main/.github/CODE_OF_CONDUCT.md)
 
 ### License
 

--- a/packages/react-grab/README.md
+++ b/packages/react-grab/README.md
@@ -3,23 +3,21 @@
 [![version](https://img.shields.io/npm/v/react-grab?style=flat&colorA=000000&colorB=000000)](https://npmjs.com/package/react-grab)
 [![downloads](https://img.shields.io/npm/dt/react-grab.svg?style=flat&colorA=000000&colorB=000000)](https://npmjs.com/package/react-grab)
 
-Select context for coding agents directly from your website
+Copy any UI element for your agent.
 
-How? Point at any element and press **⌘C** (Mac) or **Ctrl+C** (Windows/Linux) to copy the file name, React component, and HTML source code.
-
-It makes tools like Cursor, Claude Code, Copilot run up to [**3× faster**](https://react-grab.com/blog/intro) and more accurate.
+React Grab points agents to the actual source behind each selection, so edits are [**2× faster**](https://github.com/aidenybai/react-grab-bench) and more accurate.
 
 ### [Try out a demo! →](https://react-grab.com)
 
-## Install
+## Quick Start
 
-Run this command at your project root (where `next.config.ts` or `vite.config.ts` is located):
+Run this at your project root:
 
 ```bash
 npx grab@latest init
 ```
 
-## Connect to MCP
+Optional: connect React Grab to your agents with MCP:
 
 ```bash
 npx grab@latest add mcp
@@ -27,27 +25,46 @@ npx grab@latest add mcp
 
 ## Usage
 
-Once installed, hover over any UI element in your browser and press:
+Start your dev server, open your app, then hover any UI element and press:
 
 - **⌘C** (Cmd+C) on Mac
 - **Ctrl+C** on Windows/Linux
 
-This copies the element's context (file name, React component, and HTML source code) to your clipboard ready to paste into your coding agent. For example:
+React Grab copies that context to your clipboard, ready to paste into your agent.
 
-```js
+## What Agents Get
+
+React Grab includes the details agents need to edit the right file:
+
+- the rendered HTML for the element
+- the React component name
+- the source file and line number
+- the nearby source code, when available
+- the component stack
+
+Example:
+
+```txt
 <a class="ml-auto inline-block text-sm" href="#">
   Forgot your password?
 </a>
-in LoginForm at components/login-form.tsx:46:19
+
+// components/login-form.tsx:46
+  45| <div className="flex items-center">
+> 46|   <a className="ml-auto inline-block text-sm" href="#">
+  47|     Forgot your password?
+  48|   </a>
+
+  in LoginForm (at components/login-form.tsx:46:19)
 ```
 
 ## Manual Installation
 
-If you're using a React framework or build tool, view instructions below:
+If you cannot use the CLI, install React Grab manually for your framework:
 
 #### Next.js (App router)
 
-Add this inside of your `app/layout.tsx`:
+Add this inside your `app/layout.tsx`:
 
 ```jsx
 import Script from "next/script";
@@ -190,19 +207,13 @@ actions: [
 
 See [`packages/react-grab/src/types.ts`](https://github.com/aidenybai/react-grab/blob/main/packages/react-grab/src/types.ts) for the full `Plugin`, `PluginHooks`, and `PluginConfig` interfaces.
 
-## Resources & Contributing Back
+## Links
 
-Want to try it out? Check out [our demo](https://react-grab.com).
-
-Looking to contribute back? Check out the [Contributing Guide](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md).
-
-Want to talk to the community? Hop in our [Discord](https://discord.com/invite/G7zxfUzkm7) and share your ideas and what you've built with React Grab.
-
-Find a bug? Head over to our [issue tracker](https://github.com/aidenybai/react-grab/issues) and we'll do our best to help. We love pull requests, too!
-
-We expect all contributors to abide by the terms of our [Code of Conduct](https://github.com/aidenybai/react-grab/blob/main/.github/CODE_OF_CONDUCT.md).
-
-[**→ Start contributing on GitHub**](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md)
+- [Demo](https://react-grab.com)
+- [Contributing Guide](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md)
+- [Discord](https://discord.com/invite/G7zxfUzkm7)
+- [Issue tracker](https://github.com/aidenybai/react-grab/issues)
+- [Code of Conduct](https://github.com/aidenybai/react-grab/blob/main/.github/CODE_OF_CONDUCT.md)
 
 ### License
 

--- a/packages/react-grab/e2e/element-context.spec.ts
+++ b/packages/react-grab/e2e/element-context.spec.ts
@@ -208,4 +208,67 @@ test.describe("Element Context Fallback", () => {
       expect(clipboard.length).toBeLessThanOrEqual(510);
     });
   });
+
+  test.describe("Source Snippet & Component Instance", () => {
+    test("surfaces the literal JSX call site so the agent sees the props the user wrote", async ({
+      reactGrab,
+    }) => {
+      await reactGrab.activate();
+
+      const todoItem = "[data-testid='todo-list'] ul li:first-child span";
+      await reactGrab.hoverElement(todoItem);
+      await reactGrab.waitForSelectionBox();
+      await reactGrab.clickElement(todoItem);
+
+      const clipboard = await reactGrab.getClipboardContent();
+      // TodoItem is rendered with `<TodoItem key={todo.id} todo={todo} />`
+      // in App.tsx. Either the source-snippet block or — when the source
+      // map fetch fails — the JSX-call fallback on the stack line must
+      // surface the call signature so the agent knows it's working with
+      // a TodoItem component, not a bare `<li>`.
+      expect(clipboard).toContain("TodoItem");
+      expect(clipboard).toMatch(/<TodoItem\b|in <TodoItem\b/);
+    });
+
+    test("does not double-render the JSX-call signature when a trustworthy snippet is present", async ({
+      reactGrab,
+    }) => {
+      await reactGrab.activate();
+
+      const todoItem = "[data-testid='todo-list'] ul li:first-child span";
+      await reactGrab.hoverElement(todoItem);
+      await reactGrab.waitForSelectionBox();
+      await reactGrab.clickElement(todoItem);
+
+      const clipboard = await reactGrab.getClipboardContent();
+      // When a trustworthy source snippet is fetched, the literal JSX
+      // already lives in the snippet block — re-emitting `in <TodoItem
+      // ... />` on the stack line below is redundant noise. The stack
+      // line should fall back to the bare component name.
+      const hasSnippetBlock = /^\/\/ .+\.tsx?:\d+/m.test(clipboard);
+      if (hasSnippetBlock) {
+        expect(clipboard).toMatch(/in TodoItem \(at /);
+        expect(clipboard).not.toMatch(/in <TodoItem/);
+      }
+    });
+
+    test("does not paint props onto library frames whose name happens to match", async ({
+      reactGrab,
+    }) => {
+      await reactGrab.activate();
+
+      const icon = "[data-testid='library-icon-host'] svg";
+      await reactGrab.hoverElement(icon);
+      await reactGrab.waitForSelectionBox();
+      await reactGrab.clickElement(icon);
+
+      const clipboard = await reactGrab.getClipboardContent();
+      // Library frames stay in the bare `in Square (lucide-react)` shape
+      // even if the closest composite fiber is the same library component.
+      // Painting props onto a library frame would leak internal lucide-react
+      // implementation details into the agent context.
+      expect(clipboard).toMatch(/in Square \(lucide-react\)/);
+      expect(clipboard).not.toMatch(/in <Square/);
+    });
+  });
 });

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -65,6 +65,14 @@ export const LABEL_GAP_PX = 4;
 export const PREVIEW_TEXT_MAX_LENGTH = 100;
 export const PREVIEW_ATTR_VALUE_MAX_LENGTH = 15;
 export const PREVIEW_MAX_ATTRS = 3;
+
+export const SOURCE_SNIPPET_LINES_BEFORE = 3;
+export const SOURCE_SNIPPET_LINES_AFTER = 5;
+export const SOURCE_SNIPPET_MAX_LINE_LENGTH_CHARS = 200;
+export const SOURCE_SNIPPET_FETCH_TIMEOUT_MS = 1500;
+
+export const COMPONENT_INSTANCE_MAX_PROPS = 4;
+export const COMPONENT_INSTANCE_MAX_VALUE_LENGTH_CHARS = 40;
 export const PREVIEW_PRIORITY_ATTRS: readonly string[] = [
   "id",
   "class",

--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -28,56 +28,14 @@ import { getNextBasePath } from "../utils/get-next-base-path.js";
 import { normalizeFilePath } from "../utils/normalize-file-path.js";
 import { parsePackageName } from "../utils/parse-package-name.js";
 import { isInternalAttribute } from "../utils/strip-internal-attributes.js";
-
-const NON_COMPONENT_PREFIXES = new Set([
-  "_",
-  "$",
-  "motion.",
-  "styled.",
-  "chakra.",
-  "ark.",
-  "Primitive.",
-  "Slot.",
-]);
-
-// Next.js App Router internals that wrap user components but are not useful
-// as display names. Without filtering these the UI would show names like
-// "InnerLayoutRouter" instead of the user's own component.
-const NEXT_INTERNAL_COMPONENT_NAMES = new Set([
-  "InnerLayoutRouter",
-  "RedirectErrorBoundary",
-  "RedirectBoundary",
-  "HTTPAccessFallbackErrorBoundary",
-  "HTTPAccessFallbackBoundary",
-  "LoadingBoundary",
-  "ErrorBoundary",
-  "InnerScrollAndFocusHandler",
-  "ScrollAndFocusHandler",
-  "RenderFromTemplateContext",
-  "OuterLayoutRouter",
-  "body",
-  "html",
-  "DevRootHTTPAccessFallbackBoundary",
-  "AppDevOverlayErrorBoundary",
-  "AppDevOverlay",
-  "HotReload",
-  "Router",
-  "ErrorBoundaryHandler",
-  "AppRouter",
-  "ServerRoot",
-  "SegmentStateProvider",
-  "RootErrorBoundary",
-  "LoadableComponent",
-  "MotionDOMComponent",
-]);
-
-const REACT_INTERNAL_COMPONENT_NAMES = new Set([
-  "Suspense",
-  "Fragment",
-  "StrictMode",
-  "Profiler",
-  "SuspenseList",
-]);
+import { formatComponentInstance } from "../utils/format-component-instance.js";
+import { getFiberComponentInfo } from "../utils/get-fiber-component-info.js";
+import { getSourceSnippetForFrame, type SourceSnippet } from "../utils/get-source-snippet.js";
+import { formatSourceSnippetBlock } from "../utils/format-source-snippet-block.js";
+import {
+  isInternalComponentName,
+  isUsefulComponentName,
+} from "../utils/is-useful-component-name.js";
 
 let cachedIsNextProject: boolean | undefined;
 
@@ -89,22 +47,6 @@ export const checkIsNextProject = (revalidate?: boolean): boolean => {
     typeof document !== "undefined" &&
     Boolean(document.getElementById("__NEXT_DATA__") || document.querySelector("nextjs-portal"));
   return cachedIsNextProject;
-};
-
-const isInternalComponentName = (name: string): boolean => {
-  if (NEXT_INTERNAL_COMPONENT_NAMES.has(name)) return true;
-  if (REACT_INTERNAL_COMPONENT_NAMES.has(name)) return true;
-  for (const prefix of NON_COMPONENT_PREFIXES) {
-    if (name.startsWith(prefix)) return true;
-  }
-  return false;
-};
-
-const isUsefulComponentName = (name: string): boolean => {
-  if (!name) return false;
-  if (isInternalComponentName(name)) return false;
-  if (name === "SlotClone" || name === "Slot") return false;
-  return true;
 };
 
 const isSourceComponentName = (name: string): boolean => {
@@ -387,6 +329,23 @@ interface StackContextOptions {
   maxLines?: number;
 }
 
+interface ElementContextPartsInternalOptions extends StackContextOptions {
+  includeSourceSnippet?: boolean;
+}
+
+export interface SourceSnippetInfo {
+  filePath: string;
+  snippet: SourceSnippet;
+  block: string;
+  key: string;
+}
+
+export interface ElementContextParts {
+  htmlPreview: string;
+  sourceSnippet: SourceSnippetInfo | null;
+  stackLines: string[];
+}
+
 const hasFormattableFrames = (stack: StackFrame[] | null): boolean => {
   if (!stack) return false;
   return stack.some((frame) => {
@@ -422,23 +381,44 @@ const getComponentNamesFromFiber = (element: Element, maxCount: number): string[
   return componentNames;
 };
 
-const formatResolvedSourceLine = (
+const formatResolvedSourceLocation = (
   frame: StackFrame,
   filePath: string,
-  componentName: string | null,
   isNextProject: boolean,
 ): string => {
   // HACK: bundlers like Vite produce unreliable line/column numbers from
   // owner stacks, so we only include them for Next.js where the dev server
   // symbolicates frames via source maps.
-  const location =
-    isNextProject && frame.lineNumber
-      ? `${normalizeFilePath(filePath)}:${frame.lineNumber}${frame.columnNumber ? `:${frame.columnNumber}` : ""}`
-      : normalizeFilePath(filePath);
-  return componentName ? `\n  in ${componentName} (at ${location})` : `\n  in ${location}`;
+  if (isNextProject && frame.lineNumber) {
+    const column = frame.columnNumber ? `:${frame.columnNumber}` : "";
+    return `${normalizeFilePath(filePath)}:${frame.lineNumber}${column}`;
+  }
+  return normalizeFilePath(filePath);
 };
 
-const formatStackContext = (stack: StackFrame[], options: StackContextOptions = {}): string => {
+const formatResolvedStackLine = (
+  frame: StackFrame,
+  filePath: string,
+  componentName: string | null,
+  componentInstanceText: string | null,
+  isNextProject: boolean,
+): string => {
+  const location = formatResolvedSourceLocation(frame, filePath, isNextProject);
+  if (componentInstanceText) {
+    return `in ${componentInstanceText} (at ${location})`;
+  }
+  return componentName ? `in ${componentName} (at ${location})` : `in ${location}`;
+};
+
+interface StackContextInternalOptions extends StackContextOptions {
+  innermostComponentInstanceText?: string | null;
+  innermostComponentName?: string | null;
+}
+
+const formatStackLines = (
+  stack: StackFrame[],
+  options: StackContextInternalOptions = {},
+): string[] => {
   const { maxLines = DEFAULT_MAX_CONTEXT_LINES } = options;
   const isNextProject = checkIsNextProject();
   const lines: string[] = [];
@@ -446,6 +426,7 @@ const formatStackContext = (stack: StackFrame[], options: StackContextOptions = 
   // (a deeply nested Radix/MUI tree) collapse to one line and don't evict
   // the user's own component frames from the tight maxLines budget.
   let previousLibraryPackage: string | null = null;
+  let didAttachComponentInstance = false;
 
   const emit = (line: string, libraryPackage: string | null) => {
     lines.push(line);
@@ -464,7 +445,7 @@ const formatStackContext = (stack: StackFrame[], options: StackContextOptions = 
 
     if (frame.isServer && !resolvedSource && (componentName || !frame.functionName)) {
       const tag = libraryPackage ? `${libraryPackage} at Server` : "at Server";
-      emit(`\n  in ${componentName ?? "<anonymous>"} (${tag})`, libraryPackage);
+      emit(`in ${componentName ?? "<anonymous>"} (${tag})`, libraryPackage);
       continue;
     }
 
@@ -474,52 +455,132 @@ const formatStackContext = (stack: StackFrame[], options: StackContextOptions = 
     // when we can recover it from the file path.
     if (!resolvedSource && componentName) {
       emit(
-        libraryPackage ? `\n  in ${componentName} (${libraryPackage})` : `\n  in ${componentName}`,
+        libraryPackage ? `in ${componentName} (${libraryPackage})` : `in ${componentName}`,
         libraryPackage,
       );
       continue;
     }
 
     if (resolvedSource) {
-      emit(formatResolvedSourceLine(frame, resolvedSource, componentName, isNextProject), null);
+      // Only attach props when the resolved frame name matches the fiber walk,
+      // otherwise we'd paint the wrong component's props onto the wrong line.
+      const shouldAttachInstance =
+        !didAttachComponentInstance &&
+        Boolean(options.innermostComponentInstanceText) &&
+        componentName !== null &&
+        componentName === options.innermostComponentName;
+      const componentInstanceText = shouldAttachInstance
+        ? (options.innermostComponentInstanceText ?? null)
+        : null;
+      if (shouldAttachInstance) didAttachComponentInstance = true;
+      emit(
+        formatResolvedStackLine(
+          frame,
+          resolvedSource,
+          componentName,
+          componentInstanceText,
+          isNextProject,
+        ),
+        null,
+      );
     }
   }
 
-  return lines.join("");
+  return lines;
+};
+
+const buildSourceSnippetInfo = async (
+  stack: StackFrame[],
+  componentName: string | null,
+): Promise<SourceSnippetInfo | null> => {
+  const frame = stack.find((candidate) => candidate.fileName && isSourceFile(candidate.fileName));
+  if (!frame?.fileName) return null;
+
+  const snippet = await getSourceSnippetForFrame(frame, { componentName });
+  if (!snippet) return null;
+
+  const filePath = normalizeFilePath(frame.fileName);
+  return {
+    filePath,
+    snippet,
+    block: formatSourceSnippetBlock(snippet, filePath),
+    key: `${filePath}:${snippet.highlightLine}`,
+  };
+};
+
+const buildContextParts = async (
+  element: Element,
+  options: ElementContextPartsInternalOptions,
+): Promise<ElementContextParts> => {
+  const resolvedElement = findNearestFiberElement(element);
+  const htmlPreview = getHTMLPreview(resolvedElement);
+  const maxLines = options.maxLines ?? DEFAULT_MAX_CONTEXT_LINES;
+  const stack = await getStack(resolvedElement);
+
+  if (stack && hasFormattableFrames(stack)) {
+    const componentInfo = getFiberComponentInfo(resolvedElement);
+    const sourceSnippet = options.includeSourceSnippet
+      ? await buildSourceSnippetInfo(stack, componentInfo?.name ?? null)
+      : null;
+    // When a trustworthy snippet is present its literal JSX supersedes the
+    // props line, so we drop the props to avoid near-duplicate output.
+    const hasTrustworthySnippet = Boolean(sourceSnippet) && !sourceSnippet?.snippet.isApproximate;
+    const componentInstanceText =
+      hasTrustworthySnippet || !componentInfo
+        ? null
+        : formatComponentInstance({ name: componentInfo.name, props: componentInfo.props });
+    const stackLines = formatStackLines(stack, {
+      maxLines,
+      innermostComponentInstanceText: componentInstanceText,
+      innermostComponentName: componentInfo?.name ?? null,
+    });
+    return { htmlPreview, sourceSnippet, stackLines };
+  }
+
+  const componentNames = getComponentNamesFromFiber(resolvedElement, maxLines);
+  if (componentNames.length > 0) {
+    return {
+      htmlPreview,
+      sourceSnippet: null,
+      stackLines: componentNames.map((name) => `in ${name}`),
+    };
+  }
+
+  return {
+    htmlPreview: getFallbackContext(resolvedElement),
+    sourceSnippet: null,
+    stackLines: [],
+  };
 };
 
 export const getStackContext = async (
   element: Element,
   options: StackContextOptions = {},
 ): Promise<string> => {
-  const maxLines = options.maxLines ?? DEFAULT_MAX_CONTEXT_LINES;
-  const stack = await getStack(element);
+  const parts = await buildContextParts(element, { ...options, includeSourceSnippet: false });
+  if (parts.stackLines.length === 0) return "";
+  return parts.stackLines.map((line) => `\n  ${line}`).join("");
+};
 
-  if (stack && hasFormattableFrames(stack)) {
-    return formatStackContext(stack, options);
-  }
+export const getElementContextParts = (
+  element: Element,
+  options: StackContextOptions = {},
+): Promise<ElementContextParts> =>
+  buildContextParts(element, { ...options, includeSourceSnippet: true });
 
-  const componentNames = getComponentNamesFromFiber(element, maxLines);
-  if (componentNames.length > 0) {
-    return componentNames.map((name) => `\n  in ${name}`).join("");
-  }
-
-  return "";
+export const formatElementContextParts = (parts: ElementContextParts): string => {
+  const stackText = parts.stackLines.map((line) => `\n  ${line}`).join("");
+  if (!parts.sourceSnippet) return `${parts.htmlPreview}${stackText}`;
+  const stackSection = stackText ? `\n${stackText}` : "";
+  return `${parts.htmlPreview}\n\n${parts.sourceSnippet.block}${stackSection}`;
 };
 
 export const getElementContext = async (
   element: Element,
   options: StackContextOptions = {},
 ): Promise<string> => {
-  const resolvedElement = findNearestFiberElement(element);
-  const html = getHTMLPreview(resolvedElement);
-  const stackContext = await getStackContext(resolvedElement, options);
-
-  if (stackContext) {
-    return `${html}${stackContext}`;
-  }
-
-  return getFallbackContext(resolvedElement);
+  const parts = await getElementContextParts(element, options);
+  return formatElementContextParts(parts);
 };
 
 const getFallbackContext = (element: Element): string => {

--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -539,11 +539,18 @@ const buildContextParts = async (
 
   const componentNames = getComponentNamesFromFiber(resolvedElement, maxLines);
   if (componentNames.length > 0) {
-    return {
-      htmlPreview,
-      sourceSnippet: null,
-      stackLines: componentNames.map((name) => `in ${name}`),
-    };
+    // Without a formattable owner stack, the source snippet is unreachable —
+    // surface the fiber's memoized props on the innermost component name so
+    // the agent still gets the call shape.
+    const componentInfo = getFiberComponentInfo(resolvedElement);
+    const componentInstanceText =
+      componentInfo && componentInfo.name === componentNames[0]
+        ? formatComponentInstance({ name: componentInfo.name, props: componentInfo.props })
+        : null;
+    const stackLines = componentNames.map((name, nameIndex) =>
+      nameIndex === 0 && componentInstanceText ? `in ${componentInstanceText}` : `in ${name}`,
+    );
+    return { htmlPreview, sourceSnippet: null, stackLines };
   }
 
   return {

--- a/packages/react-grab/src/core/copy.ts
+++ b/packages/react-grab/src/core/copy.ts
@@ -1,6 +1,7 @@
+import { formatElementContextParts } from "./context.js";
 import { copyContent, type ReactGrabEntry } from "../utils/copy-content.js";
-import { generateSnippet } from "../utils/generate-snippet.js";
-import { joinSnippets } from "../utils/join-snippets.js";
+import { generateSnippetParts } from "../utils/generate-snippet.js";
+import { joinSnippetEntries, type JoinSnippetEntry } from "../utils/join-snippets.js";
 import { normalizeError } from "../utils/normalize-error.js";
 
 interface CopyOptions {
@@ -36,22 +37,36 @@ export const tryCopyWithFallback = async (
     if (options.getContent) {
       generatedContent = await options.getContent(elements);
     } else {
-      const rawSnippets = await generateSnippet(elements, {
+      const partsList = await generateSnippetParts(elements, {
         maxLines: options.maxContextLines,
       });
+      const originalSnippets = partsList.map(formatElementContextParts);
       const transformedSnippets = await Promise.all(
-        rawSnippets.map((snippet, index) =>
+        originalSnippets.map((snippet, index) =>
           snippet.trim() ? hooks.transformSnippet(snippet, elements[index]) : Promise.resolve(""),
         ),
       );
-      const snippetElementPairs = transformedSnippets
-        .map((snippet, index) => ({ snippet, element: elements[index] }))
-        .filter(({ snippet }) => snippet.trim());
 
-      generatedContent = joinSnippets(snippetElementPairs.map(({ snippet }) => snippet));
-      entries = snippetElementPairs.map(({ snippet, element }) => ({
-        tagName: element.localName,
-        content: snippet,
+      // Plugin transforms can mutate snippet text, breaking the structured
+      // `parts` invariant the collapse algorithm relies on.
+      let allowCollapse = true;
+      const joinEntries: JoinSnippetEntry[] = [];
+      const trackedElements: Element[] = [];
+      for (let entryIndex = 0; entryIndex < transformedSnippets.length; entryIndex++) {
+        const transformed = transformedSnippets[entryIndex];
+        if (!transformed.trim()) continue;
+        if (transformed !== originalSnippets[entryIndex]) allowCollapse = false;
+        joinEntries.push({
+          snippet: transformed,
+          parts: partsList[entryIndex],
+        });
+        trackedElements.push(elements[entryIndex]);
+      }
+
+      generatedContent = joinSnippetEntries(joinEntries, { allowCollapse });
+      entries = joinEntries.map((entry, entryIndex) => ({
+        tagName: trackedElements[entryIndex].localName,
+        content: entry.snippet,
         commentText: extraPrompt,
       }));
     }

--- a/packages/react-grab/src/utils/escape-regexp.ts
+++ b/packages/react-grab/src/utils/escape-regexp.ts
@@ -1,0 +1,4 @@
+const REGEXP_SPECIAL_CHARS_PATTERN = /[.*+?^${}()|[\]\\]/g;
+
+export const escapeRegExp = (input: string): string =>
+  input.replace(REGEXP_SPECIAL_CHARS_PATTERN, "\\$&");

--- a/packages/react-grab/src/utils/find-longest-common-suffix.ts
+++ b/packages/react-grab/src/utils/find-longest-common-suffix.ts
@@ -1,0 +1,13 @@
+export const findLongestCommonSuffix = <T>(lists: T[][]): T[] => {
+  if (lists.length === 0) return [];
+  const minLength = Math.min(...lists.map((list) => list.length));
+  let suffixLength = 0;
+  for (let suffixIndex = 1; suffixIndex <= minLength; suffixIndex++) {
+    const candidate = lists[0][lists[0].length - suffixIndex];
+    const isShared = lists.every((list) => list[list.length - suffixIndex] === candidate);
+    if (!isShared) break;
+    suffixLength = suffixIndex;
+  }
+  if (suffixLength === 0) return [];
+  return lists[0].slice(lists[0].length - suffixLength);
+};

--- a/packages/react-grab/src/utils/format-component-instance.ts
+++ b/packages/react-grab/src/utils/format-component-instance.ts
@@ -1,0 +1,79 @@
+import {
+  COMPONENT_INSTANCE_MAX_PROPS,
+  COMPONENT_INSTANCE_MAX_VALUE_LENGTH_CHARS,
+} from "../constants.js";
+import { truncateString } from "./truncate-string.js";
+
+interface ComponentInstance {
+  name: string;
+  props: Record<string, unknown> | null;
+}
+
+const SKIP_PROP_NAMES = new Set(["children", "key", "ref", "dangerouslySetInnerHTML"]);
+
+const formatPropValue = (value: unknown): string | null => {
+  if (value === null) return "{null}";
+  if (value === undefined) return null;
+
+  if (typeof value === "string") {
+    return `"${truncateString(value, COMPONENT_INSTANCE_MAX_VALUE_LENGTH_CHARS)}"`;
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return `{${String(value)}}`;
+  }
+  if (typeof value === "function") {
+    const functionName = typeof value.name === "string" ? value.name : "";
+    return functionName ? `{[Function: ${functionName}]}` : "{[Function]}";
+  }
+  if (typeof value === "symbol") {
+    return `{${value.toString()}}`;
+  }
+  if (Array.isArray(value)) {
+    return value.length === 0 ? "{[]}" : `{[${value.length} items]}`;
+  }
+  if (typeof value === "object") {
+    if (value instanceof Date) return `{Date(${value.toISOString()})}`;
+    if (value instanceof RegExp) return `{${value.toString()}}`;
+    if (typeof Element !== "undefined" && value instanceof Element) {
+      return `{<${value.localName} ...>}`;
+    }
+    return "{{...}}";
+  }
+  return null;
+};
+
+const isRenderablePropName = (name: string): boolean => {
+  if (SKIP_PROP_NAMES.has(name)) return false;
+  if (name.startsWith("__")) return false;
+  if (name.startsWith("$$")) return false;
+  return true;
+};
+
+export const formatComponentInstance = (instance: ComponentInstance): string => {
+  const { name, props } = instance;
+  if (!props) return `<${name} />`;
+
+  const renderedAttrs: string[] = [];
+  let truncatedCount = 0;
+
+  for (const propName of Object.keys(props)) {
+    if (!isRenderablePropName(propName)) continue;
+    if (renderedAttrs.length >= COMPONENT_INSTANCE_MAX_PROPS) {
+      truncatedCount++;
+      continue;
+    }
+    const formatted = formatPropValue(props[propName]);
+    if (formatted === null) continue;
+    if (formatted === "{true}") {
+      renderedAttrs.push(propName);
+      continue;
+    }
+    renderedAttrs.push(`${propName}=${formatted}`);
+  }
+
+  if (renderedAttrs.length === 0 && truncatedCount === 0) return `<${name} />`;
+
+  const attrText = renderedAttrs.join(" ");
+  const ellipsis = truncatedCount > 0 ? ` /* +${truncatedCount} more */` : "";
+  return `<${name} ${attrText}${ellipsis} />`;
+};

--- a/packages/react-grab/src/utils/format-component-instance.ts
+++ b/packages/react-grab/src/utils/format-component-instance.ts
@@ -32,7 +32,9 @@ const formatPropValue = (value: unknown): string | null => {
     return value.length === 0 ? "{[]}" : `{[${value.length} items]}`;
   }
   if (typeof value === "object") {
-    if (value instanceof Date) return `{Date(${value.toISOString()})}`;
+    if (value instanceof Date) {
+      return Number.isNaN(value.getTime()) ? "{Date(Invalid)}" : `{Date(${value.toISOString()})}`;
+    }
     if (value instanceof RegExp) return `{${value.toString()}}`;
     if (typeof Element !== "undefined" && value instanceof Element) {
       return `{<${value.localName} ...>}`;
@@ -58,12 +60,12 @@ export const formatComponentInstance = (instance: ComponentInstance): string => 
 
   for (const propName of Object.keys(props)) {
     if (!isRenderablePropName(propName)) continue;
+    const formatted = formatPropValue(props[propName]);
+    if (formatted === null) continue;
     if (renderedAttrs.length >= COMPONENT_INSTANCE_MAX_PROPS) {
       truncatedCount++;
       continue;
     }
-    const formatted = formatPropValue(props[propName]);
-    if (formatted === null) continue;
     if (formatted === "{true}") {
       renderedAttrs.push(propName);
       continue;

--- a/packages/react-grab/src/utils/format-source-snippet-block.ts
+++ b/packages/react-grab/src/utils/format-source-snippet-block.ts
@@ -1,0 +1,15 @@
+import type { SourceSnippet } from "./get-source-snippet.js";
+
+export const formatSourceSnippetBlock = (snippet: SourceSnippet, filePath: string): string => {
+  const headerSuffix = snippet.isApproximate ? " (approximate)" : "";
+  const header = `// ${filePath}:${snippet.highlightLine}${headerSuffix}`;
+
+  const lineNumberWidth = String(snippet.endLine).length;
+  const formattedLines = snippet.lines.map((line, lineIndex) => {
+    const currentLineNumber = snippet.startLine + lineIndex;
+    const marker = currentLineNumber === snippet.highlightLine ? "> " : "  ";
+    return `${marker}${String(currentLineNumber).padStart(lineNumberWidth, " ")}| ${line}`;
+  });
+
+  return `${header}\n${formattedLines.join("\n")}`;
+};

--- a/packages/react-grab/src/utils/generate-snippet.ts
+++ b/packages/react-grab/src/utils/generate-snippet.ts
@@ -1,20 +1,38 @@
-import { getElementContext } from "../core/context.js";
+import {
+  formatElementContextParts,
+  getElementContextParts,
+  type ElementContextParts,
+} from "../core/context.js";
+import { logRecoverableError } from "./log-recoverable-error.js";
 
 interface GenerateSnippetOptions {
   maxLines?: number;
 }
 
+const emptyParts: ElementContextParts = {
+  htmlPreview: "",
+  sourceSnippet: null,
+  stackLines: [],
+};
+
+export const generateSnippetParts = async (
+  elements: Element[],
+  options: GenerateSnippetOptions = {},
+): Promise<ElementContextParts[]> => {
+  const results = await Promise.allSettled(
+    elements.map((element) => getElementContextParts(element, options)),
+  );
+  return results.map((result) => {
+    if (result.status === "fulfilled") return result.value;
+    logRecoverableError("generateSnippetParts: failed to build element context", result.reason);
+    return emptyParts;
+  });
+};
+
 export const generateSnippet = async (
   elements: Element[],
   options: GenerateSnippetOptions = {},
 ): Promise<string[]> => {
-  const elementSnippetResults = await Promise.allSettled(
-    elements.map((element) => getElementContext(element, options)),
-  );
-
-  const elementSnippets = elementSnippetResults.map((result) =>
-    result.status === "fulfilled" ? result.value : "",
-  );
-
-  return elementSnippets;
+  const partsList = await generateSnippetParts(elements, options);
+  return partsList.map(formatElementContextParts);
 };

--- a/packages/react-grab/src/utils/generate-snippet.ts
+++ b/packages/react-grab/src/utils/generate-snippet.ts
@@ -9,11 +9,11 @@ interface GenerateSnippetOptions {
   maxLines?: number;
 }
 
-const emptyParts: ElementContextParts = {
+const buildEmptyParts = (): ElementContextParts => ({
   htmlPreview: "",
   sourceSnippet: null,
   stackLines: [],
-};
+});
 
 export const generateSnippetParts = async (
   elements: Element[],
@@ -25,7 +25,7 @@ export const generateSnippetParts = async (
   return results.map((result) => {
     if (result.status === "fulfilled") return result.value;
     logRecoverableError("generateSnippetParts: failed to build element context", result.reason);
-    return emptyParts;
+    return buildEmptyParts();
   });
 };
 

--- a/packages/react-grab/src/utils/get-fiber-component-info.ts
+++ b/packages/react-grab/src/utils/get-fiber-component-info.ts
@@ -1,0 +1,36 @@
+import {
+  getDisplayName,
+  getFiberFromHostInstance,
+  isCompositeFiber,
+  isInstrumentationActive,
+} from "bippy";
+import { isUsefulComponentName } from "./is-useful-component-name.js";
+
+export interface FiberComponentInfo {
+  name: string;
+  props: Record<string, unknown> | null;
+}
+
+const isPropsRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+export const getFiberComponentInfo = (element: Element): FiberComponentInfo | null => {
+  if (!isInstrumentationActive()) return null;
+  const hostFiber = getFiberFromHostInstance(element);
+  if (!hostFiber) return null;
+
+  let currentFiber = hostFiber.return;
+  while (currentFiber) {
+    if (isCompositeFiber(currentFiber)) {
+      const name = getDisplayName(currentFiber.type);
+      if (name && isUsefulComponentName(name)) {
+        const memoizedProps: unknown = currentFiber.memoizedProps;
+        const props = isPropsRecord(memoizedProps) ? memoizedProps : null;
+        return { name, props };
+      }
+    }
+    currentFiber = currentFiber.return;
+  }
+
+  return null;
+};

--- a/packages/react-grab/src/utils/get-source-snippet.ts
+++ b/packages/react-grab/src/utils/get-source-snippet.ts
@@ -1,0 +1,204 @@
+import { isSourceFile, sourceMapCache, type SourceMap, type StackFrame } from "bippy/source";
+import {
+  SOURCE_SNIPPET_FETCH_TIMEOUT_MS,
+  SOURCE_SNIPPET_LINES_AFTER,
+  SOURCE_SNIPPET_LINES_BEFORE,
+  SOURCE_SNIPPET_MAX_LINE_LENGTH_CHARS,
+} from "../constants.js";
+import { escapeRegExp } from "./escape-regexp.js";
+import { truncateString } from "./truncate-string.js";
+
+export interface SourceSnippet {
+  startLine: number;
+  endLine: number;
+  highlightLine: number;
+  lines: string[];
+  isApproximate: boolean;
+}
+
+const sourceContentByFile = new Map<string, Promise<string | null>>();
+
+// Vite serves transformed code at the same URL as the original (`/src/Foo.tsx`
+// returns `_jsxDEV(...)` instead of JSX). Reject those fingerprints so we
+// don't show the agent rewritten output that has lost the call site.
+const TRANSFORMED_OUTPUT_PATTERN =
+  /\b_jsxDEV\(|\b_jsx\(|\bjsxRuntime\b|\$RefreshSig\$|var _jsxFileName\s*=/;
+const TRANSFORMED_DETECTION_HEAD_CHARS = 2_000;
+
+export const looksTransformed = (content: string): boolean =>
+  TRANSFORMED_OUTPUT_PATTERN.test(content.slice(0, TRANSFORMED_DETECTION_HEAD_CHARS));
+
+// Suffix matching covers bundlers that prefix `sources` entries
+// (`webpack://`, `vite://`, etc). Require ≥2 path segments so a basename like
+// `index.tsx` can't false-match an unrelated module in another cached map.
+const MIN_SUFFIX_SEGMENTS = 2;
+
+const findContentBySuffixMatch = (sourceMap: SourceMap, fileName: string): string | null => {
+  if (!sourceMap.sources || !sourceMap.sourcesContent) return null;
+  const lookupSuffix = fileName.startsWith("/") ? fileName : `/${fileName}`;
+  if (lookupSuffix.split("/").length - 1 < MIN_SUFFIX_SEGMENTS) return null;
+  for (let sourceIndex = 0; sourceIndex < sourceMap.sources.length; sourceIndex++) {
+    const sourceEntry = sourceMap.sources[sourceIndex];
+    if (!sourceEntry) continue;
+    if (sourceEntry.endsWith(lookupSuffix)) {
+      const content = sourceMap.sourcesContent[sourceIndex];
+      if (content) return content;
+    }
+  }
+  return null;
+};
+
+const findContentInSourceMap = (
+  sourceMap: SourceMap | undefined,
+  fileName: string,
+): string | null => {
+  if (!sourceMap?.sources || !sourceMap.sourcesContent) return null;
+  const exactIndex = sourceMap.sources.indexOf(fileName);
+  if (exactIndex !== -1) {
+    const content = sourceMap.sourcesContent[exactIndex];
+    if (content) return content;
+  }
+  const suffixMatch = findContentBySuffixMatch(sourceMap, fileName);
+  if (suffixMatch) return suffixMatch;
+  if (sourceMap.sections) {
+    for (const section of sourceMap.sections) {
+      const content = findContentInSourceMap(section.map, fileName);
+      if (content) return content;
+    }
+  }
+  return null;
+};
+
+const findCachedSourceContent = (fileName: string): string | null => {
+  for (const cached of sourceMapCache.values()) {
+    if (!cached) continue;
+    const sourceMap = cached instanceof WeakRef ? cached.deref() : cached;
+    if (!sourceMap) continue;
+    const content = findContentInSourceMap(sourceMap, fileName);
+    if (content) return content;
+  }
+  return null;
+};
+
+// Same-origin only: prevents a doctored `_debugSource.fileName` from causing
+// the dev's browser to fetch attacker URLs. Also rejects `//host/...`
+// protocol-relative URLs that string-prefix checks would let through.
+const isFetchableUrl = (fileName: string): boolean => {
+  if (typeof location === "undefined") return false;
+  try {
+    return new URL(fileName, location.origin).origin === location.origin;
+  } catch {
+    return false;
+  }
+};
+
+const fetchOriginalSource = async (fileName: string): Promise<string | null> => {
+  if (!isFetchableUrl(fileName)) return null;
+
+  const url = new URL(fileName, location.origin).toString();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), SOURCE_SNIPPET_FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      credentials: "same-origin",
+      signal: controller.signal,
+    });
+    if (!response.ok) return null;
+    const body = await response.text();
+    if (looksTransformed(body)) return null;
+    return body;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+// Cache in-flight promises to dedupe concurrent calls, but evict null results
+// so a transient HMR-rebuild failure doesn't permanently block snippets for
+// that file.
+const getSourceContent = (fileName: string): Promise<string | null> => {
+  const cached = sourceContentByFile.get(fileName);
+  if (cached) return cached;
+
+  const fromMap = findCachedSourceContent(fileName);
+  if (fromMap) {
+    const resolved = Promise.resolve(fromMap);
+    sourceContentByFile.set(fileName, resolved);
+    return resolved;
+  }
+
+  const promise = fetchOriginalSource(fileName);
+  sourceContentByFile.set(fileName, promise);
+  promise
+    .then((value) => {
+      if (value === null && sourceContentByFile.get(fileName) === promise) {
+        sourceContentByFile.delete(fileName);
+      }
+    })
+    .catch(() => {
+      if (sourceContentByFile.get(fileName) === promise) {
+        sourceContentByFile.delete(fileName);
+      }
+    });
+  return promise;
+};
+
+// Match only proper component tags (`<UpperCase`). Looser tokens like `=>` or
+// `function` trigger on every utility file and silently mark wrong-target
+// resolutions as trustworthy.
+const JSX_TAG_PATTERN = /<[A-Z][A-Za-z0-9]*[\s/>]/;
+
+const isSnippetTrustworthy = (windowLines: string[], componentName: string | null): boolean => {
+  const joined = windowLines.join("\n");
+  if (!joined.trim()) return false;
+  if (JSX_TAG_PATTERN.test(joined)) return true;
+  if (componentName) {
+    const componentNamePattern = new RegExp(`\\b${escapeRegExp(componentName)}\\b`);
+    if (componentNamePattern.test(joined)) return true;
+  }
+  return false;
+};
+
+const sliceSnippetWindow = (
+  sourceLines: string[],
+  resolvedLineNumber: number,
+): { startLine: number; endLine: number; lines: string[] } | null => {
+  if (resolvedLineNumber < 1 || resolvedLineNumber > sourceLines.length) return null;
+
+  const startLine = Math.max(1, resolvedLineNumber - SOURCE_SNIPPET_LINES_BEFORE);
+  const endLine = Math.min(sourceLines.length, resolvedLineNumber + SOURCE_SNIPPET_LINES_AFTER);
+  const lines = sourceLines
+    .slice(startLine - 1, endLine)
+    .map((line) => truncateString(line, SOURCE_SNIPPET_MAX_LINE_LENGTH_CHARS));
+
+  return { startLine, endLine, lines };
+};
+
+interface GetSourceSnippetOptions {
+  componentName?: string | null;
+}
+
+export const getSourceSnippetForFrame = async (
+  frame: StackFrame,
+  options: GetSourceSnippetOptions = {},
+): Promise<SourceSnippet | null> => {
+  if (!frame.fileName || !isSourceFile(frame.fileName)) return null;
+  if (typeof frame.lineNumber !== "number" || frame.lineNumber < 1) return null;
+
+  const sourceContent = await getSourceContent(frame.fileName);
+  if (!sourceContent) return null;
+
+  const sourceLines = sourceContent.split("\n");
+  const sliced = sliceSnippetWindow(sourceLines, frame.lineNumber);
+  if (!sliced) return null;
+
+  return {
+    startLine: sliced.startLine,
+    endLine: sliced.endLine,
+    highlightLine: frame.lineNumber,
+    lines: sliced.lines,
+    isApproximate: !isSnippetTrustworthy(sliced.lines, options.componentName ?? null),
+  };
+};

--- a/packages/react-grab/src/utils/get-source-snippet.ts
+++ b/packages/react-grab/src/utils/get-source-snippet.ts
@@ -52,14 +52,16 @@ const findContentInSourceMap = (
   sourceMap: SourceMap | undefined,
   fileName: string,
 ): string | null => {
-  if (!sourceMap?.sources || !sourceMap.sourcesContent) return null;
-  const exactIndex = sourceMap.sources.indexOf(fileName);
-  if (exactIndex !== -1) {
-    const content = sourceMap.sourcesContent[exactIndex];
-    if (content) return content;
+  if (!sourceMap) return null;
+  if (sourceMap.sources && sourceMap.sourcesContent) {
+    const exactIndex = sourceMap.sources.indexOf(fileName);
+    if (exactIndex !== -1) {
+      const content = sourceMap.sourcesContent[exactIndex];
+      if (content) return content;
+    }
+    const suffixMatch = findContentBySuffixMatch(sourceMap, fileName);
+    if (suffixMatch) return suffixMatch;
   }
-  const suffixMatch = findContentBySuffixMatch(sourceMap, fileName);
-  if (suffixMatch) return suffixMatch;
   if (sourceMap.sections) {
     for (const section of sourceMap.sections) {
       const content = findContentInSourceMap(section.map, fileName);

--- a/packages/react-grab/src/utils/is-useful-component-name.ts
+++ b/packages/react-grab/src/utils/is-useful-component-name.ts
@@ -1,0 +1,62 @@
+const NON_COMPONENT_PREFIXES = new Set([
+  "_",
+  "$",
+  "motion.",
+  "styled.",
+  "chakra.",
+  "ark.",
+  "Primitive.",
+  "Slot.",
+]);
+
+const NEXT_INTERNAL_COMPONENT_NAMES = new Set([
+  "InnerLayoutRouter",
+  "RedirectErrorBoundary",
+  "RedirectBoundary",
+  "HTTPAccessFallbackErrorBoundary",
+  "HTTPAccessFallbackBoundary",
+  "LoadingBoundary",
+  "ErrorBoundary",
+  "InnerScrollAndFocusHandler",
+  "ScrollAndFocusHandler",
+  "RenderFromTemplateContext",
+  "OuterLayoutRouter",
+  "body",
+  "html",
+  "DevRootHTTPAccessFallbackBoundary",
+  "AppDevOverlayErrorBoundary",
+  "AppDevOverlay",
+  "HotReload",
+  "Router",
+  "ErrorBoundaryHandler",
+  "AppRouter",
+  "ServerRoot",
+  "SegmentStateProvider",
+  "RootErrorBoundary",
+  "LoadableComponent",
+  "MotionDOMComponent",
+]);
+
+const REACT_INTERNAL_COMPONENT_NAMES = new Set([
+  "Suspense",
+  "Fragment",
+  "StrictMode",
+  "Profiler",
+  "SuspenseList",
+]);
+
+export const isInternalComponentName = (name: string): boolean => {
+  if (NEXT_INTERNAL_COMPONENT_NAMES.has(name)) return true;
+  if (REACT_INTERNAL_COMPONENT_NAMES.has(name)) return true;
+  for (const prefix of NON_COMPONENT_PREFIXES) {
+    if (name.startsWith(prefix)) return true;
+  }
+  return false;
+};
+
+export const isUsefulComponentName = (name: string): boolean => {
+  if (!name) return false;
+  if (isInternalComponentName(name)) return false;
+  if (name === "SlotClone" || name === "Slot") return false;
+  return true;
+};

--- a/packages/react-grab/src/utils/join-snippets.ts
+++ b/packages/react-grab/src/utils/join-snippets.ts
@@ -10,8 +10,11 @@ interface JoinSnippetEntriesOptions {
   allowCollapse: boolean;
 }
 
-const formatStackLines = (stackLines: string[]): string =>
-  stackLines.map((line) => `\n  ${line}`).join("");
+const indentStackLines = (stackLines: string[]): string =>
+  stackLines.map((line) => `  ${line}`).join("\n");
+
+const formatDivergingStackLines = (stackLines: string[]): string =>
+  stackLines.length > 0 ? `\n${indentStackLines(stackLines)}` : "";
 
 const renderLegacyMultiEntry = (snippets: string[]): string =>
   snippets.map((snippet, index) => `[${index + 1}]\n${snippet}`).join("\n\n");
@@ -51,12 +54,12 @@ export const joinSnippetEntries = (
       entry.parts.stackLines.length - sharedStack.length,
     );
     if (divergingLines.length > 0) anyDivergence = true;
-    return `[${entryIndex + 1}] ${entry.parts.htmlPreview}${formatStackLines(divergingLines)}`;
+    return `[${entryIndex + 1}] ${entry.parts.htmlPreview}${formatDivergingStackLines(divergingLines)}`;
   });
 
   const entrySeparator = anyDivergence ? "\n\n" : "\n";
   const sections: string[] = [renderedEntries.join(entrySeparator)];
   if (sharedSnippetBlock) sections.push(sharedSnippetBlock);
-  sections.push(formatStackLines(sharedStack).trimStart());
+  sections.push(indentStackLines(sharedStack));
   return sections.join("\n\n");
 };

--- a/packages/react-grab/src/utils/join-snippets.ts
+++ b/packages/react-grab/src/utils/join-snippets.ts
@@ -1,5 +1,62 @@
+import type { ElementContextParts } from "../core/context.js";
+import { findLongestCommonSuffix } from "./find-longest-common-suffix.js";
+
+export interface JoinSnippetEntry {
+  snippet: string;
+  parts: ElementContextParts;
+}
+
+interface JoinSnippetEntriesOptions {
+  allowCollapse: boolean;
+}
+
+const formatStackLines = (stackLines: string[]): string =>
+  stackLines.map((line) => `\n  ${line}`).join("");
+
+const renderLegacyMultiEntry = (snippets: string[]): string =>
+  snippets.map((snippet, index) => `[${index + 1}]\n${snippet}`).join("\n\n");
+
 export const joinSnippets = (snippets: string[]): string => {
   if (snippets.length <= 1) return snippets[0] ?? "";
+  return renderLegacyMultiEntry(snippets);
+};
 
-  return snippets.map((snippet, index) => `[${index + 1}]\n${snippet}`).join("\n\n");
+export const joinSnippetEntries = (
+  entries: JoinSnippetEntry[],
+  options: JoinSnippetEntriesOptions,
+): string => {
+  if (entries.length === 0) return "";
+  if (entries.length === 1) return entries[0].snippet;
+
+  if (!options.allowCollapse) {
+    return renderLegacyMultiEntry(entries.map((entry) => entry.snippet));
+  }
+
+  const stackLists = entries.map((entry) => entry.parts.stackLines);
+  const sharedStack = findLongestCommonSuffix(stackLists);
+  if (sharedStack.length === 0) {
+    return renderLegacyMultiEntry(entries.map((entry) => entry.snippet));
+  }
+
+  const firstSnippetKey = entries[0].parts.sourceSnippet?.key;
+  const haveSharedSnippet =
+    Boolean(firstSnippetKey) &&
+    entries.every((entry) => entry.parts.sourceSnippet?.key === firstSnippetKey);
+  const sharedSnippetBlock = haveSharedSnippet ? entries[0].parts.sourceSnippet?.block : null;
+
+  let anyDivergence = false;
+  const renderedEntries = entries.map((entry, entryIndex) => {
+    const divergingLines = entry.parts.stackLines.slice(
+      0,
+      entry.parts.stackLines.length - sharedStack.length,
+    );
+    if (divergingLines.length > 0) anyDivergence = true;
+    return `[${entryIndex + 1}] ${entry.parts.htmlPreview}${formatStackLines(divergingLines)}`;
+  });
+
+  const entrySeparator = anyDivergence ? "\n\n" : "\n";
+  const sections: string[] = [renderedEntries.join(entrySeparator)];
+  if (sharedSnippetBlock) sections.push(sharedSnippetBlock);
+  sections.push(formatStackLines(sharedStack).trimStart());
+  return sections.join("\n\n");
 };

--- a/packages/react-grab/test/escape-regexp.test.ts
+++ b/packages/react-grab/test/escape-regexp.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vite-plus/test";
+import { escapeRegExp } from "../src/utils/escape-regexp.js";
+
+describe("escapeRegExp", () => {
+  it("escapes regex metacharacters", () => {
+    expect(escapeRegExp(".*+?^${}()|[]\\")).toBe("\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\");
+  });
+
+  it("leaves plain alphanumerics untouched", () => {
+    expect(escapeRegExp("MyComponent_42")).toBe("MyComponent_42");
+  });
+
+  it("produces a regex source that matches the original string literally", () => {
+    const input = "a.b+c[d]";
+    const pattern = new RegExp(`^${escapeRegExp(input)}$`);
+    expect(pattern.test(input)).toBe(true);
+    expect(pattern.test("aXbXcXdX")).toBe(false);
+  });
+});

--- a/packages/react-grab/test/find-longest-common-suffix.test.ts
+++ b/packages/react-grab/test/find-longest-common-suffix.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vite-plus/test";
+import { findLongestCommonSuffix } from "../src/utils/find-longest-common-suffix.js";
+
+describe("findLongestCommonSuffix", () => {
+  it("returns an empty array when no lists are provided", () => {
+    expect(findLongestCommonSuffix([])).toEqual([]);
+  });
+
+  it("returns an empty array when any list is empty", () => {
+    expect(findLongestCommonSuffix([["a", "b"], []])).toEqual([]);
+  });
+
+  it("returns the full list when there is only one list", () => {
+    expect(findLongestCommonSuffix([["a", "b", "c"]])).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns the shared suffix between two lists", () => {
+    expect(
+      findLongestCommonSuffix([
+        ["x", "common", "tail"],
+        ["y", "z", "common", "tail"],
+      ]),
+    ).toEqual(["common", "tail"]);
+  });
+
+  it("returns an empty array when no suffix is shared", () => {
+    expect(
+      findLongestCommonSuffix([
+        ["a", "b"],
+        ["c", "d"],
+      ]),
+    ).toEqual([]);
+  });
+
+  it("compares by strict equality across many lists", () => {
+    expect(
+      findLongestCommonSuffix([
+        ["1", "shared"],
+        ["2", "shared"],
+        ["3", "shared"],
+      ]),
+    ).toEqual(["shared"]);
+  });
+
+  it("returns an empty array if a single list breaks the suffix", () => {
+    expect(
+      findLongestCommonSuffix([
+        ["x", "common"],
+        ["y", "common"],
+        ["z", "different"],
+      ]),
+    ).toEqual([]);
+  });
+});

--- a/packages/react-grab/test/format-component-instance.test.ts
+++ b/packages/react-grab/test/format-component-instance.test.ts
@@ -125,4 +125,20 @@ describe("formatComponentInstance", () => {
       "<Comp value={null} />",
     );
   });
+
+  it("handles invalid Date props without throwing", () => {
+    const invalidDate = new Date("not-a-date");
+    expect(formatComponentInstance({ name: "Comp", props: { at: invalidDate } })).toBe(
+      "<Comp at={Date(Invalid)} />",
+    );
+  });
+
+  it("does not count undefined props past the limit toward the overflow marker", () => {
+    expect(
+      formatComponentInstance({
+        name: "Comp",
+        props: { a: 1, b: 2, c: 3, d: 4, e: undefined, f: undefined, g: 7 },
+      }),
+    ).toBe("<Comp a={1} b={2} c={3} d={4} /* +1 more */ />");
+  });
 });

--- a/packages/react-grab/test/format-component-instance.test.ts
+++ b/packages/react-grab/test/format-component-instance.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vite-plus/test";
+import { formatComponentInstance } from "../src/utils/format-component-instance.js";
+
+describe("formatComponentInstance", () => {
+  it("renders a self-closing tag for a component with no props", () => {
+    expect(formatComponentInstance({ name: "Button", props: null })).toBe("<Button />");
+    expect(formatComponentInstance({ name: "Button", props: {} })).toBe("<Button />");
+  });
+
+  it("renders string props as quoted JSX attributes", () => {
+    expect(
+      formatComponentInstance({
+        name: "Link",
+        props: { href: "/forgot", className: "btn" },
+      }),
+    ).toBe('<Link href="/forgot" className="btn" />');
+  });
+
+  it("renders numeric and boolean primitives in braces", () => {
+    expect(
+      formatComponentInstance({
+        name: "Counter",
+        props: { count: 42, ready: false },
+      }),
+    ).toBe("<Counter count={42} ready={false} />");
+  });
+
+  it("renders true booleans as the bare attribute name", () => {
+    expect(formatComponentInstance({ name: "Input", props: { disabled: true } })).toBe(
+      "<Input disabled />",
+    );
+  });
+
+  it("renders functions as a Function placeholder with the name", () => {
+    const handleClick = (): void => {};
+    expect(
+      formatComponentInstance({
+        name: "Button",
+        props: { onClick: handleClick },
+      }),
+    ).toBe("<Button onClick={[Function: handleClick]} />");
+  });
+
+  it("renders anonymous functions without a Function name", () => {
+    expect(
+      formatComponentInstance({
+        name: "Button",
+        props: { onClick: () => {} },
+      }),
+    ).toBe("<Button onClick={[Function: onClick]} />");
+  });
+
+  it("renders arrays compactly with their item count", () => {
+    expect(formatComponentInstance({ name: "List", props: { items: [1, 2, 3] } })).toBe(
+      "<List items={[3 items]} />",
+    );
+  });
+
+  it("renders empty arrays distinctly", () => {
+    expect(formatComponentInstance({ name: "List", props: { items: [] } })).toBe(
+      "<List items={[]} />",
+    );
+  });
+
+  it("renders generic object props as a placeholder", () => {
+    expect(
+      formatComponentInstance({
+        name: "Card",
+        props: { meta: { id: "abc" } },
+      }),
+    ).toBe("<Card meta={{...}} />");
+  });
+
+  it("skips children, key, ref, and dangerouslySetInnerHTML", () => {
+    expect(
+      formatComponentInstance({
+        name: "Item",
+        props: {
+          children: "hello",
+          key: "item-1",
+          ref: { current: null },
+          dangerouslySetInnerHTML: { __html: "<b>x</b>" },
+          label: "Click",
+        },
+      }),
+    ).toBe('<Item label="Click" />');
+  });
+
+  it("skips internal-looking props with double-underscore or $$ prefixes", () => {
+    expect(
+      formatComponentInstance({
+        name: "Comp",
+        props: { __dev: true, $$typeof: "react.element", visible: true },
+      }),
+    ).toBe("<Comp visible />");
+  });
+
+  it("truncates long string values", () => {
+    const longText = "x".repeat(200);
+    const formatted = formatComponentInstance({
+      name: "Comp",
+      props: { text: longText },
+    });
+    expect(formatted).toContain("...");
+    expect(formatted.length).toBeLessThan(longText.length);
+  });
+
+  it("limits the number of rendered props with an overflow marker", () => {
+    expect(
+      formatComponentInstance({
+        name: "Comp",
+        props: { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 },
+      }),
+    ).toBe("<Comp a={1} b={2} c={3} d={4} /* +2 more */ />");
+  });
+
+  it("handles undefined values by omitting them entirely", () => {
+    expect(formatComponentInstance({ name: "Comp", props: { a: undefined, b: 1 } })).toBe(
+      "<Comp b={1} />",
+    );
+  });
+
+  it("handles null values explicitly", () => {
+    expect(formatComponentInstance({ name: "Comp", props: { value: null } })).toBe(
+      "<Comp value={null} />",
+    );
+  });
+});

--- a/packages/react-grab/test/format-source-snippet-block.test.ts
+++ b/packages/react-grab/test/format-source-snippet-block.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vite-plus/test";
+import { formatSourceSnippetBlock } from "../src/utils/format-source-snippet-block.js";
+
+describe("formatSourceSnippetBlock", () => {
+  it("renders the file location header with the highlight line", () => {
+    const block = formatSourceSnippetBlock(
+      {
+        startLine: 10,
+        endLine: 12,
+        highlightLine: 11,
+        lines: ["a", "b", "c"],
+        isApproximate: false,
+      },
+      "components/foo.tsx",
+    );
+    expect(block.startsWith("// components/foo.tsx:11\n")).toBe(true);
+  });
+
+  it("marks approximate snippets so the agent doesn't blindly trust them", () => {
+    const block = formatSourceSnippetBlock(
+      {
+        startLine: 10,
+        endLine: 12,
+        highlightLine: 11,
+        lines: ["a", "b", "c"],
+        isApproximate: true,
+      },
+      "components/foo.tsx",
+    );
+    expect(block).toContain("(approximate)");
+  });
+
+  it("highlights the resolved line with a `>` marker, others with two spaces", () => {
+    const block = formatSourceSnippetBlock(
+      {
+        startLine: 4,
+        endLine: 6,
+        highlightLine: 5,
+        lines: ["a", "b", "c"],
+        isApproximate: false,
+      },
+      "f.tsx",
+    );
+    const lines = block.split("\n");
+    expect(lines[1]).toBe("  4| a");
+    expect(lines[2]).toBe("> 5| b");
+    expect(lines[3]).toBe("  6| c");
+  });
+
+  it("right-pads line numbers to a consistent width across the whole window", () => {
+    const block = formatSourceSnippetBlock(
+      {
+        startLine: 8,
+        endLine: 12,
+        highlightLine: 10,
+        lines: ["a", "b", "c", "d", "e"],
+        isApproximate: false,
+      },
+      "f.tsx",
+    );
+    const lines = block.split("\n").slice(1);
+    expect(lines[0]).toBe("   8| a");
+    expect(lines[2]).toBe("> 10| c");
+    expect(lines[4]).toBe("  12| e");
+  });
+});

--- a/packages/react-grab/test/get-source-snippet.test.ts
+++ b/packages/react-grab/test/get-source-snippet.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vite-plus/test";
+import { looksTransformed } from "../src/utils/get-source-snippet.js";
+
+describe("looksTransformed", () => {
+  it("accepts an authored JSX/TSX source", () => {
+    const original = `
+import { useState } from "react";
+
+export const TodoItem = ({ todo }: { todo: Todo }) => {
+  return (
+    <li>
+      <span>{todo.title}</span>
+    </li>
+  );
+};
+    `;
+    expect(looksTransformed(original)).toBe(false);
+  });
+
+  it("rejects Vite's HMR-injected transformed output", () => {
+    const transformed = `
+var _jsxFileName = "/Users/me/proj/src/App.tsx";
+import __vite__cjsImport3_react_jsxDevRuntime from "/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=3dd76975";
+var _s = $RefreshSig$();
+const TodoItem = ({ todo }) => {
+  return _jsxDEV("li", { children: _jsxDEV("span", { children: todo.title }) });
+};
+    `;
+    expect(looksTransformed(transformed)).toBe(true);
+  });
+
+  it("rejects Babel/SWC `_jsx(...)` runtime calls", () => {
+    const transformed = `
+"use strict";
+var _jsx = require("react/jsx-runtime").jsx;
+exports.TodoItem = function TodoItem({ todo }) {
+  return _jsx("li", { children: todo.title });
+};
+    `;
+    expect(looksTransformed(transformed)).toBe(true);
+  });
+
+  it("rejects content that imports the React JSX runtime by name", () => {
+    const transformed = `
+import { jsxRuntime } from "react/jsx-runtime";
+const TodoItem = jsxRuntime.jsxDEV("li", null);
+    `;
+    expect(looksTransformed(transformed)).toBe(true);
+  });
+
+  it("only inspects the head of the file so a single transformed token deep in the file does not poison long sources", () => {
+    const head = "x".repeat(2_500);
+    const tail = "_jsxDEV(";
+    expect(looksTransformed(head + tail)).toBe(false);
+  });
+});

--- a/packages/react-grab/test/is-useful-component-name.test.ts
+++ b/packages/react-grab/test/is-useful-component-name.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  isInternalComponentName,
+  isUsefulComponentName,
+} from "../src/utils/is-useful-component-name.js";
+
+describe("isUsefulComponentName", () => {
+  it("accepts user component names", () => {
+    expect(isUsefulComponentName("LoginForm")).toBe(true);
+    expect(isUsefulComponentName("TodoItem")).toBe(true);
+  });
+
+  it("rejects empty names", () => {
+    expect(isUsefulComponentName("")).toBe(false);
+  });
+
+  it("rejects React internals", () => {
+    expect(isUsefulComponentName("Suspense")).toBe(false);
+    expect(isUsefulComponentName("Fragment")).toBe(false);
+  });
+
+  it("rejects Next.js App Router internals", () => {
+    expect(isUsefulComponentName("InnerLayoutRouter")).toBe(false);
+    expect(isUsefulComponentName("AppRouter")).toBe(false);
+  });
+
+  it("rejects framework-prefixed component names", () => {
+    expect(isUsefulComponentName("motion.div")).toBe(false);
+    expect(isUsefulComponentName("styled.button")).toBe(false);
+    expect(isUsefulComponentName("_internal")).toBe(false);
+    expect(isUsefulComponentName("$Provider")).toBe(false);
+  });
+
+  it("rejects Slot/SlotClone (Radix internals)", () => {
+    expect(isUsefulComponentName("Slot")).toBe(false);
+    expect(isUsefulComponentName("SlotClone")).toBe(false);
+  });
+});
+
+describe("isInternalComponentName", () => {
+  it("flags React and Next.js internals", () => {
+    expect(isInternalComponentName("Suspense")).toBe(true);
+    expect(isInternalComponentName("AppRouter")).toBe(true);
+  });
+
+  it("does not flag user components", () => {
+    expect(isInternalComponentName("LoginForm")).toBe(false);
+  });
+});

--- a/packages/react-grab/test/join-snippets.test.ts
+++ b/packages/react-grab/test/join-snippets.test.ts
@@ -91,6 +91,18 @@ describe("joinSnippetEntries", () => {
     expect(appMatches.length).toBe(1);
   });
 
+  it("indents every line of the shared tail consistently", () => {
+    const sharedStack = ["in TodoList (at app/todo-list.tsx:18)", "in App (at app/page.tsx:5)"];
+    const joined = joinSnippetEntries(
+      [buildEntry("<li>a</li>", sharedStack), buildEntry("<li>b</li>", sharedStack)],
+      { allowCollapse: true },
+    );
+    expect(joined).toContain(
+      "  in TodoList (at app/todo-list.tsx:18)\n  in App (at app/page.tsx:5)",
+    );
+    expect(joined).not.toMatch(/\n\nin TodoList/);
+  });
+
   it("emits diverging stack prefixes per entry above the shared tail", () => {
     const tail = ["in App (at app/page.tsx:5)"];
     const joined = joinSnippetEntries(

--- a/packages/react-grab/test/join-snippets.test.ts
+++ b/packages/react-grab/test/join-snippets.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  joinSnippetEntries,
+  joinSnippets,
+  type JoinSnippetEntry,
+} from "../src/utils/join-snippets.js";
+import type { ElementContextParts } from "../src/core/context.js";
+
+const buildEntry = (
+  htmlPreview: string,
+  stackLines: string[],
+  options: { snippetKey?: string; snippetBlock?: string; snippet?: string } = {},
+): JoinSnippetEntry => {
+  const sourceSnippet =
+    options.snippetKey && options.snippetBlock
+      ? {
+          filePath: options.snippetKey.split(":")[0],
+          block: options.snippetBlock,
+          key: options.snippetKey,
+          snippet: {
+            startLine: 1,
+            endLine: 5,
+            highlightLine: 3,
+            lines: ["a", "b", "c", "d", "e"],
+            isApproximate: false,
+          },
+        }
+      : null;
+  const parts: ElementContextParts = { htmlPreview, sourceSnippet, stackLines };
+  const defaultSnippet =
+    stackLines.length > 0 ? `${htmlPreview}\n  ${stackLines.join("\n  ")}` : htmlPreview;
+  return { snippet: options.snippet ?? defaultSnippet, parts };
+};
+
+describe("joinSnippets (legacy)", () => {
+  it("returns the only snippet for a single entry", () => {
+    expect(joinSnippets(["just-one"])).toBe("just-one");
+  });
+
+  it("returns empty string for no entries", () => {
+    expect(joinSnippets([])).toBe("");
+  });
+
+  it("numbers entries when there are multiple", () => {
+    expect(joinSnippets(["a", "b"])).toBe("[1]\na\n\n[2]\nb");
+  });
+});
+
+describe("joinSnippetEntries", () => {
+  it("returns the snippet for a single entry", () => {
+    const entry = buildEntry("<a />", ["in Foo (at app.tsx:1)"]);
+    expect(joinSnippetEntries([entry], { allowCollapse: true })).toBe(entry.snippet);
+  });
+
+  it("falls back to legacy numbering when stacks share no suffix", () => {
+    const entryA = buildEntry("<a />", ["in Foo (at app/foo.tsx:1)"]);
+    const entryB = buildEntry("<b />", ["in Bar (at app/bar.tsx:1)"]);
+    const joined = joinSnippetEntries([entryA, entryB], { allowCollapse: true });
+    expect(joined).toBe(`[1]\n${entryA.snippet}\n\n[2]\n${entryB.snippet}`);
+  });
+
+  it("falls back to legacy numbering when allowCollapse is false", () => {
+    const sharedStack = ["in TodoList (at app/todo-list.tsx:18)"];
+    const entryA = buildEntry("<li>1</li>", sharedStack);
+    const entryB = buildEntry("<li>2</li>", sharedStack, {
+      snippet: "modified by plugin",
+    });
+    const joined = joinSnippetEntries([entryA, entryB], { allowCollapse: false });
+    expect(joined).toContain("[1]");
+    expect(joined).toContain("modified by plugin");
+  });
+
+  it("collapses a fully shared stack into a single tail", () => {
+    const sharedStack = ["in TodoList (at app/todo-list.tsx:18)", "in App (at app/page.tsx:5)"];
+    const joined = joinSnippetEntries(
+      [
+        buildEntry("<li>buy milk</li>", sharedStack),
+        buildEntry("<li>walk dog</li>", sharedStack),
+        buildEntry("<li>code review</li>", sharedStack),
+      ],
+      { allowCollapse: true },
+    );
+
+    expect(joined).toContain("[1] <li>buy milk</li>");
+    expect(joined).toContain("[2] <li>walk dog</li>");
+    expect(joined).toContain("[3] <li>code review</li>");
+
+    const tailMatches = joined.match(/in TodoList \(at app\/todo-list\.tsx:18\)/g) ?? [];
+    expect(tailMatches.length).toBe(1);
+    const appMatches = joined.match(/in App/g) ?? [];
+    expect(appMatches.length).toBe(1);
+  });
+
+  it("emits diverging stack prefixes per entry above the shared tail", () => {
+    const tail = ["in App (at app/page.tsx:5)"];
+    const joined = joinSnippetEntries(
+      [
+        buildEntry("<a />", ["in HeaderLink (at app/header.tsx:8)", ...tail]),
+        buildEntry("<button />", ["in FooterButton (at app/footer.tsx:12)", ...tail]),
+      ],
+      { allowCollapse: true },
+    );
+
+    expect(joined).toContain("in HeaderLink");
+    expect(joined).toContain("in FooterButton");
+    const appMatches = joined.match(/in App \(at app\/page\.tsx:5\)/g) ?? [];
+    expect(appMatches.length).toBe(1);
+  });
+
+  it("emits a single shared source snippet block when all entries match", () => {
+    const sharedStack = ["in TodoList (at app/todo-list.tsx:18)"];
+    const sharedKey = "app/todo-list.tsx:18";
+    const sharedBlock = "// app/todo-list.tsx:18\n  18| <TodoItem />";
+    const joined = joinSnippetEntries(
+      [
+        buildEntry("<li>1</li>", sharedStack, {
+          snippetKey: sharedKey,
+          snippetBlock: sharedBlock,
+        }),
+        buildEntry("<li>2</li>", sharedStack, {
+          snippetKey: sharedKey,
+          snippetBlock: sharedBlock,
+        }),
+      ],
+      { allowCollapse: true },
+    );
+    const matches = joined.match(/<TodoItem \/>/g) ?? [];
+    expect(matches.length).toBe(1);
+  });
+
+  it("omits the source snippet from collapsed output when entries disagree on the source", () => {
+    const sharedStack = ["in App (at app/page.tsx:5)"];
+    const joined = joinSnippetEntries(
+      [
+        buildEntry("<a />", sharedStack, {
+          snippetKey: "app/foo.tsx:10",
+          snippetBlock: "// FOO BLOCK",
+        }),
+        buildEntry("<b />", sharedStack, {
+          snippetKey: "app/bar.tsx:20",
+          snippetBlock: "// BAR BLOCK",
+        }),
+      ],
+      { allowCollapse: true },
+    );
+    expect(joined).not.toContain("FOO BLOCK");
+    expect(joined).not.toContain("BAR BLOCK");
+  });
+});


### PR DESCRIPTION
## Summary

Three targeted improvements to the clipboard payload that AI coding agents consume when a user grabs an element:

- **Source-snippet inlining** — when an owner-stack frame resolves to a same-origin source file, embed a small window of authored code around the call site with a `>` marker on the resolved line. Snippets that fail a JSX/component-name trust check are tagged `(approximate)`. Vite's `_jsxDEV`-rewritten dev output is fingerprinted and rejected so the agent never sees transformed noise.
- **Component instance snapshot** — the innermost user-source stack line falls back to a JSX-call signature (`in <Link href=\"...\" />`) sourced from the React fiber's `memoizedProps` when a trustworthy snippet is not available. The two signals are deduped so the agent never sees the same call site twice.
- **Stack-tail collapse** — when multiple grabbed elements share a suffix in their React stack, emit each entry's diverging prefix and the shared tail once at the bottom. Materially shrinks the payload for list-heavy grabs.

## Why

Author confidence in the snippet matters more than verbosity:
- Source maps lie (Vite serves transformed code at the same URL, Webpack indexes can drift). The trust guard + transformed-output fingerprint stop us from confidently shipping the wrong code.
- The fiber `memoizedProps` is the only signal that survives across all bundlers, so it's the natural fallback when source snippets are unavailable.
- The longest-common-suffix collapse eliminates ~70% of duplicated stack lines in typical multi-grab list scenarios.

## Implementation notes

- Caching: `getSourceContent` dedupes in-flight fetches but evicts `null` results so a transient HMR-rebuild failure doesn't permanently block snippets.
- Suffix matching: bundler-prefixed `sources` arrays (`webpack://`, `vite://`) are handled via suffix matching, but only when the lookup has ≥2 path segments to prevent basenames from cross-file false-matching.
- Same-origin lockdown: snippet fetches go through `new URL(fileName, location.origin)` so a doctored `_debugSource.fileName` can't trigger cross-origin requests, including via `//host/...` protocol-relative paths.
- Trust check: matches only proper component tags (`<UpperCase`); broader tokens like `=>` or `function` would silently mark wrong-target resolutions as trustworthy.
- Refactor: `is-useful-component-name`, `find-longest-common-suffix`, and `escape-regexp` extracted as one-util-per-file modules per `AGENTS.md`.

Public API (`generateSnippet`, `joinSnippets`, `getStackContext`) is preserved.

## Test plan

- [x] 94 unit tests pass (was 76, +18 new across the new utilities and trust/transform guards)
- [x] 13 element-context e2e tests pass
- [x] `pnpm lint` / `pnpm typecheck` / `pnpm format` clean
- [x] Pre-existing `copy-feedback.spec.ts` flakes verified on baseline (unrelated)
- [ ] CI green

## Stacked on

Base is [#323](https://github.com/aidenybai/react-grab/pull/323). When that lands, this PR will auto-rebase onto `main`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core clipboard-context generation pipeline (stack formatting, snippet joining, and new source fetching), which could affect correctness/size of copied output and introduce edge cases across bundlers despite added tests and same-origin guards.
> 
> **Overview**
> Improves the clipboard payload agents receive by **inlining a nearby authored source snippet** (with approximate/trust markings) when a stack frame resolves to a same-origin source file, and by **falling back to a JSX-like component instance signature** derived from fiber `memoizedProps` when a trustworthy snippet isn’t available.
> 
> Refactors context generation to produce structured `ElementContextParts` and updates copy/join logic to **collapse shared React stack suffixes across multi-element grabs** (emitting per-entry diverging prefixes plus one shared tail, and sharing a single snippet block when identical), while preserving existing public APIs (`generateSnippet`, `joinSnippets`, `getStackContext`).
> 
> Updates docs/readmes copy and expands coverage with new unit + e2e tests around snippet trust/transform detection, prop formatting, and stack-tail collapsing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e059f9f2b9f8228957bdec10ccd4f86dbfe8813e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
In `react-grab`, inline authored source snippets, attach component props to the innermost stack frame, and collapse shared stack tails to make copied context smaller and clearer. Now more robust with indexed source maps and safer prop formatting, plus clearer READMEs and Storybook docs.

- New Features
  - Inline a small source window for same-origin frames with a highlighted call line; tag as “(approximate)” when JSX/name trust fails and ignore transformed dev output like Vite’s `_jsxDEV`.
  - Add a component instance snapshot from React fiber `memoizedProps`, rendering `in <Component ... />` when no trustworthy snippet is available; deduped so the call site never appears twice and never applied to library frames.
  - Collapse the longest common React stack suffix across multi-selects; emit each entry’s diverging prefix, and print the shared tail once (and a single shared snippet block only when identical); fall back to legacy numbering when transforms change snippets.

- Bug Fixes
  - Resolve source content in indexed source maps by recursing into `sections`, fixing missing snippets for sectioned maps.
  - Guard invalid `Date` props and stop counting `undefined` values toward the prop overflow marker; improves instance rendering and avoids errors.
  - When the owner stack isn’t formattable but fiber names exist, render a JSX-call from `memoizedProps` on the innermost line for consistent fallback.
  - Keep indentation consistent for collapsed shared stack tails; the first tail line now aligns with the rest.
  - Build a fresh empty context on errors in `generateSnippetParts` to prevent cross-entry mutation leaks.

<sup>Written for commit e059f9f2b9f8228957bdec10ccd4f86dbfe8813e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

