### PR TITLE
docs: improve README clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,15 @@
 [![version](https://img.shields.io/npm/v/react-grab?style=flat&colorA=000000&colorB=000000)](https://npmjs.com/package/react-grab)
 [![downloads](https://img.shields.io/npm/dt/react-grab.svg?style=flat&colorA=000000&colorB=000000)](https://npmjs.com/package/react-grab)
 
-Select context for coding agents directly from your website
+Copy any UI element for your agent.
 
-How? Point at any element and press **⌘C** (Mac) or **Ctrl+C** (Windows/Linux) to copy the file name, React component, and HTML source code.
-
-It makes tools like Cursor, Claude Code, Copilot run up to [**3× faster**](https://react-grab.com/blog/intro) and more accurate.
+React Grab points agents to the actual source behind each selection, so edits are [**2× faster**](https://github.com/aidenybai/react-grab-bench) and more accurate.
 
 ### [Try out a demo! →](https://react-grab.com)
 
-## Install
+## Quick Start
 
-Run this command at your project root (where `next.config.ts` or `vite.config.ts` is located):
+Run this at your project root:
 
 ```bash
 npx grab@latest init
@@ -21,27 +19,46 @@ npx grab@latest init
 
 ## Usage
 
-Once installed, hover over any UI element in your browser and press:
+Start your dev server, open your app, then hover any UI element and press:
 
 - **⌘C** (Cmd+C) on Mac
 - **Ctrl+C** on Windows/Linux
 
-This copies the element's context (file name, React component, and HTML source code) to your clipboard ready to paste into your coding agent. For example:
+React Grab copies that context to your clipboard, ready to paste into your agent.
 
-```js
+## What Agents Get
+
+React Grab includes the details agents need to edit the right file:
+
+- the rendered HTML for the element
+- the React component name
+- the source file and line number
+- the nearby source code, when available
+- the component stack
+
+Example:
+
+```txt
 <a class="ml-auto inline-block text-sm" href="#">
   Forgot your password?
 </a>
-in LoginForm at components/login-form.tsx:46:19
+
+// components/login-form.tsx:46
+  45| <div className="flex items-center">
+> 46|   <a className="ml-auto inline-block text-sm" href="#">
+  47|     Forgot your password?
+  48|   </a>
+
+  in LoginForm (at components/login-form.tsx:46:19)
 ```
 
 ## Manual Installation
 
-If you're using a React framework or build tool, view instructions below:
+If you cannot use the CLI, install React Grab manually for your framework:
 
 #### Next.js (App router)
 
-Add this inside of your `app/layout.tsx`:
+Add this inside your `app/layout.tsx`:
 
 ```jsx
 import Script from "next/script";
@@ -184,19 +201,13 @@ actions: [
 
 See [`packages/react-grab/src/types.ts`](https://github.com/aidenybai/react-grab/blob/main/packages/react-grab/src/types.ts) for the full `Plugin`, `PluginHooks`, and `PluginConfig` interfaces.
 
-## Resources & Contributing Back
+## Links
 
-Want to try it out? Check out [our demo](https://react-grab.com).
-
-Looking to contribute back? Check out the [Contributing Guide](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md).
-
-Want to talk to the community? Hop in our [Discord](https://discord.com/invite/G7zxfUzkm7) and share your ideas and what you've built with React Grab.
-
-Find a bug? Head over to our [issue tracker](https://github.com/aidenybai/react-grab/issues) and we'll do our best to help. We love pull requests, too!
-
-We expect all contributors to abide by the terms of our [Code of Conduct](https://github.com/aidenybai/react-grab/blob/main/.github/CODE_OF_CONDUCT.md).
-
-[**→ Start contributing on GitHub**](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md)
+- [Demo](https://react-grab.com)
+- [Contributing Guide](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md)
+- [Discord](https://discord.com/invite/G7zxfUzkm7)
+- [Issue tracker](https://github.com/aidenybai/react-grab/issues)
+- [Code of Conduct](https://github.com/aidenybai/react-grab/blob/main/.github/CODE_OF_CONDUCT.md)
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,7 @@ npx grab@latest init
 
 ## Usage
 
-Start your dev server, open your app, then hover any UI element and press:
-
-- **⌘C** (Cmd+C) on Mac
-- **Ctrl+C** on Windows/Linux
+Start your dev server, open your app, then hover any UI element and press **⌘C** or **Ctrl+C**.
 
 React Grab copies that context to your clipboard, ready to paste into your agent.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Copy any UI element for your agent.
 
-React Grab points agents to the actual source behind each selection, so edits are [**2× faster**](https://github.com/aidenybai/react-grab-bench) and more accurate.
+React Grab points agents to the actual source behind each selection, so edits are [**2× faster**](https://benchmark.react-grab.com/) and more accurate.
 
 ### [Try out a demo! →](https://react-grab.com)
 
@@ -17,15 +17,15 @@ Run this at your project root:
 npx grab@latest init
 ```
 
-## Usage
+## How It Works
 
-Start your dev server, open your app, then hover any UI element and press **⌘C** or **Ctrl+C**.
+React Grab turns a browser selection into source context your agent can use:
 
-React Grab copies that context to your clipboard, ready to paste into your agent.
+1. Hover any UI element in your app.
+2. Press **⌘C** or **Ctrl+C**.
+3. Paste the copied context into your agent.
 
-## Copied Context
-
-React Grab copies the selected element, its source location, nearby code, and component stack:
+The copied context includes the selected element, source location, nearby code, and component stack:
 
 ```txt
 <a class="ml-auto inline-block text-sm" href="#">

--- a/README.md
+++ b/README.md
@@ -201,13 +201,19 @@ actions: [
 
 See [`packages/react-grab/src/types.ts`](https://github.com/aidenybai/react-grab/blob/main/packages/react-grab/src/types.ts) for the full `Plugin`, `PluginHooks`, and `PluginConfig` interfaces.
 
-## Links
+## Resources & Contributing Back
 
-- [Demo](https://react-grab.com)
-- [Contributing Guide](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md)
-- [Discord](https://discord.com/invite/G7zxfUzkm7)
-- [Issue tracker](https://github.com/aidenybai/react-grab/issues)
-- [Code of Conduct](https://github.com/aidenybai/react-grab/blob/main/.github/CODE_OF_CONDUCT.md)
+Want to try it out? Check out [our demo](https://react-grab.com).
+
+Looking to contribute back? Check out the [Contributing Guide](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md).
+
+Want to talk to the community? Hop in our [Discord](https://discord.com/invite/G7zxfUzkm7) and share your ideas and what you've built with React Grab.
+
+Find a bug? Head over to our [issue tracker](https://github.com/aidenybai/react-grab/issues) and we'll do our best to help. We love pull requests, too!
+
+We expect all contributors to abide by the terms of our [Code of Conduct](https://github.com/aidenybai/react-grab/blob/main/.github/CODE_OF_CONDUCT.md).
+
+[**Start contributing on GitHub**](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md)
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -23,17 +23,9 @@ Start your dev server, open your app, then hover any UI element and press **⌘C
 
 React Grab copies that context to your clipboard, ready to paste into your agent.
 
-## What Agents Get
+## Copied Context
 
-React Grab includes the details agents need to edit the right file:
-
-- the rendered HTML for the element
-- the React component name
-- the source file and line number
-- the nearby source code, when available
-- the component stack
-
-Example:
+React Grab copies the selected element, its source location, nearby code, and component stack:
 
 ```txt
 <a class="ml-auto inline-block text-sm" href="#">

--- a/apps/storybook/README.md
+++ b/apps/storybook/README.md
@@ -1,6 +1,8 @@
 # @react-grab/storybook
 
-Visual playground for React Grab's overlay system - renders the full `ReactGrabRenderer` on a sample page with Storybook controls for every user-facing state.
+Internal playground for React Grab's overlay UI.
+
+Storybook renders the full `ReactGrabRenderer` against mocked states and realistic playground pages, so overlay states can be inspected without running the e2e app.
 
 Uses [Storybook 10](https://storybook.js.org/) with [`storybook-solidjs-vite`](https://github.com/nicolo-ribaudo/storybook-solidjs-vite).
 
@@ -29,13 +31,13 @@ Static build output is written to `storybook-static/`.
 ```
 apps/storybook/
 ├── .storybook/
-│   ├── main.ts                 ← Storybook config
-│   └── preview.tsx             ← global parameters & CSS import
+│   ├── main.ts                 Storybook config
+│   └── preview.tsx             global parameters and CSS import
 └── stories/
-    ├── fixtures.ts             ← preset comment items + menu actions
-    ├── noop.ts                 ← no-op callback for handlers
-    ├── *.stories.tsx           ← Component stories (mock renderer states)
-    └── playground/             ← Ad-hoc scenarios with real init() running
+    ├── fixtures.ts             preset comment items and menu actions
+    ├── noop.ts                 no-op callback for handlers
+    ├── *.stories.tsx           component stories with mocked renderer states
+    └── playground/             scenarios with real init() running
         ├── composite-dashboard.stories.tsx
         ├── freeze-demo.stories.tsx
         └── live-updates.stories.tsx
@@ -43,9 +45,9 @@ apps/storybook/
 
 ## Two kinds of stories
 
-**Component stories** (toolbar, selection-label, context-menu, comments-dropdown, renderer) render the overlay with mocked props. They're single sources of truth for every user-facing state: idle, context menu, comment input, pending dismiss, etc.
+**Component stories** render toolbar, selection label, context menu, comments dropdown, and renderer states with mocked props. Use these to inspect specific UI states such as idle, context menu, comment input, and pending dismiss.
 
-**Playground stories** import `react-grab` for its side effect, so `init()` actually runs and hooks into the story DOM. They replace the former `apps/gym` and exist for ad-hoc hover/grab testing against realistic fixtures:
+**Playground stories** import `react-grab` for its side effect, so `init()` runs against the story DOM. Use these for ad-hoc hover and grab testing against realistic fixtures:
 
 - **Composite Dashboard** - sidebar, metric cards, chart, and data table for dense-DOM selection testing
 - **Freeze Demo** - bouncing animated timer for verifying freeze-animations + freeze-updates

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,8 @@
 # @react-grab/cli
 
-Interactive CLI to install and configure React Grab in your project.
+CLI for installing React Grab and configuring its activation behavior.
+
+The CLI detects supported React projects, applies the dev-only setup, and can reconfigure an existing installation without hand-editing framework files.
 
 ## Quick Start
 
@@ -12,7 +14,7 @@ npx grab@latest init
 
 ### `grab init`
 
-Initialize React Grab in your project. Auto-detects your framework and applies the necessary changes.
+Install React Grab in the current project. The CLI auto-detects the framework and applies the required development-only integration.
 
 ```bash
 npx grab@latest init
@@ -29,7 +31,7 @@ npx grab@latest init
 
 ### `grab configure`
 
-Configure React Grab options. Runs an interactive wizard when called without flags.
+Update React Grab options. Runs an interactive wizard when called without flags.
 
 ```bash
 npx grab@latest configure
@@ -67,9 +69,10 @@ npx grab@latest configure
 
 ## Supported Frameworks
 
-| Framework              | Detection                             |
-| ---------------------- | ------------------------------------- |
-| Next.js (App Router)   | `next.config.ts` + `app/` directory   |
-| Next.js (Pages Router) | `next.config.ts` + `pages/` directory |
-| Vite                   | `vite.config.ts`                      |
-| Webpack                | `webpack.config.*`                    |
+The CLI currently configures:
+
+- Next.js App Router
+- Next.js Pages Router
+- Vite
+- TanStack Start
+- Webpack

--- a/packages/grab/README.md
+++ b/packages/grab/README.md
@@ -19,10 +19,7 @@ npx grab@latest init
 
 ## Usage
 
-Start your dev server, open your app, then hover any UI element and press:
-
-- **⌘C** (Cmd+C) on Mac
-- **Ctrl+C** on Windows/Linux
+Start your dev server, open your app, then hover any UI element and press **⌘C** or **Ctrl+C**.
 
 React Grab copies that context to your clipboard, ready to paste into your agent.
 

--- a/packages/grab/README.md
+++ b/packages/grab/README.md
@@ -5,7 +5,7 @@
 
 Copy any UI element for your agent.
 
-React Grab points agents to the actual source behind each selection, so edits are [**2× faster**](https://github.com/aidenybai/react-grab-bench) and more accurate.
+React Grab points agents to the actual source behind each selection, so edits are [**2× faster**](https://benchmark.react-grab.com/) and more accurate.
 
 ### [Try out a demo! →](https://react-grab.com)
 
@@ -17,15 +17,15 @@ Run this at your project root:
 npx grab@latest init
 ```
 
-## Usage
+## How It Works
 
-Start your dev server, open your app, then hover any UI element and press **⌘C** or **Ctrl+C**.
+React Grab turns a browser selection into source context your agent can use:
 
-React Grab copies that context to your clipboard, ready to paste into your agent.
+1. Hover any UI element in your app.
+2. Press **⌘C** or **Ctrl+C**.
+3. Paste the copied context into your agent.
 
-## Copied Context
-
-React Grab copies the selected element, its source location, nearby code, and component stack:
+The copied context includes the selected element, source location, nearby code, and component stack:
 
 ```txt
 <a class="ml-auto inline-block text-sm" href="#">

--- a/packages/grab/README.md
+++ b/packages/grab/README.md
@@ -3,17 +3,15 @@
 [![version](https://img.shields.io/npm/v/grab?style=flat&colorA=000000&colorB=000000)](https://npmjs.com/package/grab)
 [![downloads](https://img.shields.io/npm/dt/grab.svg?style=flat&colorA=000000&colorB=000000)](https://npmjs.com/package/grab)
 
-Select context for coding agents directly from your website
+Copy any UI element for your agent.
 
-How? Point at any element and press **⌘C** (Mac) or **Ctrl+C** (Windows/Linux) to copy the file name, React component, and HTML source code.
-
-It makes tools like Cursor, Claude Code, Copilot run up to [**3× faster**](https://react-grab.com/blog/intro) and more accurate.
+React Grab points agents to the actual source behind each selection, so edits are [**2× faster**](https://github.com/aidenybai/react-grab-bench) and more accurate.
 
 ### [Try out a demo! →](https://react-grab.com)
 
-## Install
+## Quick Start
 
-Run this command at your project root (where `next.config.ts` or `vite.config.ts` is located):
+Run this at your project root:
 
 ```bash
 npx grab@latest init
@@ -21,27 +19,46 @@ npx grab@latest init
 
 ## Usage
 
-Once installed, hover over any UI element in your browser and press:
+Start your dev server, open your app, then hover any UI element and press:
 
 - **⌘C** (Cmd+C) on Mac
 - **Ctrl+C** on Windows/Linux
 
-This copies the element's context (file name, React component, and HTML source code) to your clipboard ready to paste into your coding agent. For example:
+React Grab copies that context to your clipboard, ready to paste into your agent.
 
-```js
+## What Agents Get
+
+React Grab includes the details agents need to edit the right file:
+
+- the rendered HTML for the element
+- the React component name
+- the source file and line number
+- the nearby source code, when available
+- the component stack
+
+Example:
+
+```txt
 <a class="ml-auto inline-block text-sm" href="#">
   Forgot your password?
 </a>
-in LoginForm at components/login-form.tsx:46:19
+
+// components/login-form.tsx:46
+  45| <div className="flex items-center">
+> 46|   <a className="ml-auto inline-block text-sm" href="#">
+  47|     Forgot your password?
+  48|   </a>
+
+  in LoginForm (at components/login-form.tsx:46:19)
 ```
 
 ## Manual Installation
 
-If you're using a React framework or build tool, view instructions below:
+If you cannot use the CLI, install React Grab manually for your framework:
 
 #### Next.js (App router)
 
-Add this inside of your `app/layout.tsx`:
+Add this inside your `app/layout.tsx`:
 
 ```jsx
 import Script from "next/script";
@@ -184,19 +201,13 @@ actions: [
 
 See [`packages/react-grab/src/types.ts`](https://github.com/aidenybai/react-grab/blob/main/packages/react-grab/src/types.ts) for the full `Plugin`, `PluginHooks`, and `PluginConfig` interfaces.
 
-## Resources & Contributing Back
+## Links
 
-Want to try it out? Check out [our demo](https://react-grab.com).
-
-Looking to contribute back? Check out the [Contributing Guide](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md).
-
-Want to talk to the community? Hop in our [Discord](https://discord.com/invite/G7zxfUzkm7) and share your ideas and what you've built with React Grab.
-
-Find a bug? Head over to our [issue tracker](https://github.com/aidenybai/react-grab/issues) and we'll do our best to help. We love pull requests, too!
-
-We expect all contributors to abide by the terms of our [Code of Conduct](https://github.com/aidenybai/react-grab/blob/main/.github/CODE_OF_CONDUCT.md).
-
-[**→ Start contributing on GitHub**](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md)
+- [Demo](https://react-grab.com)
+- [Contributing Guide](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md)
+- [Discord](https://discord.com/invite/G7zxfUzkm7)
+- [Issue tracker](https://github.com/aidenybai/react-grab/issues)
+- [Code of Conduct](https://github.com/aidenybai/react-grab/blob/main/.github/CODE_OF_CONDUCT.md)
 
 ### License
 

--- a/packages/grab/README.md
+++ b/packages/grab/README.md
@@ -201,13 +201,19 @@ actions: [
 
 See [`packages/react-grab/src/types.ts`](https://github.com/aidenybai/react-grab/blob/main/packages/react-grab/src/types.ts) for the full `Plugin`, `PluginHooks`, and `PluginConfig` interfaces.
 
-## Links
+## Resources & Contributing Back
 
-- [Demo](https://react-grab.com)
-- [Contributing Guide](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md)
-- [Discord](https://discord.com/invite/G7zxfUzkm7)
-- [Issue tracker](https://github.com/aidenybai/react-grab/issues)
-- [Code of Conduct](https://github.com/aidenybai/react-grab/blob/main/.github/CODE_OF_CONDUCT.md)
+Want to try it out? Check out [our demo](https://react-grab.com).
+
+Looking to contribute back? Check out the [Contributing Guide](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md).
+
+Want to talk to the community? Hop in our [Discord](https://discord.com/invite/G7zxfUzkm7) and share your ideas and what you've built with React Grab.
+
+Find a bug? Head over to our [issue tracker](https://github.com/aidenybai/react-grab/issues) and we'll do our best to help. We love pull requests, too!
+
+We expect all contributors to abide by the terms of our [Code of Conduct](https://github.com/aidenybai/react-grab/blob/main/.github/CODE_OF_CONDUCT.md).
+
+[**Start contributing on GitHub**](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md)
 
 ### License
 

--- a/packages/grab/README.md
+++ b/packages/grab/README.md
@@ -23,17 +23,9 @@ Start your dev server, open your app, then hover any UI element and press **⌘C
 
 React Grab copies that context to your clipboard, ready to paste into your agent.
 
-## What Agents Get
+## Copied Context
 
-React Grab includes the details agents need to edit the right file:
-
-- the rendered HTML for the element
-- the React component name
-- the source file and line number
-- the nearby source code, when available
-- the component stack
-
-Example:
+React Grab copies the selected element, its source location, nearby code, and component stack:
 
 ```txt
 <a class="ml-auto inline-block text-sm" href="#">

--- a/packages/react-grab/README.md
+++ b/packages/react-grab/README.md
@@ -3,17 +3,15 @@
 [![version](https://img.shields.io/npm/v/react-grab?style=flat&colorA=000000&colorB=000000)](https://npmjs.com/package/react-grab)
 [![downloads](https://img.shields.io/npm/dt/react-grab.svg?style=flat&colorA=000000&colorB=000000)](https://npmjs.com/package/react-grab)
 
-Select context for coding agents directly from your website
+Copy any UI element for your agent.
 
-How? Point at any element and press **⌘C** (Mac) or **Ctrl+C** (Windows/Linux) to copy the file name, React component, and HTML source code.
-
-It makes tools like Cursor, Claude Code, Copilot run up to [**3× faster**](https://react-grab.com/blog/intro) and more accurate.
+React Grab points agents to the actual source behind each selection, so edits are [**2× faster**](https://github.com/aidenybai/react-grab-bench) and more accurate.
 
 ### [Try out a demo! →](https://react-grab.com)
 
-## Install
+## Quick Start
 
-Run this command at your project root (where `next.config.ts` or `vite.config.ts` is located):
+Run this at your project root:
 
 ```bash
 npx grab@latest init
@@ -21,27 +19,46 @@ npx grab@latest init
 
 ## Usage
 
-Once installed, hover over any UI element in your browser and press:
+Start your dev server, open your app, then hover any UI element and press:
 
 - **⌘C** (Cmd+C) on Mac
 - **Ctrl+C** on Windows/Linux
 
-This copies the element's context (file name, React component, and HTML source code) to your clipboard ready to paste into your coding agent. For example:
+React Grab copies that context to your clipboard, ready to paste into your agent.
 
-```js
+## What Agents Get
+
+React Grab includes the details agents need to edit the right file:
+
+- the rendered HTML for the element
+- the React component name
+- the source file and line number
+- the nearby source code, when available
+- the component stack
+
+Example:
+
+```txt
 <a class="ml-auto inline-block text-sm" href="#">
   Forgot your password?
 </a>
-in LoginForm at components/login-form.tsx:46:19
+
+// components/login-form.tsx:46
+  45| <div className="flex items-center">
+> 46|   <a className="ml-auto inline-block text-sm" href="#">
+  47|     Forgot your password?
+  48|   </a>
+
+  in LoginForm (at components/login-form.tsx:46:19)
 ```
 
 ## Manual Installation
 
-If you're using a React framework or build tool, view instructions below:
+If you cannot use the CLI, install React Grab manually for your framework:
 
 #### Next.js (App router)
 
-Add this inside of your `app/layout.tsx`:
+Add this inside your `app/layout.tsx`:
 
 ```jsx
 import Script from "next/script";
@@ -184,19 +201,13 @@ actions: [
 
 See [`packages/react-grab/src/types.ts`](https://github.com/aidenybai/react-grab/blob/main/packages/react-grab/src/types.ts) for the full `Plugin`, `PluginHooks`, and `PluginConfig` interfaces.
 
-## Resources & Contributing Back
+## Links
 
-Want to try it out? Check out [our demo](https://react-grab.com).
-
-Looking to contribute back? Check out the [Contributing Guide](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md).
-
-Want to talk to the community? Hop in our [Discord](https://discord.com/invite/G7zxfUzkm7) and share your ideas and what you've built with React Grab.
-
-Find a bug? Head over to our [issue tracker](https://github.com/aidenybai/react-grab/issues) and we'll do our best to help. We love pull requests, too!
-
-We expect all contributors to abide by the terms of our [Code of Conduct](https://github.com/aidenybai/react-grab/blob/main/.github/CODE_OF_CONDUCT.md).
-
-[**→ Start contributing on GitHub**](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md)
+- [Demo](https://react-grab.com)
+- [Contributing Guide](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md)
+- [Discord](https://discord.com/invite/G7zxfUzkm7)
+- [Issue tracker](https://github.com/aidenybai/react-grab/issues)
+- [Code of Conduct](https://github.com/aidenybai/react-grab/blob/main/.github/CODE_OF_CONDUCT.md)
 
 ### License
 

--- a/packages/react-grab/README.md
+++ b/packages/react-grab/README.md
@@ -19,10 +19,7 @@ npx grab@latest init
 
 ## Usage
 
-Start your dev server, open your app, then hover any UI element and press:
-
-- **⌘C** (Cmd+C) on Mac
-- **Ctrl+C** on Windows/Linux
+Start your dev server, open your app, then hover any UI element and press **⌘C** or **Ctrl+C**.
 
 React Grab copies that context to your clipboard, ready to paste into your agent.
 

--- a/packages/react-grab/README.md
+++ b/packages/react-grab/README.md
@@ -5,7 +5,7 @@
 
 Copy any UI element for your agent.
 
-React Grab points agents to the actual source behind each selection, so edits are [**2× faster**](https://github.com/aidenybai/react-grab-bench) and more accurate.
+React Grab points agents to the actual source behind each selection, so edits are [**2× faster**](https://benchmark.react-grab.com/) and more accurate.
 
 ### [Try out a demo! →](https://react-grab.com)
 
@@ -17,15 +17,15 @@ Run this at your project root:
 npx grab@latest init
 ```
 
-## Usage
+## How It Works
 
-Start your dev server, open your app, then hover any UI element and press **⌘C** or **Ctrl+C**.
+React Grab turns a browser selection into source context your agent can use:
 
-React Grab copies that context to your clipboard, ready to paste into your agent.
+1. Hover any UI element in your app.
+2. Press **⌘C** or **Ctrl+C**.
+3. Paste the copied context into your agent.
 
-## Copied Context
-
-React Grab copies the selected element, its source location, nearby code, and component stack:
+The copied context includes the selected element, source location, nearby code, and component stack:
 
 ```txt
 <a class="ml-auto inline-block text-sm" href="#">

--- a/packages/react-grab/README.md
+++ b/packages/react-grab/README.md
@@ -201,13 +201,19 @@ actions: [
 
 See [`packages/react-grab/src/types.ts`](https://github.com/aidenybai/react-grab/blob/main/packages/react-grab/src/types.ts) for the full `Plugin`, `PluginHooks`, and `PluginConfig` interfaces.
 
-## Links
+## Resources & Contributing Back
 
-- [Demo](https://react-grab.com)
-- [Contributing Guide](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md)
-- [Discord](https://discord.com/invite/G7zxfUzkm7)
-- [Issue tracker](https://github.com/aidenybai/react-grab/issues)
-- [Code of Conduct](https://github.com/aidenybai/react-grab/blob/main/.github/CODE_OF_CONDUCT.md)
+Want to try it out? Check out [our demo](https://react-grab.com).
+
+Looking to contribute back? Check out the [Contributing Guide](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md).
+
+Want to talk to the community? Hop in our [Discord](https://discord.com/invite/G7zxfUzkm7) and share your ideas and what you've built with React Grab.
+
+Find a bug? Head over to our [issue tracker](https://github.com/aidenybai/react-grab/issues) and we'll do our best to help. We love pull requests, too!
+
+We expect all contributors to abide by the terms of our [Code of Conduct](https://github.com/aidenybai/react-grab/blob/main/.github/CODE_OF_CONDUCT.md).
+
+[**Start contributing on GitHub**](https://github.com/aidenybai/react-grab/blob/main/CONTRIBUTING.md)
 
 ### License
 

--- a/packages/react-grab/README.md
+++ b/packages/react-grab/README.md
@@ -23,17 +23,9 @@ Start your dev server, open your app, then hover any UI element and press **⌘C
 
 React Grab copies that context to your clipboard, ready to paste into your agent.
 
-## What Agents Get
+## Copied Context
 
-React Grab includes the details agents need to edit the right file:
-
-- the rendered HTML for the element
-- the React component name
-- the source file and line number
-- the nearby source code, when available
-- the component stack
-
-Example:
+React Grab copies the selected element, its source location, nearby code, and component stack:
 
 ```txt
 <a class="ml-auto inline-block text-sm" href="#">


### PR DESCRIPTION
## Summary
- tighten the public README positioning around copying UI elements for agents
- clarify quick start, usage, and copied payload details
- update package, CLI, and Storybook READMEs for consistent wording

## Testing
- not run; docs-only change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, documentation-only changes with no runtime or API behavior modifications.
> 
> **Overview**
> Refreshes the main `README.md` and the `react-grab`/`grab` package READMEs to better position the tool as *copying UI elements for agents*, rename **Install → Quick Start**, and explain the copy workflow with a more detailed *copied context* example (source location + nearby code + component stack).
> 
> Updates `@react-grab/cli` and Storybook READMEs for clearer descriptions and consistent terminology, including listing TanStack Start as supported and clarifying mocked vs playground Storybook stories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02eadd5346bb348e9e3fc1e091fc668da1998be3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies READMEs to make setup and the copy-to-agent flow obvious. Renames Install to Quick Start, adds a simple How It Works, tightens the copied context example, and explains the root/package README mirroring workflow; docs-only.

- **Docs**
  - `@react-grab/cli`: adds TanStack Start; clarifies dev‑only setup and reconfiguration.
  - `@react-grab/storybook`: clearer mocked vs playground testing notes.
  - Restores Resources; standardizes manual install wording and minor copy tweaks.

<sup>Written for commit 02eadd5346bb348e9e3fc1e091fc668da1998be3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

