### PR TITLE
feat(react-grab): export getElementsAtPosition and document primitives API

### DIFF
--- a/packages/react-grab/README.md
+++ b/packages/react-grab/README.md
@@ -124,6 +124,87 @@ if (process.env.NODE_ENV === "development") {
 }
 ```
 
+## Primitives
+
+Low-level building blocks for tools that need to freeze the page, hit-test elements, and gather React source context independently of React Grab's built-in UI. Import from `react-grab/primitives`.
+
+```js
+import {
+  freeze,
+  unfreeze,
+  isFreezeActive,
+  getElementsAtPosition,
+  getElementContext,
+  openFile,
+} from "react-grab/primitives";
+```
+
+### `freeze(elements?)`
+
+Freezes the page: pauses React state updates, halts CSS/JS/SVG animations, and preserves pseudo-states (`:hover`, `:focus`) as inline styles. Installs `pointer-events: none` on `<html>` to prevent the user from triggering hover side-effects.
+
+Pass an array of elements to scope animation freezing; omit to freeze the entire page.
+
+```js
+freeze(); // freeze everything
+freeze([document.querySelector(".modal")]); // freeze a subtree
+```
+
+### `unfreeze()`
+
+Reverses `freeze()`: replays buffered React updates, resumes animations, and removes the pointer-events block.
+
+```js
+unfreeze();
+```
+
+### `isFreezeActive()`
+
+Returns `true` while the page is frozen.
+
+```js
+if (isFreezeActive()) {
+  // skip work until unfreeze()
+}
+```
+
+### `getElementsAtPosition(clientX, clientY)`
+
+Returns all elements at the given viewport coordinates (z-order, topmost first). Temporarily suspends the pointer-events freeze so `elementsFromPoint` can reach real elements underneath.
+
+```js
+freeze();
+document.addEventListener("pointermove", (e) => {
+  const elements = getElementsAtPosition(e.clientX, e.clientY);
+  console.log("topmost:", elements[0]);
+});
+```
+
+### `getElementContext(element)`
+
+Gathers comprehensive context for a DOM element: React fiber, component name, owner stack with source locations, CSS selector, computed styles, and an HTML preview.
+
+```js
+const context = await getElementContext(document.querySelector(".btn"));
+
+context.componentName; // "SubmitButton"
+context.selector;      // "button.btn"
+context.stackString;   // "\n  in SubmitButton (at Button.tsx:12:5)"
+context.stack;         // [{ functionName, fileName, lineNumber, columnNumber }]
+context.htmlPreview;   // '<button class="btn">\n  Submit\n</button>'
+context.styles;        // "color: #fff; background: #000; ..."
+context.fiber;         // React Fiber node (or null outside React)
+context.element;       // the Element itself
+```
+
+### `openFile(filePath, lineNumber?)`
+
+Opens a source file in the user's editor. Tries the dev-server endpoint first (Vite / Next.js), then falls back to a protocol URL (`vscode://file/…`).
+
+```js
+await openFile("/src/components/Button.tsx", 42);
+```
+
 ## Plugins
 
 Use plugins to extend React Grab's built-in UI with context menu actions, toolbar menu items, lifecycle hooks, and theme overrides. Plugins run within React Grab.

