### PR TITLE
fix(react-grab): code review cleanup — dedupe util, fix CDN decode, categorize filters

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @react-grab/cli
 
+## 0.1.34
+
+### Patch Changes
+
+- fix
+
 ## 0.1.33
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-grab/cli",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "bin": {
     "react-grab": "./bin/cli.js"
   },

--- a/packages/grab/CHANGELOG.md
+++ b/packages/grab/CHANGELOG.md
@@ -1,5 +1,13 @@
 # grab
 
+## 0.1.34
+
+### Patch Changes
+
+- fix
+- Updated dependencies
+  - @react-grab/cli@0.1.34
+
 ## 0.1.33
 
 ### Patch Changes

--- a/packages/grab/package.json
+++ b/packages/grab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grab",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "Select context for coding agents directly from your website",
   "keywords": [
     "agent",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @react-grab/mcp
 
+## 0.1.34
+
+### Patch Changes
+
+- fix
+- Updated dependencies
+  - react-grab@0.1.34
+
 ## 0.1.33
 
 ### Patch Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-grab/mcp",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "bin": {
     "react-grab-mcp": "./dist/cli.cjs"
   },

--- a/packages/react-grab/CHANGELOG.md
+++ b/packages/react-grab/CHANGELOG.md
@@ -1,5 +1,13 @@
 # react-grab
 
+## 0.1.34
+
+### Patch Changes
+
+- fix
+- Updated dependencies
+  - @react-grab/cli@0.1.34
+
 ## 0.1.33
 
 ### Patch Changes

