### PR TITLE
refactor(react-grab): extract component name filters to own util

### DIFF
--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -27,56 +27,10 @@ import { truncateString } from "../utils/truncate-string.js";
 import { getNextBasePath } from "../utils/get-next-base-path.js";
 import { normalizeFilePath } from "../utils/normalize-file-path.js";
 import { isInternalAttribute } from "../utils/strip-internal-attributes.js";
-
-const NON_COMPONENT_PREFIXES = new Set([
-  "_",
-  "$",
-  "motion.",
-  "styled.",
-  "chakra.",
-  "ark.",
-  "Primitive.",
-  "Slot.",
-]);
-
-// Next.js App Router internals that wrap user components but are not useful
-// as display names. Without filtering these the UI would show names like
-// "InnerLayoutRouter" instead of the user's own component.
-const NEXT_INTERNAL_COMPONENT_NAMES = new Set([
-  "InnerLayoutRouter",
-  "RedirectErrorBoundary",
-  "RedirectBoundary",
-  "HTTPAccessFallbackErrorBoundary",
-  "HTTPAccessFallbackBoundary",
-  "LoadingBoundary",
-  "ErrorBoundary",
-  "InnerScrollAndFocusHandler",
-  "ScrollAndFocusHandler",
-  "RenderFromTemplateContext",
-  "OuterLayoutRouter",
-  "body",
-  "html",
-  "DevRootHTTPAccessFallbackBoundary",
-  "AppDevOverlayErrorBoundary",
-  "AppDevOverlay",
-  "HotReload",
-  "Router",
-  "ErrorBoundaryHandler",
-  "AppRouter",
-  "ServerRoot",
-  "SegmentStateProvider",
-  "RootErrorBoundary",
-  "LoadableComponent",
-  "MotionDOMComponent",
-]);
-
-const REACT_INTERNAL_COMPONENT_NAMES = new Set([
-  "Suspense",
-  "Fragment",
-  "StrictMode",
-  "Profiler",
-  "SuspenseList",
-]);
+import {
+  isInternalComponentName,
+  isUsefulComponentName,
+} from "../utils/is-useful-component-name.js";
 
 let cachedIsNextProject: boolean | undefined;
 
@@ -88,22 +42,6 @@ export const checkIsNextProject = (revalidate?: boolean): boolean => {
     typeof document !== "undefined" &&
     Boolean(document.getElementById("__NEXT_DATA__") || document.querySelector("nextjs-portal"));
   return cachedIsNextProject;
-};
-
-const isInternalComponentName = (name: string): boolean => {
-  if (NEXT_INTERNAL_COMPONENT_NAMES.has(name)) return true;
-  if (REACT_INTERNAL_COMPONENT_NAMES.has(name)) return true;
-  for (const prefix of NON_COMPONENT_PREFIXES) {
-    if (name.startsWith(prefix)) return true;
-  }
-  return false;
-};
-
-const isUsefulComponentName = (name: string): boolean => {
-  if (!name) return false;
-  if (isInternalComponentName(name)) return false;
-  if (name === "SlotClone" || name === "Slot") return false;
-  return true;
 };
 
 const isSourceComponentName = (name: string): boolean => {

--- a/packages/react-grab/src/utils/is-useful-component-name.ts
+++ b/packages/react-grab/src/utils/is-useful-component-name.ts
@@ -1,0 +1,62 @@
+const NON_COMPONENT_PREFIXES = new Set([
+  "_",
+  "$",
+  "motion.",
+  "styled.",
+  "chakra.",
+  "ark.",
+  "Primitive.",
+  "Slot.",
+]);
+
+const NEXT_INTERNAL_COMPONENT_NAMES = new Set([
+  "InnerLayoutRouter",
+  "RedirectErrorBoundary",
+  "RedirectBoundary",
+  "HTTPAccessFallbackErrorBoundary",
+  "HTTPAccessFallbackBoundary",
+  "LoadingBoundary",
+  "ErrorBoundary",
+  "InnerScrollAndFocusHandler",
+  "ScrollAndFocusHandler",
+  "RenderFromTemplateContext",
+  "OuterLayoutRouter",
+  "body",
+  "html",
+  "DevRootHTTPAccessFallbackBoundary",
+  "AppDevOverlayErrorBoundary",
+  "AppDevOverlay",
+  "HotReload",
+  "Router",
+  "ErrorBoundaryHandler",
+  "AppRouter",
+  "ServerRoot",
+  "SegmentStateProvider",
+  "RootErrorBoundary",
+  "LoadableComponent",
+  "MotionDOMComponent",
+]);
+
+const REACT_INTERNAL_COMPONENT_NAMES = new Set([
+  "Suspense",
+  "Fragment",
+  "StrictMode",
+  "Profiler",
+  "SuspenseList",
+]);
+
+export const isInternalComponentName = (name: string): boolean => {
+  if (NEXT_INTERNAL_COMPONENT_NAMES.has(name)) return true;
+  if (REACT_INTERNAL_COMPONENT_NAMES.has(name)) return true;
+  for (const prefix of NON_COMPONENT_PREFIXES) {
+    if (name.startsWith(prefix)) return true;
+  }
+  return false;
+};
+
+export const isUsefulComponentName = (name: string): boolean => {
+  if (!name) return false;
+  if (isInternalComponentName(name)) return false;
+  if (name === "SlotClone" || name === "Slot") return false;
+  return true;
+};


### PR DESCRIPTION
## Summary

- Moves the component name filter lists and `isInternalComponentName` / `isUsefulComponentName` functions from `context.ts` into `utils/is-useful-component-name.ts`.
- No behavior change, no output change. Pure extraction per AGENTS.md conventions.
- Makes these functions importable by other modules (needed for upcoming component instance feature).

## Test plan

- [ ] `pnpm typecheck` clean
- [ ] `pnpm lint` clean
- [ ] Existing e2e tests pass (`pnpm test`)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only moves constants/functions without changing call sites or logic, but could subtly affect filtering if exports/import paths are misconfigured.
> 
> **Overview**
> Refactors component-name filtering in `react-grab` by moving the internal prefix/name allow/deny lists and the `isInternalComponentName`/`isUsefulComponentName` helpers out of `core/context.ts` into a new `utils/is-useful-component-name.ts` module.
> 
> `context.ts` now imports these helpers, making the filtering logic reusable by other modules while keeping behavior intended to remain the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5e7b348ced1f5ec3384d211d4d8dca6a82ec555. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted `isInternalComponentName`, `isUsefulComponentName`, and internal name sets/prefixes from `packages/react-grab/src/core/context.ts` to `packages/react-grab/src/utils/is-useful-component-name.ts` for reuse. No behavior or output changes.

- **Refactors**
  - Moved `NON_COMPONENT_PREFIXES`, `NEXT_INTERNAL_COMPONENT_NAMES`, `REACT_INTERNAL_COMPONENT_NAMES`; updated `context.ts` to import `isInternalComponentName` and `isUsefulComponentName` from the new util.

<sup>Written for commit c5e7b348ced1f5ec3384d211d4d8dca6a82ec555. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

