### PR TITLE
Improve CLI package installation with tinyexec and pnpm safety flags

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,14 +27,15 @@
     "check": "vp check"
   },
   "dependencies": {
-    "@antfu/ni": "^30.1.0",
     "commander": "^14.0.3",
     "ignore": "^7.0.5",
     "jsonc-parser": "^3.3.1",
     "ora": "^9.4.0",
+    "package-manager-detector": "^1.6.0",
     "picocolors": "^1.1.1",
     "prompts": "^2.4.2",
-    "smol-toml": "^1.6.1"
+    "smol-toml": "^1.6.1",
+    "tinyexec": "^1.1.2"
   },
   "devDependencies": {
     "@types/prompts": "^2.4.9",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -527,7 +527,7 @@ export const init = new Command()
       const shouldInstallReactGrab = !projectInfo.hasReactGrab;
 
       if (!opts.skipInstall && shouldInstallReactGrab) {
-        installPackagesWithFeedback(
+        await installPackagesWithFeedback(
           getPackagesToInstall(shouldInstallReactGrab),
           finalPackageManager,
           projectInfo.projectRoot,

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -93,12 +93,11 @@ export const upgrade = new Command()
       const upgradeSpinner = spinner("Upgrading react-grab.").start();
 
       try {
-        installPackages(
-          ["react-grab@latest"],
-          projectInfo.packageManager,
-          projectInfo.projectRoot,
-          isDevDependency(projectInfo.projectRoot),
-        );
+        await installPackages(["react-grab@latest"], {
+          packageManager: projectInfo.packageManager,
+          cwd: projectInfo.projectRoot,
+          isDev: isDevDependency(projectInfo.projectRoot),
+        });
         upgradeSpinner.succeed();
       } catch {
         upgradeSpinner.fail();

--- a/packages/cli/src/utils/cli-helpers.ts
+++ b/packages/cli/src/utils/cli-helpers.ts
@@ -19,15 +19,15 @@ export const applyTransformWithFeedback = (result: TransformResult, message?: st
   writeSpinner.succeed();
 };
 
-export const installPackagesWithFeedback = (
+export const installPackagesWithFeedback = async (
   packages: string[],
   packageManager: PackageManager,
   projectRoot: string,
-): void => {
+): Promise<void> => {
   if (packages.length === 0) return;
   const installSpinner = spinner(`Installing ${packages.join(", ")}.`).start();
   try {
-    installPackages(packages, packageManager, projectRoot);
+    await installPackages(packages, { packageManager, cwd: projectRoot });
     installSpinner.succeed();
   } catch (error) {
     installSpinner.fail();

--- a/packages/cli/src/utils/detect.ts
+++ b/packages/cli/src/utils/detect.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
-import { detect } from "@antfu/ni";
+import { detect } from "package-manager-detector/detect";
 import ignore from "ignore";
 
 export type PackageManager = "npm" | "yarn" | "pnpm" | "bun";
@@ -21,11 +21,10 @@ interface ProjectInfo {
 
 const VALID_PACKAGE_MANAGERS: ReadonlySet<string> = new Set(["npm", "yarn", "pnpm", "bun"]);
 
-const detectPackageManager = async (projectRoot: string): Promise<PackageManager> => {
-  const detected = await detect({ cwd: projectRoot });
-  if (detected) {
-    // @antfu/ni returns versioned agents like "pnpm@6" or "yarn@berry"
-    const managerName = detected.split("@")[0];
+export const detectPackageManager = async (projectRoot: string): Promise<PackageManager> => {
+  const result = await detect({ cwd: projectRoot });
+  if (result?.agent) {
+    const managerName = result.agent.split("@")[0];
     if (VALID_PACKAGE_MANAGERS.has(managerName)) {
       return managerName as PackageManager;
     }

--- a/packages/cli/src/utils/install.ts
+++ b/packages/cli/src/utils/install.ts
@@ -37,14 +37,11 @@ export const installPackages = async (
     args.push(...options.additionalArgs);
   }
 
+  const installVerb = detectedAgent === "npm" ? "install" : "add";
+
   await x(
     detectedAgent,
-    [
-      detectedAgent === "yarn" ? "add" : "install",
-      ...(options.isDev !== false ? ["-D"] : []),
-      ...args,
-      ...packages,
-    ],
+    [installVerb, ...(options.isDev !== false ? ["-D"] : []), ...args, ...packages],
     {
       nodeOptions: {
         stdio: options.silent ? "ignore" : "inherit",
@@ -77,17 +74,13 @@ export const uninstallPackages = async (
     args.push(...options.additionalArgs);
   }
 
-  await x(
-    detectedAgent,
-    [detectedAgent === "yarn" ? "remove" : "uninstall", ...args, ...packages],
-    {
-      nodeOptions: {
-        stdio: options.silent ? "ignore" : "inherit",
-        cwd: options.cwd,
-      },
-      throwOnError: true,
+  await x(detectedAgent, [detectedAgent === "npm" ? "uninstall" : "remove", ...args, ...packages], {
+    nodeOptions: {
+      stdio: options.silent ? "ignore" : "inherit",
+      cwd: options.cwd,
     },
-  );
+    throwOnError: true,
+  });
 };
 
 export const getPackagesToInstall = (includeReactGrab: boolean = true): string[] => {

--- a/packages/cli/src/utils/install.ts
+++ b/packages/cli/src/utils/install.ts
@@ -1,34 +1,93 @@
-import { execSync } from "node:child_process";
-import type { PackageManager } from "./detect.js";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { x } from "tinyexec";
+import { detectPackageManager, type PackageManager } from "./detect.js";
 
-const INSTALL_COMMANDS: Record<PackageManager, string> = {
-  npm: "npm install",
-  yarn: "yarn add",
-  pnpm: "pnpm add",
-  bun: "bun add",
-};
+export interface InstallPackageOptions {
+  cwd?: string;
+  isDev?: boolean;
+  silent?: boolean;
+  packageManager?: PackageManager;
+  preferOffline?: boolean;
+  additionalArgs?: string[];
+}
 
-export const installPackages = (
+export const installPackages = async (
   packages: string[],
-  packageManager: PackageManager,
-  projectRoot: string,
-  isDev: boolean = true,
-): void => {
-  if (packages.length === 0) {
-    return;
+  options: InstallPackageOptions = {},
+): Promise<void> => {
+  if (packages.length === 0) return;
+
+  const detectedAgent =
+    options.packageManager ?? (await detectPackageManager(options.cwd ?? process.cwd()));
+  const args: string[] = [];
+
+  if (options.preferOffline) {
+    args.push("--prefer-offline");
   }
 
-  const command = INSTALL_COMMANDS[packageManager];
-  const devFlag = isDev ? " -D" : "";
-  const fullCommand = `${command}${devFlag} ${packages.join(" ")}`;
+  if (detectedAgent === "pnpm") {
+    args.push("--prod=false");
+    if (existsSync(resolve(options.cwd ?? process.cwd(), "pnpm-workspace.yaml"))) {
+      args.push("-w");
+    }
+  }
 
-  console.log(`Running: ${fullCommand}\n`);
+  if (options.additionalArgs) {
+    args.push(...options.additionalArgs);
+  }
 
-  execSync(fullCommand, {
-    cwd: projectRoot,
-    stdio: "inherit",
-    env: { ...process.env, REACT_GRAB_INIT: "1" },
-  });
+  await x(
+    detectedAgent,
+    [
+      detectedAgent === "yarn" ? "add" : "install",
+      ...(options.isDev !== false ? ["-D"] : []),
+      ...args,
+      ...packages,
+    ],
+    {
+      nodeOptions: {
+        stdio: options.silent ? "ignore" : "inherit",
+        cwd: options.cwd,
+        env: { ...process.env, REACT_GRAB_INIT: "1" },
+      },
+      throwOnError: true,
+    },
+  );
+};
+
+export const uninstallPackages = async (
+  packages: string[],
+  options: Omit<InstallPackageOptions, "isDev" | "preferOffline"> = {},
+): Promise<void> => {
+  if (packages.length === 0) return;
+
+  const detectedAgent =
+    options.packageManager ?? (await detectPackageManager(options.cwd ?? process.cwd()));
+  const args: string[] = [];
+
+  if (
+    detectedAgent === "pnpm" &&
+    existsSync(resolve(options.cwd ?? process.cwd(), "pnpm-workspace.yaml"))
+  ) {
+    args.push("-w");
+  }
+
+  if (options.additionalArgs) {
+    args.push(...options.additionalArgs);
+  }
+
+  await x(
+    detectedAgent,
+    [detectedAgent === "yarn" ? "remove" : "uninstall", ...args, ...packages],
+    {
+      nodeOptions: {
+        stdio: options.silent ? "ignore" : "inherit",
+        cwd: options.cwd,
+      },
+      throwOnError: true,
+    },
+  );
 };
 
 export const getPackagesToInstall = (includeReactGrab: boolean = true): string[] => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,9 +212,6 @@ importers:
 
   packages/cli:
     dependencies:
-      '@antfu/ni':
-        specifier: ^30.1.0
-        version: 30.1.0
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -227,6 +224,9 @@ importers:
       ora:
         specifier: ^9.4.0
         version: 9.4.0
+      package-manager-detector:
+        specifier: ^1.6.0
+        version: 1.6.0
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -236,6 +236,9 @@ importers:
       smol-toml:
         specifier: ^1.6.1
         version: 1.6.1
+      tinyexec:
+        specifier: ^1.1.2
+        version: 1.1.2
     devDependencies:
       '@types/prompts':
         specifier: ^2.4.9
@@ -368,11 +371,6 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
-
-  '@antfu/ni@30.1.0':
-    resolution: {integrity: sha512-3VuAbPjgY52rQNn4wABaXMhBU2Oq91uy6L8nX49eJ35OLI68CyckGU+HZxcaHix4ymuGM2nFL1D6sLpgODK5xw==}
-    engines: {node: '>=20.19.0'}
-    hasBin: true
 
   '@anthropic-ai/claude-agent-sdk@0.2.84':
     resolution: {integrity: sha512-rvp3kZJM4IgDBE1zwj30H3N0bI3pYRF28tDJoyAVuWTLiWls7diNVCyFz7GeXZEAYYD87lCBE3vnQplLLluNHg==}
@@ -6363,13 +6361,6 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@antfu/ni@30.1.0':
-    dependencies:
-      fzf: 0.5.2
-      package-manager-detector: 1.6.0
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.16
-
   '@anthropic-ai/claude-agent-sdk@0.2.84(zod@4.4.3)':
     dependencies:
       zod: 4.4.3
@@ -7088,7 +7079,7 @@ snapshots:
       '@google-cloud/logging': 11.2.1
       '@google-cloud/opentelemetry-cloud-monitoring-exporter': 0.21.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1))
       '@google-cloud/opentelemetry-cloud-trace-exporter': 3.0.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))
-      '@google/genai': 1.30.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+      '@google/genai': 1.30.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))
       '@grpc/grpc-js': 1.14.3
       '@iarna/toml': 2.2.5
       '@joshua.litt/get-ripgrep': 0.0.3
@@ -7175,9 +7166,9 @@ snapshots:
     dependencies:
       '@agentclientprotocol/sdk': 0.12.0(zod@3.25.76)
       '@google/gemini-cli-core': 0.35.3(express@5.2.1)
-      '@google/genai': 1.30.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+      '@google/genai': 1.30.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))
       '@iarna/toml': 2.2.5
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       ansi-escapes: 7.3.0
       ansi-regex: 6.2.2
       chalk: 4.1.2
@@ -7228,12 +7219,12 @@ snapshots:
       - tree-sitter
       - utf-8-validate
 
-  '@google/genai@1.30.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
+  '@google/genai@1.30.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))':
     dependencies:
       google-auth-library: 10.6.2
       ws: 8.20.0
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -7559,7 +7550,7 @@ snapshots:
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
       zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -12600,10 +12591,6 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
-
-  zod-to-json-schema@3.25.2(zod@4.4.3):
-    dependencies:
-      zod: 4.4.3
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## Summary

- Replace `execSync` string concatenation with `tinyexec` async arg arrays — safer (no shell injection), non-blocking
- Add pnpm `--prod=false` (prevents devDep stripping when `NODE_ENV=production` in CI) and `-w` (auto-detected when `pnpm-workspace.yaml` exists)
- Switch detection from `@antfu/ni` to the lighter `package-manager-detector` (same author, just the detection subset)
- Add `uninstallPackages` utility and new options: `preferOffline`, `silent`, `additionalArgs`

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm format` passes
- [ ] Manual: run `npx react-grab init` in a fresh project and verify install works
- [ ] Manual: run `npx react-grab upgrade` and verify upgrade works

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CLI’s dependency install/upgrade execution path and package-manager detection, which could affect real user installs across npm/yarn/pnpm/bun (especially in monorepos/CI). Logic is straightforward but touches critical setup/upgrade flows.
> 
> **Overview**
> Updates the CLI’s package installation pipeline to be **async and argument-based** (via `tinyexec`) instead of `execSync` string commands, and adds a new `uninstallPackages` helper plus install options like `silent`, `preferOffline`, and `additionalArgs`.
> 
> Improves `pnpm` behavior by forcing `--prod=false` and auto-adding `-w` when a `pnpm-workspace.yaml` is present, and switches package-manager detection from `@antfu/ni` to `package-manager-detector`. `init` and `upgrade` now `await` installs and use the new `installPackages` options API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51180b48e27d8ef15b128447957841dc63e7e31c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make CLI installs safer and non-blocking with `tinyexec`. Adds `pnpm` safety flags and uses the correct install/uninstall verbs across package managers.

- **New Features**
  - Add `uninstallPackages`.
  - New install options: `preferOffline`, `silent`, `additionalArgs`.
  - `pnpm`: use `--prod=false`; auto `-w` when `pnpm-workspace.yaml` exists.

- **Refactors**
  - Replace `execSync` with async `tinyexec` arg arrays and correct verbs (`npm` uses `install`/`uninstall`; `pnpm`/`yarn`/`bun` use `add`/`remove`).
  - Switch detection from `@antfu/ni` to `package-manager-detector`.
  - Make install helpers async; update `init` and `upgrade` to `await` installs.

<sup>Written for commit 51180b48e27d8ef15b128447957841dc63e7e31c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

