### PR TITLE
fix(react-grab): improve HTML preview signal density and fix flaky test

### DIFF
--- a/packages/react-grab/README.md
+++ b/packages/react-grab/README.md
@@ -134,7 +134,7 @@ if (process.env.NODE_ENV === "development") {
 | `unfreeze()` | Resume everything `freeze()` paused. |
 | `isFreezeActive()` | Returns `true` while frozen. |
 | `getElementsAtPosition(x, y)` | Hit-test elements at viewport coordinates while frozen (temporarily lifts the pointer-events block). |
-| `getElementContext(element)` | Returns component name, owner stack, CSS selector, computed styles, HTML preview, and fiber for a DOM element. |
+| `getElementContext(element)` | Returns the same context React Grab copies to clipboard (`snippet`), plus structured source location, component name, owner stack, CSS selector, computed styles, HTML preview, and fiber. |
 | `copyContent(entry)` | Copy structured context to the clipboard in plain-text, HTML, and custom metadata formats. |
 | `openFile(path, line?)` | Open a source file in the user's editor via the dev server or `vscode://` protocol. |
 
@@ -156,7 +156,9 @@ document.addEventListener("pointermove", (e) => {
 document.addEventListener("click", async (e) => {
   const [target] = getElementsAtPosition(e.clientX, e.clientY);
   const context = await getElementContext(target);
-  console.log(context.componentName, context.selector);
+  console.log(context.snippet);    // formatted text identical to clipboard output
+  console.log(context.filePath);   // "/src/components/Button.tsx"
+  console.log(context.lineNumber); // 42
   unfreeze();
 });
 ```

--- a/packages/react-grab/README.md
+++ b/packages/react-grab/README.md
@@ -135,7 +135,7 @@ if (process.env.NODE_ENV === "development") {
 | `isFreezeActive()` | Returns `true` while frozen. |
 | `getElementsAtPosition(x, y)` | Hit-test elements at viewport coordinates while frozen (temporarily lifts the pointer-events block). |
 | `getElementContext(element)` | Returns the same context React Grab copies to clipboard (`snippet`), plus structured source location, component name, owner stack, CSS selector, computed styles, HTML preview, and fiber. |
-| `copyContent(entry)` | Copy structured context to the clipboard in plain-text, HTML, and custom metadata formats. |
+| `copyContent(text, options?)` | Copies text to the clipboard in the same three-format layout React Grab uses (plain text, HTML, structured metadata). Returns `true` on success. |
 | `openFile(path, line?)` | Open a source file in the user's editor via the dev server or `vscode://` protocol. |
 
 ```js
@@ -144,6 +144,7 @@ import {
   unfreeze,
   getElementsAtPosition,
   getElementContext,
+  copyContent,
 } from "react-grab/primitives";
 
 freeze();

--- a/packages/react-grab/e2e/fixtures.ts
+++ b/packages/react-grab/e2e/fixtures.ts
@@ -242,6 +242,11 @@ const createReactGrabPageObject = (page: Page): ReactGrabPageObject => {
   };
 
   const activate = async () => {
+    await page.waitForFunction(
+      () => (window as { __REACT_GRAB__?: unknown }).__REACT_GRAB__ !== undefined,
+      undefined,
+      { timeout: 5000 },
+    );
     await page.evaluate(() => {
       const api = (window as { __REACT_GRAB__?: { activate: () => void } }).__REACT_GRAB__;
       api?.activate();

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -73,6 +73,29 @@ export const PREVIEW_PRIORITY_ATTRS: readonly string[] = [
   "title",
 ];
 
+export const PREVIEW_IDENTIFYING_ATTRS = new Set([
+  "id",
+  "data-testid",
+  "aria-label",
+  "href",
+  "src",
+  "alt",
+  "type",
+  "name",
+  "placeholder",
+  "role",
+  "for",
+  "action",
+  "method",
+  "title",
+  "disabled",
+  "checked",
+  "readonly",
+  "required",
+  "selected",
+  "open",
+]);
+
 export const MODIFIER_KEYS: readonly string[] = ["Meta", "Control", "Shift", "Alt"];
 
 export const ARROW_KEYS = new Set(["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"]);

--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -19,6 +19,7 @@ import {
   PREVIEW_ATTR_VALUE_MAX_LENGTH,
   PREVIEW_MAX_ATTRS,
   PREVIEW_PRIORITY_ATTRS,
+  PREVIEW_IDENTIFYING_ATTRS,
   SYMBOLICATION_TIMEOUT_MS,
   DEFAULT_MAX_CONTEXT_LINES,
 } from "../constants.js";
@@ -468,15 +469,9 @@ const getFallbackContext = (element: Element): string => {
     return `<${tagName}${attrsHint} />`;
   }
 
-  const text = element.innerText?.trim() ?? element.textContent?.trim() ?? "";
-
-  let attrsText = "";
-  for (const { name, value } of element.attributes) {
-    if (isInternalAttribute(name)) continue;
-    attrsText += ` ${name}="${value}"`;
-  }
-
-  const truncatedText = truncateString(text, PREVIEW_TEXT_MAX_LENGTH);
+  const attrsText = formatAttrsForPreview(element);
+  const directText = getDirectTextContent(element);
+  const truncatedText = truncateString(directText, PREVIEW_TEXT_MAX_LENGTH);
 
   if (truncatedText.length > 0) {
     return `<${tagName}${attrsText}>\n  ${truncatedText}\n</${tagName}>`;
@@ -511,27 +506,65 @@ const formatPriorityAttrs = (
   return priorityAttrs.length > 0 ? ` ${priorityAttrs.join(" ")}` : "";
 };
 
-export const getHTMLPreview = (element: Element): string => {
-  const tagName = getTagName(element);
-  const text =
-    element instanceof HTMLElement
-      ? (element.innerText?.trim() ?? element.textContent?.trim() ?? "")
-      : (element.textContent?.trim() ?? "");
+const isClassOrStyleAttr = (name: string): boolean =>
+  name === "class" || name === "className" || name === "style";
 
-  let attrsText = "";
+const formatAttrsForPreview = (element: Element): string => {
+  const identifyingParts: string[] = [];
+  const remainingParts: string[] = [];
+  let classAttr = "";
+
   for (const { name, value } of element.attributes) {
     if (isInternalAttribute(name)) continue;
-    attrsText += ` ${name}="${truncateAttrValue(value)}"`;
+    if (!value) continue;
+    if (isClassOrStyleAttr(name)) {
+      if (name !== "style") {
+        classAttr = ` class="${truncateAttrValue(value)}"`;
+      }
+      continue;
+    }
+    if (PREVIEW_IDENTIFYING_ATTRS.has(name)) {
+      identifyingParts.push(` ${name}="${value}"`);
+    } else {
+      remainingParts.push(` ${name}="${truncateAttrValue(value)}"`);
+    }
   }
+
+  return identifyingParts.join("") + remainingParts.join("") + classAttr;
+};
+
+const getDirectTextContent = (element: Element): string => {
+  let directText = "";
+  for (const node of element.childNodes) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const trimmed = node.textContent?.trim() ?? "";
+      if (trimmed) {
+        directText += (directText ? " " : "") + trimmed;
+      }
+    }
+  }
+  return directText;
+};
+
+const formatChildElements = (elements: Array<Element>): string => {
+  if (elements.length === 0) return "";
+  if (elements.length <= 2) {
+    return elements.map((childElement) => `<${getTagName(childElement)} ...>`).join("\n  ");
+  }
+  return `(${elements.length} elements)`;
+};
+
+export const getHTMLPreview = (element: Element): string => {
+  const tagName = getTagName(element);
+  const attrsText = formatAttrsForPreview(element);
+  const directText = getDirectTextContent(element);
 
   const topElements: Array<Element> = [];
   const bottomElements: Array<Element> = [];
   let foundFirstText = false;
 
-  const childNodes = Array.from(element.childNodes);
-  for (const node of childNodes) {
+  for (const node of element.childNodes) {
     if (node.nodeType === Node.COMMENT_NODE) continue;
-
     if (node.nodeType === Node.TEXT_NODE) {
       if (node.textContent && node.textContent.trim().length > 0) {
         foundFirstText = true;
@@ -545,21 +578,13 @@ export const getHTMLPreview = (element: Element): string => {
     }
   }
 
-  const formatElements = (elements: Array<Element>): string => {
-    if (elements.length === 0) return "";
-    if (elements.length <= 2) {
-      return elements.map((childElement) => `<${getTagName(childElement)} ...>`).join("\n  ");
-    }
-    return `(${elements.length} elements)`;
-  };
-
   let content = "";
-  const topElementsStr = formatElements(topElements);
+  const topElementsStr = formatChildElements(topElements);
   if (topElementsStr) content += `\n  ${topElementsStr}`;
-  if (text.length > 0) {
-    content += `\n  ${truncateString(text, PREVIEW_TEXT_MAX_LENGTH)}`;
+  if (directText.length > 0) {
+    content += `\n  ${truncateString(directText, PREVIEW_TEXT_MAX_LENGTH)}`;
   }
-  const bottomElementsStr = formatElements(bottomElements);
+  const bottomElementsStr = formatChildElements(bottomElements);
   if (bottomElementsStr) content += `\n  ${bottomElementsStr}`;
 
   if (content.length > 0) {

--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -516,16 +516,15 @@ const formatAttrsForPreview = (element: Element): string => {
 
   for (const { name, value } of element.attributes) {
     if (isInternalAttribute(name)) continue;
-    if (!value) continue;
     if (isClassOrStyleAttr(name)) {
-      if (name !== "style") {
+      if (name !== "style" && value) {
         classAttr = ` class="${truncateAttrValue(value)}"`;
       }
       continue;
     }
     if (PREVIEW_IDENTIFYING_ATTRS.has(name)) {
-      identifyingParts.push(` ${name}="${value}"`);
-    } else {
+      identifyingParts.push(value ? ` ${name}="${value}"` : ` ${name}`);
+    } else if (value) {
       remainingParts.push(` ${name}="${truncateAttrValue(value)}"`);
     }
   }

--- a/packages/react-grab/src/primitives.ts
+++ b/packages/react-grab/src/primitives.ts
@@ -14,6 +14,8 @@ import {
   getHTMLPreview,
   getStack,
   getStackContext,
+  getElementContext as formatElementSnippet,
+  resolveSource,
 } from "./core/context.js";
 import { Fiber, getFiberFromHostInstance } from "bippy";
 import type { StackFrame } from "bippy/source";
@@ -24,28 +26,37 @@ import { openFile as openFileAsync } from "./utils/open-file.js";
 
 export interface ReactGrabElementContext {
   element: Element;
+  snippet: string;
   htmlPreview: string;
   stackString: string;
   stack: StackFrame[];
   componentName: string | null;
+  filePath: string | null;
+  lineNumber: number | null;
+  columnNumber: number | null;
   fiber: Fiber | null;
   selector: string | null;
   styles: string;
 }
 
 /**
- * Gathers comprehensive context for a DOM element, including its React fiber,
- * component name, source stack, HTML preview, CSS selector, and computed styles.
+ * Gathers comprehensive context for a DOM element — the same context
+ * React Grab copies to the clipboard, plus structured source location
+ * and computed styles.
  *
  * @example
- * const context = await getElementContext(document.querySelector('.my-button')!);
- * console.log(context.componentName); // "SubmitButton"
- * console.log(context.selector);      // "button.my-button"
- * console.log(context.stackString);   // "\n  in SubmitButton (at Button.tsx:12:5)"
- * console.log(context.stack[0]);      // { functionName: "SubmitButton", fileName: "Button.tsx", lineNumber: 12, columnNumber: 5 }
+ * const ctx = await getElementContext(document.querySelector('.my-button')!);
+ * ctx.snippet;       // formatted text identical to React Grab's clipboard output
+ * ctx.componentName; // "SubmitButton"
+ * ctx.filePath;      // "/src/components/Button.tsx"
+ * ctx.lineNumber;    // 12
  */
 export const getElementContext = async (element: Element): Promise<ReactGrabElementContext> => {
-  const stack = (await getStack(element)) ?? [];
+  const [snippet, source, stack] = await Promise.all([
+    formatElementSnippet(element),
+    resolveSource(element),
+    getStack(element).then((result) => result ?? []),
+  ]);
   const stackString = await getStackContext(element);
   const htmlPreview = getHTMLPreview(element);
   const componentName = getComponentDisplayName(element);
@@ -55,10 +66,14 @@ export const getElementContext = async (element: Element): Promise<ReactGrabElem
 
   return {
     element,
+    snippet,
     htmlPreview,
     stackString,
     stack,
     componentName,
+    filePath: source?.filePath ?? null,
+    lineNumber: source?.lineNumber ?? null,
+    columnNumber: source?.columnNumber ?? null,
     fiber,
     selector,
     styles,

--- a/packages/react-grab/src/primitives.ts
+++ b/packages/react-grab/src/primitives.ts
@@ -80,6 +80,8 @@ export const getElementContext = async (element: Element): Promise<ReactGrabElem
   };
 };
 
+export { copyContent } from "./utils/copy-content.js";
+
 /**
  * Returns all elements at the given viewport coordinates, temporarily
  * suspending the pointer-events freeze so `elementsFromPoint` can


### PR DESCRIPTION
## Summary

- Reorder attrs in HTML preview: identifying attrs (`data-testid`, `id`, `href`, `type`, `placeholder`, etc.) come first, `class` moves to the end, so agents see the signal before Tailwind noise.
- Drop empty-value attrs (`style=""`, `value=""`) and `style` attr entirely.
- Use direct child text nodes instead of `innerText`, which was flattening all descendant text into one unreadable dump (e.g. a container would show "Todo List Buy milk Walk the dog" as one blob).
- Don't truncate identifying attr values — `id="plain-dom-element"` was being cut to `id="plain-dom-eleme..."` at 15 chars.
- Apply same fixes to `getFallbackContext` for non-React elements.
- Fix flaky `activate()` in e2e fixtures by waiting for API readiness before `page.evaluate`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] Element context e2e tests pass 5x with zero flakes
- [x] Adversarial browser testing via expect-cli (12 passed, 0 failed)
- [ ] CI green

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how element snippets/HTML previews and source locations are generated and exposed via `react-grab/primitives`, which may affect downstream tooling and clipboard/snippet expectations; also tweaks e2e activation timing.
> 
> **Overview**
> Improves the element HTML preview/snippet to surface more identifying signal: prioritizes a new set of *identifying* attributes (untruncated), moves `class` to the end, drops `style` and empty-value attrs, and uses only direct child text nodes instead of `innerText` to avoid dumping descendant text.
> 
> Expands `react-grab/primitives` element context by returning the exact clipboard `snippet` plus structured source location (`filePath`, `lineNumber`, `columnNumber`), and re-exports `copyContent(text, options?)` for programmatic clipboard writes.
> 
> Stabilizes Playwright e2e `activate()` by waiting for `window.__REACT_GRAB__` to be defined before calling into the API, reducing race-condition flakes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6739be298a43bee7cecfbd8b0e829f4c3679510d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the HTML preview to surface identifying signals and reduce noise, and expands `getElementContext` to return the exact clipboard snippet plus source location. Stabilizes e2e activation by waiting for the API to be ready.

- **New Features**
  - `getElementContext` now returns `snippet` and resolved source location (`filePath`, `lineNumber`, `columnNumber`); re-exports `copyContent` from `react-grab/primitives`.
  - HTML preview: identifying attrs first, `class` last; drop `style` and empty attrs; use direct child text instead of `innerText`; do not truncate identifying attr values; same logic applied in `getFallbackContext`.

- **Bug Fixes**
  - HTML preview: preserve boolean attrs (e.g. `disabled`, `checked`) as bare names.
  - e2e: wait for `__REACT_GRAB__` before calling `activate()` to prevent HMR race flakes.

<sup>Written for commit 6739be298a43bee7cecfbd8b0e829f4c3679510d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

