### PR TITLE
feat(react-grab): enrich getElementContext with snippet and source location, export copyContent

### DIFF
--- a/packages/react-grab/README.md
+++ b/packages/react-grab/README.md
@@ -134,7 +134,7 @@ if (process.env.NODE_ENV === "development") {
 | `unfreeze()` | Resume everything `freeze()` paused. |
 | `isFreezeActive()` | Returns `true` while frozen. |
 | `getElementsAtPosition(x, y)` | Hit-test elements at viewport coordinates while frozen (temporarily lifts the pointer-events block). |
-| `getElementContext(element)` | Returns component name, owner stack, CSS selector, computed styles, HTML preview, and fiber for a DOM element. |
+| `getElementContext(element)` | Returns the same context React Grab copies to clipboard (`snippet`), plus structured source location, component name, owner stack, CSS selector, computed styles, HTML preview, and fiber. |
 | `copyContent(entry)` | Copy structured context to the clipboard in plain-text, HTML, and custom metadata formats. |
 | `openFile(path, line?)` | Open a source file in the user's editor via the dev server or `vscode://` protocol. |
 
@@ -156,7 +156,9 @@ document.addEventListener("pointermove", (e) => {
 document.addEventListener("click", async (e) => {
   const [target] = getElementsAtPosition(e.clientX, e.clientY);
   const context = await getElementContext(target);
-  console.log(context.componentName, context.selector);
+  console.log(context.snippet);    // formatted text identical to clipboard output
+  console.log(context.filePath);   // "/src/components/Button.tsx"
+  console.log(context.lineNumber); // 42
   unfreeze();
 });
 ```

--- a/packages/react-grab/README.md
+++ b/packages/react-grab/README.md
@@ -135,7 +135,7 @@ if (process.env.NODE_ENV === "development") {
 | `isFreezeActive()` | Returns `true` while frozen. |
 | `getElementsAtPosition(x, y)` | Hit-test elements at viewport coordinates while frozen (temporarily lifts the pointer-events block). |
 | `getElementContext(element)` | Returns the same context React Grab copies to clipboard (`snippet`), plus structured source location, component name, owner stack, CSS selector, computed styles, HTML preview, and fiber. |
-| `copyContent(entry)` | Copy structured context to the clipboard in plain-text, HTML, and custom metadata formats. |
+| `copyContent(text, options?)` | Copies text to the clipboard in the same three-format layout React Grab uses (plain text, HTML, structured metadata). Returns `true` on success. |
 | `openFile(path, line?)` | Open a source file in the user's editor via the dev server or `vscode://` protocol. |
 
 ```js
@@ -144,6 +144,7 @@ import {
   unfreeze,
   getElementsAtPosition,
   getElementContext,
+  copyContent,
 } from "react-grab/primitives";
 
 freeze();

--- a/packages/react-grab/src/primitives.ts
+++ b/packages/react-grab/src/primitives.ts
@@ -14,6 +14,8 @@ import {
   getHTMLPreview,
   getStack,
   getStackContext,
+  getElementContext as formatElementSnippet,
+  resolveSource,
 } from "./core/context.js";
 import { Fiber, getFiberFromHostInstance } from "bippy";
 import type { StackFrame } from "bippy/source";
@@ -24,28 +26,37 @@ import { openFile as openFileAsync } from "./utils/open-file.js";
 
 export interface ReactGrabElementContext {
   element: Element;
+  snippet: string;
   htmlPreview: string;
   stackString: string;
   stack: StackFrame[];
   componentName: string | null;
+  filePath: string | null;
+  lineNumber: number | null;
+  columnNumber: number | null;
   fiber: Fiber | null;
   selector: string | null;
   styles: string;
 }
 
 /**
- * Gathers comprehensive context for a DOM element, including its React fiber,
- * component name, source stack, HTML preview, CSS selector, and computed styles.
+ * Gathers comprehensive context for a DOM element — the same context
+ * React Grab copies to the clipboard, plus structured source location
+ * and computed styles.
  *
  * @example
- * const context = await getElementContext(document.querySelector('.my-button')!);
- * console.log(context.componentName); // "SubmitButton"
- * console.log(context.selector);      // "button.my-button"
- * console.log(context.stackString);   // "\n  in SubmitButton (at Button.tsx:12:5)"
- * console.log(context.stack[0]);      // { functionName: "SubmitButton", fileName: "Button.tsx", lineNumber: 12, columnNumber: 5 }
+ * const ctx = await getElementContext(document.querySelector('.my-button')!);
+ * ctx.snippet;       // formatted text identical to React Grab's clipboard output
+ * ctx.componentName; // "SubmitButton"
+ * ctx.filePath;      // "/src/components/Button.tsx"
+ * ctx.lineNumber;    // 12
  */
 export const getElementContext = async (element: Element): Promise<ReactGrabElementContext> => {
-  const stack = (await getStack(element)) ?? [];
+  const [snippet, source, stack] = await Promise.all([
+    formatElementSnippet(element),
+    resolveSource(element),
+    getStack(element).then((result) => result ?? []),
+  ]);
   const stackString = await getStackContext(element);
   const htmlPreview = getHTMLPreview(element);
   const componentName = getComponentDisplayName(element);
@@ -55,10 +66,14 @@ export const getElementContext = async (element: Element): Promise<ReactGrabElem
 
   return {
     element,
+    snippet,
     htmlPreview,
     stackString,
     stack,
     componentName,
+    filePath: source?.filePath ?? null,
+    lineNumber: source?.lineNumber ?? null,
+    columnNumber: source?.columnNumber ?? null,
     fiber,
     selector,
     styles,

--- a/packages/react-grab/src/primitives.ts
+++ b/packages/react-grab/src/primitives.ts
@@ -80,6 +80,8 @@ export const getElementContext = async (element: Element): Promise<ReactGrabElem
   };
 };
 
+export { copyContent } from "./utils/copy-content.js";
+
 /**
  * Returns all elements at the given viewport coordinates, temporarily
  * suspending the pointer-events freeze so `elementsFromPoint` can


### PR DESCRIPTION
## Summary

- `getElementContext` now returns `snippet` (same formatted text React Grab copies to clipboard), plus resolved `filePath`, `lineNumber`, and `columnNumber` from the owner stack
- Re-export `copyContent` directly from `react-grab/primitives` so consumers can copy to clipboard in React Grab's three-format layout

Cherry-picked from `feat/export-primitives-api` (71096a57, 2eb2b087).

## Test plan

- [x] `pnpm build` passes
- [ ] CI (lint, typecheck, E2E)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk additive primitives API change: `getElementContext` returns extra fields and does a bit more async work to compute snippet/source location, and `copyContent` is re-exported for external clipboard usage.
> 
> **Overview**
> `react-grab/primitives`’s `getElementContext()` now returns a `snippet` string (matching React Grab’s clipboard text) plus resolved `filePath`, `lineNumber`, and `columnNumber` alongside the existing context fields.
> 
> The primitives entrypoint also re-exports `copyContent(text, options?)` so external tools can copy content using React Grab’s three-format clipboard payload, and the README updates the primitives API docs and example accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9002a792b072091fb837acd78060de5fe1ee6acb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `snippet` and source location to `getElementContext`, and re-exports `copyContent` from `react-grab/primitives` for direct clipboard copying in React Grab’s three-format layout.

- **New Features**
  - `getElementContext(element)` now returns `snippet`, `filePath`, `lineNumber`, and `columnNumber` alongside existing fields.
  - Export `copyContent(text, options?)` from `react-grab/primitives`; copies plain text, HTML, and structured metadata, and returns `true` on success.

<sup>Written for commit 9002a792b072091fb837acd78060de5fe1ee6acb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

