### PR TITLE
docs: add agent integration roadmap to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,57 @@ actions: [
 
 See [`packages/react-grab/src/types.ts`](https://github.com/aidenybai/react-grab/blob/main/packages/react-grab/src/types.ts) for the full `Plugin`, `PluginHooks`, and `PluginConfig` interfaces.
 
+## Agent Integration
+
+React Grab connects to coding agents through a layered architecture. Each layer builds on the previous — use whichever fits your workflow.
+
+### Layer 0 — Paste (zero setup)
+
+Grab an element, then **⌘V** / **Ctrl+V** into any agent chat. The clipboard already carries the source location, component stack, and HTML snippet. Works with every agent, no configuration needed.
+
+### Layer 1 — Context File (zero-config auto-discovery)
+
+When `grab watch` is running, React Grab maintains a living context file at `.react-grab/context.md` with the latest grab formatted as markdown. Agents that auto-index project files (Cursor, Claude Code, Copilot, etc.) discover it automatically — no skill or tool call required.
+
+```bash
+# Start the background watcher (polls clipboard → writes to .react-grab/)
+npx grab@latest watch
+```
+
+The `.react-grab/` directory also keeps a grab journal (`.react-grab/grabs/`) so past selections survive clipboard overwrites and can be referenced later via `grab history`.
+
+### Layer 2 — CLI Primitives
+
+Composable one-shot commands that skills and scripts can call:
+
+```bash
+grab latest              # latest grab as JSON (reads .react-grab/ or falls back to clipboard)
+grab context             # latest grab as formatted markdown
+grab log                 # stream grabs as NDJSON (runs until killed)
+grab history             # list past grabs from .react-grab/grabs/
+```
+
+### Layer 3 — Hooks
+
+Git-hook-style executables that fire on each grab:
+
+```bash
+.react-grab/hooks/
+└── on-grab              # receives JSON via stdin + env vars
+```
+
+Hooks are completely agent-agnostic — any executable that reads stdin works.
+
+### Per-Agent Setup
+
+`grab add` detects your agent and installs the right integration format:
+
+```bash
+grab add                 # interactive: pick agents
+grab add cursor          # Cursor-specific integration
+grab add claude          # Claude Code-specific integration
+```
+
 ## Resources & Contributing Back
 
 Want to try it out? Check out [our demo](https://react-grab.com).


### PR DESCRIPTION
## Summary

Adds an "Agent Integration" section to the README documenting the planned layered architecture for connecting React Grab to coding agents.

The four layers:
- **Layer 0 — Paste:** Zero setup. Grab → paste into any agent chat.
- **Layer 1 — Context File:** `grab watch` maintains `.react-grab/context.md` — agents that auto-index project files discover it automatically.
- **Layer 2 — CLI Primitives:** `grab latest`, `grab context`, `grab log`, `grab history` — composable commands for skills and scripts.
- **Layer 3 — Hooks:** Git-hook-style `.react-grab/hooks/on-grab` executables, completely agent-agnostic.

Also documents per-agent setup via `grab add <agent>`.

This is a docs-only change describing the planned direction. No code changes.

## Review & Testing Checklist for Human

- [ ] Read through the Agent Integration section — does the layered framing make sense for how you want to position this?
- [ ] Check that the CLI command names (`grab watch`, `grab latest`, `grab context`, `grab history`) feel right before they get implemented
- [ ] Verify the per-agent setup section (`grab add cursor`, `grab add claude`) matches the direction you want for Phase 3

### Notes

See the full implementation plan (brainstorm + phases) shared earlier in the session. This README change is the user-facing version of that plan. The implementation phases (filesystem persistence → hooks → agent adapters → simplified skill → kill MCP) are designed to ship independently.

Link to Devin session: https://app.devin.ai/sessions/272b3ae291454c63ad621b1acb6db231
Requested by: @aidenybai

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change; no runtime behavior or APIs are modified, but it does introduce CLI and filesystem concepts that should match the intended product direction.
> 
> **Overview**
> Adds a new **"Agent Integration"** section to `README.md` that outlines a four-layer roadmap for using React Grab with coding agents: direct paste, a watched `.react-grab/context.md` file (plus grab journal), CLI primitives (`grab latest/context/log/history`), and hook-style executables under `.react-grab/hooks/on-grab`.
> 
> Also documents *per-agent* installation flow via `grab add` (including `cursor` and `claude`) to set expectations for future integrations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e3316436c5207ffaf9b9592ece3ccf2b9fd2130. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an Agent Integration section to the README that outlines a layered plan for connecting `react-grab` to coding agents. It documents Layers 0–3 (Paste; Context File via `grab watch` and `.react-grab/context.md`; CLI commands `grab latest`, `grab context`, `grab log`, `grab history`; and hooks with `.react-grab/hooks/on-grab`) and per‑agent setup with `grab add <agent>`; docs-only.

<sup>Written for commit 7e3316436c5207ffaf9b9592ece3ccf2b9fd2130. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