--- a/packages/react-grab/README.md
+++ b/packages/react-grab/README.md
@@ -135,6 +135,7 @@ if (process.env.NODE_ENV === "development") {
 | `isFreezeActive()` | Returns `true` while frozen. |
 | `getElementsAtPosition(x, y)` | Hit-test elements at viewport coordinates while frozen (temporarily lifts the pointer-events block). |
 | `getElementContext(element)` | Returns component name, owner stack, CSS selector, computed styles, HTML preview, and fiber for a DOM element. |
+| `copyContent(entry)` | Copy structured context to the clipboard in plain-text, HTML, and custom metadata formats. |
 | `openFile(path, line?)` | Open a source file in the user's editor via the dev server or `vscode://` protocol. |
 
 ```js

--- a/packages/react-grab/package.json
+++ b/packages/react-grab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-grab",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "Select context for coding agents directly from your website",
   "keywords": [
     "agent",

--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -27,6 +27,7 @@ import { truncateString } from "../utils/truncate-string.js";
 import { getNextBasePath } from "../utils/get-next-base-path.js";
 import { normalizeFilePath } from "../utils/normalize-file-path.js";
 import { parsePackageName } from "../utils/parse-package-name.js";
+import { safeDecodeURIComponent } from "../utils/safe-decode-uri-component.js";
 import { isInternalAttribute } from "../utils/strip-internal-attributes.js";
 import {
   isInternalComponentName,
@@ -62,10 +63,13 @@ const devirtualizeServerUrl = (url: string): string => {
   for (const prefix of SERVER_COMPONENT_URL_PREFIXES) {
     if (!url.startsWith(prefix)) continue;
     const environmentEndIndex = url.indexOf("/", prefix.length);
+    if (environmentEndIndex === -1) continue;
+    const pathStart = environmentEndIndex + 1;
     const querySuffixIndex = url.lastIndexOf("?");
-    if (environmentEndIndex > -1 && querySuffixIndex > -1) {
-      return decodeURI(url.slice(environmentEndIndex + 1, querySuffixIndex));
-    }
+    const rawPath = querySuffixIndex > pathStart
+      ? url.slice(pathStart, querySuffixIndex)
+      : url.slice(pathStart);
+    return safeDecodeURIComponent(rawPath);
   }
   return url;
 };

--- a/packages/react-grab/src/utils/is-useful-component-name.ts
+++ b/packages/react-grab/src/utils/is-useful-component-name.ts
@@ -10,31 +10,53 @@ const NON_COMPONENT_PREFIXES = new Set([
 ]);
 
 const NEXT_INTERNAL_COMPONENT_NAMES = new Set([
-  "InnerLayoutRouter",
-  "RedirectErrorBoundary",
-  "RedirectBoundary",
-  "HTTPAccessFallbackErrorBoundary",
-  "HTTPAccessFallbackBoundary",
-  "LoadingBoundary",
+  "AppRouter",
+  "AppRouterAnnouncer",
+  "AppDevOverlay",
+  "AppDevOverlayErrorBoundary",
+  "ClientPageRoot",
+  "ClientSegmentRoot",
+  "DevRootHTTPAccessFallbackBoundary",
   "ErrorBoundary",
+  "ErrorBoundaryHandler",
+  "GracefulDegradeBoundary",
+  "HTTPAccessErrorFallback",
+  "HTTPAccessFallbackBoundary",
+  "HTTPAccessFallbackErrorBoundary",
+  "HandleRedirect",
+  "Head",
+  "HistoryUpdater",
+  "HotReload",
+  "InnerLayoutRouter",
   "InnerScrollAndFocusHandler",
-  "ScrollAndFocusHandler",
-  "RenderFromTemplateContext",
+  "InnerScrollAndFocusHandlerOld",
+  "InnerScrollAndMaybeFocusHandler",
+  "InnerScrollHandlerNew",
+  "LoadableComponent",
+  "LoadingBoundary",
+  "LoadingBoundaryProvider",
+  "NotAllowedRootHTTPFallbackError",
+  "OfflineProvider",
   "OuterLayoutRouter",
+  "RedirectBoundary",
+  "RedirectErrorBoundary",
+  "RenderFromTemplateContext",
+  "RenderValidationBoundaryAtThisLevel",
+  "ReplaySsrOnlyErrors",
+  "RootErrorBoundary",
+  "RootLevelDevOverlayElement",
+  "Router",
+  "ScrollAndFocusHandler",
+  "ScrollAndMaybeFocusHandler",
+  "SegmentBoundaryTrigger",
+  "SegmentBoundaryTriggerNode",
+  "SegmentStateProvider",
+  "SegmentTrieNode",
+  "SegmentViewNode",
+  "SegmentViewStateNode",
+  "ServerRoot",
   "body",
   "html",
-  "DevRootHTTPAccessFallbackBoundary",
-  "AppDevOverlayErrorBoundary",
-  "AppDevOverlay",
-  "HotReload",
-  "Router",
-  "ErrorBoundaryHandler",
-  "AppRouter",
-  "ServerRoot",
-  "SegmentStateProvider",
-  "RootErrorBoundary",
-  "LoadableComponent",
-  "MotionDOMComponent",
 ]);
 
 const REACT_INTERNAL_COMPONENT_NAMES = new Set([
@@ -45,9 +67,14 @@ const REACT_INTERNAL_COMPONENT_NAMES = new Set([
   "SuspenseList",
 ]);
 
+const LIBRARY_INTERNAL_COMPONENT_NAMES = new Set([
+  "MotionDOMComponent",
+]);
+
 export const isInternalComponentName = (name: string): boolean => {
   if (NEXT_INTERNAL_COMPONENT_NAMES.has(name)) return true;
   if (REACT_INTERNAL_COMPONENT_NAMES.has(name)) return true;
+  if (LIBRARY_INTERNAL_COMPONENT_NAMES.has(name)) return true;
   for (const prefix of NON_COMPONENT_PREFIXES) {
     if (name.startsWith(prefix)) return true;
   }

--- a/packages/react-grab/src/utils/parse-package-name.ts
+++ b/packages/react-grab/src/utils/parse-package-name.ts
@@ -1,4 +1,5 @@
 import { normalizeFileName } from "bippy/source";
+import { safeDecodeURIComponent } from "./safe-decode-uri-component.js";
 
 const NODE_MODULES_PATTERN = /(?:^|[/\\])node_modules[/\\]/g;
 const VITE_OPTIMIZED_DEPS_PATTERN = /[/\\]\.vite[/\\]deps[^/\\]*[/\\]/g;
@@ -59,7 +60,7 @@ const extractVersionedPackageFromUrl = (rawFileName: string): string | null => {
   }
   if (!url.hostname) return null;
 
-  const segments = splitPathSegments(url.pathname);
+  const segments = splitPathSegments(url.pathname).map(safeDecodeURIComponent);
   for (const [index, segment] of segments.entries()) {
     if (segment.startsWith("@")) {
       const name = extractNameAtVersion(segments[index + 1]);
@@ -79,11 +80,16 @@ const extractFromLocalPath = (normalizedPath: string): string | null =>
 export const parsePackageName = (fileName: string | null | undefined): string | null => {
   if (!fileName) return null;
 
-  const cdnResult = extractVersionedPackageFromUrl(fileName);
-  if (cdnResult) return cdnResult;
-
   const normalized = normalizeFileName(fileName);
   if (!normalized) return null;
 
-  return extractFromLocalPath(normalized);
+  const decoded = safeDecodeURIComponent(normalized);
+
+  const localResult = extractFromLocalPath(decoded);
+  if (localResult) return localResult;
+
+  const cdnResult = extractVersionedPackageFromUrl(fileName);
+  if (cdnResult) return safeDecodeURIComponent(cdnResult);
+
+  return null;
 };

--- a/packages/react-grab/src/utils/parse-package-name.ts
+++ b/packages/react-grab/src/utils/parse-package-name.ts
@@ -89,7 +89,7 @@ export const parsePackageName = (fileName: string | null | undefined): string | 
   if (localResult) return localResult;
 
   const cdnResult = extractVersionedPackageFromUrl(fileName);
-  if (cdnResult) return safeDecodeURIComponent(cdnResult);
+  if (cdnResult) return cdnResult;
 
   return null;
 };

--- a/packages/react-grab/src/utils/safe-decode-uri-component.ts
+++ b/packages/react-grab/src/utils/safe-decode-uri-component.ts
@@ -1,0 +1,7 @@
+export const safeDecodeURIComponent = (input: string): string => {
+  try {
+    return decodeURIComponent(input);
+  } catch {
+    return input;
+  }
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,31 @@ importers:
         specifier: npm:@voidzero-dev/vite-plus-core
         version: '@voidzero-dev/vite-plus-core@0.1.20(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.37.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.4)'
 
+  apps/nextjs-e2e:
+    dependencies:
+      next:
+        specifier: 16.2.6
+        version: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react:
+        specifier: 19.2.6
+        version: 19.2.6
+      react-dom:
+        specifier: 19.2.6
+        version: 19.2.6(react@19.2.6)
+      react-grab:
+        specifier: workspace:*
+        version: link:../../packages/react-grab
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   apps/storybook:
     devDependencies:
       '@storybook/addon-a11y':


### PR DESCRIPTION
## Summary

- Extract `safeDecodeURIComponent` to a shared `utils/safe-decode-uri-component.ts` to remove duplication between `parse-package-name.ts` and `context.ts`
- Decode CDN URL path segments in `extractVersionedPackageFromUrl` before the `startsWith('@')` check, fixing scoped package detection on encoded CDN URLs
- Move `MotionDOMComponent` from `NEXT_INTERNAL_COMPONENT_NAMES` to a new `LIBRARY_INTERNAL_COMPONENT_NAMES` set for accurate categorization
- Restore the Primitives documentation section in README (including new `copyContent` export)

## Test plan

- [x] `pnpm build` passes
- [x] Playwright E2E tests pass (8/8)
- [x] `pnpm lint` — 0 errors
- [x] `pnpm typecheck` — passes


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches stack-frame URL decoding and package-name parsing used for source context generation, which could subtly change what context is extracted or displayed in some environments. Changes are localized and defensive (safe decoding, expanded internal-name filters), plus version bumps and lockfile updates.
> 
> **Overview**
> Improves robustness of source-context extraction by introducing shared `safeDecodeURIComponent` and using it when devirtualizing Next.js server-component URLs and when parsing package names from both local paths and CDN URLs (including decoding encoded path segments for scoped packages).
> 
> Refines component-name filtering by expanding Next.js internal component name lists and separating library internals (e.g. `MotionDOMComponent`) into their own set to avoid misclassification.
> 
> Updates `react-grab` primitives docs to include `copyContent`, adds a new `apps/nextjs-e2e` workspace entry in `pnpm-lock.yaml`, and bumps package versions/changelogs to `0.1.34` across related packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89edbb7d6faee83b86139de65ef175a1aea87e8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes scoped package detection on encoded CDN URLs, prevents double-decoding when parsing package names, and improves component filtering and context decoding in `react-grab`. Also deduplicates URI decoding and updates the README primitives.

- **Bug Fixes**
  - Detect scoped packages on encoded CDN URLs by decoding path segments first.
  - Prevent double-decoding of CDN package names in `parsePackageName`.
  - Safely decode server component virtual paths when extracting source context.

- **Refactors**
  - Extracted `safeDecodeURIComponent` to `utils/safe-decode-uri-component.ts` and reused in `context` and `parse-package-name`.
  - Moved `MotionDOMComponent` to `LIBRARY_INTERNAL_COMPONENT_NAMES` for clearer filtering.
  - Restored README Primitives and documented the `copyContent` export.

<sup>Written for commit 89edbb7d6faee83b86139de65ef175a1aea87e8e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

