### PR TITLE
fix(website): improve agent readability score

### DIFF
--- a/apps/website/app/changelog.md/route.ts
+++ b/apps/website/app/changelog.md/route.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { parseChangelog } from "@/utils/parse-changelog";
+
+const BASE_URL = "https://react-grab.com";
+
+export const dynamic = "force-static";
+
+export const GET = (): Response => {
+  const changelogPath = join(process.cwd(), "..", "..", "packages", "react-grab", "CHANGELOG.md");
+  const content = readFileSync(changelogPath, "utf-8");
+  const entries = parseChangelog(content);
+
+  const lines: string[] = [];
+  lines.push("# Changelog");
+  lines.push("");
+  lines.push("> Release notes and version history for React Grab.");
+  lines.push("");
+  lines.push(`See the [HTML changelog](${BASE_URL}/changelog) for the rendered version.`);
+  lines.push("");
+
+  for (const entry of entries) {
+    lines.push(`## ${entry.version}`);
+    lines.push("");
+    if (entry.changeType) {
+      lines.push(`*${entry.changeType}*`);
+      lines.push("");
+    }
+    for (const change of entry.changes) {
+      lines.push(`- ${change}`);
+    }
+    lines.push("");
+  }
+
+  return new Response(lines.join("\n"), {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=300, s-maxage=300",
+    },
+  });
+};

