### PR TITLE
feat(react-grab): collapse shared stack tails in multi-grab output

### DIFF
--- a/packages/react-grab/src/utils/find-longest-common-suffix.ts
+++ b/packages/react-grab/src/utils/find-longest-common-suffix.ts
@@ -1,0 +1,13 @@
+export const findLongestCommonSuffix = <T>(lists: T[][]): T[] => {
+  if (lists.length === 0) return [];
+  const minLength = Math.min(...lists.map((list) => list.length));
+  let suffixLength = 0;
+  for (let suffixIndex = 1; suffixIndex <= minLength; suffixIndex++) {
+    const candidate = lists[0][lists[0].length - suffixIndex];
+    const isShared = lists.every((list) => list[list.length - suffixIndex] === candidate);
+    if (!isShared) break;
+    suffixLength = suffixIndex;
+  }
+  if (suffixLength === 0) return [];
+  return lists[0].slice(lists[0].length - suffixLength);
+};

--- a/packages/react-grab/src/utils/join-snippets.ts
+++ b/packages/react-grab/src/utils/join-snippets.ts
@@ -1,5 +1,65 @@
+import { findLongestCommonSuffix } from "./find-longest-common-suffix.js";
+
+const STACK_LINE_DELIMITER = "\n  in ";
+
+interface SplitSnippet {
+  htmlPreview: string;
+  stackLines: string[];
+}
+
+const splitSnippet = (snippet: string): SplitSnippet => {
+  const firstStackIndex = snippet.indexOf(STACK_LINE_DELIMITER);
+  if (firstStackIndex === -1) return { htmlPreview: snippet, stackLines: [] };
+  const htmlPreview = snippet.slice(0, firstStackIndex);
+  const stackText = snippet.slice(firstStackIndex);
+  const stackLines = stackText.split("\n").filter((line) => line.trim().length > 0);
+  return { htmlPreview, stackLines };
+};
+
+const formatNumberedEntry = (snippet: string, index: number): string =>
+  `[${index + 1}]\n${snippet}`;
+
 export const joinSnippets = (snippets: string[]): string => {
   if (snippets.length <= 1) return snippets[0] ?? "";
 
-  return snippets.map((snippet, index) => `[${index + 1}]\n${snippet}`).join("\n\n");
+  const splitEntries = snippets.map(splitSnippet);
+  const stackLists = splitEntries.map((entry) => entry.stackLines);
+  const sharedSuffix = findLongestCommonSuffix(stackLists);
+
+  if (sharedSuffix.length === 0) {
+    return snippets.map(formatNumberedEntry).join("\n\n");
+  }
+
+  const isFullySharedStack = splitEntries.every(
+    (entry) => entry.stackLines.length === sharedSuffix.length,
+  );
+
+  if (isFullySharedStack) {
+    const inlineEntries = splitEntries
+      .map((entry, entryIndex) => `[${entryIndex + 1}] ${entry.htmlPreview}`)
+      .join("\n");
+    const sharedStackText = sharedSuffix.join("\n");
+    return `${inlineEntries}\n  (all from the same component stack)\n${sharedStackText}`;
+  }
+
+  const sections: string[] = [];
+  for (let entryIndex = 0; entryIndex < splitEntries.length; entryIndex++) {
+    const entry = splitEntries[entryIndex];
+
+    if (entryIndex === 0) {
+      sections.push(formatNumberedEntry(snippets[0], 0));
+      continue;
+    }
+
+    const divergingLines = entry.stackLines.slice(
+      0,
+      entry.stackLines.length - sharedSuffix.length,
+    );
+    const divergingText = divergingLines.length > 0 ? `\n${divergingLines.join("\n")}` : "";
+    sections.push(
+      `[${entryIndex + 1}]\n${entry.htmlPreview}${divergingText}\n  (remaining stack same as [1])`,
+    );
+  }
+
+  return sections.join("\n\n");
 };


### PR DESCRIPTION
## Summary

- When multiple grabbed elements share the same component stack, emit each element inline and the shared stack once, annotated with `(all from the same component stack)`.
- For partial overlaps (different prefixes, shared tail), entry [1] renders fully and subsequent entries show their diverging lines with `(remaining stack same as [1])`.
- Falls back to the existing `[n]` numbered format when stacks share no common suffix.
- Adds `find-longest-common-suffix` utility for generic suffix detection across arrays.

## Test plan

- [ ] `pnpm typecheck` clean
- [ ] `pnpm lint` clean
- [ ] Existing e2e tests pass (`pnpm test`)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to string formatting of copied multi-grab output, with no runtime side effects beyond potential output/annotation differences.
> 
> **Overview**
> Updates `joinSnippets` to detect a shared *component stack suffix* across multiple grabbed snippets and avoid repeating it in the combined output.
> 
> When stacks fully match, entries are emitted inline and the shared stack is printed once with an `(all from the same component stack)` note; when only the tail matches, entry `[1]` stays full and later entries show only their differing stack prefix plus `(remaining stack same as [1])`. Adds a generic `findLongestCommonSuffix` utility to compute the shared tail, and falls back to the prior numbered format when no suffix is shared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16965a02405140632c63961a2c596e7feccfde80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapse shared component stack tails in multi-grab output in `react-grab`. Reduces noise by emitting shared stacks once and adding clear labels for identical or partial overlaps.

- **New Features**
  - Detects the longest shared stack tail and prints identical stacks once with "(all from the same component stack)".
  - For partial overlaps, prints [1] fully and shows only diverging lines for later entries with "(remaining stack same as [1])"; falls back to numbered format if no shared suffix.
  - Adds `findLongestCommonSuffix` and updates `joinSnippets` to split previews from stack lines and format inline entries.

<sup>Written for commit 16965a02405140632c63961a2c596e7feccfde80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

