### PR TITLE
feat(react-grab): tag library frames with their npm package name

### DIFF
--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -26,6 +26,7 @@ import { getTagName } from "../utils/get-tag-name.js";
 import { truncateString } from "../utils/truncate-string.js";
 import { getNextBasePath } from "../utils/get-next-base-path.js";
 import { normalizeFilePath } from "../utils/normalize-file-path.js";
+import { parsePackageName } from "../utils/parse-package-name.js";
 import { isInternalAttribute } from "../utils/strip-internal-attributes.js";
 
 const NON_COMPONENT_PREFIXES = new Set([
@@ -393,6 +394,7 @@ const hasFormattableFrames = (stack: StackFrame[] | null): boolean => {
     if (frame.isServer && (!frame.functionName || isSourceComponentName(frame.functionName))) {
       return true;
     }
+    if (frame.functionName && isSourceComponentName(frame.functionName)) return true;
     return false;
   });
 };
@@ -420,54 +422,63 @@ const getComponentNamesFromFiber = (element: Element, maxCount: number): string[
   return componentNames;
 };
 
+const formatResolvedSourceLine = (
+  frame: StackFrame,
+  filePath: string,
+  componentName: string | null,
+  isNextProject: boolean,
+): string => {
+  // HACK: bundlers like Vite produce unreliable line/column numbers from
+  // owner stacks, so we only include them for Next.js where the dev server
+  // symbolicates frames via source maps.
+  const location =
+    isNextProject && frame.lineNumber
+      ? `${normalizeFilePath(filePath)}:${frame.lineNumber}${frame.columnNumber ? `:${frame.columnNumber}` : ""}`
+      : normalizeFilePath(filePath);
+  return componentName ? `\n  in ${componentName} (at ${location})` : `\n  in ${location}`;
+};
+
 const formatStackContext = (stack: StackFrame[], options: StackContextOptions = {}): string => {
   const { maxLines = DEFAULT_MAX_CONTEXT_LINES } = options;
   const isNextProject = checkIsNextProject();
-  const formattedLines: string[] = [];
+  const lines: string[] = [];
+  let previousLibraryPackage: string | null = null;
+
+  const emit = (line: string, libraryPackage: string | null) => {
+    lines.push(line);
+    previousLibraryPackage = libraryPackage;
+  };
 
   for (const frame of stack) {
-    if (formattedLines.length >= maxLines) break;
+    if (lines.length >= maxLines) break;
 
-    const hasResolvedSource = frame.fileName && isSourceFile(frame.fileName);
+    const resolvedSource = frame.fileName && isSourceFile(frame.fileName) ? frame.fileName : null;
+    const libraryPackage = resolvedSource ? null : parsePackageName(frame.fileName);
+    if (libraryPackage && libraryPackage === previousLibraryPackage) continue;
 
-    if (
-      frame.isServer &&
-      !hasResolvedSource &&
-      (!frame.functionName || isSourceComponentName(frame.functionName))
-    ) {
-      formattedLines.push(`\n  in ${frame.functionName || "<anonymous>"} (at Server)`);
+    const componentName =
+      frame.functionName && isSourceComponentName(frame.functionName) ? frame.functionName : null;
+
+    if (frame.isServer && !resolvedSource && (componentName || !frame.functionName)) {
+      const tag = libraryPackage ? `${libraryPackage} at Server` : "at Server";
+      emit(`\n  in ${componentName ?? "<anonymous>"} (${tag})`, libraryPackage);
       continue;
     }
 
-    if (hasResolvedSource) {
-      let line = "\n  in ";
-      const hasComponentName = frame.functionName && isSourceComponentName(frame.functionName);
+    if (!resolvedSource && componentName) {
+      emit(
+        libraryPackage ? `\n  in ${componentName} (${libraryPackage})` : `\n  in ${componentName}`,
+        libraryPackage,
+      );
+      continue;
+    }
 
-      if (hasComponentName) {
-        line += `${frame.functionName} (at `;
-      }
-
-      line += normalizeFilePath(frame.fileName!);
-
-      // HACK: bundlers like Vite produce unreliable line/column numbers from
-      // owner stacks, so we only include them for Next.js where the dev
-      // server symbolicates frames via source maps.
-      if (isNextProject && frame.lineNumber) {
-        line += `:${frame.lineNumber}`;
-        if (frame.columnNumber) {
-          line += `:${frame.columnNumber}`;
-        }
-      }
-
-      if (hasComponentName) {
-        line += `)`;
-      }
-
-      formattedLines.push(line);
+    if (resolvedSource) {
+      emit(formatResolvedSourceLine(frame, resolvedSource, componentName, isNextProject), null);
     }
   }
 
-  return formattedLines.join("");
+  return lines.join("");
 };
 
 export const getStackContext = async (

--- a/packages/react-grab/src/utils/parse-package-name.ts
+++ b/packages/react-grab/src/utils/parse-package-name.ts
@@ -1,0 +1,89 @@
+import { normalizeFileName } from "bippy/source";
+
+const NODE_MODULES_PATTERN = /(?:^|[/\\])node_modules[/\\]/g;
+const VITE_OPTIMIZED_DEPS_PATTERN = /[/\\]\.vite[/\\]deps[^/\\]*[/\\]/g;
+const FILE_EXTENSION_PATTERN = /\.[mc]?[jt]sx?$/i;
+const VITE_INTERNAL_CHUNK_PATTERN = /^chunk-[A-Za-z0-9_-]+$/;
+const PATH_SEPARATOR_PATTERN = /[/\\]/;
+const NAME_AT_VERSION_PATTERN = /^(.+?)@v?\d/;
+
+const splitPathSegments = (path: string): string[] =>
+  path.split(PATH_SEPARATOR_PATTERN).filter(Boolean);
+
+const readNodeModulesPackage = (afterMarker: string): string | null => {
+  const [first, second] = splitPathSegments(afterMarker);
+  if (!first || first.startsWith(".")) return null;
+  if (!first.startsWith("@")) return first;
+  return second ? `${first}/${second}` : null;
+};
+
+// Vite flattens scoped packages because filenames cannot contain a slash:
+// `@radix-ui/react-dialog` becomes `@radix-ui_react-dialog.js`.
+// Ambiguity: if the scope itself contains an underscore (`@my_org/pkg` ->
+// `@my_org_pkg.js`), indexOf("_") splits at the wrong boundary. This is
+// inherent to Vite's encoding and unresolvable without a registry lookup.
+const readViteOptimizedDepPackage = (afterMarker: string): string | null => {
+  const firstSegment = splitPathSegments(afterMarker)[0];
+  if (!firstSegment) return null;
+  const stem = firstSegment.replace(FILE_EXTENSION_PATTERN, "");
+  if (VITE_INTERNAL_CHUNK_PATTERN.test(stem)) return null;
+  if (!stem.startsWith("@")) return stem;
+  const scopeBoundary = stem.indexOf("_");
+  if (scopeBoundary === -1) return null;
+  return `${stem.slice(0, scopeBoundary)}/${stem.slice(scopeBoundary + 1)}`;
+};
+
+const extractAfterLastMarker = (
+  input: string,
+  pattern: RegExp,
+  read: (afterMarker: string) => string | null,
+): string | null => {
+  let lastMatch: RegExpExecArray | null = null;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(input)) !== null) {
+    lastMatch = match;
+  }
+  if (!lastMatch) return null;
+  return read(input.slice(lastMatch.index + lastMatch[0].length));
+};
+
+const extractNameAtVersion = (segment: string | undefined): string | null =>
+  segment?.match(NAME_AT_VERSION_PATTERN)?.[1] ?? null;
+
+const extractVersionedPackageFromUrl = (rawFileName: string): string | null => {
+  let url: URL;
+  try {
+    url = new URL(rawFileName);
+  } catch {
+    return null;
+  }
+  if (!url.hostname) return null;
+
+  const segments = splitPathSegments(url.pathname);
+  for (const [index, segment] of segments.entries()) {
+    if (segment.startsWith("@")) {
+      const name = extractNameAtVersion(segments[index + 1]);
+      if (name) return `${segment}/${name}`;
+      continue;
+    }
+    const name = extractNameAtVersion(segment);
+    if (name) return name;
+  }
+  return null;
+};
+
+const extractFromLocalPath = (normalizedPath: string): string | null =>
+  extractAfterLastMarker(normalizedPath, VITE_OPTIMIZED_DEPS_PATTERN, readViteOptimizedDepPackage) ??
+  extractAfterLastMarker(normalizedPath, NODE_MODULES_PATTERN, readNodeModulesPackage);
+
+export const parsePackageName = (fileName: string | null | undefined): string | null => {
+  if (!fileName) return null;
+
+  const cdnResult = extractVersionedPackageFromUrl(fileName);
+  if (cdnResult) return cdnResult;
+
+  const normalized = normalizeFileName(fileName);
+  if (!normalized) return null;
+
+  return extractFromLocalPath(normalized);
+};


### PR DESCRIPTION
## Summary

- Show third-party component names in the stack context tagged with their originating npm package (`in Square (lucide-react)`) instead of silently dropping them.
- Consecutive same-package frames coalesce to one line so deeply nested library trees (Radix, MUI) don't evict user component frames from the `maxLines` budget.
- Adds `parse-package-name` utility that extracts the npm package name from file paths across the bundler matrix: Vite optimized deps, pnpm `.pnpm` hoist, Yarn PnP, Bun cache, webpack/turbopack URLs, and CDN versioned URLs.

## Test plan

- [ ] Existing e2e tests pass (`pnpm test`)
- [ ] `pnpm typecheck` clean
- [ ] `pnpm lint` clean

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to stack-context formatting and a new path-parsing utility, affecting only how debug context is displayed.
> 
> **Overview**
> Improves `react-grab` stack-context output by **including third-party component frames** and tagging them with the inferred npm package name (e.g. `in Button (radix-ui)`), instead of dropping non-source frames.
> 
> Adds `parsePackageName` to derive package names from `fileName` values (URLs and `node_modules`/Vite optimized deps paths), and updates stack formatting to **coalesce consecutive frames from the same package** so library-heavy traces don’t consume the `maxLines` budget. Also broadens `hasFormattableFrames` to treat source-like component `functionName`s as renderable even without a source file path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3ab2ea78ee11435b88a597329b489c226739967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tag library frames in the React stack context with their npm package (e.g. `in Square (lucide-react)`) and collapse same-package frames to keep user components visible within `maxLines`. Adds a cross-bundler `parse-package-name` utility to reliably detect package names.

- **New Features**
  - Tag non-source frames with their package and show component names when available.
  - Collapse consecutive frames from the same package into one line.
  - New `parse-package-name` works with `node_modules`, `Vite` optimized deps, `pnpm` hoists, `Yarn PnP`, `Bun` cache, `webpack`/`turbopack` URLs, and CDN versioned URLs.

<sup>Written for commit d3ab2ea78ee11435b88a597329b489c226739967. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