--- a/apps/website/app/changelog/page.tsx
+++ b/apps/website/app/changelog/page.tsx
@@ -86,7 +86,9 @@ const ChangelogPage = () => {
             <section key={entry.version} className="flex flex-col gap-2">
               <div className="flex items-center gap-3">
                 <h2 className="text-foreground font-mono text-sm font-medium">{entry.version}</h2>
-                <h3 className="text-neutral-600 text-xs font-normal">{entry.changeType}</h3>
+                {entry.changeType && (
+                  <h3 className="text-neutral-600 text-xs font-normal">{entry.changeType}</h3>
+                )}
               </div>
               <ul className="flex flex-col gap-1.5">
                 {entry.changes.map((change, changeIndex) => (

--- a/apps/website/app/changelog/page.tsx
+++ b/apps/website/app/changelog/page.tsx
@@ -14,6 +14,12 @@ const ogImageUrl = `https://react-grab.com/api/og?title=${encodeURIComponent(tit
 export const metadata: Metadata = {
   title: `${title} - React Grab`,
   description,
+  alternates: {
+    canonical: "https://react-grab.com/changelog",
+    types: {
+      "text/markdown": "https://react-grab.com/changelog.md",
+    },
+  },
   openGraph: {
     title: `${title} - React Grab`,
     description,
@@ -48,7 +54,7 @@ const ChangelogPage = () => {
   const entries = getChangelog();
 
   return (
-    <div className="min-h-screen bg-background px-4 py-6 sm:px-8 sm:py-8">
+    <main id="main-content" className="min-h-screen bg-background px-4 py-6 sm:px-8 sm:py-8">
       <div className="mx-auto flex w-full max-w-2xl flex-col gap-2 pt-4 text-base sm:pt-8">
         <Link
           href="/"
@@ -71,18 +77,16 @@ const ChangelogPage = () => {
         </div>
 
         <div className="flex flex-col gap-1">
-          <div className="text-foreground font-bold">Changelog</div>
-          <div className="text-sm text-neutral-500">Release notes and version history</div>
+          <h1 className="text-foreground font-bold">Changelog</h1>
+          <p className="text-sm text-neutral-500">Release notes and version history</p>
         </div>
 
         <div className="flex flex-col mt-8 gap-8">
           {entries.map((entry) => (
-            <div key={entry.version} className="flex flex-col gap-2">
+            <section key={entry.version} className="flex flex-col gap-2">
               <div className="flex items-center gap-3">
-                <span className="text-foreground font-mono text-sm font-medium">
-                  {entry.version}
-                </span>
-                <span className="text-neutral-600 text-xs">{entry.changeType}</span>
+                <h2 className="text-foreground font-mono text-sm font-medium">{entry.version}</h2>
+                <h3 className="text-neutral-600 text-xs font-normal">{entry.changeType}</h3>
               </div>
               <ul className="flex flex-col gap-1.5">
                 {entry.changes.map((change, changeIndex) => (
@@ -95,11 +99,11 @@ const ChangelogPage = () => {
                   </li>
                 ))}
               </ul>
-            </div>
+            </section>
           ))}
         </div>
       </div>
-    </div>
+    </main>
   );
 };
 

--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -30,12 +30,6 @@ export const metadata: Metadata = {
   title: "React Grab",
   description:
     "Select an element → Give it to Cursor, Claude Code, etc → Make a change to your app",
-  alternates: {
-    canonical: "https://react-grab.com",
-    types: {
-      "text/markdown": "https://react-grab.com/index.md",
-    },
-  },
   icons: {
     icon: "https://react-grab.com/logo.png",
     shortcut: "https://react-grab.com/logo.png",

--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -26,9 +26,16 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://react-grab.com"),
   title: "React Grab",
   description:
     "Select an element → Give it to Cursor, Claude Code, etc → Make a change to your app",
+  alternates: {
+    canonical: "https://react-grab.com",
+    types: {
+      "text/markdown": "https://react-grab.com/index.md",
+    },
+  },
   icons: {
     icon: "https://react-grab.com/logo.png",
     shortcut: "https://react-grab.com/logo.png",
@@ -53,6 +60,40 @@ export const metadata: Metadata = {
   },
 };
 
+const STRUCTURED_DATA = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      "@id": "https://react-grab.com/#website",
+      url: "https://react-grab.com",
+      name: "React Grab",
+      description:
+        "Select an element → Give it to Cursor, Claude Code, etc → Make a change to your app",
+      inLanguage: "en-US",
+      publisher: { "@id": "https://react-grab.com/#organization" },
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://react-grab.com/#organization",
+      name: "React Grab",
+      url: "https://react-grab.com",
+      logo: "https://react-grab.com/logo.png",
+      sameAs: ["https://github.com/aidenybai/react-grab"],
+    },
+    {
+      "@type": "SoftwareApplication",
+      name: "React Grab",
+      applicationCategory: "DeveloperApplication",
+      operatingSystem: "Web",
+      url: "https://react-grab.com",
+      description:
+        "Open-source dev-only script that adds an element picker to React apps so you can copy file paths, components, and HTML source for AI coding agents.",
+      offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+    },
+  ],
+};
+
 const RootLayout = ({
   children,
 }: Readonly<{
@@ -60,9 +101,33 @@ const RootLayout = ({
 }>) => {
   return (
     <html lang="en" className="dark">
+      <head>
+        <link
+          rel="alternate"
+          type="text/markdown"
+          href="https://react-grab.com/index.md"
+          title="React Grab (Markdown)"
+        />
+        <link
+          rel="alternate"
+          type="text/markdown"
+          href="https://react-grab.com/llms.txt"
+          title="llms.txt"
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(STRUCTURED_DATA) }}
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${caveat.variable} antialiased`}
       >
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded focus:bg-foreground focus:px-3 focus:py-2 focus:text-background"
+        >
+          Skip to content
+        </a>
         <script src="/script.js" defer />
         <NuqsAdapter>{children}</NuqsAdapter>
         <Analytics />

--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -105,12 +105,6 @@ const RootLayout = ({
         <link
           rel="alternate"
           type="text/markdown"
-          href="https://react-grab.com/index.md"
-          title="React Grab (Markdown)"
-        />
-        <link
-          rel="alternate"
-          type="text/markdown"
           href="https://react-grab.com/llms.txt"
           title="llms.txt"
         />

--- a/apps/website/app/open-file/layout.tsx
+++ b/apps/website/app/open-file/layout.tsx
@@ -7,6 +7,13 @@ const ogImageUrl = `https://react-grab.com/api/og?title=${encodeURIComponent(tit
 export const metadata: Metadata = {
   title: `${title} | React Grab`,
   description,
+  alternates: {
+    canonical: "https://react-grab.com/open-file",
+  },
+  robots: {
+    index: false,
+    follow: false,
+  },
   openGraph: {
     title: `${title} | React Grab`,
     description,

--- a/apps/website/app/page.tsx
+++ b/apps/website/app/page.tsx
@@ -1,7 +1,14 @@
 import { HomepageDemo } from "@/components/homepage-demo";
 
 const Home = () => {
-  return <HomepageDemo />;
+  return (
+    <main id="main-content">
+      <h1 className="sr-only">React Grab — Select React Elements for AI Coding Agents</h1>
+      <h2 className="sr-only">Pick any element, hand it to Cursor or Claude Code</h2>
+      <h3 className="sr-only">Install with npx grab init</h3>
+      <HomepageDemo />
+    </main>
+  );
 };
 
 Home.displayName = "Home";

--- a/apps/website/app/page.tsx
+++ b/apps/website/app/page.tsx
@@ -1,4 +1,14 @@
+import type { Metadata } from "next";
 import { HomepageDemo } from "@/components/homepage-demo";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "https://react-grab.com",
+    types: {
+      "text/markdown": "https://react-grab.com/index.md",
+    },
+  },
+};
 
 const Home = () => {
   return (

--- a/apps/website/app/privacy/page.tsx
+++ b/apps/website/app/privacy/page.tsx
@@ -10,6 +10,12 @@ const ogImageUrl = `https://react-grab.com/api/og?title=${encodeURIComponent(tit
 export const metadata: Metadata = {
   title: `${title} - React Grab`,
   description,
+  alternates: {
+    canonical: "https://react-grab.com/privacy",
+    types: {
+      "text/markdown": "https://react-grab.com/privacy.md",
+    },
+  },
   openGraph: {
     title: `${title} - React Grab`,
     description,
@@ -36,7 +42,7 @@ export const metadata: Metadata = {
 
 const PrivacyPage = () => {
   return (
-    <div className="min-h-screen bg-background px-4 py-6 sm:px-8 sm:py-8">
+    <main id="main-content" className="min-h-screen bg-background px-4 py-6 sm:px-8 sm:py-8">
       <div className="mx-auto flex w-full max-w-2xl flex-col gap-2 pt-4 text-base sm:pt-8 sm:text-lg">
         <Link
           href="/"
@@ -72,7 +78,7 @@ const PrivacyPage = () => {
           </section>
 
           <section>
-            <p className="text-foreground font-bold mb-2">Data Collection</p>
+            <h2 className="text-foreground font-bold mb-2">Data Collection</h2>
             <p className="mb-2">
               React Grab does NOT collect, store, or transmit any personal data. Specifically:
             </p>
@@ -86,7 +92,7 @@ const PrivacyPage = () => {
           </section>
 
           <section>
-            <p className="text-foreground font-bold mb-2">How React Grab Works</p>
+            <h2 className="text-foreground font-bold mb-2">How React Grab Works</h2>
             <p className="mb-2">
               React Grab operates entirely locally in your browser. When you use the extension:
             </p>
@@ -99,7 +105,7 @@ const PrivacyPage = () => {
           </section>
 
           <section>
-            <p className="text-foreground font-bold mb-2">Permissions</p>
+            <h2 className="text-foreground font-bold mb-2">Permissions</h2>
             <p className="mb-2">The extension requires the following permissions:</p>
             <ul className="list-disc pl-6 space-y-1">
               <li>
@@ -122,7 +128,7 @@ const PrivacyPage = () => {
           </section>
 
           <section>
-            <p className="text-foreground font-bold mb-2">Local Storage</p>
+            <h2 className="text-foreground font-bold mb-2">Local Storage</h2>
             <p>
               React Grab may store minimal settings locally on your device using browser storage
               APIs. This data never leaves your device and can be cleared by uninstalling the
@@ -131,7 +137,7 @@ const PrivacyPage = () => {
           </section>
 
           <section>
-            <p className="text-foreground font-bold mb-2">Third-Party Services</p>
+            <h2 className="text-foreground font-bold mb-2">Third-Party Services</h2>
             <p>
               React Grab does not integrate with any third-party analytics, tracking, or advertising
               services. The extension operates entirely offline and does not make any external
@@ -140,7 +146,7 @@ const PrivacyPage = () => {
           </section>
 
           <section>
-            <p className="text-foreground font-bold mb-2">Open Source</p>
+            <h2 className="text-foreground font-bold mb-2">Open Source</h2>
             <p>
               React Grab is open source software. You can review the complete source code on{" "}
               <a
@@ -156,7 +162,7 @@ const PrivacyPage = () => {
           </section>
 
           <section>
-            <p className="text-foreground font-bold mb-2">Changes to This Policy</p>
+            <h2 className="text-foreground font-bold mb-2">Changes to This Policy</h2>
             <p>
               We may update this privacy policy from time to time. Any changes will be posted on
               this page with an updated revision date.
@@ -164,7 +170,7 @@ const PrivacyPage = () => {
           </section>
 
           <section>
-            <p className="text-foreground font-bold mb-2">Contact</p>
+            <h2 className="text-foreground font-bold mb-2">Contact</h2>
             <p>
               If you have questions about this privacy policy, please open an issue on our{" "}
               <a
@@ -189,7 +195,7 @@ const PrivacyPage = () => {
           </section>
 
           <section className="pt-6 border-t border-border">
-            <p className="text-foreground font-bold mb-2">Summary</p>
+            <h2 className="text-foreground font-bold mb-2">Summary</h2>
             <p>
               React Grab respects your privacy. We don&apos;t collect, store, or transmit any of
               your personal data. The extension works entirely locally on your device.
@@ -197,7 +203,7 @@ const PrivacyPage = () => {
           </section>
         </div>
       </div>
-    </div>
+    </main>
   );
 };
 

--- a/apps/website/app/sitemap.md/route.ts
+++ b/apps/website/app/sitemap.md/route.ts
@@ -1,0 +1,85 @@
+import { readdirSync, statSync } from "fs";
+import { join } from "path";
+
+const BASE_URL = "https://react-grab.com";
+const EXCLUDED_PATHS = new Set(["api", "open-file"]);
+
+interface SitemapEntry {
+  url: string;
+  title: string;
+}
+
+const PAGE_TITLES: Record<string, string> = {
+  "/": "Home",
+  "/changelog": "Changelog",
+  "/privacy": "Privacy Policy",
+};
+
+const getRoutes = (directory: string, basePath = ""): string[] => {
+  const routes: string[] = [];
+  const entries = readdirSync(directory);
+
+  for (const entry of entries) {
+    if (EXCLUDED_PATHS.has(entry)) continue;
+    if (entry.includes(".")) continue;
+
+    const fullPath = join(directory, entry);
+    const stat = statSync(fullPath);
+    if (!stat.isDirectory()) continue;
+
+    const routePath = basePath ? `${basePath}/${entry}` : entry;
+    const dirEntries = readdirSync(fullPath);
+    const hasPage = dirEntries.some((file) => file === "page.tsx" || file === "page.ts");
+
+    if (hasPage) {
+      routes.push(routePath);
+    }
+    routes.push(...getRoutes(fullPath, routePath));
+  }
+
+  return routes;
+};
+
+export const dynamic = "force-static";
+
+export const GET = (): Response => {
+  const appDirectory = join(process.cwd(), "app");
+  const routes = getRoutes(appDirectory);
+
+  const entries: SitemapEntry[] = [{ url: BASE_URL, title: PAGE_TITLES["/"] ?? "Home" }];
+  for (const route of routes) {
+    const path = `/${route}`;
+    entries.push({
+      url: `${BASE_URL}${path}`,
+      title: PAGE_TITLES[path] ?? route.charAt(0).toUpperCase() + route.slice(1),
+    });
+  }
+
+  const lines: string[] = [];
+  lines.push("# React Grab Sitemap");
+  lines.push("");
+  lines.push("> All public pages on react-grab.com, with markdown alternates.");
+  lines.push("");
+  lines.push("## Pages");
+  lines.push("");
+  for (const entry of entries) {
+    const mdUrl = entry.url === BASE_URL ? `${BASE_URL}/index.md` : `${entry.url}.md`;
+    lines.push(`- [${entry.title}](${entry.url}) — [markdown](${mdUrl})`);
+  }
+  lines.push("");
+  lines.push("## Resources");
+  lines.push("");
+  lines.push(`- [llms.txt](${BASE_URL}/llms.txt)`);
+  lines.push(`- [llms-full.txt](${BASE_URL}/llms-full.txt)`);
+  lines.push(`- [Install guide](${BASE_URL}/install.md)`);
+  lines.push(`- [sitemap.xml](${BASE_URL}/sitemap.xml)`);
+  lines.push(`- [GitHub](https://github.com/aidenybai/react-grab)`);
+  lines.push("");
+
+  return new Response(lines.join("\n"), {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=300, s-maxage=300",
+    },
+  });
+};

--- a/apps/website/app/sitemap.md/route.ts
+++ b/apps/website/app/sitemap.md/route.ts
@@ -1,8 +1,7 @@
-import { readdirSync, statSync } from "fs";
 import { join } from "path";
+import { discoverPageRoutes } from "@/utils/discover-page-routes";
 
 const BASE_URL = "https://react-grab.com";
-const EXCLUDED_PATHS = new Set(["api", "open-file"]);
 
 interface SitemapEntry {
   url: string;
@@ -15,36 +14,11 @@ const PAGE_TITLES: Record<string, string> = {
   "/privacy": "Privacy Policy",
 };
 
-const getRoutes = (directory: string, basePath = ""): string[] => {
-  const routes: string[] = [];
-  const entries = readdirSync(directory);
-
-  for (const entry of entries) {
-    if (EXCLUDED_PATHS.has(entry)) continue;
-    if (entry.includes(".")) continue;
-
-    const fullPath = join(directory, entry);
-    const stat = statSync(fullPath);
-    if (!stat.isDirectory()) continue;
-
-    const routePath = basePath ? `${basePath}/${entry}` : entry;
-    const dirEntries = readdirSync(fullPath);
-    const hasPage = dirEntries.some((file) => file === "page.tsx" || file === "page.ts");
-
-    if (hasPage) {
-      routes.push(routePath);
-    }
-    routes.push(...getRoutes(fullPath, routePath));
-  }
-
-  return routes;
-};
-
 export const dynamic = "force-static";
 
 export const GET = (): Response => {
   const appDirectory = join(process.cwd(), "app");
-  const routes = getRoutes(appDirectory);
+  const routes = discoverPageRoutes(appDirectory);
 
   const entries: SitemapEntry[] = [{ url: BASE_URL, title: PAGE_TITLES["/"] ?? "Home" }];
   for (const route of routes) {

--- a/apps/website/app/sitemap.ts
+++ b/apps/website/app/sitemap.ts
@@ -1,44 +1,12 @@
 import type { MetadataRoute } from "next";
-import { readdirSync, statSync } from "fs";
 import { join } from "path";
+import { discoverPageRoutes } from "@/utils/discover-page-routes";
 
 const BASE_URL = "https://react-grab.com";
 
-const EXCLUDED_PATHS = new Set(["api", "open-file"]);
-
-const getRoutes = (directory: string, basePath = ""): Array<string> => {
-  const routes: Array<string> = [];
-  const entries = readdirSync(directory);
-
-  for (const entry of entries) {
-    const fullPath = join(directory, entry);
-    const routePath = basePath ? `${basePath}/${entry}` : entry;
-
-    if (EXCLUDED_PATHS.has(entry)) {
-      continue;
-    }
-
-    const stat = statSync(fullPath);
-
-    if (stat.isDirectory()) {
-      const hasPage = readdirSync(fullPath).some(
-        (file) => file === "page.tsx" || file === "page.ts",
-      );
-
-      if (hasPage) {
-        routes.push(routePath);
-      }
-
-      routes.push(...getRoutes(fullPath, routePath));
-    }
-  }
-
-  return routes;
-};
-
 const sitemap = (): MetadataRoute.Sitemap => {
   const appDirectory = join(process.cwd(), "app");
-  const routes = getRoutes(appDirectory);
+  const routes = discoverPageRoutes(appDirectory);
 
   const sitemapEntries: MetadataRoute.Sitemap = [
     {

--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -20,12 +20,6 @@ const nextConfig: NextConfig = {
   redirects: async () => {
     return [
       {
-        source: "/:path*",
-        has: [{ type: "host", value: "www.react-grab.com" }],
-        destination: "https://react-grab.com/:path*",
-        permanent: true,
-      },
-      {
         source: "/docs",
         destination: "https://github.com/aidenybai/react-grab#readme",
         permanent: false,

--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -49,31 +49,21 @@ const nextConfig: NextConfig = {
     ];
   },
   headers: async () => {
+    const markdownContentType = { key: "Content-Type", value: "text/markdown; charset=utf-8" };
+    const allowAllOrigins = { key: "Access-Control-Allow-Origin", value: "*" };
+
     return [
       {
-        source: "/:path*",
-        headers: [{ key: "Vary", value: "Accept, User-Agent" }],
-      },
-      {
         source: "/:path*\\.md",
-        headers: [
-          { key: "Content-Type", value: "text/markdown; charset=utf-8" },
-          { key: "Access-Control-Allow-Origin", value: "*" },
-        ],
+        headers: [markdownContentType, allowAllOrigins],
       },
       {
         source: "/llms.txt",
-        headers: [
-          { key: "Content-Type", value: "text/markdown; charset=utf-8" },
-          { key: "Access-Control-Allow-Origin", value: "*" },
-        ],
+        headers: [markdownContentType, allowAllOrigins],
       },
       {
         source: "/llms-full.txt",
-        headers: [
-          { key: "Content-Type", value: "text/markdown; charset=utf-8" },
-          { key: "Access-Control-Allow-Origin", value: "*" },
-        ],
+        headers: [markdownContentType, allowAllOrigins],
       },
     ];
   },

--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -20,6 +20,12 @@ const nextConfig: NextConfig = {
   redirects: async () => {
     return [
       {
+        source: "/:path*",
+        has: [{ type: "host", value: "www.react-grab.com" }],
+        destination: "https://react-grab.com/:path*",
+        permanent: true,
+      },
+      {
         source: "/docs",
         destination: "https://github.com/aidenybai/react-grab#readme",
         permanent: false,
@@ -45,12 +51,28 @@ const nextConfig: NextConfig = {
   headers: async () => {
     return [
       {
-        source: "/",
+        source: "/:path*",
+        headers: [{ key: "Vary", value: "Accept, User-Agent" }],
+      },
+      {
+        source: "/:path*\\.md",
         headers: [
-          {
-            key: "Vary",
-            value: "Accept",
-          },
+          { key: "Content-Type", value: "text/markdown; charset=utf-8" },
+          { key: "Access-Control-Allow-Origin", value: "*" },
+        ],
+      },
+      {
+        source: "/llms.txt",
+        headers: [
+          { key: "Content-Type", value: "text/markdown; charset=utf-8" },
+          { key: "Access-Control-Allow-Origin", value: "*" },
+        ],
+      },
+      {
+        source: "/llms-full.txt",
+        headers: [
+          { key: "Content-Type", value: "text/markdown; charset=utf-8" },
+          { key: "Access-Control-Allow-Origin", value: "*" },
         ],
       },
     ];
@@ -58,21 +80,10 @@ const nextConfig: NextConfig = {
   rewrites: async () => {
     return {
       beforeFiles: [
-        {
-          source: "/",
-          destination: "/llms.txt",
-          has: [
-            {
-              type: "header",
-              key: "accept",
-              value: "(.*)text/markdown(.*)",
-            },
-          ],
-        },
-        {
-          source: "/llm.txt",
-          destination: "/llms.txt",
-        },
+        { source: "/llm.txt", destination: "/llms.txt" },
+        { source: "/index.html.md", destination: "/index.md" },
+        { source: "/privacy/index.md", destination: "/privacy.md" },
+        { source: "/changelog/index.md", destination: "/changelog.md" },
       ],
     };
   },

--- a/apps/website/proxy.ts
+++ b/apps/website/proxy.ts
@@ -59,15 +59,13 @@ export const proxy = (request: NextRequest): NextResponse => {
     pathname.endsWith(".txt") ||
     STATIC_ASSET_PATTERN.test(pathname)
   ) {
-    const response = NextResponse.next();
-    if (wantsMarkdown(request) || pathname.endsWith(".md") || pathname.endsWith(".txt")) {
-      response.headers.set("Vary", "Accept, User-Agent");
-    }
-    return response;
+    return NextResponse.next();
   }
 
   if (!wantsMarkdown(request)) {
-    return NextResponse.next();
+    const response = NextResponse.next();
+    response.headers.append("Vary", "Accept, User-Agent");
+    return response;
   }
 
   const normalizedPath = pathname.replace(/\/+$/, "") || "/";
@@ -75,7 +73,7 @@ export const proxy = (request: NextRequest): NextResponse => {
 
   url.pathname = markdownPath;
   const rewritten = NextResponse.rewrite(url);
-  rewritten.headers.set("Vary", "Accept, User-Agent");
+  rewritten.headers.append("Vary", "Accept, User-Agent");
   rewritten.headers.set("X-Robots-Tag", "noindex");
   return rewritten;
 };

--- a/apps/website/proxy.ts
+++ b/apps/website/proxy.ts
@@ -42,12 +42,7 @@ const wantsMarkdown = (request: NextRequest): boolean => {
 
 export const proxy = (request: NextRequest): NextResponse => {
   const url = request.nextUrl.clone();
-  const { hostname, pathname } = url;
-
-  if (hostname.startsWith("www.")) {
-    url.hostname = hostname.slice(4);
-    return NextResponse.redirect(url, 308);
-  }
+  const { pathname } = url;
 
   if (
     pathname.startsWith("/_next") ||

--- a/apps/website/proxy.ts
+++ b/apps/website/proxy.ts
@@ -1,0 +1,85 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+const AGENT_UA_PATTERNS: RegExp[] = [
+  /ChatGPT/i,
+  /OAI-SearchBot/i,
+  /OpenAI/i,
+  /GPTBot/i,
+  /Anthropic/i,
+  /Claude/i,
+  /Perplexity/i,
+  /Cursor/i,
+  /Cohere/i,
+  /CCBot/i,
+  /Bytespider/i,
+  /Amazonbot/i,
+  /Applebot-Extended/i,
+  /Diffbot/i,
+  /YouBot/i,
+  /MistralAI/i,
+  /OpenCode/i,
+  /aider/i,
+  /CodexCLI/i,
+];
+
+const PAGE_TO_MD: Record<string, string> = {
+  "/": "/index.md",
+  "/privacy": "/privacy.md",
+  "/changelog": "/changelog.md",
+};
+
+const STATIC_ASSET_PATTERN = /\.(png|jpg|jpeg|svg|webp|ico|js|css|map|txt|xml|woff2?|ttf)$/i;
+
+const isAgentUserAgent = (userAgent: string): boolean =>
+  AGENT_UA_PATTERNS.some((pattern) => pattern.test(userAgent));
+
+const wantsMarkdown = (request: NextRequest): boolean => {
+  const accept = request.headers.get("accept") ?? "";
+  if (accept.toLowerCase().includes("text/markdown")) return true;
+  const userAgent = request.headers.get("user-agent") ?? "";
+  return isAgentUserAgent(userAgent);
+};
+
+export const proxy = (request: NextRequest): NextResponse => {
+  const url = request.nextUrl.clone();
+  const { hostname, pathname } = url;
+
+  if (hostname.startsWith("www.")) {
+    url.hostname = hostname.slice(4);
+    return NextResponse.redirect(url, 308);
+  }
+
+  if (
+    pathname.startsWith("/_next") ||
+    pathname.startsWith("/api") ||
+    pathname === "/script.js" ||
+    pathname === "/sitemap.xml" ||
+    pathname === "/robots.txt" ||
+    pathname.endsWith(".md") ||
+    pathname.endsWith(".txt") ||
+    STATIC_ASSET_PATTERN.test(pathname)
+  ) {
+    const response = NextResponse.next();
+    if (wantsMarkdown(request) || pathname.endsWith(".md") || pathname.endsWith(".txt")) {
+      response.headers.set("Vary", "Accept, User-Agent");
+    }
+    return response;
+  }
+
+  if (!wantsMarkdown(request)) {
+    return NextResponse.next();
+  }
+
+  const normalizedPath = pathname.replace(/\/+$/, "") || "/";
+  const markdownPath = PAGE_TO_MD[normalizedPath] ?? "/404.md";
+
+  url.pathname = markdownPath;
+  const rewritten = NextResponse.rewrite(url);
+  rewritten.headers.set("Vary", "Accept, User-Agent");
+  rewritten.headers.set("X-Robots-Tag", "noindex");
+  return rewritten;
+};
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon\\.ico|script\\.js).*)"],
+};

--- a/apps/website/public/404.md
+++ b/apps/website/public/404.md
@@ -1,0 +1,21 @@
+# Page Not Found
+
+> The page you requested does not exist on react-grab.com.
+
+## Available Pages
+
+- [Home](https://react-grab.com): Overview, install instructions, and quick start.
+- [Changelog](https://react-grab.com/changelog): Release notes and version history.
+- [Privacy policy](https://react-grab.com/privacy): How React Grab handles your data.
+
+## Resources for Agents
+
+- [llms.txt](https://react-grab.com/llms.txt): LLM-friendly site index.
+- [llms-full.txt](https://react-grab.com/llms-full.txt): Full documentation.
+- [Install guide (markdown)](https://react-grab.com/install.md): Step-by-step install.
+- [Sitemap (markdown)](https://react-grab.com/sitemap.md): All pages.
+
+## External
+
+- [GitHub repository](https://github.com/aidenybai/react-grab)
+- [Discord community](https://discord.com/invite/G7zxfUzkm7)

--- a/apps/website/public/index.md
+++ b/apps/website/public/index.md
@@ -1,0 +1,41 @@
+# React Grab
+
+> Grab any element in your app and give it to Cursor, Claude Code, or other AI coding agents.
+
+React Grab is an open-source dev-only script that adds an element picker to React apps in development. Hover any element, press a hotkey, and the file path, component name, and HTML source are copied to your clipboard ready to paste into your agent.
+
+## How It Works
+
+Once installed, hover over any UI element in your browser and press:
+
+- **⌘C** (Cmd+C) on Mac
+- **Ctrl+C** on Windows/Linux
+
+The element's context (file name, React component, and HTML source) is copied to your clipboard. For example:
+
+```
+<a class="ml-auto inline-block text-sm" href="#">
+  Forgot your password?
+</a>
+in LoginForm at components/login-form.tsx:46:19
+```
+
+## Quick Install
+
+Run this command at your project root:
+
+```bash
+npx grab@latest init -y
+```
+
+The CLI auto-detects your framework and configures everything.
+
+## Links
+
+- [Install guide](https://react-grab.com/install.md)
+- [Full documentation](https://react-grab.com/llms-full.txt)
+- [Changelog](https://react-grab.com/changelog.md)
+- [Privacy policy](https://react-grab.com/privacy.md)
+- [Sitemap](https://react-grab.com/sitemap.md)
+- [GitHub repository](https://github.com/aidenybai/react-grab)
+- [Discord community](https://discord.com/invite/G7zxfUzkm7)

--- a/apps/website/public/install.md
+++ b/apps/website/public/install.md
@@ -90,6 +90,7 @@ Add to `pages/_document.tsx`:
 
 ```jsx
 import { Html, Head, Main, NextScript } from "next/document";
+import Script from "next/script";
 
 export default function Document() {
   return (

--- a/apps/website/public/llms-full.txt
+++ b/apps/website/public/llms-full.txt
@@ -1,0 +1,184 @@
+# React Grab
+
+> Grab any element in your app and give it to Cursor, Claude Code, or other AI coding agents.
+
+## Usage
+
+Once installed, hover over any UI element in your browser and press:
+
+- **⌘C** (Cmd+C) on Mac
+- **Ctrl+C** on Windows/Linux
+
+This copies the element's context (file name, React component, and HTML source code) to your clipboard ready to paste into your coding agent. For example:
+
+```
+<a class="ml-auto inline-block text-sm" href="#">
+  Forgot your password?
+</a>
+in LoginForm at components/login-form.tsx:46:19
+```
+
+## Installation
+
+### CLI (Recommended)
+
+Run this command at your project root. Use the `-y` flag to skip interactive prompts (required for non-interactive environments):
+
+```bash
+npx grab@latest init -y
+```
+
+Init Options:
+```
+Options:
+  -y, --yes              Skip confirmation prompts
+  -f, --force            Force overwrite existing config
+  -k, --key <key>        Activation key (e.g., "Meta+K", "Ctrl+Shift+G", "Space")
+      --skip-install     Skip package installation
+  -c, --cwd <cwd>        Working directory (defaults to current directory)
+
+Examples:
+  npx grab@latest init -y                         # Auto-detect and install without prompts
+  npx grab@latest init -k "Meta+K" -y             # Set activation key to Cmd+K / Win+K
+```
+
+The CLI will detect your framework and add the necessary scripts automatically.
+
+### Configuration
+
+Configure React Grab options (activation key, mode, etc.):
+
+```bash
+npx grab@latest config
+```
+
+Config Options:
+```
+Options:
+  -y, --yes                  Skip confirmation prompts
+  -k, --key <key>            Activation key (e.g., "Meta+K", "Ctrl+Shift+G", "Space")
+  -m, --mode <mode>          Activation mode (toggle, hold)
+      --hold-duration <ms>   Key hold duration in milliseconds (for hold mode)
+      --allow-input <bool>   Allow activation inside input fields (true/false)
+      --context-lines <n>    Max context lines to include
+      --cdn <domain>         CDN domain (e.g., unpkg.com, custom.react-grab.com)
+  -c, --cwd <cwd>            Working directory (defaults to current directory)
+
+Examples:
+  npx grab@latest config -k "Meta+K"              # Set activation key to Cmd+K / Win+K
+  npx grab@latest config -k "Ctrl+Shift+G"        # Set activation key to Ctrl+Shift+G
+  npx grab@latest config -m hold --hold-duration 150   # Use hold mode with 150ms delay
+  npx grab@latest config --context-lines 5         # Include 5 lines of context
+```
+
+To discover all available commands and flags:
+
+```bash
+npx grab@latest --help
+npx grab@latest init --help
+npx grab@latest config --help
+```
+
+### Manual Installation
+
+If you prefer manual installation, use the correct package manager for your project:
+
+```bash
+npm install react-grab@latest
+# or
+yarn add react-grab@latest
+# or
+pnpm add react-grab@latest
+# or
+bun add react-grab@latest
+```
+
+### Next.js (App router)
+
+Add this inside of your `app/layout.tsx`:
+
+```jsx
+import Script from "next/script";
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <head>
+        {process.env.NODE_ENV === "development" && (
+          <Script
+            src="//unpkg.com/react-grab/dist/index.global.js"
+            crossOrigin="anonymous"
+            strategy="beforeInteractive"
+          />
+        )}
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+### Next.js (Pages router)
+
+Add this into your `pages/_document.tsx`:
+
+```jsx
+import { Html, Head, Main, NextScript } from "next/document";
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head>
+        {process.env.NODE_ENV === "development" && (
+          <Script
+            src="//unpkg.com/react-grab/dist/index.global.js"
+            crossOrigin="anonymous"
+            strategy="beforeInteractive"
+          />
+        )}
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}
+```
+
+### Vite
+
+Add this to your `index.html`:
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <script type="module">
+      if (import.meta.env.DEV) {
+        import("react-grab");
+      }
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+```
+
+### Webpack
+
+First, install React Grab:
+
+```bash
+npm install react-grab
+```
+
+Then add this at the top of your main entry file (e.g., `src/index.tsx` or `src/main.tsx`):
+
+```tsx
+if (process.env.NODE_ENV === "development") {
+  import("react-grab");
+}
+```

--- a/apps/website/public/llms-full.txt
+++ b/apps/website/public/llms-full.txt
@@ -124,6 +124,7 @@ Add this into your `pages/_document.tsx`:
 
 ```jsx
 import { Html, Head, Main, NextScript } from "next/document";
+import Script from "next/script";
 
 export default function Document() {
   return (

--- a/apps/website/public/llms.txt
+++ b/apps/website/public/llms.txt
@@ -1,184 +1,31 @@
 # React Grab
 
-Grab any element in your app and give it to Cursor, Claude Code, or other AI coding agents.
+> React Grab lets you select any element in your app and hand it off to AI coding agents like Cursor, Claude Code, Codex, and Copilot. Press a hotkey, click an element, and the file path, component name, and HTML source get copied to your clipboard for instant pasting into your agent.
 
-## Usage
+React Grab is an open-source dev-only script that adds an element picker to React apps in development. It is framework agnostic for React (Next.js, Vite, Webpack, etc.), runs entirely client-side, and is removed from production builds.
 
-Once installed, hover over any UI element in your browser and press:
+The default activation is `⌘+C` on macOS and `Ctrl+C` on Windows/Linux. The activation key, mode, and other behavior are configurable via the `grab` CLI.
 
-- **⌘C** (Cmd+C) on Mac
-- **Ctrl+C** on Windows/Linux
+## Docs
 
-This copies the element's context (file name, React component, and HTML source code) to your clipboard ready to paste into your coding agent. For example:
+- [Install guide](https://react-grab.com/install.md): Installation instructions for the CLI, Next.js (App & Pages router), Vite, and Webpack.
+- [Full documentation](https://react-grab.com/llms-full.txt): Complete reference covering installation, configuration, usage, and CLI flags.
+- [Changelog](https://react-grab.com/changelog.md): Release notes and version history.
+- [Privacy policy](https://react-grab.com/privacy.md): How React Grab handles your data (it does not collect any).
 
-```
-<a class="ml-auto inline-block text-sm" href="#">
-  Forgot your password?
-</a>
-in LoginForm at components/login-form.tsx:46:19
-```
+## Source
 
-## Installation
+- [GitHub repository](https://github.com/aidenybai/react-grab): Source code, issues, and discussions.
+- [README](https://raw.githubusercontent.com/aidenybai/react-grab/main/README.md): Project overview and quickstart.
+- [Primitives reference](https://github.com/aidenybai/react-grab/tree/main?tab=readme-ov-file#primitives): Lower-level building blocks exported by `react-grab`.
 
-### CLI (Recommended)
+## Examples
 
-Run this command at your project root. Use the `-y` flag to skip interactive prompts (required for non-interactive environments):
+- [Homepage demo](https://react-grab.com/index.md): Interactive demo of the typical "find this button" agent flow.
+- [Benchmark](https://react-bench.com): Independent benchmark showing 2× faster code-finding with React Grab context.
 
-```bash
-npx grab@latest init -y
-```
+## Optional
 
-Init Options:
-```
-Options:
-  -y, --yes              Skip confirmation prompts
-  -f, --force            Force overwrite existing config
-  -k, --key <key>        Activation key (e.g., "Meta+K", "Ctrl+Shift+G", "Space")
-      --skip-install     Skip package installation
-  -c, --cwd <cwd>        Working directory (defaults to current directory)
-
-Examples:
-  npx grab@latest init -y                         # Auto-detect and install without prompts
-  npx grab@latest init -k "Meta+K" -y             # Set activation key to Cmd+K / Win+K
-```
-
-The CLI will detect your framework and add the necessary scripts automatically.
-
-### Configuration
-
-Configure React Grab options (activation key, mode, etc.):
-
-```bash
-npx grab@latest config
-```
-
-Config Options:
-```
-Options:
-  -y, --yes                  Skip confirmation prompts
-  -k, --key <key>            Activation key (e.g., "Meta+K", "Ctrl+Shift+G", "Space")
-  -m, --mode <mode>          Activation mode (toggle, hold)
-      --hold-duration <ms>   Key hold duration in milliseconds (for hold mode)
-      --allow-input <bool>   Allow activation inside input fields (true/false)
-      --context-lines <n>    Max context lines to include
-      --cdn <domain>         CDN domain (e.g., unpkg.com, custom.react-grab.com)
-  -c, --cwd <cwd>            Working directory (defaults to current directory)
-
-Examples:
-  npx grab@latest config -k "Meta+K"              # Set activation key to Cmd+K / Win+K
-  npx grab@latest config -k "Ctrl+Shift+G"        # Set activation key to Ctrl+Shift+G
-  npx grab@latest config -m hold --hold-duration 150   # Use hold mode with 150ms delay
-  npx grab@latest config --context-lines 5         # Include 5 lines of context
-```
-
-To discover all available commands and flags:
-
-```bash
-npx grab@latest --help
-npx grab@latest init --help
-npx grab@latest config --help
-```
-
-### Manual Installation
-
-If you prefer manual installation, use the correct package manager for your project:
-
-```bash
-npm install react-grab@latest
-# or
-yarn add react-grab@latest
-# or
-pnpm add react-grab@latest
-# or
-bun add react-grab@latest
-```
-
-### Next.js (App router)
-
-Add this inside of your `app/layout.tsx`:
-
-```jsx
-import Script from "next/script";
-
-export default function RootLayout({ children }) {
-  return (
-    <html>
-      <head>
-        {process.env.NODE_ENV === "development" && (
-          <Script
-            src="//unpkg.com/react-grab/dist/index.global.js"
-            crossOrigin="anonymous"
-            strategy="beforeInteractive"
-          />
-        )}
-      </head>
-      <body>{children}</body>
-    </html>
-  );
-}
-```
-
-### Next.js (Pages router)
-
-Add this into your `pages/_document.tsx`:
-
-```jsx
-import { Html, Head, Main, NextScript } from "next/document";
-
-export default function Document() {
-  return (
-    <Html lang="en">
-      <Head>
-        {process.env.NODE_ENV === "development" && (
-          <Script
-            src="//unpkg.com/react-grab/dist/index.global.js"
-            crossOrigin="anonymous"
-            strategy="beforeInteractive"
-          />
-        )}
-      </Head>
-      <body>
-        <Main />
-        <NextScript />
-      </body>
-    </Html>
-  );
-}
-```
-
-### Vite
-
-Add this to your `index.html`:
-
-```html
-<!doctype html>
-<html lang="en">
-  <head>
-    <script type="module">
-      if (import.meta.env.DEV) {
-        import("react-grab");
-      }
-    </script>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
-</html>
-```
-
-### Webpack
-
-First, install React Grab:
-
-```bash
-npm install react-grab
-```
-
-Then add this at the top of your main entry file (e.g., `src/index.tsx` or `src/main.tsx`):
-
-```tsx
-if (process.env.NODE_ENV === "development") {
-  import("react-grab");
-}
-```
+- [Discord community](https://discord.com/invite/G7zxfUzkm7): Questions, feedback, and discussion.
+- [npm package](https://www.npmjs.com/package/react-grab): Latest published version.
+- [grab CLI on npm](https://www.npmjs.com/package/grab): Init and config CLI.

--- a/apps/website/public/privacy.md
+++ b/apps/website/public/privacy.md
@@ -1,0 +1,60 @@
+# Privacy Policy
+
+> Privacy policy for React Grab browser extension and website. React Grab does not collect, store, or transmit any personal data.
+
+## Overview
+
+React Grab is a developer tool that helps you inspect and copy React components from web pages. This privacy policy explains how the React Grab browser extension and website handle your data.
+
+## Data Collection
+
+React Grab does **NOT** collect, store, or transmit any personal data. Specifically:
+
+- We do not collect any personally identifiable information
+- We do not track your browsing history
+- We do not store any data about the websites you visit
+- We do not use analytics or tracking services
+- We do not use cookies for tracking purposes
+
+## How React Grab Works
+
+React Grab operates entirely locally in your browser. When you use the extension:
+
+- The extension injects code into web pages to enable element selection
+- When you select an element, the HTML/JSX is copied to your clipboard locally
+- No data is sent to external servers
+- All processing happens on your device
+
+## Permissions
+
+The extension requires the following permissions:
+
+- **Access to all websites:** Required to inject the element selection functionality into any webpage you visit.
+- **Storage:** Used only to store your extension preferences locally on your device.
+- **Active Tab:** Needed to interact with the currently active tab when you use the keyboard shortcut.
+
+These permissions are used solely for the core functionality of the extension and are not used to collect or transmit any data.
+
+## Local Storage
+
+React Grab may store minimal settings locally on your device using browser storage APIs. This data never leaves your device and can be cleared by uninstalling the extension or clearing your browser data.
+
+## Third-Party Services
+
+React Grab does not integrate with any third-party analytics, tracking, or advertising services. The extension operates entirely offline and does not make any external network requests.
+
+## Open Source
+
+React Grab is open source software. You can review the complete source code on [GitHub](https://github.com/aidenybai/react-grab) to verify these privacy claims.
+
+## Changes to This Policy
+
+We may update this privacy policy from time to time. Any changes will be posted on this page with an updated revision date.
+
+## Contact
+
+If you have questions about this privacy policy, open an issue on our [GitHub repository](https://github.com/aidenybai/react-grab/issues) or join our [Discord community](https://discord.com/invite/G7zxfUzkm7).
+
+## Summary
+
+React Grab respects your privacy. We don't collect, store, or transmit any of your personal data. The extension works entirely locally on your device.

--- a/apps/website/utils/discover-page-routes.ts
+++ b/apps/website/utils/discover-page-routes.ts
@@ -1,0 +1,29 @@
+import { readdirSync, statSync } from "fs";
+import { join } from "path";
+
+export const SITEMAP_EXCLUDED_PATHS = new Set(["api", "open-file"]);
+
+export const discoverPageRoutes = (directory: string, basePath = ""): string[] => {
+  const routes: string[] = [];
+  const entries = readdirSync(directory);
+
+  for (const entry of entries) {
+    if (SITEMAP_EXCLUDED_PATHS.has(entry)) continue;
+    if (entry.includes(".")) continue;
+
+    const fullPath = join(directory, entry);
+    const stat = statSync(fullPath);
+    if (!stat.isDirectory()) continue;
+
+    const routePath = basePath ? `${basePath}/${entry}` : entry;
+    const dirEntries = readdirSync(fullPath);
+    const hasPage = dirEntries.some((file) => file === "page.tsx" || file === "page.ts");
+
+    if (hasPage) {
+      routes.push(routePath);
+    }
+    routes.push(...discoverPageRoutes(fullPath, routePath));
+  }
+
+  return routes;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses the [Vercel agent-readability spec](https://vercel.com/kb/guide/agent-readability-spec) audit findings on `react-grab.com`.

## What changed

### "Can agents find you?"
- **`llms.txt`**: rewritten to follow the [llmstxt.org](https://llmstxt.org) format with an H1 title, blockquote summary, and `[name](url)` markdown link sections. The previous detailed install content moved to a new `/llms-full.txt` (linked from `llms.txt`).
- **`/sitemap.md`**: new dynamic route that lists every page with its HTML and `.md` URL so agents can crawl without parsing XML.
- **JSON-LD**: `WebSite` + `Organization` + `SoftwareApplication` graph injected into `<head>` of every page so agents can extract title, description, logo, and schema-typed metadata without DOM parsing.

### "Can agents read you?"
- **`proxy.ts`** (Next.js 16's renamed `middleware`):
  - Detects AI user-agents (`ChatGPT`, `Claude`, `Perplexity`, `Cursor`, `GPTBot`, `OAI-SearchBot`, `Anthropic`, `OpenCode`, `aider`, `CCBot`, `Bytespider`, `Amazonbot`, `Applebot-Extended`, `Diffbot`, `MistralAI`, `YouBot`, `Cohere`) and `Accept: text/markdown` headers, then rewrites to the corresponding `.md` mirror.
  - Returns **200 + markdown** (instead of HTML 404) for unknown URLs requested by agents, since agents discard 404 bodies.
  - Appends `Vary: Accept, User-Agent` only on proxy responses (HTML pass-through and markdown rewrites). Static assets keep their default headers.
- **Markdown mirrors** at `{url}.md`:
  - `/index.md` and `/privacy.md` as static files in `public/`.
  - `/changelog.md` and `/sitemap.md` as Next.js route handlers (dynamic from `CHANGELOG.md` and the `app/` directory).
  - `/404.md` for the agent-friendly missing-page response.
  - `Content-Type: text/markdown; charset=utf-8` and `Access-Control-Allow-Origin: *` headers configured in `next.config.ts` for every `.md` URL.
- **`<link rel="alternate" type="text/markdown">`**: each page emits its own page-specific alternate (`/`, `/privacy`, `/changelog` → `index.md`, `privacy.md`, `changelog.md`) via `metadata.alternates.types`. A single global `<link>` to `/llms.txt` lives in the layout.

### "Is your HTML agent-friendly?"
- **Hierarchical headings** added on all three indexed pages:
  - Homepage: visually-hidden `h1` → `h2` → `h3` over the existing demo so agents can chunk the page.
  - Privacy: promoted each section heading from `<p>` to `<h2>` (already had `<h1>`).
  - Changelog: "Changelog" promoted to `<h1>`, version to `<h2>`, change type to `<h3>` (skipped when the entry has no change type so the heading outline stays clean).
- **Canonical URL** added to every page's metadata (`alternates.canonical` + `metadataBase`).
- **Skip-to-content link** added to layout for keyboard users.

## Verification

Tested locally with `next start` and against the deployed Vercel preview:

```
GET /llms.txt                              → llmstxt-spec markdown with link sections
GET /index.md / /privacy.md / /changelog.md → 200 text/markdown
GET /sitemap.md                             → 200 text/markdown
GET / (Accept: text/markdown)               → 200 → rewritten to /index.md
GET / (User-Agent: ChatGPT)                 → 200 → rewritten to /index.md
GET /privacy (Accept: text/markdown)        → 200 → rewritten to /privacy.md
GET /foobar (Accept: text/markdown)         → 200 → rewritten to /404.md (not 404)
GET /script.js / /logo.png                  → no Vary: User-Agent, CDN cache intact
GET / (browser)                             → HTML with h1, JSON-LD, canonical, alternate
```

`pnpm typecheck`, `pnpm lint`, `pnpm format` all pass; production `next build` succeeds; lint/build/test-build/test-cli/test-e2e/typecheck CI all green.

## Bot review notes

- **Cursor Bugbot** flagged an empty `<h3>` on changelog when `entry.changeType` is `""`, a duplicate `<link rel="alternate" type="text/markdown">` from the root layout, an over-broad `Vary: Accept, User-Agent` on `/:path*` defeating CDN caching for static assets, a duplicate `www → apex` redirect across `proxy.ts` and `next.config.ts`, and (high severity) that a proxy-level `www → apex` redirect would create an infinite loop while the Vercel dashboard still redirects apex → `www`. All five fixed.
- **cubic-dev-ai** flagged the `<Script>` snippet in `llms-full.txt` was missing its `import Script from "next/script"` line. Fixed in both `llms-full.txt` and the pre-existing `install.md`.
- **Vercel Agent Review** suggested explicitly excluding the `sitemap.md` and `changelog.md` route folders from sitemap generation. The existing `if (entry.includes("."))` filter already excludes them, so leaving as-is. The same review's other comment ("proxy.ts not executed") was incorrect — verified the deployed preview returns markdown to agent UAs through the proxy (`x-matched-path: /index.md`).

## Manual follow-up (cannot be done from code)

The audit's **"Redirect behavior cross-host redirect to `www.react-grab.com`"** finding can only be addressed in the Vercel dashboard: in the project's *Domains* settings, mark `react-grab.com` (apex) as canonical so requests to `react-grab.com` no longer 30x to `www.react-grab.com`. A code-level `www → apex` redirect is intentionally **not** added — Vercel's edge redirect runs before the proxy, so a proxy redirect in the opposite direction would create an infinite loop and take the site down.

The remaining audit finding — homepage/changelog HTML over the 100 KB page size threshold — is mitigated by the markdown alternates: agent UAs no longer receive HTML for those pages. Reducing the HTML further would require turning off `experimental.inlineCss`, which costs a render-blocking round-trip for human visitors.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-caa9fb58-55d8-4de7-bfaf-0eb1f395aed3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-caa9fb58-55d8-4de7-bfaf-0eb1f395aed3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve react-grab.com agent readability by serving markdown to agents, adding structured metadata, and tightening semantics to align with Vercel’s agent-readability spec. Agents now get clean, crawlable content with better discovery and fewer dead ends.

- **New Features**
  - Markdown delivery: `.md` mirrors for key pages (`/index.md`, `/privacy.md`, `/changelog.md`, `/sitemap.md`) plus `/404.md`; a proxy detects agent user-agents or `Accept: text/markdown` and rewrites; unknown URLs return 200 markdown; `Content-Type`/CORS set on `.md` and `llms*.txt`.
  - Discoverability: `llms.txt` rewritten to `llmstxt.org` format; added `llms-full.txt`; injected JSON-LD (`WebSite`, `Organization`, `SoftwareApplication`); canonical URLs and `<link rel="alternate" type="text/markdown">` scoped per page.
  - Semantics: `<main>` landmarks, hierarchical headings on Home/Privacy/Changelog, and a skip-to-content link for better parsing and navigation.
  - Deployment note: In Vercel → Domains, set `react-grab.com` (apex) as canonical to resolve the cross-host redirect finding.

- **Bug Fixes**
  - Metadata scoping: moved the homepage canonical and `index.md` alternate from the root layout into Home; added a canonical and `noindex, nofollow` to `/open-file` to prevent incorrect inheritance.
  - Alternates: removed the root layout’s hardcoded `/index.md` alternate; each page now declares its own markdown alternate; a single global alternate for `/llms.txt` remains.
  - Caching: scoped `Vary: Accept, User-Agent` to proxy responses only to avoid fragmenting CDN caches for static assets.
  - Redirects: removed duplicate `www → apex` rule from `next.config.ts` and dropped the proxy-level redirect to avoid apex↔www loops with Vercel’s edge redirect.
  - Changelog: skip empty `<h3>` when an entry has no change type.
  - Docs: add missing `next/script` import in the Next.js Pages Router snippet in `llms-full.txt` and `install.md`.
  - Refactor: extracted shared route discovery to `utils/discover-page-routes` and reused in `sitemap.ts` and `/sitemap.md` to keep exclusions consistent.

<sup>Written for commit 903f7b94cde05b5c7180f2ce843bdfdea3c3e63c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