--- a/packages/react-grab/README.md
+++ b/packages/react-grab/README.md
@@ -126,83 +126,38 @@ if (process.env.NODE_ENV === "development") {
 
 ## Primitives
 
-Low-level building blocks for tools that need to freeze the page, hit-test elements, and gather React source context independently of React Grab's built-in UI. Import from `react-grab/primitives`.
+`react-grab/primitives` exposes low-level building blocks for tools that need to freeze the page, hit-test elements, or gather React source context outside of React Grab's UI.
+
+| Export | Description |
+| --- | --- |
+| `freeze(elements?)` | Pause React updates, animations, and pseudo-states. Pass elements to scope animation freezing, or omit to freeze the whole page. |
+| `unfreeze()` | Resume everything `freeze()` paused. |
+| `isFreezeActive()` | Returns `true` while frozen. |
+| `getElementsAtPosition(x, y)` | Hit-test elements at viewport coordinates while frozen (temporarily lifts the pointer-events block). |
+| `getElementContext(element)` | Returns component name, owner stack, CSS selector, computed styles, HTML preview, and fiber for a DOM element. |
+| `openFile(path, line?)` | Open a source file in the user's editor via the dev server or `vscode://` protocol. |
 
 ```js
 import {
   freeze,
   unfreeze,
-  isFreezeActive,
   getElementsAtPosition,
   getElementContext,
-  openFile,
 } from "react-grab/primitives";
-```
 
-### `freeze(elements?)`
-
-Freezes the page: pauses React state updates, halts CSS/JS/SVG animations, and preserves pseudo-states (`:hover`, `:focus`) as inline styles. Installs `pointer-events: none` on `<html>` to prevent the user from triggering hover side-effects.
-
-Pass an array of elements to scope animation freezing; omit to freeze the entire page.
-
-```js
-freeze(); // freeze everything
-freeze([document.querySelector(".modal")]); // freeze a subtree
-```
-
-### `unfreeze()`
-
-Reverses `freeze()`: replays buffered React updates, resumes animations, and removes the pointer-events block.
-
-```js
-unfreeze();
-```
-
-### `isFreezeActive()`
-
-Returns `true` while the page is frozen.
-
-```js
-if (isFreezeActive()) {
-  // skip work until unfreeze()
-}
-```
-
-### `getElementsAtPosition(clientX, clientY)`
-
-Returns all elements at the given viewport coordinates (z-order, topmost first). Temporarily suspends the pointer-events freeze so `elementsFromPoint` can reach real elements underneath.
-
-```js
 freeze();
+
 document.addEventListener("pointermove", (e) => {
-  const elements = getElementsAtPosition(e.clientX, e.clientY);
-  console.log("topmost:", elements[0]);
+  const [topElement] = getElementsAtPosition(e.clientX, e.clientY);
+  highlight(topElement);
 });
-```
 
-### `getElementContext(element)`
-
-Gathers comprehensive context for a DOM element: React fiber, component name, owner stack with source locations, CSS selector, computed styles, and an HTML preview.
-
-```js
-const context = await getElementContext(document.querySelector(".btn"));
-
-context.componentName; // "SubmitButton"
-context.selector;      // "button.btn"
-context.stackString;   // "\n  in SubmitButton (at Button.tsx:12:5)"
-context.stack;         // [{ functionName, fileName, lineNumber, columnNumber }]
-context.htmlPreview;   // '<button class="btn">\n  Submit\n</button>'
-context.styles;        // "color: #fff; background: #000; ..."
-context.fiber;         // React Fiber node (or null outside React)
-context.element;       // the Element itself
-```
-
-### `openFile(filePath, lineNumber?)`
-
-Opens a source file in the user's editor. Tries the dev-server endpoint first (Vite / Next.js), then falls back to a protocol URL (`vscode://file/…`).
-
-```js
-await openFile("/src/components/Button.tsx", 42);
+document.addEventListener("click", async (e) => {
+  const [target] = getElementsAtPosition(e.clientX, e.clientY);
+  const context = await getElementContext(target);
+  console.log(context.componentName, context.selector);
+  unfreeze();
+});
 ```
 
 ## Plugins

--- a/packages/react-grab/src/primitives.ts
+++ b/packages/react-grab/src/primitives.ts
@@ -6,6 +6,10 @@ import {
 import { freezePseudoStates, unfreezePseudoStates } from "./utils/freeze-pseudo-states.js";
 import { freezeUpdates } from "./utils/freeze-updates.js";
 import {
+  suspendPointerEventsFreeze,
+  resumePointerEventsFreeze,
+} from "./utils/pointer-events-freeze.js";
+import {
   getComponentDisplayName,
   getHTMLPreview,
   getStack,
@@ -59,6 +63,24 @@ export const getElementContext = async (element: Element): Promise<ReactGrabElem
     selector,
     styles,
   };
+};
+
+/**
+ * Returns all elements at the given viewport coordinates, temporarily
+ * suspending the pointer-events freeze so `elementsFromPoint` can
+ * reach real elements underneath.
+ *
+ * @example
+ * freeze();
+ * const elements = getElementsAtPosition(e.clientX, e.clientY);
+ * // elements[0] is the topmost element under the cursor
+ */
+export const getElementsAtPosition = (clientX: number, clientY: number): Element[] => {
+  if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) return [];
+  suspendPointerEventsFreeze();
+  const elements = document.elementsFromPoint(clientX, clientY);
+  resumePointerEventsFreeze();
+  return Array.from(elements);
 };
 
 const freezeCleanupFns = new Set<() => void>();


### PR DESCRIPTION
## Summary

- Export `getElementsAtPosition(clientX, clientY)` from `react-grab/primitives` — suspends the pointer-events freeze, calls `elementsFromPoint`, and re-enables it, so third-party tools (e.g. Budge) can hit-test elements while the page is frozen without reaching into internal stylesheets.
- Add a **Primitives** section to the README (above Plugins) documenting all six exports: `freeze`, `unfreeze`, `isFreezeActive`, `getElementsAtPosition`, `getElementContext`, `openFile`.

## Test plan

- [ ] `pnpm typecheck` passes (verified locally)
- [ ] `pnpm build` produces `primitives.d.ts` with the new export
- [ ] Importing `getElementsAtPosition` from `react-grab/primitives` resolves correctly
- [ ] Calling `freeze()` then `getElementsAtPosition(x, y)` returns real elements (not `<html>`)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: introduces a small new exported helper that temporarily toggles the existing pointer-events freeze around `document.elementsFromPoint`, plus README docs.
> 
> **Overview**
> Adds a new `getElementsAtPosition(clientX, clientY)` export to `react-grab/primitives` that temporarily suspends the pointer-events freeze to allow reliable `elementsFromPoint` hit-testing while the page is frozen.
> 
> Updates the README with a new **Primitives** section documenting the exported low-level APIs (`freeze`, `unfreeze`, `isFreezeActive`, `getElementsAtPosition`, `getElementContext`, `openFile`) and showing an example workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96d35931cd49498ef11d226f2e5a66c749a44550. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exported `getElementsAtPosition(clientX, clientY)` from `react-grab/primitives` for reliable hit-testing while the page is frozen. Rewrote the README Primitives docs as a compact table with a single example.

- **New Features**
  - Added `getElementsAtPosition` that briefly lifts the pointer-events freeze, calls `elementsFromPoint`, then restores it. Returns elements topmost-first.
  - Updated README: “Primitives” documented in a table with one example, covering `freeze`, `unfreeze`, `isFreezeActive`, `getElementsAtPosition`, `getElementContext`, and `openFile`.

<sup>Written for commit 96d35931cd49498ef11d226f2e5a66c749a44550. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

