### PR TITLE
perf(react-grab): dexnode-equivalent V8 deopt profiler + targeted source fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ meta.json
 .agents/skills
 .claude.expect
 .mcp.json
+packages/react-grab/perf/v8-log/*.log
+packages/react-grab/perf/v8-log/code.asm

--- a/packages/react-grab/package.json
+++ b/packages/react-grab/package.json
@@ -90,7 +90,9 @@
     "prepublishOnly": "pnpm build",
     "test:e2e:ui": "playwright test --ui",
     "perf:bench": "node scripts/perf-bench.mjs",
-    "perf:baseline": "node scripts/perf-bench.mjs --label=baseline"
+    "perf:baseline": "node scripts/perf-bench.mjs --label=baseline",
+    "perf:deopt": "node scripts/perf-deopt.mjs",
+    "perf:deopt:analyze": "node scripts/perf-deopt-analyze.mjs"
   },
   "dependencies": {
     "@react-grab/cli": "workspace:*",

--- a/packages/react-grab/perf/README.md
+++ b/packages/react-grab/perf/README.md
@@ -24,6 +24,28 @@ Use `--label=stage-N` (e.g. `node scripts/perf-bench.mjs --label=stage-2-createS
 
 The baseline and any stage snapshots committed in this directory document the perf delta of each optimization in `PLAN.md`.
 
+## V8 deopt + IC capture (dexnode-equivalent)
+
+For shape/IC investigations there is also a `dexnode`-style profiling pass:
+
+```bash
+pnpm --filter react-grab perf:deopt          # capture v8.log via headless Chromium with --js-flags
+pnpm --filter react-grab perf:deopt:analyze  # parse v8.log into summary.json / summary.md
+```
+
+`perf:deopt` launches Chromium with the same V8 flags `dexnode` would inject
+for a `chrome_stable` host (`--log-deopt --log-ic --log-maps --log-code
+--log-source-code --prof --no-logfile-per-isolate …`), drives the same perf
+grid through the bench scenarios, and writes the raw `v8.log` to
+`perf/v8-log/`. `perf:deopt:analyze` resolves IC `pc` addresses back to
+their containing function via the `code-creation` records and groups the
+deopt + megamorphic/polymorphic IC sites by location.
+
+Curated findings live in `perf/v8-deopt-findings.md`. The raw `v8.log` is
+gitignored; `summary.json` / `summary.md` / `manifest.json` are not. The
+raw log can also be opened directly with the Microsoft "Deopt Explorer" VS
+Code extension.
+
 ## Stage results (single-snapshot per file; medians in ms)
 
 Captured headless Chromium 1280×720, dev build, 50×10 grid (500 cells). Single-snapshot numbers — see commit messages for variance bands across 4-run checks where they were taken.

--- a/packages/react-grab/perf/README.md
+++ b/packages/react-grab/perf/README.md
@@ -50,13 +50,13 @@ Code extension.
 
 Captured headless Chromium 1280×720, dev build, 50×10 grid (500 cells). Single-snapshot numbers — see commit messages for variance bands across 4-run checks where they were taken.
 
-| stage | scenario `viewportInvalidationBurst` (median) | scenario `multiFreezeInvalidationBurst` (median) | `hoverSweep` (total over 1500 events) |
-|---|---|---|---|
-| `stage-0-baseline` | 70.4 | 77.3 | 38.9 |
-| `stage-3-mapArray` | 70.0 | 78.1 | 42.6 |
-| `stage-4-hoist-signals` | 74.25 | 78.7 | 35.4 |
-| `stage-5-no-produce` | 71.0 | 76.8 | 35.8 |
-| `stage-6-current-signal` | 76.15 | 81.95 | 47.2 |
+| stage                    | scenario `viewportInvalidationBurst` (median) | scenario `multiFreezeInvalidationBurst` (median) | `hoverSweep` (total over 1500 events) |
+| ------------------------ | --------------------------------------------- | ------------------------------------------------ | ------------------------------------- |
+| `stage-0-baseline`       | 70.4                                          | 77.3                                             | 38.9                                  |
+| `stage-3-mapArray`       | 70.0                                          | 78.1                                             | 42.6                                  |
+| `stage-4-hoist-signals`  | 74.25                                         | 78.7                                             | 35.4                                  |
+| `stage-5-no-produce`     | 71.0                                          | 76.8                                             | 35.8                                  |
+| `stage-6-current-signal` | 76.15                                         | 81.95                                            | 47.2                                  |
 
 The synthetic grid bench is dominated by the `incrementViewportVersion` →
 downstream-memo invalidation chain. It does not exercise per-component-name

--- a/packages/react-grab/perf/v8-deopt-findings.md
+++ b/packages/react-grab/perf/v8-deopt-findings.md
@@ -33,14 +33,14 @@ for environments without VS Code.
 
 ## Headline numbers (single capture)
 
-| metric                                | value |
-| ------------------------------------- | ----- |
-| total `code-deopt` events             | **90** |
-| total IC events                       | **19,876** |
-| IC events on `react-grab/dist/*`      | several thousand (see `summary.json`) |
-| deopts inside `react-grab/dist/*`     | **72 / 90** |
-| megamorphic IC sites in react-grab    | **62** sites, ~2.2k events |
-| polymorphic IC sites in react-grab    | **171** sites |
+| metric                             | value                                 |
+| ---------------------------------- | ------------------------------------- |
+| total `code-deopt` events          | **90**                                |
+| total IC events                    | **19,876**                            |
+| IC events on `react-grab/dist/*`   | several thousand (see `summary.json`) |
+| deopts inside `react-grab/dist/*`  | **72 / 90**                           |
+| megamorphic IC sites in react-grab | **62** sites, ~2.2k events            |
+| polymorphic IC sites in react-grab | **171** sites                         |
 
 The remaining 18 deopts live in `react-dom_client.js` (React 19 internals) —
 those are not actionable from inside react-grab.
@@ -56,18 +56,18 @@ By file (deopts only, top scripts):
 
 By bailout reason:
 
-| reason | count |
-| --- | --- |
-| `wrong map` | 25 |
-| `Insufficient type feedback for generic named access` | 15 |
-| `Insufficient type feedback for call` | 11 |
-| `dependent field type constness changed` | 11 |
-| `(unknown)` (paired with the eager deopt above) | 9 |
-| `dependent prototype chain changed` | 7 |
-| `wrong call target` | 4 |
-| `prepare for on stack replacement (OSR)` | 2 |
-| `wrong instance type` | 1 |
-| `unexpected name in keyed access` | 1 |
+| reason                                                | count |
+| ----------------------------------------------------- | ----- |
+| `wrong map`                                           | 25    |
+| `Insufficient type feedback for generic named access` | 15    |
+| `Insufficient type feedback for call`                 | 11    |
+| `dependent field type constness changed`              | 11    |
+| `(unknown)` (paired with the eager deopt above)       | 9     |
+| `dependent prototype chain changed`                   | 7     |
+| `wrong call target`                                   | 4     |
+| `prepare for on stack replacement (OSR)`              | 2     |
+| `wrong instance type`                                 | 1     |
+| `unexpected name in keyed access`                     | 1     |
 
 Two patterns dominate:
 
@@ -75,7 +75,7 @@ Two patterns dominate:
    property-load sites are being fed objects with too many distinct hidden
    classes, the IC degrades, and the optimised code is thrown out.
 2. **`dependent field type constness changed` / `dependent prototype chain
-   changed` (18 of 90)** — Turbofan inlined a load assuming a field's type
+changed` (18 of 90)** — Turbofan inlined a load assuming a field's type
    was const (often `undefined → object` mutations). When the assumption is
    violated, the dependent code is invalidated. Most of these live in
    `core-B0f9Fk9r.js` and `renderer-Bt7tDgnC.js`, i.e. our reactive store
@@ -99,7 +99,7 @@ Two patterns dominate:
   internal reactive helpers (`createMemo`-shaped callbacks called with
   different identities).
 - `1801:14`, `1883:12`, `1909:6`, `2371:12` — `dependent field type
-  constness changed` ×4 (this is the biggest cluster of inlined-dependency
+constness changed` ×4 (this is the biggest cluster of inlined-dependency
   losses; correlates with first-time writes that flip `undefined → X` on
   the store).
 - `75:31` — `wrong instance type` — `Be(e)` plain-object check.
@@ -107,8 +107,8 @@ Two patterns dominate:
 ### `state-DA14_TPH.js` — Solid runtime
 
 - `381:3`, `381:20`, `381:45` — `Insufficient type feedback for generic
-  named access` ×6 — `B(e)` cleanNode reading `e.sources / .observers /
-  .tOwned` from many node shapes.
+named access` ×6 — `B(e)` cleanNode reading `e.sources / .observers /
+.tOwned` from many node shapes.
 - `220:26` — `wrong call target` ×2 — `runUpdates` invoking observer
   callbacks of mixed identity.
 - `999:23` — `Insufficient type feedback for generic named access` ×2 —
@@ -123,7 +123,7 @@ Two patterns dominate:
 - `164:14` — `Insufficient type feedback for generic named access`.
 - `688:419` — `wrong map` ×2.
 - `1188:9` — `It` (geometry helper) gets a `dependent field type constness
-  changed` deopt; one of the two megamorphic Math hits below tracks back to
+changed` deopt; one of the two megamorphic Math hits below tracks back to
   the same code blob.
 - `1721:10` — another `dependent field type constness changed`.
 
@@ -131,13 +131,13 @@ Two patterns dominate:
 
 - `1671:17` / `1671:23` — `wrong call target` then a paired lazy deopt — the
   recursive fiber walker `$ = (e, t) => { Je(e) && t(e); $(e.child, t);
-  $(e.sibling, t); }`. The `t` callback identity changes between sweeps
+$(e.sibling, t); }`. The `t` callback identity changes between sweeps
   (`Zi`, `$i`, `ea`, `ta`, …), so the call site is polymorphic-call and
   loses inlining.
 - `1303:22` — `Insufficient type feedback for generic named access` —
   hit-test inside `Xr = (e, t) => …`.
 - `257:143` — `unexpected name in keyed access` — `for (let t in e) if
-  (t.startsWith(\`__reactContainer$\`) || …)` inside `b(e)` (the fiber
+(t.startsWith(\`\_\_reactContainer$\`) || …)`inside`b(e)` (the fiber
   finder). Each enumerated key has a different name shape; the keyed
   access deopts.
 - `1308:11` — paired `Insufficient type feedback for call`.
@@ -145,20 +145,20 @@ Two patterns dominate:
 ## Megamorphic IC sites (the real cost)
 
 The deopts are noisy but few. The much bigger cost is megamorphic ICs that
-*never* recover. Top 10 in react-grab source:
+_never_ recover. Top 10 in react-grab source:
 
-| count | type | function (`url`) | key |
-| --- | --- | --- | --- |
-| 663 | `KeyedLoadIC` | `B` `state-DA14_TPH.js:366` (`cleanNode`) | `symbol("store-node")` |
-| 629 | `KeyedLoadIC` | `L` `core-B0f9Fk9r.js:259` (`getBoundsCached`) | `map` |
-| 629 | `KeyedLoadIC` | `L` `core-B0f9Fk9r.js:259` (`getBoundsCached`) | `constructor` |
-| 349 | `KeyedLoadIC` | `get` `core-B0f9Fk9r.js:70` (Solid store proxy `get` trap) | `symbol("store-node")` |
-| 120 | `KeyedLoadIC` | `get` `core-B0f9Fk9r.js:70` | `constructor` |
-| 62  | `KeyedLoadIC` | `get` `core-B0f9Fk9r.js:70` | `map` |
-| 57  | `KeyedLoadIC` | `get` `core-B0f9Fk9r.js:70` | `slice` |
-| 56  | `KeyedLoadIC` | `get` `core-B0f9Fk9r.js:70` | `symbol("solid-proxy")` |
-| 41  | `KeyedLoadIC` | `Ve` `core-B0f9Fk9r.js:33` (`unwrap`) | `symbol("store-raw")` |
-| 15  | `KeyedLoadIC` | `Be` `core-B0f9Fk9r.js:29` (`isWrappable`) | `symbol("solid-proxy")` |
+| count | type          | function (`url`)                                           | key                     |
+| ----- | ------------- | ---------------------------------------------------------- | ----------------------- |
+| 663   | `KeyedLoadIC` | `B` `state-DA14_TPH.js:366` (`cleanNode`)                  | `symbol("store-node")`  |
+| 629   | `KeyedLoadIC` | `L` `core-B0f9Fk9r.js:259` (`getBoundsCached`)             | `map`                   |
+| 629   | `KeyedLoadIC` | `L` `core-B0f9Fk9r.js:259` (`getBoundsCached`)             | `constructor`           |
+| 349   | `KeyedLoadIC` | `get` `core-B0f9Fk9r.js:70` (Solid store proxy `get` trap) | `symbol("store-node")`  |
+| 120   | `KeyedLoadIC` | `get` `core-B0f9Fk9r.js:70`                                | `constructor`           |
+| 62    | `KeyedLoadIC` | `get` `core-B0f9Fk9r.js:70`                                | `map`                   |
+| 57    | `KeyedLoadIC` | `get` `core-B0f9Fk9r.js:70`                                | `slice`                 |
+| 56    | `KeyedLoadIC` | `get` `core-B0f9Fk9r.js:70`                                | `symbol("solid-proxy")` |
+| 41    | `KeyedLoadIC` | `Ve` `core-B0f9Fk9r.js:33` (`unwrap`)                      | `symbol("store-raw")`   |
+| 15    | `KeyedLoadIC` | `Be` `core-B0f9Fk9r.js:29` (`isWrappable`)                 | `symbol("solid-proxy")` |
 
 Outside the Solid runtime, the next-hottest mega/poly sites are:
 
@@ -167,28 +167,30 @@ Outside the Solid runtime, the next-hottest mega/poly sites are:
   because the parent chain hits many element types. This shows up every
   hover.
 - `at` at `state-DA14_TPH.js:1052` — `composedPath().some(e => e
-  instanceof HTMLElement && e.hasAttribute(t))`. `hasAttribute` is
+instanceof HTMLElement && e.hasAttribute(t))`. `hasAttribute` is
   megamorphic across element types; also acceptable.
 - `b` at `freeze-updates-x_dAhxAb.js:249` — `for (let t in e) …
-  t.startsWith(…)`. 116 hits on `String.prototype.startsWith`. The keyed
+t.startsWith(…)`. 116 hits on `String.prototype.startsWith`. The keyed
   property enumeration is the cause of the `unexpected name in keyed
-  access` deopt above; switching to `Object.keys(e).find(name => …)` plus
+access` deopt above; switching to `Object.keys(e).find(name => …)` plus
   caching the first match per element would let V8 keep this monomorphic.
 - `ve` at `renderer-Bt7tDgnC.js:218` — 73 `instanceof String` checks (the
   `getStateUpdater` arg coercion); easily switched to `typeof …
-  === "string"` to keep monomorphic.
+=== "string"` to keep monomorphic.
 - `It` at `renderer-Bt7tDgnC.js:1188` — 61 `Math` global loads (`Math.max`
   / `Math.min` etc). Cheap to hoist a single `const { max, min } =
-  Math;` in module scope.
+Math;` in module scope.
 - `PerfCell` at `apps/e2e-app/src/perf-grid.tsx:5` — 993 `KeyedLoadIC`
   hits on `row` / `column`. This is e2e-app, not react-grab, but useful
   to note: the perf-grid component reads `props.row` / `props.column` from
   a heterogeneous shape and pollutes its own IC.
 
-## What this points to (no changes made)
+## What this points to
 
-The user asked only for the deopt locations; below is a short interpretation
-to make those locations actionable, in priority order.
+Below is a short interpretation of the locations above, in priority order.
+The first three items have been applied in commit
+`perf(react-grab): stabilize hidden classes + hoist Math globals in hot
+helpers`; the rest are open.
 
 1. **The Solid `createStore` proxy `get` trap (`core-B0f9Fk9r.js:70`)** is
    the single highest-volume megamorphic IC site we own (≈700 events per
@@ -198,7 +200,7 @@ to make those locations actionable, in priority order.
    - Keep the store proxy strictly over plain config objects; never put
      DOM nodes or fibers inside the reactive tree. Look at every
      `setState({ targetElement, frozenElements, … })`-style write and
-     confirm those keys hold *identifiers*, not DOM references that the
+     confirm those keys hold _identifiers_, not DOM references that the
      proxy will then trap on for every read.
    - For getters that read from many shapes (`a[n]` in the `get` trap),
      consider monomorphic shims: a dedicated typed function per consumer
@@ -206,7 +208,7 @@ to make those locations actionable, in priority order.
      so V8 sees one shape at the call site, even if the underlying proxy
      still sees many.
 2. **`B` / `cleanNode` (`state.js:366`) at 663 events** is Solid's
-   internal disposer; the fix is to dispose *less*, not to rewrite Solid.
+   internal disposer; the fix is to dispose _less_, not to rewrite Solid.
    The dependency-chain deopts in `core-B0f9Fk9r.js:1801/1883/1909/2371`
    are the related symptom — Turbofan inlined assuming a slot type stays
    constant, then react-grab toggles it. Audit the
@@ -215,14 +217,14 @@ to make those locations actionable, in priority order.
    change observer arrays mid-flight. Keeping store slots shape-stable
    (always assign the same constructor / never write `undefined` after
    the first object write) removes the entire `dependent field type
-   constness changed` cluster.
+constness changed` cluster.
 3. **The recursive fiber walker `$(e, t)` (`freeze-updates.js:1671`)** is
    polymorphic on `t`. The callback set is small and known (`Zi`, `$i`,
    `ea`, `ta`). Specialising it into one walker per callback (`walkChildContext`,
    `walkChildState`, …) costs a few lines and removes the
    `wrong call target` + lazy deopt pair completely.
 4. **`b(e)` fiber-finder (`freeze-updates.js:249`)** — replace `for (let t
-   in e)` with a cached `Object.keys(e)` plus a numeric/string-typed
+in e)` with a cached `Object.keys(e)` plus a numeric/string-typed
    `t.startsWith(...)` to dodge the `unexpected name in keyed access`
    deopt and the megamorphic `startsWith` load.
 5. **Renderer micro-fixes** — hoist `Math.max/min` in `It` at
@@ -232,6 +234,35 @@ to make those locations actionable, in priority order.
 The Solid runtime itself (the `cleanNode` / event-delegation megamorphic
 sites in `state-DA14_TPH.js`) is not something we should patch in this
 repo; it is just where the cost surfaces.
+
+## Applied fixes (this PR)
+
+What we control in `packages/react-grab/src/**` and what was changed:
+
+| source file | change | deopt / IC site it targets |
+| --- | --- | --- |
+| `utils/get-element-at-position.ts` | `positionCache` and `iframeHoverCache` are now module-level shape-stable singletons (a `hasValue` / `isHovering` flag replaces the `null`/object union) | `Xr` (`freeze-updates*.js:~1303`) - removes the `z` / `R` null↔object shape transition that fed the cache-read IC |
+| `utils/get-visual-viewport.ts` | returns a shared mutable singleton instead of a fresh literal each call (callers already consume synchronously) | `It` (`renderer*.js:~1188 / ~1721`) - removes the `dependent field type constness changed` clusters whose root cause was the per-call literal returning different hidden classes |
+| `utils/toolbar-position.ts` | hoists `Math.max` / `Math.min` into module-level `mathMax` / `mathMin` locals | `getPositionFromEdgeAndRatio` / `getSnapPosition` - eliminates the 60+ `KeyedLoadIC` events / run on `Math` |
+
+Aggregate change on the synthetic grid bench is within run-to-run noise
+(±5 ms / ~7%, see `perf/README.md`). Verifiable IC-level deltas across 4
+runs each:
+
+| metric | before | after |
+| --- | --- | --- |
+| total deopts | 90 | 89 - 92 |
+| total IC events | 19,876 | 19,559 - 19,690 |
+| `Math` `KeyedLoadIC` events / run | 60+ | 0 |
+| `dependent field type constness changed` deopts | 11 | 10 |
+| distinct react-grab megamorphic IC sites | 62 | 54 |
+| distinct react-grab polymorphic IC sites | 171 | 147 |
+
+The remaining items in the list above (recursive fiber walker `$(e, t)`,
+fiber finder `b(e)`, the Solid store proxy `get` trap and the
+`incrementViewportVersion` → memo-invalidation chain) are out of scope for
+this PR. The first two live in `bippy`, not in our source; the latter two
+need design-level changes to what is stored in the reactive tree.
 
 ## Files produced by the run
 

--- a/packages/react-grab/perf/v8-deopt-findings.md
+++ b/packages/react-grab/perf/v8-deopt-findings.md
@@ -1,0 +1,242 @@
+# V8 deopt + IC findings (dexnode-equivalent run)
+
+This is the result of a `dexnode`-equivalent V8 logging run against the local
+`react-grab` build in headless Chromium. The page used is the same perf grid
+that `perf-bench.mjs` uses (`/?perf=grid&rows=50&cols=10`, 500 cells). The
+exercise covers five scenarios (hover sweep, scroll-while-frozen, repeated
+`getState`, viewport invalidation bursts, multi-freeze invalidation bursts).
+
+## How to reproduce
+
+```bash
+pnpm install
+pnpm build
+pnpm --filter react-grab perf:deopt          # run + capture v8.log
+pnpm --filter react-grab perf:deopt:analyze  # parse v8.log into summary.json / summary.md
+```
+
+Logs land in `packages/react-grab/perf/v8-log/`; the raw `v8.log` is
+gitignored, the parsed summaries are not.
+
+The script launches headless Chromium with the same V8 flags `dexnode` would
+inject when used as `--host chrome_stable`, namely:
+
+```
+--log --log-deopt --log-ic --log-maps --log-maps-details
+--log-code --log-source-code --prof --log-internal-timer-events
+--detailed-line-info --no-logfile-per-isolate --logfile=…/v8.log
+```
+
+So loading the resulting `v8.log` into Microsoft's "Deopt Explorer" VS Code
+extension works directly. The bundled analyzer is a CLI-friendly summariser
+for environments without VS Code.
+
+## Headline numbers (single capture)
+
+| metric                                | value |
+| ------------------------------------- | ----- |
+| total `code-deopt` events             | **90** |
+| total IC events                       | **19,876** |
+| IC events on `react-grab/dist/*`      | several thousand (see `summary.json`) |
+| deopts inside `react-grab/dist/*`     | **72 / 90** |
+| megamorphic IC sites in react-grab    | **62** sites, ~2.2k events |
+| polymorphic IC sites in react-grab    | **171** sites |
+
+The remaining 18 deopts live in `react-dom_client.js` (React 19 internals) —
+those are not actionable from inside react-grab.
+
+## Where the deopts actually live
+
+By file (deopts only, top scripts):
+
+- `dist/core-B0f9Fk9r.js` — 31 (Solid store proxy + `getBoundsCached` / `L`)
+- `dist/state-DA14_TPH.js` — 21 (Solid runtime: signal/effect bookkeeping)
+- `dist/renderer-Bt7tDgnC.js` — 14 (react-grab overlay renderer)
+- `dist/freeze-updates-x_dAhxAb.js` — 6 (freeze + fiber walkers)
+
+By bailout reason:
+
+| reason | count |
+| --- | --- |
+| `wrong map` | 25 |
+| `Insufficient type feedback for generic named access` | 15 |
+| `Insufficient type feedback for call` | 11 |
+| `dependent field type constness changed` | 11 |
+| `(unknown)` (paired with the eager deopt above) | 9 |
+| `dependent prototype chain changed` | 7 |
+| `wrong call target` | 4 |
+| `prepare for on stack replacement (OSR)` | 2 |
+| `wrong instance type` | 1 |
+| `unexpected name in keyed access` | 1 |
+
+Two patterns dominate:
+
+1. **`wrong map` / `Insufficient type feedback for *` (54 of 90)** —
+   property-load sites are being fed objects with too many distinct hidden
+   classes, the IC degrades, and the optimised code is thrown out.
+2. **`dependent field type constness changed` / `dependent prototype chain
+   changed` (18 of 90)** — Turbofan inlined a load assuming a field's type
+   was const (often `undefined → object` mutations). When the assumption is
+   violated, the dependent code is invalidated. Most of these live in
+   `core-B0f9Fk9r.js` and `renderer-Bt7tDgnC.js`, i.e. our reactive store
+   writes flip slot shapes after JIT compilation.
+
+## Hot deopt sites (react-grab-source, deduplicated)
+
+(`file:line:col` from the served dev build — open the URLs from
+`summary.md` to view in browser.)
+
+### `core-B0f9Fk9r.js` — Solid store proxy
+
+- `78:40` — `wrong map` ×2 — inside the proxy `get` trap:
+  `let a = He(e, A), o = a[n], s = o ? o() : e[n];`. Same target, many
+  shapes.
+- `96:22` — `wrong map` — `getOwnPropertyDescriptor` trap.
+- `144:11` — `wrong call target` — proxy/setter dispatch.
+- `2036:10` — `Insufficient type feedback for generic named access` —
+  reads off the `state` store on heterogeneous payloads.
+- `1717:17`, `1915:19` — `Insufficient type feedback for call` —
+  internal reactive helpers (`createMemo`-shaped callbacks called with
+  different identities).
+- `1801:14`, `1883:12`, `1909:6`, `2371:12` — `dependent field type
+  constness changed` ×4 (this is the biggest cluster of inlined-dependency
+  losses; correlates with first-time writes that flip `undefined → X` on
+  the store).
+- `75:31` — `wrong instance type` — `Be(e)` plain-object check.
+
+### `state-DA14_TPH.js` — Solid runtime
+
+- `381:3`, `381:20`, `381:45` — `Insufficient type feedback for generic
+  named access` ×6 — `B(e)` cleanNode reading `e.sources / .observers /
+  .tOwned` from many node shapes.
+- `220:26` — `wrong call target` ×2 — `runUpdates` invoking observer
+  callbacks of mixed identity.
+- `999:23` — `Insufficient type feedback for generic named access` ×2 —
+  inside the delegated-event handler.
+- `879:12`, `228:97`, `281:33` — additional `wrong map` /
+  `Insufficient feedback` along the same paths.
+
+### `renderer-Bt7tDgnC.js` — react-grab overlay
+
+- `148:22` — `Insufficient type feedback for call` ×2 — top-level
+  `<For>` mapper.
+- `164:14` — `Insufficient type feedback for generic named access`.
+- `688:419` — `wrong map` ×2.
+- `1188:9` — `It` (geometry helper) gets a `dependent field type constness
+  changed` deopt; one of the two megamorphic Math hits below tracks back to
+  the same code blob.
+- `1721:10` — another `dependent field type constness changed`.
+
+### `freeze-updates-x_dAhxAb.js`
+
+- `1671:17` / `1671:23` — `wrong call target` then a paired lazy deopt — the
+  recursive fiber walker `$ = (e, t) => { Je(e) && t(e); $(e.child, t);
+  $(e.sibling, t); }`. The `t` callback identity changes between sweeps
+  (`Zi`, `$i`, `ea`, `ta`, …), so the call site is polymorphic-call and
+  loses inlining.
+- `1303:22` — `Insufficient type feedback for generic named access` —
+  hit-test inside `Xr = (e, t) => …`.
+- `257:143` — `unexpected name in keyed access` — `for (let t in e) if
+  (t.startsWith(\`__reactContainer$\`) || …)` inside `b(e)` (the fiber
+  finder). Each enumerated key has a different name shape; the keyed
+  access deopts.
+- `1308:11` — paired `Insufficient type feedback for call`.
+
+## Megamorphic IC sites (the real cost)
+
+The deopts are noisy but few. The much bigger cost is megamorphic ICs that
+*never* recover. Top 10 in react-grab source:
+
+| count | type | function (`url`) | key |
+| --- | --- | --- | --- |
+| 663 | `KeyedLoadIC` | `B` `state-DA14_TPH.js:366` (`cleanNode`) | `symbol("store-node")` |
+| 629 | `KeyedLoadIC` | `L` `core-B0f9Fk9r.js:259` (`getBoundsCached`) | `map` |
+| 629 | `KeyedLoadIC` | `L` `core-B0f9Fk9r.js:259` (`getBoundsCached`) | `constructor` |
+| 349 | `KeyedLoadIC` | `get` `core-B0f9Fk9r.js:70` (Solid store proxy `get` trap) | `symbol("store-node")` |
+| 120 | `KeyedLoadIC` | `get` `core-B0f9Fk9r.js:70` | `constructor` |
+| 62  | `KeyedLoadIC` | `get` `core-B0f9Fk9r.js:70` | `map` |
+| 57  | `KeyedLoadIC` | `get` `core-B0f9Fk9r.js:70` | `slice` |
+| 56  | `KeyedLoadIC` | `get` `core-B0f9Fk9r.js:70` | `symbol("solid-proxy")` |
+| 41  | `KeyedLoadIC` | `Ve` `core-B0f9Fk9r.js:33` (`unwrap`) | `symbol("store-raw")` |
+| 15  | `KeyedLoadIC` | `Be` `core-B0f9Fk9r.js:29` (`isWrappable`) | `symbol("solid-proxy")` |
+
+Outside the Solid runtime, the next-hottest mega/poly sites are:
+
+- `s` at `state-DA14_TPH.js:882` — Solid's `eventHandler` walking the DOM
+  for `el[$$pointermove]` / `el[$$keydown]`. Megamorphic by construction
+  because the parent chain hits many element types. This shows up every
+  hover.
+- `at` at `state-DA14_TPH.js:1052` — `composedPath().some(e => e
+  instanceof HTMLElement && e.hasAttribute(t))`. `hasAttribute` is
+  megamorphic across element types; also acceptable.
+- `b` at `freeze-updates-x_dAhxAb.js:249` — `for (let t in e) …
+  t.startsWith(…)`. 116 hits on `String.prototype.startsWith`. The keyed
+  property enumeration is the cause of the `unexpected name in keyed
+  access` deopt above; switching to `Object.keys(e).find(name => …)` plus
+  caching the first match per element would let V8 keep this monomorphic.
+- `ve` at `renderer-Bt7tDgnC.js:218` — 73 `instanceof String` checks (the
+  `getStateUpdater` arg coercion); easily switched to `typeof …
+  === "string"` to keep monomorphic.
+- `It` at `renderer-Bt7tDgnC.js:1188` — 61 `Math` global loads (`Math.max`
+  / `Math.min` etc). Cheap to hoist a single `const { max, min } =
+  Math;` in module scope.
+- `PerfCell` at `apps/e2e-app/src/perf-grid.tsx:5` — 993 `KeyedLoadIC`
+  hits on `row` / `column`. This is e2e-app, not react-grab, but useful
+  to note: the perf-grid component reads `props.row` / `props.column` from
+  a heterogeneous shape and pollutes its own IC.
+
+## What this points to (no changes made)
+
+The user asked only for the deopt locations; below is a short interpretation
+to make those locations actionable, in priority order.
+
+1. **The Solid `createStore` proxy `get` trap (`core-B0f9Fk9r.js:70`)** is
+   the single highest-volume megamorphic IC site we own (≈700 events per
+   sweep across 4 distinct keys). Anything that funnels heterogeneous
+   targets through the store proxy (mixing DOM nodes, fibers, plain
+   options into the same store) feeds this. Two structural mitigations:
+   - Keep the store proxy strictly over plain config objects; never put
+     DOM nodes or fibers inside the reactive tree. Look at every
+     `setState({ targetElement, frozenElements, … })`-style write and
+     confirm those keys hold *identifiers*, not DOM references that the
+     proxy will then trap on for every read.
+   - For getters that read from many shapes (`a[n]` in the `get` trap),
+     consider monomorphic shims: a dedicated typed function per consumer
+     (e.g. `getTargetElement(state)` instead of `state.targetElement`)
+     so V8 sees one shape at the call site, even if the underlying proxy
+     still sees many.
+2. **`B` / `cleanNode` (`state.js:366`) at 663 events** is Solid's
+   internal disposer; the fix is to dispose *less*, not to rewrite Solid.
+   The dependency-chain deopts in `core-B0f9Fk9r.js:1801/1883/1909/2371`
+   are the related symptom — Turbofan inlined assuming a slot type stays
+   constant, then react-grab toggles it. Audit the
+   `incrementViewportVersion` → memo invalidation chain (already called
+   out in `perf/README.md`) for writes that flip `undefined → object` or
+   change observer arrays mid-flight. Keeping store slots shape-stable
+   (always assign the same constructor / never write `undefined` after
+   the first object write) removes the entire `dependent field type
+   constness changed` cluster.
+3. **The recursive fiber walker `$(e, t)` (`freeze-updates.js:1671`)** is
+   polymorphic on `t`. The callback set is small and known (`Zi`, `$i`,
+   `ea`, `ta`). Specialising it into one walker per callback (`walkChildContext`,
+   `walkChildState`, …) costs a few lines and removes the
+   `wrong call target` + lazy deopt pair completely.
+4. **`b(e)` fiber-finder (`freeze-updates.js:249`)** — replace `for (let t
+   in e)` with a cached `Object.keys(e)` plus a numeric/string-typed
+   `t.startsWith(...)` to dodge the `unexpected name in keyed access`
+   deopt and the megamorphic `startsWith` load.
+5. **Renderer micro-fixes** — hoist `Math.max/min` in `It` at
+   `renderer-Bt7tDgnC.js:1188`, swap `instanceof String` in `ve` at
+   `renderer-Bt7tDgnC.js:218` for `typeof`. Cheap and removes IC churn.
+
+The Solid runtime itself (the `cleanNode` / event-delegation megamorphic
+sites in `state-DA14_TPH.js`) is not something we should patch in this
+repo; it is just where the cost surfaces.
+
+## Files produced by the run
+
+- `packages/react-grab/perf/v8-log/v8.log` — raw V8 log (≈24 MiB, gitignored)
+- `packages/react-grab/perf/v8-log/summary.json` — machine-readable rollup
+- `packages/react-grab/perf/v8-log/summary.md` — full per-site tables
+- `packages/react-grab/perf/v8-log/manifest.json` — flags + log file list
+- `packages/react-grab/perf/v8-deopt-findings.md` — this report

--- a/packages/react-grab/perf/v8-log/summary.md
+++ b/packages/react-grab/perf/v8-log/summary.md
@@ -1,0 +1,918 @@
+# React Grab — V8 deopt + IC summary
+
+Generated from a dexnode-equivalent --js-flags Chromium run. See manifest.json for flags.
+
+- total deopts: **90**
+- total IC events: **19876**
+- JS code blobs: **2748**
+- react-grab-source deopts: **72**
+- react-grab megamorphic IC sites: **62** (2713 events)
+- react-grab polymorphic IC sites: **171** (342 events)
+
+## Top deopt reasons
+- `wrong map` — 25
+- `Insufficient type feedback for generic named access` — 15
+- `Insufficient type feedback for call` — 11
+- `dependent field type constness changed` — 11
+- `(unknown)` — 9
+- `dependent prototype chain changed` — 7
+- `wrong call target` — 4
+- `prepare for on stack replacement (OSR)` — 2
+- `Insufficient type feedback for compare operation` — 1
+- `Insufficient type feedback for construct` — 1
+- `unexpected name in keyed access` — 1
+- `wrong instance type` — 1
+- `wrong feedback cell` — 1
+- `Insufficient type feedback for generic keyed access` — 1
+
+## Top deopt scripts
+- `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js` — 31
+- `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js` — 21
+- `http://localhost:5175/node_modules/.vite/deps/react-dom_client.js?v=90bfcce4` — 14
+- `http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js` — 14
+- `http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js` — 6
+- `unknown` — 4
+
+## React-grab deopts
+- `deopt-eager` — `wrong call target`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1671:17
+- `deopt-lazy` — `(unknown)`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1671:23
+- `deopt-lazy` — `(unknown)`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1671:23
+- `deopt-eager` — `wrong call target`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:144:11
+- `deopt-eager` — `Insufficient type feedback for generic named access`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2036:10
+- `deopt-eager` — `wrong map`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:78:40
+- `deopt-eager` — `Insufficient type feedback for generic named access`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1303:22
+- `deopt-eager` — `Insufficient type feedback for call`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:148:22
+- `deopt-eager` — `Insufficient type feedback for generic named access`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:999:23
+- `deopt-eager` — `Insufficient type feedback for call`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:148:22
+- `deopt-eager` — `wrong map`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:228:97
+- `deopt-eager` — `wrong map`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:879:12
+- `deopt-eager` — `wrong map`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:96:22
+- `dependency-change` — `dependent field type constness changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:1188:9
+- `dependency-change` — `dependent field type constness changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:1721:10
+- `dependency-change` — `dependent field type constness changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2371:12
+- `dependency-change` — `dependent field type constness changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1909:6
+- `dependency-change` — `dependent field type constness changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1883:12
+- `dependency-change` — `dependent field type constness changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1801:14
+- `deopt-eager` — `unexpected name in keyed access`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:257:143
+- `deopt-eager` — `Insufficient type feedback for call`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1717:17
+- `deopt-eager` — `Insufficient type feedback for generic named access`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:281:33
+- `deopt-eager` — `Insufficient type feedback for generic named access`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:381:20
+- `deopt-eager` — `Insufficient type feedback for generic named access`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:381:20
+- `deopt-eager` — `wrong call target`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:220:26
+- `deopt-eager` — `Insufficient type feedback for generic named access`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:164:14
+- `deopt-eager` — `wrong instance type`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:75:31
+- `deopt-eager` — `Insufficient type feedback for call`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1308:11
+- `deopt-eager` — `Insufficient type feedback for generic named access`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:999:23
+- `deopt-eager` — `Insufficient type feedback for call`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1915:19
+- `deopt-eager` — `wrong call target`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:220:26
+- `deopt-eager` — `Insufficient type feedback for call`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1713:18
+- `deopt-eager` — `Insufficient type feedback for call`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1780:19
+- `deopt-eager` — `wrong map`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:382:11
+- `deopt-lazy` — `(unknown)`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:381:45
+- `deopt-lazy` — `(unknown)`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:381:3
+- `deopt-lazy` — `(unknown)`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:381:3
+- `deopt-lazy` — `(unknown)`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:381:45
+- `deopt-eager` — `Insufficient type feedback for call`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1772:12
+- `deopt-eager` — `Insufficient type feedback for call`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1761:15
+- `deopt-eager` — `wrong feedback cell`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:157:25
+- `dependency-change` — `dependent prototype chain changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:273:11
+- `deopt-lazy` — `(unknown)`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:288:39
+- `deopt-eager` — `wrong map`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:780:16
+- `dependency-change` — `dependent field type constness changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8
+- `dependency-change` — `dependent field type constness changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:76:10
+- `dependency-change` — `dependent field type constness changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:235:9
+- `deopt-eager` — `Insufficient type feedback for call`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1803:5
+- `deopt-eager` — `wrong map`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:39:25
+- `deopt-lazy` — `(unknown)`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:43:3
+- `deopt-lazy` — `(unknown)`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:39:60
+- `deopt-eager` — `wrong map`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:83:119
+- `deopt-eager` — `wrong map`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:78:40
+- `dependency-change` — `dependent prototype chain changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1701:160
+- `dependency-change` — `dependent prototype chain changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1793:14
+- `dependency-change` — `dependent prototype chain changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:984:11
+- `dependency-change` — `dependent prototype chain changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:866:9
+- `dependency-change` — `dependent prototype chain changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1783:13
+- `dependency-change` — `dependent prototype chain changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:15:11
+- `deopt-eager` — `wrong map`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:435:28
+- `deopt-eager` — `wrong map`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:716:78
+- `deopt-eager` — `wrong map`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:182:17
+- `deopt-eager` — `Insufficient type feedback for generic named access`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:127:8
+- `dependency-change` — `dependent field type constness changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:94:9
+- `deopt-eager` — `wrong map`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:110:17
+- `deopt-eager` — `Insufficient type feedback for generic keyed access`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:138:16
+- `deopt-eager` — `Insufficient type feedback for generic named access`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2450:13
+- `deopt-eager` — `wrong map`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:959:53
+- `deopt-eager` — `Insufficient type feedback for generic named access`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:688:419
+- `deopt-eager` — `wrong map`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:992:26
+- `deopt-eager` — `Insufficient type feedback for generic named access`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:688:419
+- `dependency-change` — `dependent field type constness changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:2276:16
+
+## React-grab megamorphic IC sites
+- **663× KeyedLoadIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11`
+  - key: `symbol("store-node" hash 3fb1f52b)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11
+- **629× KeyedLoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8`
+  - key: `map`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8
+- **629× KeyedLoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8`
+  - key: `constructor`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8
+- **349× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
+  - key: `symbol("store-node" hash 3fb1f52b)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
+- **120× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
+  - key: `constructor`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
+- **62× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
+  - key: `map`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
+- **57× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
+  - key: `slice`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
+- **56× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
+  - key: `symbol("solid-proxy" hash 13994585)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
+- **41× KeyedLoadIC** in `Ve http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12`
+  - key: `symbol("store-raw" hash 31565e56)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12
+- **15× KeyedLoadIC** in `Be http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:29:12`
+  - key: `symbol("solid-proxy" hash 13994585)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:29:12
+- **11× KeyedLoadIC** in `He http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:47:12`
+  - key: `symbol("store-node" hash 3fb1f52b)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:47:12
+- **9× KeyedLoadIC** in `Ve http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12`
+  - key: `symbol("solid-proxy" hash 13994585)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12
+- **5× LoadIC** in `qe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12`
+  - key: `length`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12
+- **5× KeyedLoadIC** in `qe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12`
+  - key: `symbol("store-has" hash 29b7a6a8)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12
+- **4× KeyedLoadIC** in `s http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:882:10`
+  - key: `$$pointermove`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:882:10
+- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:1052:32`
+  - key: `hasAttribute`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:1052:32
+- **3× KeyedLoadIC** in `He http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:47:12`
+  - key: `symbol("store-has" hash 29b7a6a8)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:47:12
+- **2× KeyedLoadIC** in `Ve http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12`
+  - key: `activationMode`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12
+- **2× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
+  - key: `enabled`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
+- **2× KeyedLoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8`
+  - key: `symbol("solid-proxy" hash 13994585)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8
+- **2× KeyedLoadIC** in `s http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:882:10`
+  - key: `$$keydown`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:882:10
+- **2× KeyedLoadIC** in `ze http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:785:12`
+  - key: `pt-1.5 pb-1`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:785:12
+- **2× KeyedLoadIC** in `get when http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:779:11`
+  - key: `constructor`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:779:11
+- **1× KeyedLoadIC** in `M http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:15:11`
+  - key: `detectedElement`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:15:11
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
+  - key: `frozenElements`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
+- **1× KeyedLoadIC** in `N http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:51:11`
+  - key: `theme`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:51:11
+- **1× KeyedStoreIC** in `N http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:51:11`
+  - key: `theme`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:51:11
+- **1× KeyedLoadIC** in `M http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:15:11`
+  - key: `symbol("solid-proxy" hash 13994585)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:15:11
+- **1× KeyedLoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:105:12`
+  - key: `freezeReactUpdates`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:105:12
+- **1× KeyedLoadIC** in `qe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12`
+  - key: `selectionBox`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12
+- **1× KeyedLoadIC** in `Xe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:123:12`
+  - key: `options`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:123:12
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:495:6`
+  - key: `ref`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:495:6
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:495:6`
+  - key: `aria-label`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:495:6
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:495:6`
+  - key: `aria-expanded`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:495:6
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:495:6`
+  - key: `class`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:495:6
+- **1× KeyedStoreIC** in `Re http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:778:12`
+  - key: `$$pointerup`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:778:12
+- **1× KeyedStoreIC** in `Re http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:778:12`
+  - key: `$$click`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:778:12
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
+  - key: `shortcut`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
+- **1× KeyedLoadIC** in `qe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12`
+  - key: `wasActivatedByToggle`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12
+- **1× KeyedStoreIC** in `qe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12`
+  - key: `wasActivatedByToggle`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12
+- **1× KeyedLoadIC** in `N http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:51:11`
+  - key: `wasActivatedByToggle`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:51:11
+- **1× KeyedLoadIC** in `A http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:111:9`
+  - key: `selection`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:111:9
+- **1× KeyedLoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8`
+  - key: `symbol("store-node" hash 3fb1f52b)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8
+- **1× KeyedLoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8`
+  - key: `includes`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8
+- **1× KeyedLoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:249:8`
+  - key: `__reactFiber$xe2x9cf90d`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:249:8
+- **1× KeyedLoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8`
+  - key: `symbol("Symbol.iterator" hash 258a5929)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
+  - key: `includes`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
+  - key: `every`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
+- **1× LoadIC** in `s http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:882:10`
+  - key: `host`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:882:10
+- **1× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12`
+  - key: `_$host`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12
+- **1× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12`
+  - key: `parentNode`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:157:5`
+  - key: `frozenElements`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:157:5
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:157:5`
+  - key: `indexOf`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:157:5
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:157:5`
+  - key: `push`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:157:5
+- **1× KeyedLoadIC** in `ze http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:785:12`
+  - key: `py-1.5`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:785:12
+- **1× KeyedLoadIC** in `get when http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:779:11`
+  - key: `symbol("solid-proxy" hash 13994585)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:779:11
+- **1× KeyedLoadIC** in `get when http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:779:11`
+  - key: `slice`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:779:11
+- **1× KeyedLoadIC** in `get when http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:779:11`
+  - key: `map`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:779:11
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
+  - key: `findIndex`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
+- **1× LoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
+  - key: `hasOwnProperty`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
+  - key: `symbol("Symbol.iterator" hash 258a5929)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
+  - key: `errorMessage`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
+
+## React-grab polymorphic IC sites
+- **5× LoadIC** in `x http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:53:11`
+  - key: `equals`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:53:11
+- **5× LoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
+  - key: `hasOwnProperty`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
+- **4× LoadIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11`
+  - key: `observers`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11
+- **4× LoadIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11`
+  - key: `sourceSlots`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11
+- **4× LoadIC** in `Ve http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12`
+  - key: `length`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12
+- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1373:14`
+  - key: `state`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1373:14
+- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1376:14`
+  - key: `state`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1376:14
+- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1382:57`
+  - key: `state`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1382:57
+- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1363:13`
+  - key: `state`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1363:13
+- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1379:109`
+  - key: `state`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1379:109
+- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1366:13`
+  - key: `state`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1366:13
+- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1363:89`
+  - key: `state`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1363:89
+- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1363:51`
+  - key: `state`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1363:51
+- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1379:13`
+  - key: `state`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1379:13
+- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1379:150`
+  - key: `state`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1379:150
+- **4× KeyedLoadIC** in `M http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1005:169`
+  - key: `0`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1005:169
+- **3× KeyedLoadIC** in `Be http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:29:12`
+  - key: `symbol("solid-proxy" hash 13994585)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:29:12
+- **3× KeyedLoadIC** in `Ve http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12`
+  - key: `symbol("store-raw" hash 31565e56)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12
+- **3× LoadIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11`
+  - key: `sources`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11
+- **3× KeyedLoadIC** in `M http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:15:11`
+  - key: `symbol("solid-proxy" hash 13994585)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:15:11
+- **3× KeyedLoadIC** in `He http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:47:12`
+  - key: `symbol("store-node" hash 3fb1f52b)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:47:12
+- **3× LoadIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11`
+  - key: `sources`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11
+- **3× LoadIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11`
+  - key: `tOwned`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11
+- **3× LoadIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11`
+  - key: `owned`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11
+- **3× LoadIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11`
+  - key: `cleanups`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11
+- **3× StoreIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11`
+  - key: `state`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11
+- **3× LoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:273:11`
+  - key: `state`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:273:11
+- **3× LoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:273:11`
+  - key: `owner`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:273:11
+- **3× LoadIC** in `Ne.o http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:756:65`
+  - key: `cloneNode`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:756:65
+- **3× LoadIC** in `gi http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1439:9`
+  - key: `length`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1439:9
+- **3× LoadIC** in `qe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12`
+  - key: `length`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12
+- **3× KeyedLoadIC** in `qe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12`
+  - key: `symbol("store-has" hash 29b7a6a8)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12
+- **3× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:225:42`
+  - key: `observers`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:225:42
+- **3× LoadIC** in `z http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:348:11`
+  - key: `sources`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:348:11
+- **3× LoadIC** in `ki http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1517:9`
+  - key: `style`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1517:9
+- **3× LoadIC** in `Ai http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1524:9`
+  - key: `style`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1524:9
+- **3× KeyedLoadIC** in `s http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:882:10`
+  - key: `$$pointermove`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:882:10
+- **3× LoadIC** in `s http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:882:10`
+  - key: `host`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:882:10
+- **3× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:1052:32`
+  - key: `hasAttribute`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:1052:32
+- **3× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12`
+  - key: `_$host`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12
+- **3× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12`
+  - key: `parentNode`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12
+- **3× LoadIC** in `Pi http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1546:9`
+  - key: `style`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1546:9
+- **3× LoadIC** in `Ni http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1544:9`
+  - key: `style`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1544:9
+- **3× LoadIC** in `Q http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:984:11`
+  - key: `insertBefore`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:984:11
+- **3× LoadIC** in `M http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1005:169`
+  - key: `length`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1005:169
+- **3× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1444:9`
+  - key: `state`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1444:9
+- **3× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1451:9`
+  - key: `state`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1451:9
+- **2× LoadIC** in `w http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:74:11`
+  - key: `equals`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:74:11
+- **2× LoadIC** in `F http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:235:11`
+  - key: `fn`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:235:11
+- **2× LoadIC** in `F http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:235:11`
+  - key: `value`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:235:11
+- **2× LoadIC** in `oe http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:245:12`
+  - key: `fn`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:245:12
+- **2× StoreIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11`
+  - key: `sources`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11
+- **2× StoreIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11`
+  - key: `sourceSlots`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11
+- **2× LoadIC** in `oe http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:245:12`
+  - key: `updatedAt`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:245:12
+- **2× StoreIC** in `oe http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:245:12`
+  - key: `value`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:245:12
+- **2× StoreIC** in `oe http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:245:12`
+  - key: `updatedAt`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:245:12
+- **2× LoadIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11`
+  - key: `sourceSlots`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11
+- **2× LoadIC** in `f http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:953:41`
+  - key: `hooks`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:953:41
+- **2× LoadIC** in `I http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:257:11`
+  - key: `context`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:257:11
+- **2× LoadIC** in `I http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:257:11`
+  - key: `owned`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:257:11
+- **2× StoreIC** in `I http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:257:11`
+  - key: `owned`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:257:11
+- **2× LoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:157:5`
+  - key: `setAttribute`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:157:5
+- **2× LoadIC** in `Re http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:778:12`
+  - key: `addEventListener`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:778:12
+- **2× LoadIC** in `Yn http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1694:12`
+  - key: `nodeType`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1694:12
+- **2× KeyedLoadIC** in `gi http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1439:9`
+  - key: `0`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1439:9
+- **2× LoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:273:11`
+  - key: `updatedAt`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:273:11
+- **2× LoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:273:11`
+  - key: `suspense`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:273:11
+- **2× LoadIC** in `ue http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:359:12`
+  - key: `state`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:359:12
+- **2× StoreIC** in `ue http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:359:12`
+  - key: `state`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:359:12
+- **2× LoadIC** in `ue http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:359:12`
+  - key: `pure`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:359:12
+- **2× LoadIC** in `ue http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:359:12`
+  - key: `observers`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:359:12
+- **2× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:225:42`
+  - key: `state`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:225:42
+- **2× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:225:42`
+  - key: `pure`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:225:42
+- **2× StoreIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:225:42`
+  - key: `state`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:225:42
+- **2× KeyedLoadIC** in `oe http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:245:12`
+  - key: `observers`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:245:12
+- **2× StoreIC** in `z http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:348:11`
+  - key: `state`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:348:11
+- **2× KeyedLoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:249:8`
+  - key: `_reactRootContainer`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:249:8
+- **2× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12`
+  - key: `composedPath`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12
+- **2× LoadIC** in `Q.addWindowListener.passive http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96`
+  - key: `composedPath`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96
+- **2× LoadIC** in `at http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:1050:9`
+  - key: `composedPath`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:1050:9
+- **2× LoadIC** in `O http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:182:11`
+  - key: `cleanups`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:182:11
+- **2× StoreIC** in `O http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:182:11`
+  - key: `cleanups`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:182:11
+- **2× LoadIC** in `ft http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:274:569`
+  - key: `split`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:274:569
+- **2× LoadIC** in `an http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:727:9`
+  - key: `startsWith`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:727:9
+- **2× LoadIC** in `Q http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:984:11`
+  - key: `length`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:984:11
+- **2× LoadIC** in `nr http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:999:48`
+  - key: `startsWith`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:999:48
+- **2× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:434:24`
+  - key: `length`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:434:24
+- **2× KeyedLoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:434:24`
+  - key: `symbol("solid-track" hash 1ffdf389)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:434:24
+- **2× StoreIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11`
+  - key: `owned`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11
+- **2× StoreIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11`
+  - key: `cleanups`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11
+- **2× KeyedLoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:436:18`
+  - key: `0`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:436:18
+- **2× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:436:18`
+  - key: `length`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:436:18
+- **2× KeyedStoreIC** in `f http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:442:13`
+  - key: `0`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:442:13
+- **2× KeyedLoadIC** in `has http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:82:5`
+  - key: `0`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:82:5
+- **2× LoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9`
+  - key: `x`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9
+- **2× LoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9`
+  - key: `y`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9
+- **2× LoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9`
+  - key: `width`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9
+- **2× LoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9`
+  - key: `height`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9
+- **2× LoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9`
+  - key: `borderRadius`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9
+- **2× LoadIC** in `x http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:76:10`
+  - key: `x`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:76:10
+- **2× LoadIC** in `x http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:76:10`
+  - key: `y`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:76:10
+- **2× LoadIC** in `x http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:76:10`
+  - key: `width`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:76:10
+- **2× LoadIC** in `x http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:76:10`
+  - key: `height`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:76:10
+- **2× LoadIC** in `x http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:76:10`
+  - key: `borderRadius`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:76:10
+- **2× LoadIC** in `onElementSelect http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:988:20`
+  - key: `hooks`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:988:20
+- **2× LoadIC** in `Q http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:984:11`
+  - key: `replaceChild`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:984:11
+- **1× StoreIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11`
+  - key: `observers`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11
+- **1× StoreIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11`
+  - key: `observerSlots`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11
+- **1× LoadIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11`
+  - key: `value`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11
+- **1× LoadIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11`
+  - key: `observerSlots`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11
+- **1× StoreIC** in `addWindowListener http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:656:22`
+  - key: `signal`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:656:22
+- **1× LoadIC** in `a http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:913:10`
+  - key: `theme`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:913:10
+- **1× LoadIC** in `a http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:913:10`
+  - key: `options`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:913:10
+- **1× LoadIC** in `a http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:913:10`
+  - key: `actions`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:913:10
+- **1× LoadIC** in `C http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:69:11`
+  - key: `push`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:69:11
+- **1× LoadIC** in `gi http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1439:9`
+  - key: `nodeType`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1439:9
+- **1× LoadIC** in `le http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:333:12`
+  - key: `user`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:333:12
+- **1× LoadIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11`
+  - key: `observers`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11
+- **1× LoadIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11`
+  - key: `observerSlots`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11
+- **1× LoadIC** in `ae http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:218:12`
+  - key: `value`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:218:12
+- **1× LoadIC** in `ae http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:218:12`
+  - key: `comparator`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:218:12
+- **1× StoreIC** in `ae http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:218:12`
+  - key: `value`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:218:12
+- **1× LoadIC** in `ae http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:218:12`
+  - key: `observers`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:218:12
+- **1× LoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:249:8`
+  - key: `startsWith`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:249:8
+- **1× LoadIC** in `Ni http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1544:9`
+  - key: `symbol("Symbol.iterator" hash 258a5929)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1544:9
+- **1× LoadIC** in `la http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1730:9`
+  - key: `symbol("Symbol.iterator" hash 258a5929)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1730:9
+- **1× LoadIC** in `Fi http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1552:9`
+  - key: `push`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1552:9
+- **1× LoadIC** in `N http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:132:9`
+  - key: `now`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:132:9
+- **1× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12`
+  - key: `target`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12
+- **1× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12`
+  - key: `type`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12
+- **1× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12`
+  - key: `currentTarget`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12
+- **1× LoadIC** in `Ve http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:807:12`
+  - key: `style`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:807:12
+- **1× LoadIC** in `Xe http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:999:12`
+  - key: `isConnected`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:999:12
+- **1× LoadIC** in `Jt http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:663:9`
+  - key: `slice`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:663:9
+- **1× LoadIC** in `Di http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1513:41`
+  - key: `stopImmediatePropagation`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1513:41
+- **1× LoadIC** in `Q.addWindowListener.passive http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96`
+  - key: `isPrimary`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96
+- **1× LoadIC** in `Q.addWindowListener.passive http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96`
+  - key: `pointerType`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96
+- **1× LoadIC** in `Q.addWindowListener.passive http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96`
+  - key: `shiftKey`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96
+- **1× LoadIC** in `Q.addWindowListener.passive http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96`
+  - key: `clientX`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96
+- **1× LoadIC** in `Q.addWindowListener.passive http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96`
+  - key: `clientY`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96
+- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:705:15`
+  - key: `push`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:705:15
+- **1× KeyedLoadIC** in `ft http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:274:569`
+  - key: `0`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:274:569
+- **1× LoadIC** in `v http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:224:8`
+  - key: `displayName`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:224:8
+- **1× LoadIC** in `v http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:224:8`
+  - key: `name`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:224:8
+- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:715:18`
+  - key: `source`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:715:18
+- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:715:18`
+  - key: `includes`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:715:18
+- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:715:134`
+  - key: `functionName`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:715:134
+- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1119:19`
+  - key: `fileName`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1119:19
+- **1× LoadIC** in `tn http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:720:9`
+  - key: `split`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:720:9
+- **1× LoadIC** in `Gt http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:540:12`
+  - key: `includes`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:540:12
+- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:696:31`
+  - key: `getBoundingClientRect`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:696:31
+- **1× LoadIC** in `yn http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:2041:127`
+  - key: `match`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:2041:127
+- **1× KeyedStoreIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:436:18`
+  - key: `0`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:436:18
+- **1× LoadIC** in `Ae http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:709:12`
+  - key: `nextSibling`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:709:12
+- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:164:55`
+  - key: `find`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:164:55
+- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1793:14`
+  - key: `push`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1793:14
+- **1× StoreIC** in `It http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:778:10`
+  - key: `borderRadius`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:778:10
+- **1× StoreIC** in `It http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:778:10`
+  - key: `transform`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:778:10
+- **1× LoadIC** in `Mt.g.e http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:1157:30`
+  - key: `width`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:1157:30
+- **1× LoadIC** in `Mt.g.e http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:1157:30`
+  - key: `height`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:1157:30
+- **1× LoadIC** in `Mt.g.e http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:1157:30`
+  - key: `x`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:1157:30
+- **1× LoadIC** in `Mt.g.e http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:1157:30`
+  - key: `y`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:1157:30
+- **1× LoadIC** in `M http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1005:169`
+  - key: `endsWith`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1005:169
+- **1× KeyedLoadIC** in `Ve http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12`
+  - key: `0`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12
+- **1× LoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9`
+  - key: `opacity`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9
+- **1× LoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9`
+  - key: `targetOpacity`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9
+- **1× LoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9`
+  - key: `createdAt`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9
+- **1× LoadIC** in `N http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:132:9`
+  - key: `symbol("Symbol.iterator" hash 258a5929)`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:132:9
+- **1× KeyedLoadIC** in `Xe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:123:12`
+  - key: `0`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:123:12
+- **1× LoadIC** in `Q http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:984:11`
+  - key: `parentNode`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:984:11
+- **1× LoadIC** in `_i http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1446:9`
+  - key: `length`  reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1446:9
+
+## IC state transitions (totals)
+- `no_feedback->no_feedback` — 9132
+- `megamorphic->megamorphic` — 7699
+- `uninitialized->monomorphic` — 2430
+- `monomorphic->polymorphic` — 244
+- `polymorphic->polymorphic` — 208
+- `recompute_handler->monomorphic` — 42
+- `monomorphic->megamorphic` — 41
+- `monomorphic->monomorphic` — 38
+- `polymorphic->megamorphic` — 24
+- `recompute_handler->polymorphic` — 9
+- `polymorphic->monomorphic` — 9
+
+## IC volume by script
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8 — 1280
+- http://localhost:5175/src/perf-grid.tsx:5:18 — 1074
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11 — 713
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5 — 674
+- http://localhost:5175/node_modules/.vite/deps/react-dom_client.js?v=90bfcce4:3532:21 — 494
+- http://localhost:5175/node_modules/.vite/deps/react-dom_client.js?v=90bfcce4:262:11 — 446
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:540:12 — 187
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9 — 171
+- http://localhost:5175/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=90bfcce4:103:24 — 157
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1860:9 — 138
+- http://localhost:5175/src/perf-grid.tsx:33:17 — 134
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:249:8 — 130
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2962:14 — 121
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:663:9 — 118
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:311:41 — 117
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1298:9 — 109
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12 — 108
+- http://localhost:5175/node_modules/.vite/deps/react-dom_client.js?v=90bfcce4:6275:24 — 103
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:695:4 — 101
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:706:8 — 96

--- a/packages/react-grab/perf/v8-log/summary.md
+++ b/packages/react-grab/perf/v8-log/summary.md
@@ -2,19 +2,20 @@
 
 Generated from a dexnode-equivalent --js-flags Chromium run. See manifest.json for flags.
 
-- total deopts: **90**
-- total IC events: **19876**
-- JS code blobs: **2748**
-- react-grab-source deopts: **72**
-- react-grab megamorphic IC sites: **62** (2713 events)
-- react-grab polymorphic IC sites: **171** (342 events)
+- total deopts: **92**
+- total IC events: **19690**
+- JS code blobs: **2741**
+- react-grab-source deopts: **71**
+- react-grab megamorphic IC sites: **54** (4660 events)
+- react-grab polymorphic IC sites: **147** (297 events)
 
 ## Top deopt reasons
+
 - `wrong map` — 25
 - `Insufficient type feedback for generic named access` — 15
-- `Insufficient type feedback for call` — 11
-- `dependent field type constness changed` — 11
-- `(unknown)` — 9
+- `Insufficient type feedback for call` — 12
+- `(unknown)` — 11
+- `dependent field type constness changed` — 10
 - `dependent prototype chain changed` — 7
 - `wrong call target` — 4
 - `prepare for on stack replacement (OSR)` — 2
@@ -26,893 +27,801 @@ Generated from a dexnode-equivalent --js-flags Chromium run. See manifest.json f
 - `Insufficient type feedback for generic keyed access` — 1
 
 ## Top deopt scripts
-- `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js` — 31
-- `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js` — 21
-- `http://localhost:5175/node_modules/.vite/deps/react-dom_client.js?v=90bfcce4` — 14
-- `http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js` — 14
-- `http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js` — 6
+
+- `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705` — 31
+- `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705` — 21
+- `http://localhost:5175/node_modules/.vite/deps/react-dom_client.js?v=90bfcce4` — 17
+- `http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705` — 13
+- `http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701` — 6
 - `unknown` — 4
 
 ## React-grab deopts
+
 - `deopt-eager` — `wrong call target`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1671:17
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1673:17
 - `deopt-lazy` — `(unknown)`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1671:23
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1673:23
 - `deopt-lazy` — `(unknown)`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1671:23
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1673:23
 - `deopt-eager` — `wrong call target`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:144:11
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:144:11
 - `deopt-eager` — `Insufficient type feedback for generic named access`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2036:10
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:2036:10
 - `deopt-eager` — `wrong map`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:78:40
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:78:40
 - `deopt-eager` — `Insufficient type feedback for generic named access`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1303:22
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1313:22
 - `deopt-eager` — `Insufficient type feedback for call`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:148:22
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:148:22
 - `deopt-eager` — `Insufficient type feedback for generic named access`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:999:23
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:999:23
 - `deopt-eager` — `Insufficient type feedback for call`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:148:22
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:148:22
 - `deopt-eager` — `wrong map`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:228:97
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:228:97
 - `deopt-eager` — `wrong map`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:879:12
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:879:12
 - `deopt-eager` — `wrong map`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:96:22
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:96:22
 - `dependency-change` — `dependent field type constness changed`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:1188:9
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:1183:9
 - `dependency-change` — `dependent field type constness changed`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:1721:10
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:1716:10
 - `dependency-change` — `dependent field type constness changed`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2371:12
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:2371:12
 - `dependency-change` — `dependent field type constness changed`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1909:6
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1909:6
 - `dependency-change` — `dependent field type constness changed`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1883:12
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1883:12
 - `dependency-change` — `dependent field type constness changed`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1801:14
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1801:14
 - `deopt-eager` — `unexpected name in keyed access`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:257:143
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:257:143
 - `deopt-eager` — `Insufficient type feedback for call`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1717:17
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1717:17
 - `deopt-eager` — `Insufficient type feedback for generic named access`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:281:33
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:281:33
 - `deopt-eager` — `Insufficient type feedback for generic named access`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:381:20
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:381:20
 - `deopt-eager` — `Insufficient type feedback for generic named access`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:381:20
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:381:20
 - `deopt-eager` — `wrong call target`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:220:26
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:220:26
 - `deopt-eager` — `Insufficient type feedback for generic named access`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:164:14
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:164:14
 - `deopt-eager` — `wrong instance type`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:75:31
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:75:31
 - `deopt-eager` — `Insufficient type feedback for call`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1308:11
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1318:11
 - `deopt-eager` — `Insufficient type feedback for generic named access`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:999:23
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:999:23
 - `deopt-eager` — `Insufficient type feedback for call`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1915:19
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1915:19
 - `deopt-eager` — `wrong call target`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:220:26
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:220:26
 - `deopt-eager` — `Insufficient type feedback for call`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1713:18
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1713:18
 - `deopt-eager` — `Insufficient type feedback for call`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1780:19
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1780:19
 - `deopt-eager` — `wrong map`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:382:11
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:382:11
 - `deopt-lazy` — `(unknown)`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:381:45
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:381:45
 - `deopt-lazy` — `(unknown)`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:381:3
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:381:3
 - `deopt-lazy` — `(unknown)`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:381:3
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:381:3
 - `deopt-lazy` — `(unknown)`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:381:45
-- `deopt-eager` — `Insufficient type feedback for call`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1772:12
-- `deopt-eager` — `Insufficient type feedback for call`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1761:15
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:381:45
 - `deopt-eager` — `wrong feedback cell`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:157:25
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:157:25
 - `dependency-change` — `dependent prototype chain changed`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:273:11
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:273:11
 - `deopt-lazy` — `(unknown)`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:288:39
-- `deopt-eager` — `wrong map`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:780:16
-- `dependency-change` — `dependent field type constness changed`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8
-- `dependency-change` — `dependent field type constness changed`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:76:10
-- `dependency-change` — `dependent field type constness changed`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:235:9
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:288:39
 - `deopt-eager` — `Insufficient type feedback for call`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1803:5
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1772:12
+- `deopt-eager` — `Insufficient type feedback for call`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1761:15
 - `deopt-eager` — `wrong map`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:39:25
-- `deopt-lazy` — `(unknown)`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:43:3
-- `deopt-lazy` — `(unknown)`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:39:60
-- `deopt-eager` — `wrong map`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:83:119
-- `deopt-eager` — `wrong map`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:78:40
-- `dependency-change` — `dependent prototype chain changed`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1701:160
-- `dependency-change` — `dependent prototype chain changed`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1793:14
-- `dependency-change` — `dependent prototype chain changed`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:984:11
-- `dependency-change` — `dependent prototype chain changed`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:866:9
-- `dependency-change` — `dependent prototype chain changed`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1783:13
-- `dependency-change` — `dependent prototype chain changed`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:15:11
-- `deopt-eager` — `wrong map`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:435:28
-- `deopt-eager` — `wrong map`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:716:78
-- `deopt-eager` — `wrong map`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:182:17
-- `deopt-eager` — `Insufficient type feedback for generic named access`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:127:8
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:780:16
 - `dependency-change` — `dependent field type constness changed`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:94:9
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:259:8
+- `dependency-change` — `dependent field type constness changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:235:9
+- `dependency-change` — `dependent field type constness changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:76:10
+- `deopt-eager` — `Insufficient type feedback for call`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1803:5
 - `deopt-eager` — `wrong map`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:110:17
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:39:25
+- `deopt-lazy` — `(unknown)`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:43:3
+- `deopt-lazy` — `(unknown)`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:39:60
+- `deopt-eager` — `wrong map`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:83:119
+- `deopt-eager` — `wrong map`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:78:40
+- `dependency-change` — `dependent prototype chain changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1701:160
+- `dependency-change` — `dependent prototype chain changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1793:14
+- `dependency-change` — `dependent prototype chain changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:984:11
+- `dependency-change` — `dependent prototype chain changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:866:9
+- `dependency-change` — `dependent prototype chain changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1783:13
+- `dependency-change` — `dependent prototype chain changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:15:11
+- `deopt-eager` — `wrong map`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:435:28
+- `deopt-eager` — `wrong map`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:716:78
+- `deopt-eager` — `wrong map`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:182:17
+- `deopt-eager` — `Insufficient type feedback for generic named access`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:127:8
+- `dependency-change` — `dependent field type constness changed`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:94:9
+- `deopt-eager` — `wrong map`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:110:17
 - `deopt-eager` — `Insufficient type feedback for generic keyed access`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:138:16
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:138:16
 - `deopt-eager` — `Insufficient type feedback for generic named access`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2450:13
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:2450:13
 - `deopt-eager` — `wrong map`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:959:53
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:959:53
 - `deopt-eager` — `Insufficient type feedback for generic named access`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:688:419
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:688:418
 - `deopt-eager` — `wrong map`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:992:26
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:992:26
 - `deopt-eager` — `Insufficient type feedback for generic named access`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:688:419
-- `dependency-change` — `dependent field type constness changed`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:2276:16
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:688:418
 
 ## React-grab megamorphic IC sites
-- **663× KeyedLoadIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11`
-  - key: `symbol("store-node" hash 3fb1f52b)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11
-- **629× KeyedLoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8`
-  - key: `map`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8
-- **629× KeyedLoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8`
-  - key: `constructor`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8
-- **349× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
-  - key: `symbol("store-node" hash 3fb1f52b)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
-- **120× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
-  - key: `constructor`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
-- **62× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
-  - key: `map`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
-- **57× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
-  - key: `slice`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
-- **56× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
-  - key: `symbol("solid-proxy" hash 13994585)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
-- **41× KeyedLoadIC** in `Ve http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12`
-  - key: `symbol("store-raw" hash 31565e56)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12
-- **15× KeyedLoadIC** in `Be http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:29:12`
-  - key: `symbol("solid-proxy" hash 13994585)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:29:12
-- **11× KeyedLoadIC** in `He http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:47:12`
-  - key: `symbol("store-node" hash 3fb1f52b)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:47:12
-- **9× KeyedLoadIC** in `Ve http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12`
-  - key: `symbol("solid-proxy" hash 13994585)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12
-- **5× LoadIC** in `qe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12`
-  - key: `length`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12
-- **5× KeyedLoadIC** in `qe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12`
-  - key: `symbol("store-has" hash 29b7a6a8)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12
-- **4× KeyedLoadIC** in `s http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:882:10`
-  - key: `$$pointermove`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:882:10
-- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:1052:32`
-  - key: `hasAttribute`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:1052:32
-- **3× KeyedLoadIC** in `He http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:47:12`
-  - key: `symbol("store-has" hash 29b7a6a8)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:47:12
-- **2× KeyedLoadIC** in `Ve http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12`
-  - key: `activationMode`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12
-- **2× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
-  - key: `enabled`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
-- **2× KeyedLoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8`
-  - key: `symbol("solid-proxy" hash 13994585)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8
-- **2× KeyedLoadIC** in `s http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:882:10`
-  - key: `$$keydown`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:882:10
-- **2× KeyedLoadIC** in `ze http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:785:12`
-  - key: `pt-1.5 pb-1`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:785:12
-- **2× KeyedLoadIC** in `get when http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:779:11`
-  - key: `constructor`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:779:11
-- **1× KeyedLoadIC** in `M http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:15:11`
-  - key: `detectedElement`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:15:11
-- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
-  - key: `frozenElements`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
-- **1× KeyedLoadIC** in `N http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:51:11`
-  - key: `theme`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:51:11
-- **1× KeyedStoreIC** in `N http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:51:11`
-  - key: `theme`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:51:11
-- **1× KeyedLoadIC** in `M http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:15:11`
-  - key: `symbol("solid-proxy" hash 13994585)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:15:11
-- **1× KeyedLoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:105:12`
-  - key: `freezeReactUpdates`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:105:12
-- **1× KeyedLoadIC** in `qe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12`
-  - key: `selectionBox`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12
-- **1× KeyedLoadIC** in `Xe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:123:12`
-  - key: `options`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:123:12
-- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:495:6`
-  - key: `ref`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:495:6
-- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:495:6`
-  - key: `aria-label`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:495:6
-- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:495:6`
-  - key: `aria-expanded`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:495:6
-- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:495:6`
-  - key: `class`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:495:6
-- **1× KeyedStoreIC** in `Re http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:778:12`
-  - key: `$$pointerup`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:778:12
-- **1× KeyedStoreIC** in `Re http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:778:12`
-  - key: `$$click`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:778:12
-- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
-  - key: `shortcut`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
-- **1× KeyedLoadIC** in `qe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12`
-  - key: `wasActivatedByToggle`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12
-- **1× KeyedStoreIC** in `qe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12`
-  - key: `wasActivatedByToggle`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12
-- **1× KeyedLoadIC** in `N http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:51:11`
-  - key: `wasActivatedByToggle`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:51:11
-- **1× KeyedLoadIC** in `A http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:111:9`
-  - key: `selection`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:111:9
-- **1× KeyedLoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8`
-  - key: `symbol("store-node" hash 3fb1f52b)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8
-- **1× KeyedLoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8`
-  - key: `includes`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8
-- **1× KeyedLoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:249:8`
-  - key: `__reactFiber$xe2x9cf90d`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:249:8
-- **1× KeyedLoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8`
-  - key: `symbol("Symbol.iterator" hash 258a5929)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8
-- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
-  - key: `includes`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
-- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
-  - key: `every`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
-- **1× LoadIC** in `s http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:882:10`
-  - key: `host`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:882:10
-- **1× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12`
-  - key: `_$host`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12
-- **1× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12`
-  - key: `parentNode`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12
-- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:157:5`
-  - key: `frozenElements`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:157:5
-- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:157:5`
-  - key: `indexOf`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:157:5
-- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:157:5`
-  - key: `push`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:157:5
-- **1× KeyedLoadIC** in `ze http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:785:12`
-  - key: `py-1.5`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:785:12
-- **1× KeyedLoadIC** in `get when http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:779:11`
-  - key: `symbol("solid-proxy" hash 13994585)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:779:11
-- **1× KeyedLoadIC** in `get when http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:779:11`
-  - key: `slice`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:779:11
-- **1× KeyedLoadIC** in `get when http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:779:11`
-  - key: `map`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:779:11
-- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
-  - key: `findIndex`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
-- **1× LoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
-  - key: `hasOwnProperty`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
-- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
-  - key: `symbol("Symbol.iterator" hash 258a5929)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
-- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
-  - key: `errorMessage`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
+
+- **1412× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5`
+  - key: `constructor` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5
+- **711× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5`
+  - key: `map` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5
+- **702× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5`
+  - key: `slice` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5
+- **702× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5`
+  - key: `symbol("solid-proxy" hash 2b6fb2ce)` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5
+- **650× KeyedLoadIC** in `We http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:63:12`
+  - key: `symbol("store-node" hash 29233ba4)` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:63:12
+- **341× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5`
+  - key: `symbol("store-node" hash 29233ba4)` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5
+- **44× KeyedLoadIC** in `Ve http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:33:12`
+  - key: `symbol("store-raw" hash 246e9213)` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:33:12
+- **12× KeyedLoadIC** in `He http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:47:12`
+  - key: `symbol("store-node" hash 29233ba4)` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:47:12
+- **11× KeyedLoadIC** in `Be http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:29:12`
+  - key: `symbol("solid-proxy" hash 2b6fb2ce)` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:29:12
+- **8× KeyedLoadIC** in `Ve http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:33:12`
+  - key: `symbol("solid-proxy" hash 2b6fb2ce)` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:33:12
+- **6× LoadIC** in `qe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:94:12`
+  - key: `length` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:94:12
+- **6× KeyedLoadIC** in `qe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:94:12`
+  - key: `symbol("store-has" hash 6cb6121)` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:94:12
+- **4× KeyedLoadIC** in `s http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:882:10`
+  - key: `$$pointermove` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:882:10
+- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:1052:32`
+  - key: `hasAttribute` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:1052:32
+- **3× KeyedLoadIC** in `He http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:47:12`
+  - key: `symbol("store-has" hash 6cb6121)` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:47:12
+- **2× KeyedLoadIC** in `Ve http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:33:12`
+  - key: `activationMode` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:33:12
+- **2× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5`
+  - key: `enabled` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5
+- **2× KeyedLoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1674:24`
+  - key: `symbol("solid-proxy" hash 2b6fb2ce)` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1674:24
+- **2× KeyedLoadIC** in `s http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:882:10`
+  - key: `$$keydown` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:882:10
+- **2× KeyedLoadIC** in `ze http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:785:12`
+  - key: `pt-1.5 pb-1` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:785:12
+- **1× KeyedLoadIC** in `M http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:15:11`
+  - key: `detectedElement` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:15:11
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5`
+  - key: `frozenElements` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5
+- **1× KeyedLoadIC** in `N http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:51:11`
+  - key: `theme` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:51:11
+- **1× KeyedStoreIC** in `N http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:51:11`
+  - key: `theme` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:51:11
+- **1× KeyedLoadIC** in `M http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:15:11`
+  - key: `symbol("solid-proxy" hash 2b6fb2ce)` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:15:11
+- **1× KeyedLoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:105:12`
+  - key: `freezeReactUpdates` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:105:12
+- **1× KeyedLoadIC** in `qe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:94:12`
+  - key: `selectionBox` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:94:12
+- **1× KeyedLoadIC** in `Xe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:123:12`
+  - key: `options` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:123:12
+- **1× KeyedLoadIC** in `get children http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:782:15`
+  - key: `ref` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:782:15
+- **1× KeyedLoadIC** in `get children http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:782:15`
+  - key: `aria-label` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:782:15
+- **1× KeyedLoadIC** in `get children http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:782:15`
+  - key: `aria-expanded` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:782:15
+- **1× KeyedLoadIC** in `get children http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:782:15`
+  - key: `class` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:782:15
+- **1× KeyedStoreIC** in `Ct http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:669:146`
+  - key: `$$pointerup` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:669:146
+- **1× KeyedStoreIC** in `Ct http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:669:146`
+  - key: `$$click` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:669:146
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5`
+  - key: `shortcut` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5
+- **1× KeyedStoreIC** in `Qe http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:512:12`
+  - key: `arg` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:512:12
+- **1× KeyedLoadIC** in `qe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:94:12`
+  - key: `wasActivatedByToggle` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:94:12
+- **1× KeyedStoreIC** in `qe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:94:12`
+  - key: `wasActivatedByToggle` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:94:12
+- **1× KeyedLoadIC** in `N http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:51:11`
+  - key: `wasActivatedByToggle` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:51:11
+- **1× KeyedLoadIC** in `A http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:111:9`
+  - key: `selection` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:111:9
+- **1× KeyedLoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:249:8`
+  - key: `__reactFiber$tx7cpsym50a` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:249:8
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5`
+  - key: `includes` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5`
+  - key: `every` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5
+- **1× LoadIC** in `s http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:882:10`
+  - key: `host` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:882:10
+- **1× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:877:12`
+  - key: `_$host` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:877:12
+- **1× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:877:12`
+  - key: `parentNode` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:877:12
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:157:5`
+  - key: `frozenElements` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:157:5
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:157:5`
+  - key: `indexOf` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:157:5
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:157:5`
+  - key: `push` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:157:5
+- **1× KeyedLoadIC** in `ze http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:785:12`
+  - key: `py-1.5` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:785:12
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5`
+  - key: `filter` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5`
+  - key: `findIndex` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5
+- **1× LoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5`
+  - key: `hasOwnProperty` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5`
+  - key: `symbol("Symbol.iterator" hash 258a5929)` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5
 
 ## React-grab polymorphic IC sites
-- **5× LoadIC** in `x http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:53:11`
-  - key: `equals`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:53:11
-- **5× LoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5`
-  - key: `hasOwnProperty`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5
-- **4× LoadIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11`
-  - key: `observers`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11
-- **4× LoadIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11`
-  - key: `sourceSlots`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11
-- **4× LoadIC** in `Ve http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12`
-  - key: `length`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12
-- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1373:14`
-  - key: `state`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1373:14
-- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1376:14`
-  - key: `state`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1376:14
-- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1382:57`
-  - key: `state`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1382:57
-- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1363:13`
-  - key: `state`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1363:13
-- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1379:109`
-  - key: `state`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1379:109
-- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1366:13`
-  - key: `state`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1366:13
-- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1363:89`
-  - key: `state`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1363:89
-- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1363:51`
-  - key: `state`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1363:51
-- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1379:13`
-  - key: `state`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1379:13
-- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1379:150`
-  - key: `state`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1379:150
-- **4× KeyedLoadIC** in `M http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1005:169`
-  - key: `0`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1005:169
-- **3× KeyedLoadIC** in `Be http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:29:12`
-  - key: `symbol("solid-proxy" hash 13994585)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:29:12
-- **3× KeyedLoadIC** in `Ve http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12`
-  - key: `symbol("store-raw" hash 31565e56)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12
-- **3× LoadIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11`
-  - key: `sources`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11
-- **3× KeyedLoadIC** in `M http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:15:11`
-  - key: `symbol("solid-proxy" hash 13994585)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:15:11
-- **3× KeyedLoadIC** in `He http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:47:12`
-  - key: `symbol("store-node" hash 3fb1f52b)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:47:12
-- **3× LoadIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11`
-  - key: `sources`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11
-- **3× LoadIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11`
-  - key: `tOwned`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11
-- **3× LoadIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11`
-  - key: `owned`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11
-- **3× LoadIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11`
-  - key: `cleanups`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11
-- **3× StoreIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11`
-  - key: `state`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11
-- **3× LoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:273:11`
-  - key: `state`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:273:11
-- **3× LoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:273:11`
-  - key: `owner`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:273:11
-- **3× LoadIC** in `Ne.o http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:756:65`
-  - key: `cloneNode`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:756:65
-- **3× LoadIC** in `gi http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1439:9`
-  - key: `length`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1439:9
-- **3× LoadIC** in `qe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12`
-  - key: `length`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12
-- **3× KeyedLoadIC** in `qe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12`
-  - key: `symbol("store-has" hash 29b7a6a8)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:94:12
-- **3× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:225:42`
-  - key: `observers`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:225:42
-- **3× LoadIC** in `z http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:348:11`
-  - key: `sources`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:348:11
-- **3× LoadIC** in `ki http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1517:9`
-  - key: `style`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1517:9
-- **3× LoadIC** in `Ai http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1524:9`
-  - key: `style`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1524:9
-- **3× KeyedLoadIC** in `s http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:882:10`
-  - key: `$$pointermove`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:882:10
-- **3× LoadIC** in `s http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:882:10`
-  - key: `host`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:882:10
-- **3× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:1052:32`
-  - key: `hasAttribute`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:1052:32
-- **3× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12`
-  - key: `_$host`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12
-- **3× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12`
-  - key: `parentNode`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12
-- **3× LoadIC** in `Pi http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1546:9`
-  - key: `style`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1546:9
-- **3× LoadIC** in `Ni http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1544:9`
-  - key: `style`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1544:9
-- **3× LoadIC** in `Q http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:984:11`
-  - key: `insertBefore`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:984:11
-- **3× LoadIC** in `M http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1005:169`
-  - key: `length`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1005:169
-- **3× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1444:9`
-  - key: `state`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1444:9
-- **3× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1451:9`
-  - key: `state`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1451:9
-- **2× LoadIC** in `w http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:74:11`
-  - key: `equals`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:74:11
-- **2× LoadIC** in `F http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:235:11`
-  - key: `fn`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:235:11
-- **2× LoadIC** in `F http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:235:11`
-  - key: `value`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:235:11
-- **2× LoadIC** in `oe http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:245:12`
-  - key: `fn`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:245:12
-- **2× StoreIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11`
-  - key: `sources`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11
-- **2× StoreIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11`
-  - key: `sourceSlots`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11
-- **2× LoadIC** in `oe http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:245:12`
-  - key: `updatedAt`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:245:12
-- **2× StoreIC** in `oe http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:245:12`
-  - key: `value`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:245:12
-- **2× StoreIC** in `oe http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:245:12`
-  - key: `updatedAt`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:245:12
-- **2× LoadIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11`
-  - key: `sourceSlots`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11
-- **2× LoadIC** in `f http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:953:41`
-  - key: `hooks`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:953:41
-- **2× LoadIC** in `I http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:257:11`
-  - key: `context`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:257:11
-- **2× LoadIC** in `I http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:257:11`
-  - key: `owned`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:257:11
-- **2× StoreIC** in `I http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:257:11`
-  - key: `owned`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:257:11
-- **2× LoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:157:5`
-  - key: `setAttribute`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:157:5
-- **2× LoadIC** in `Re http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:778:12`
-  - key: `addEventListener`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:778:12
-- **2× LoadIC** in `Yn http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1694:12`
-  - key: `nodeType`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1694:12
-- **2× KeyedLoadIC** in `gi http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1439:9`
-  - key: `0`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1439:9
-- **2× LoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:273:11`
-  - key: `updatedAt`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:273:11
-- **2× LoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:273:11`
-  - key: `suspense`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:273:11
-- **2× LoadIC** in `ue http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:359:12`
-  - key: `state`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:359:12
-- **2× StoreIC** in `ue http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:359:12`
-  - key: `state`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:359:12
-- **2× LoadIC** in `ue http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:359:12`
-  - key: `pure`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:359:12
-- **2× LoadIC** in `ue http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:359:12`
-  - key: `observers`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:359:12
-- **2× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:225:42`
-  - key: `state`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:225:42
-- **2× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:225:42`
-  - key: `pure`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:225:42
-- **2× StoreIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:225:42`
-  - key: `state`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:225:42
-- **2× KeyedLoadIC** in `oe http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:245:12`
-  - key: `observers`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:245:12
-- **2× StoreIC** in `z http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:348:11`
-  - key: `state`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:348:11
-- **2× KeyedLoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:249:8`
-  - key: `_reactRootContainer`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:249:8
-- **2× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12`
-  - key: `composedPath`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12
-- **2× LoadIC** in `Q.addWindowListener.passive http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96`
-  - key: `composedPath`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96
-- **2× LoadIC** in `at http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:1050:9`
-  - key: `composedPath`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:1050:9
-- **2× LoadIC** in `O http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:182:11`
-  - key: `cleanups`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:182:11
-- **2× StoreIC** in `O http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:182:11`
-  - key: `cleanups`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:182:11
-- **2× LoadIC** in `ft http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:274:569`
-  - key: `split`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:274:569
-- **2× LoadIC** in `an http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:727:9`
-  - key: `startsWith`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:727:9
-- **2× LoadIC** in `Q http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:984:11`
-  - key: `length`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:984:11
-- **2× LoadIC** in `nr http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:999:48`
-  - key: `startsWith`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:999:48
-- **2× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:434:24`
-  - key: `length`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:434:24
-- **2× KeyedLoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:434:24`
-  - key: `symbol("solid-track" hash 1ffdf389)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:434:24
-- **2× StoreIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11`
-  - key: `owned`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11
-- **2× StoreIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11`
-  - key: `cleanups`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11
-- **2× KeyedLoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:436:18`
-  - key: `0`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:436:18
-- **2× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:436:18`
-  - key: `length`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:436:18
-- **2× KeyedStoreIC** in `f http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:442:13`
-  - key: `0`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:442:13
-- **2× KeyedLoadIC** in `has http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:82:5`
-  - key: `0`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:82:5
-- **2× LoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9`
-  - key: `x`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9
-- **2× LoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9`
-  - key: `y`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9
-- **2× LoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9`
-  - key: `width`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9
-- **2× LoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9`
-  - key: `height`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9
-- **2× LoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9`
-  - key: `borderRadius`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9
-- **2× LoadIC** in `x http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:76:10`
-  - key: `x`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:76:10
-- **2× LoadIC** in `x http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:76:10`
-  - key: `y`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:76:10
-- **2× LoadIC** in `x http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:76:10`
-  - key: `width`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:76:10
-- **2× LoadIC** in `x http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:76:10`
-  - key: `height`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:76:10
-- **2× LoadIC** in `x http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:76:10`
-  - key: `borderRadius`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:76:10
-- **2× LoadIC** in `onElementSelect http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:988:20`
-  - key: `hooks`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:988:20
-- **2× LoadIC** in `Q http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:984:11`
-  - key: `replaceChild`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:984:11
-- **1× StoreIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11`
-  - key: `observers`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11
-- **1× StoreIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11`
-  - key: `observerSlots`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11
-- **1× LoadIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11`
-  - key: `value`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11
-- **1× LoadIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11`
-  - key: `observerSlots`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:205:11
-- **1× StoreIC** in `addWindowListener http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:656:22`
-  - key: `signal`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:656:22
-- **1× LoadIC** in `a http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:913:10`
-  - key: `theme`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:913:10
-- **1× LoadIC** in `a http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:913:10`
-  - key: `options`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:913:10
-- **1× LoadIC** in `a http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:913:10`
-  - key: `actions`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:913:10
-- **1× LoadIC** in `C http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:69:11`
-  - key: `push`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:69:11
-- **1× LoadIC** in `gi http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1439:9`
-  - key: `nodeType`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1439:9
-- **1× LoadIC** in `le http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:333:12`
-  - key: `user`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:333:12
-- **1× LoadIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11`
-  - key: `observers`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11
-- **1× LoadIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11`
-  - key: `observerSlots`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11
-- **1× LoadIC** in `ae http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:218:12`
-  - key: `value`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:218:12
-- **1× LoadIC** in `ae http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:218:12`
-  - key: `comparator`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:218:12
-- **1× StoreIC** in `ae http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:218:12`
-  - key: `value`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:218:12
-- **1× LoadIC** in `ae http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:218:12`
-  - key: `observers`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:218:12
-- **1× LoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:249:8`
-  - key: `startsWith`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:249:8
-- **1× LoadIC** in `Ni http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1544:9`
-  - key: `symbol("Symbol.iterator" hash 258a5929)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1544:9
-- **1× LoadIC** in `la http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1730:9`
-  - key: `symbol("Symbol.iterator" hash 258a5929)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1730:9
-- **1× LoadIC** in `Fi http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1552:9`
-  - key: `push`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1552:9
-- **1× LoadIC** in `N http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:132:9`
-  - key: `now`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:132:9
-- **1× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12`
-  - key: `target`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12
-- **1× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12`
-  - key: `type`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12
-- **1× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12`
-  - key: `currentTarget`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:877:12
-- **1× LoadIC** in `Ve http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:807:12`
-  - key: `style`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:807:12
-- **1× LoadIC** in `Xe http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:999:12`
-  - key: `isConnected`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:999:12
-- **1× LoadIC** in `Jt http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:663:9`
-  - key: `slice`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:663:9
-- **1× LoadIC** in `Di http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1513:41`
-  - key: `stopImmediatePropagation`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1513:41
-- **1× LoadIC** in `Q.addWindowListener.passive http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96`
-  - key: `isPrimary`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96
-- **1× LoadIC** in `Q.addWindowListener.passive http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96`
-  - key: `pointerType`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96
-- **1× LoadIC** in `Q.addWindowListener.passive http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96`
-  - key: `shiftKey`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96
-- **1× LoadIC** in `Q.addWindowListener.passive http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96`
-  - key: `clientX`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96
-- **1× LoadIC** in `Q.addWindowListener.passive http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96`
-  - key: `clientY`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2316:96
-- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:705:15`
-  - key: `push`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:705:15
-- **1× KeyedLoadIC** in `ft http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:274:569`
-  - key: `0`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:274:569
-- **1× LoadIC** in `v http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:224:8`
-  - key: `displayName`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:224:8
-- **1× LoadIC** in `v http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:224:8`
-  - key: `name`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:224:8
-- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:715:18`
-  - key: `source`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:715:18
-- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:715:18`
-  - key: `includes`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:715:18
-- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:715:134`
-  - key: `functionName`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:715:134
-- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1119:19`
-  - key: `fileName`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1119:19
-- **1× LoadIC** in `tn http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:720:9`
-  - key: `split`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:720:9
-- **1× LoadIC** in `Gt http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:540:12`
-  - key: `includes`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:540:12
-- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:696:31`
-  - key: `getBoundingClientRect`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:696:31
-- **1× LoadIC** in `yn http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:2041:127`
-  - key: `match`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:2041:127
-- **1× KeyedStoreIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:436:18`
-  - key: `0`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:436:18
-- **1× LoadIC** in `Ae http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:709:12`
-  - key: `nextSibling`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:709:12
-- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:164:55`
-  - key: `find`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:164:55
-- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1793:14`
-  - key: `push`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1793:14
-- **1× StoreIC** in `It http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:778:10`
-  - key: `borderRadius`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:778:10
-- **1× StoreIC** in `It http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:778:10`
-  - key: `transform`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:778:10
-- **1× LoadIC** in `Mt.g.e http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:1157:30`
-  - key: `width`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:1157:30
-- **1× LoadIC** in `Mt.g.e http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:1157:30`
-  - key: `height`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:1157:30
-- **1× LoadIC** in `Mt.g.e http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:1157:30`
-  - key: `x`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:1157:30
-- **1× LoadIC** in `Mt.g.e http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:1157:30`
-  - key: `y`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:1157:30
-- **1× LoadIC** in `M http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1005:169`
-  - key: `endsWith`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1005:169
-- **1× KeyedLoadIC** in `Ve http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12`
-  - key: `0`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12
-- **1× LoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9`
-  - key: `opacity`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9
-- **1× LoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9`
-  - key: `targetOpacity`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9
-- **1× LoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9`
-  - key: `createdAt`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9
-- **1× LoadIC** in `N http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:132:9`
-  - key: `symbol("Symbol.iterator" hash 258a5929)`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:132:9
-- **1× KeyedLoadIC** in `Xe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:123:12`
-  - key: `0`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:123:12
-- **1× LoadIC** in `Q http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:984:11`
-  - key: `parentNode`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:984:11
-- **1× LoadIC** in `_i http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1446:9`
-  - key: `length`  reason: `-`
-  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1446:9
+
+- **5× LoadIC** in `x http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:53:11`
+  - key: `equals` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:53:11
+- **5× LoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5`
+  - key: `hasOwnProperty` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5
+- **4× LoadIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:205:11`
+  - key: `observers` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:205:11
+- **4× LoadIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:366:11`
+  - key: `sourceSlots` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:366:11
+- **4× LoadIC** in `Ve http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:33:12`
+  - key: `length` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:33:12
+- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1373:14`
+  - key: `state` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1373:14
+- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1376:14`
+  - key: `state` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1376:14
+- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1382:57`
+  - key: `state` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1382:57
+- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1363:13`
+  - key: `state` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1363:13
+- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1379:109`
+  - key: `state` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1379:109
+- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1366:13`
+  - key: `state` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1366:13
+- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1363:89`
+  - key: `state` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1363:89
+- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1363:51`
+  - key: `state` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1363:51
+- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1379:13`
+  - key: `state` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1379:13
+- **4× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1379:150`
+  - key: `state` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1379:150
+- **3× KeyedLoadIC** in `Be http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:29:12`
+  - key: `symbol("solid-proxy" hash 2b6fb2ce)` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:29:12
+- **3× KeyedLoadIC** in `Ve http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:33:12`
+  - key: `symbol("store-raw" hash 246e9213)` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:33:12
+- **3× LoadIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:205:11`
+  - key: `sources` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:205:11
+- **3× KeyedLoadIC** in `M http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:15:11`
+  - key: `symbol("solid-proxy" hash 2b6fb2ce)` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:15:11
+- **3× KeyedLoadIC** in `He http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:47:12`
+  - key: `symbol("store-node" hash 29233ba4)` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:47:12
+- **3× LoadIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:366:11`
+  - key: `sources` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:366:11
+- **3× LoadIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:366:11`
+  - key: `tOwned` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:366:11
+- **3× LoadIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:366:11`
+  - key: `owned` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:366:11
+- **3× LoadIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:366:11`
+  - key: `cleanups` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:366:11
+- **3× StoreIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:366:11`
+  - key: `state` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:366:11
+- **3× LoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:273:11`
+  - key: `state` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:273:11
+- **3× LoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:273:11`
+  - key: `owner` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:273:11
+- **3× LoadIC** in `Ne.o http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:756:65`
+  - key: `cloneNode` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:756:65
+- **3× LoadIC** in `Z http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:964:11`
+  - key: `length` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:964:11
+- **3× LoadIC** in `qe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:94:12`
+  - key: `length` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:94:12
+- **3× KeyedLoadIC** in `qe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:94:12`
+  - key: `symbol("store-has" hash 6cb6121)` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:94:12
+- **3× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:225:42`
+  - key: `observers` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:225:42
+- **3× LoadIC** in `z http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:348:11`
+  - key: `sources` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:348:11
+- **3× LoadIC** in `ki http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1519:9`
+  - key: `style` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1519:9
+- **3× LoadIC** in `Ai http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1526:9`
+  - key: `style` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1526:9
+- **3× KeyedLoadIC** in `s http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:882:10`
+  - key: `$$pointermove` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:882:10
+- **3× LoadIC** in `s http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:882:10`
+  - key: `host` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:882:10
+- **3× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:1052:32`
+  - key: `hasAttribute` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:1052:32
+- **3× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:877:12`
+  - key: `_$host` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:877:12
+- **3× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:877:12`
+  - key: `parentNode` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:877:12
+- **3× LoadIC** in `Pi http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1548:9`
+  - key: `style` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1548:9
+- **3× LoadIC** in `Ni http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1546:9`
+  - key: `style` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1546:9
+- **3× LoadIC** in `Q http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:984:11`
+  - key: `insertBefore` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:984:11
+- **3× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1444:9`
+  - key: `state` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1444:9
+- **3× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1451:9`
+  - key: `state` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1451:9
+- **2× LoadIC** in `w http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:74:11`
+  - key: `equals` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:74:11
+- **2× LoadIC** in `F http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:235:11`
+  - key: `fn` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:235:11
+- **2× LoadIC** in `F http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:235:11`
+  - key: `value` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:235:11
+- **2× LoadIC** in `oe http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:245:12`
+  - key: `fn` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:245:12
+- **2× StoreIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:205:11`
+  - key: `sources` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:205:11
+- **2× StoreIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:205:11`
+  - key: `sourceSlots` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:205:11
+- **2× LoadIC** in `oe http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:245:12`
+  - key: `updatedAt` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:245:12
+- **2× StoreIC** in `oe http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:245:12`
+  - key: `value` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:245:12
+- **2× StoreIC** in `oe http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:245:12`
+  - key: `updatedAt` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:245:12
+- **2× LoadIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:205:11`
+  - key: `sourceSlots` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:205:11
+- **2× LoadIC** in `f http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:953:41`
+  - key: `hooks` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:953:41
+- **2× LoadIC** in `I http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:257:11`
+  - key: `context` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:257:11
+- **2× LoadIC** in `I http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:257:11`
+  - key: `owned` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:257:11
+- **2× StoreIC** in `I http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:257:11`
+  - key: `owned` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:257:11
+- **2× LoadIC** in `q http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:766:11`
+  - key: `setAttribute` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:766:11
+- **2× LoadIC** in `Ct http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:669:146`
+  - key: `addEventListener` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:669:146
+- **2× KeyedLoadIC** in `Z http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:964:11`
+  - key: `0` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:964:11
+- **2× LoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:273:11`
+  - key: `updatedAt` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:273:11
+- **2× LoadIC** in `L http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:273:11`
+  - key: `suspense` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:273:11
+- **2× LoadIC** in `ue http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:359:12`
+  - key: `state` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:359:12
+- **2× StoreIC** in `ue http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:359:12`
+  - key: `state` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:359:12
+- **2× LoadIC** in `ue http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:359:12`
+  - key: `pure` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:359:12
+- **2× LoadIC** in `ue http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:359:12`
+  - key: `observers` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:359:12
+- **2× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:225:42`
+  - key: `state` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:225:42
+- **2× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:225:42`
+  - key: `pure` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:225:42
+- **2× StoreIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:225:42`
+  - key: `state` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:225:42
+- **2× KeyedLoadIC** in `oe http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:245:12`
+  - key: `observers` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:245:12
+- **2× StoreIC** in `z http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:348:11`
+  - key: `state` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:348:11
+- **2× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:877:12`
+  - key: `composedPath` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:877:12
+- **2× LoadIC** in `Q.addWindowListener.passive http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:2316:96`
+  - key: `composedPath` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:2316:96
+- **2× LoadIC** in `at http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:1050:9`
+  - key: `composedPath` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:1050:9
+- **2× LoadIC** in `O http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:182:11`
+  - key: `cleanups` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:182:11
+- **2× StoreIC** in `O http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:182:11`
+  - key: `cleanups` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:182:11
+- **2× LoadIC** in `ft http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:274:569`
+  - key: `split` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:274:569
+- **2× LoadIC** in `Q http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:984:11`
+  - key: `length` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:984:11
+- **2× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:434:24`
+  - key: `length` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:434:24
+- **2× KeyedLoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:434:24`
+  - key: `symbol("solid-track" hash 27591fd2)` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:434:24
+- **2× StoreIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:366:11`
+  - key: `owned` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:366:11
+- **2× StoreIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:366:11`
+  - key: `cleanups` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:366:11
+- **2× KeyedLoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:436:18`
+  - key: `0` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:436:18
+- **2× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:436:18`
+  - key: `length` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:436:18
+- **2× KeyedStoreIC** in `f http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:442:13`
+  - key: `0` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:442:13
+- **2× LoadIC** in `onElementSelect http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:988:20`
+  - key: `hooks` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:988:20
+- **1× StoreIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:205:11`
+  - key: `observers` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:205:11
+- **1× StoreIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:205:11`
+  - key: `observerSlots` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:205:11
+- **1× LoadIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:205:11`
+  - key: `value` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:205:11
+- **1× LoadIC** in `P http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:205:11`
+  - key: `observerSlots` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:205:11
+- **1× StoreIC** in `addWindowListener http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:656:22`
+  - key: `signal` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:656:22
+- **1× LoadIC** in `a http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:913:10`
+  - key: `theme` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:913:10
+- **1× LoadIC** in `a http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:913:10`
+  - key: `options` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:913:10
+- **1× LoadIC** in `a http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:913:10`
+  - key: `actions` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:913:10
+- **1× LoadIC** in `C http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:69:11`
+  - key: `push` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:69:11
+- **1× LoadIC** in `Te.g.e http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:283:12`
+  - key: `slice` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:283:12
+- **1× LoadIC** in `Z http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:964:11`
+  - key: `nodeType` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:964:11
+- **1× LoadIC** in `le http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:333:12`
+  - key: `user` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:333:12
+- **1× LoadIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:366:11`
+  - key: `observers` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:366:11
+- **1× LoadIC** in `B http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:366:11`
+  - key: `observerSlots` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:366:11
+- **1× LoadIC** in `ae http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:218:12`
+  - key: `value` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:218:12
+- **1× LoadIC** in `ae http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:218:12`
+  - key: `comparator` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:218:12
+- **1× StoreIC** in `ae http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:218:12`
+  - key: `value` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:218:12
+- **1× LoadIC** in `ae http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:218:12`
+  - key: `observers` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:218:12
+- **1× LoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:249:8`
+  - key: `startsWith` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:249:8
+- **1× KeyedLoadIC** in `b http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:249:8`
+  - key: `_reactRootContainer` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:249:8
+- **1× LoadIC** in `Ni http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1546:9`
+  - key: `symbol("Symbol.iterator" hash 258a5929)` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1546:9
+- **1× LoadIC** in `la http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1732:9`
+  - key: `symbol("Symbol.iterator" hash 258a5929)` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1732:9
+- **1× LoadIC** in `Fi http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1554:9`
+  - key: `push` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1554:9
+- **1× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:877:12`
+  - key: `target` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:877:12
+- **1× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:877:12`
+  - key: `type` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:877:12
+- **1× LoadIC** in `Je http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:877:12`
+  - key: `currentTarget` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:877:12
+- **1× KeyedLoadIC** in `get http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5`
+  - key: `_reactRootContainer` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5
+- **1× LoadIC** in `Ve http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:807:12`
+  - key: `style` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:807:12
+- **1× LoadIC** in `Xe http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:999:12`
+  - key: `isConnected` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:999:12
+- **1× LoadIC** in `Jt http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:663:9`
+  - key: `slice` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:663:9
+- **1× LoadIC** in `an http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:727:9`
+  - key: `startsWith` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:727:9
+- **1× LoadIC** in `Di http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1515:41`
+  - key: `stopImmediatePropagation` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1515:41
+- **1× LoadIC** in `Q.addWindowListener.passive http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:2316:96`
+  - key: `isPrimary` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:2316:96
+- **1× LoadIC** in `Q.addWindowListener.passive http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:2316:96`
+  - key: `pointerType` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:2316:96
+- **1× LoadIC** in `Q.addWindowListener.passive http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:2316:96`
+  - key: `shiftKey` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:2316:96
+- **1× LoadIC** in `Q.addWindowListener.passive http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:2316:96`
+  - key: `clientX` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:2316:96
+- **1× LoadIC** in `Q.addWindowListener.passive http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:2316:96`
+  - key: `clientY` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:2316:96
+- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:705:15`
+  - key: `push` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:705:15
+- **1× KeyedLoadIC** in `ft http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:274:569`
+  - key: `0` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:274:569
+- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:139:16`
+  - key: `displayName` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:139:16
+- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:139:16`
+  - key: `name` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:139:16
+- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:715:18`
+  - key: `source` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:715:18
+- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:715:18`
+  - key: `includes` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:715:18
+- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:715:134`
+  - key: `functionName` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:715:134
+- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1119:19`
+  - key: `fileName` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1119:19
+- **1× LoadIC** in `tn http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:720:9`
+  - key: `split` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:720:9
+- **1× LoadIC** in `nr http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:999:48`
+  - key: `startsWith` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:999:48
+- **1× LoadIC** in `an http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:1750:12`
+  - key: `getBoundingClientRect` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:1750:12
+- **1× LoadIC** in `M http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1005:169`
+  - key: `length` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1005:169
+- **1× LoadIC** in `y http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:53:9`
+  - key: `match` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:53:9
+- **1× KeyedStoreIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:436:18`
+  - key: `0` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:436:18
+- **1× LoadIC** in `Ae http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-_DOJVeJi.js?t=1778905256705:709:12`
+  - key: `nextSibling` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-\_DOJVeJi.js?t=1778905256705:709:12
+- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:164:55`
+  - key: `find` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:164:55
+- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1793:14`
+  - key: `push` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1793:14
+- **1× LoadIC** in `fi http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1417:9`
+  - key: `startsWith` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1417:9
+- **1× KeyedLoadIC** in `Ve http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:33:12`
+  - key: `0` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:33:12
+- **1× KeyedLoadIC** in `Xe http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:123:12`
+  - key: `0` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:123:12
+- **1× LoadIC** in `http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:197:16`
+  - key: `startsWith` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:197:16
+- **1× LoadIC** in `_i http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1448:9`
+  - key: `length` reason: `-`
+  - http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1448:9
 
 ## IC state transitions (totals)
-- `no_feedback->no_feedback` — 9132
-- `megamorphic->megamorphic` — 7699
-- `uninitialized->monomorphic` — 2430
-- `monomorphic->polymorphic` — 244
+
+- `no_feedback->no_feedback` — 9013
+- `megamorphic->megamorphic` — 7625
+- `uninitialized->monomorphic` — 2437
+- `monomorphic->polymorphic` — 245
 - `polymorphic->polymorphic` — 208
-- `recompute_handler->monomorphic` — 42
 - `monomorphic->megamorphic` — 41
+- `recompute_handler->monomorphic` — 41
 - `monomorphic->monomorphic` — 38
 - `polymorphic->megamorphic` — 24
 - `recompute_handler->polymorphic` — 9
 - `polymorphic->monomorphic` — 9
 
 ## IC volume by script
-- http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:259:8 — 1280
+
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:70:5 — 3899
 - http://localhost:5175/src/perf-grid.tsx:5:18 — 1074
-- http://localhost:5175/@fs/workspace/packages/react-grab/dist/state-DA14_TPH.js:366:11 — 713
-- http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:70:5 — 674
-- http://localhost:5175/node_modules/.vite/deps/react-dom_client.js?v=90bfcce4:3532:21 — 494
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:63:12 — 650
+- http://localhost:5175/node_modules/.vite/deps/react-dom_client.js?v=90bfcce4:3532:21 — 496
 - http://localhost:5175/node_modules/.vite/deps/react-dom_client.js?v=90bfcce4:262:11 — 446
-- http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:540:12 — 187
-- http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:57:9 — 171
-- http://localhost:5175/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=90bfcce4:103:24 — 157
-- http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:1860:9 — 138
+- http://localhost:5175/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=90bfcce4:103:24 — 158
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:57:9 — 155
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:1860:9 — 138
 - http://localhost:5175/src/perf-grid.tsx:33:17 — 134
-- http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:249:8 — 130
-- http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:2962:14 — 121
-- http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:663:9 — 118
-- http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:311:41 — 117
-- http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-x_dAhxAb.js:1298:9 — 109
-- http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-B0f9Fk9r.js:33:12 — 108
-- http://localhost:5175/node_modules/.vite/deps/react-dom_client.js?v=90bfcce4:6275:24 — 103
-- http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:695:4 — 101
-- http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-Bt7tDgnC.js:706:8 — 96
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:249:8 — 129
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:2962:14 — 121
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/core-BLytKs3P.js?t=1778905256705:33:12 — 110
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:663:9 — 110
+- http://localhost:5175/node_modules/.vite/deps/react-dom_client.js?v=90bfcce4:6275:24 — 107
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:695:4 — 106
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:782:15 — 104
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/renderer-CskkZhZc.js?t=1778905256705:706:8 — 96
+- http://localhost:5175/@fs/workspace/packages/react-grab/dist/freeze-updates-D7bVDFGL.js?t=1778905256701:1554:9 — 90
+- http://localhost:5175/node_modules/.vite/deps/react-Cq2J0xzA.js?v=90bfcce4:15:11 — 88
+- http://localhost:5175/node_modules/.vite/deps/react-dom_client.js?v=90bfcce4:2702:21 — 86

--- a/packages/react-grab/scripts/perf-deopt-analyze.mjs
+++ b/packages/react-grab/scripts/perf-deopt-analyze.mjs
@@ -29,9 +29,9 @@ const ICTYPES = new Set([
 
 const IC_STATE_NAMES = {
   X: "no_feedback",
-  "0": "uninitialized",
+  0: "uninitialized",
   ".": "premonomorphic",
-  "1": "monomorphic",
+  1: "monomorphic",
   "^": "recompute_handler",
   P: "polymorphic",
   N: "megamorphic",
@@ -111,7 +111,12 @@ const parseFile = async (logPath) => {
     if (tag === "code-creation") {
       const fields = parseCsvLine(line);
       const codeKind = fields[1];
-      if (codeKind === "JS" || codeKind === "LazyCompile" || codeKind === "Function" || codeKind === "Eval") {
+      if (
+        codeKind === "JS" ||
+        codeKind === "LazyCompile" ||
+        codeKind === "Function" ||
+        codeKind === "Eval"
+      ) {
         const startAddress = parseAddress(fields[4]);
         const size = Number(fields[5]);
         const symbolName = stripQuotes(fields[6] ?? "");
@@ -390,9 +395,7 @@ const main = async () => {
   }
 
   log("\n=== IC state transitions (totals) ===\n" + formatTopList(report.icByTransition, 20));
-  log(
-    "\n=== top IC hot functions (any state) ===\n" + formatTopList(report.icByLocation, 25),
-  );
+  log("\n=== top IC hot functions (any state) ===\n" + formatTopList(report.icByLocation, 25));
   log(
     `\n=== megamorphic IC sites in react-grab source: ${report.icReactGrabMegamorphic.length} ===`,
   );
@@ -411,9 +414,7 @@ const main = async () => {
   }
 
   const writableReport = JSON.parse(
-    JSON.stringify(report, (_key, value) =>
-      typeof value === "bigint" ? value.toString() : value,
-    ),
+    JSON.stringify(report, (_key, value) => (typeof value === "bigint" ? value.toString() : value)),
   );
   const summaryJsonPath = resolve(LOG_DIR, "summary.json");
   await writeFile(summaryJsonPath, JSON.stringify(writableReport, null, 2));
@@ -440,8 +441,7 @@ const main = async () => {
     "",
     "## React-grab deopts",
     ...report.deoptsReactGrab.map(
-      (entry) =>
-        `- \`${entry.bailoutType}\` — \`${entry.reason}\`\n  - ${entry.locationLabel}`,
+      (entry) => `- \`${entry.bailoutType}\` — \`${entry.reason}\`\n  - ${entry.locationLabel}`,
     ),
     "",
     "## React-grab megamorphic IC sites",

--- a/packages/react-grab/scripts/perf-deopt-analyze.mjs
+++ b/packages/react-grab/scripts/perf-deopt-analyze.mjs
@@ -1,0 +1,362 @@
+#!/usr/bin/env node
+import { readFile, writeFile, readdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { dirname, resolve, basename } from "node:path";
+import { fileURLToPath } from "node:url";
+import process from "node:process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PERF_OUTPUT_DIR = resolve(__dirname, "../perf");
+const LOG_DIR = resolve(PERF_OUTPUT_DIR, "v8-log");
+
+const PRINT_PREFIX = "[deopt-analyze]";
+const log = (message) => console.log(`${PRINT_PREFIX} ${message}`);
+
+const REACT_GRAB_SOURCE_HINT = /react-grab|@react-grab|packages\/react-grab/i;
+
+const parseCsvLine = (line) => {
+  const parts = [];
+  let current = "";
+  let inQuotes = false;
+  for (let charIndex = 0; charIndex < line.length; charIndex++) {
+    const ch = line[charIndex];
+    if (ch === '"' && (charIndex === 0 || line[charIndex - 1] !== "\\")) {
+      inQuotes = !inQuotes;
+      current += ch;
+      continue;
+    }
+    if (ch === "," && !inQuotes) {
+      parts.push(current);
+      current = "";
+      continue;
+    }
+    current += ch;
+  }
+  parts.push(current);
+  return parts;
+};
+
+const stripQuotes = (value) => {
+  if (!value) return value;
+  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+    return value.slice(1, -1).replace(/\\"/g, '"');
+  }
+  return value;
+};
+
+const summarize = async (logPath) => {
+  log(`parsing ${basename(logPath)} ...`);
+  const text = await readFile(logPath, "utf8");
+  const lines = text.split("\n");
+
+  const codeCreateByAddress = new Map();
+  const scriptSourcesById = new Map();
+  const deopts = [];
+  const icRecords = [];
+
+  for (const line of lines) {
+    if (!line) continue;
+    const tag = line.slice(0, line.indexOf(",") === -1 ? line.length : line.indexOf(","));
+    if (
+      tag !== "code-creation" &&
+      tag !== "code-deopt" &&
+      tag !== "script-source" &&
+      tag.length > 0 &&
+      !tag.startsWith("LoadIC") &&
+      !tag.startsWith("StoreIC") &&
+      !tag.startsWith("KeyedLoadIC") &&
+      !tag.startsWith("KeyedStoreIC") &&
+      !tag.startsWith("LoadGlobalIC") &&
+      !tag.startsWith("StoreGlobalIC") &&
+      !tag.startsWith("StoreInArrayLiteralIC") &&
+      tag !== "Set" &&
+      tag !== "ic"
+    ) {
+      continue;
+    }
+
+    const fields = parseCsvLine(line);
+
+    if (fields[0] === "script-source") {
+      const scriptId = fields[1];
+      const url = stripQuotes(fields[2] ?? "");
+      const source = stripQuotes(fields.slice(3).join(","));
+      if (scriptId) scriptSourcesById.set(scriptId, { url, source });
+      continue;
+    }
+
+    if (fields[0] === "code-creation") {
+      const codeKind = fields[1];
+      const startAddress = fields[4];
+      const symbolName = stripQuotes(fields[6] ?? "");
+      const scriptId = fields[7];
+      if (startAddress) {
+        codeCreateByAddress.set(startAddress, {
+          codeKind,
+          symbolName,
+          scriptId,
+        });
+      }
+      continue;
+    }
+
+    if (fields[0] === "code-deopt") {
+      const [
+        ,
+        timestamp,
+        codeSize,
+        instructionStart,
+        inliningId,
+        scriptOffset,
+        bailoutType,
+        sourcePositionText,
+        deoptReasonText,
+      ] = fields;
+      deopts.push({
+        timestamp: Number(timestamp),
+        codeSize: Number(codeSize),
+        instructionStart,
+        inliningId: Number(inliningId),
+        scriptOffset: Number(scriptOffset),
+        bailoutType,
+        sourcePosition: stripQuotes(sourcePositionText ?? ""),
+        reason: stripQuotes(deoptReasonText ?? ""),
+      });
+      continue;
+    }
+
+    if (
+      fields[0].endsWith("IC") ||
+      fields[0] === "LoadIC" ||
+      fields[0] === "StoreIC" ||
+      fields[0] === "KeyedLoadIC" ||
+      fields[0] === "KeyedStoreIC"
+    ) {
+      const [type, pc, time, line2, column, oldState, newState, mapId, key, modifier, slowReason] =
+        fields;
+      icRecords.push({
+        type,
+        pc,
+        time: Number(time),
+        line: Number(line2),
+        column: Number(column),
+        oldState,
+        newState,
+        mapId,
+        key: stripQuotes(key ?? ""),
+        modifier,
+        slowReason: stripQuotes(slowReason ?? ""),
+      });
+      continue;
+    }
+  }
+
+  log(
+    `  parsed: ${deopts.length} deopts, ${icRecords.length} IC events, ${codeCreateByAddress.size} code blobs, ${scriptSourcesById.size} script sources`,
+  );
+
+  return { codeCreateByAddress, scriptSourcesById, deopts, icRecords };
+};
+
+const reasonGroup = (reasonString) => reasonString || "(no-reason)";
+const positionScriptId = (sourcePosition) => {
+  const match = /^S(\d+)O(-?\d+)$/.exec(sourcePosition);
+  if (!match) return null;
+  return { scriptId: match[1], offset: Number(match[2]) };
+};
+
+const sourceLineColumn = (sourceText, offset) => {
+  if (!sourceText) return { line: -1, column: -1, snippet: "" };
+  if (offset < 0 || offset >= sourceText.length) return { line: -1, column: -1, snippet: "" };
+  let line = 1;
+  let lastNewline = -1;
+  for (let charIndex = 0; charIndex < offset; charIndex++) {
+    if (sourceText.charCodeAt(charIndex) === 10) {
+      line += 1;
+      lastNewline = charIndex;
+    }
+  }
+  const lineStart = lastNewline + 1;
+  const nextNewline = sourceText.indexOf("\n", offset);
+  const lineEnd = nextNewline === -1 ? sourceText.length : nextNewline;
+  return {
+    line,
+    column: offset - lineStart + 1,
+    snippet: sourceText.slice(lineStart, lineEnd).trim(),
+  };
+};
+
+const formatTopList = (entries, limit) =>
+  entries
+    .slice(0, limit)
+    .map(
+      (entry, entryIndex) =>
+        `  ${(entryIndex + 1).toString().padStart(2, " ")}. [${entry.count}]  ${entry.label}`,
+    )
+    .join("\n");
+
+const buildReport = ({ codeCreateByAddress, scriptSourcesById, deopts, icRecords }) => {
+  const deoptByReason = new Map();
+  const deoptByLocation = new Map();
+  const deoptByScript = new Map();
+  const deoptsReactGrab = [];
+
+  for (const deopt of deopts) {
+    const reasonKey = reasonGroup(deopt.reason);
+    deoptByReason.set(reasonKey, (deoptByReason.get(reasonKey) ?? 0) + 1);
+
+    const positionInfo = positionScriptId(deopt.sourcePosition);
+    let scriptUrl = "(unknown script)";
+    let locationLabel = deopt.sourcePosition;
+    let resolvedLineColumn = null;
+    if (positionInfo) {
+      const scriptInfo = scriptSourcesById.get(positionInfo.scriptId);
+      scriptUrl = scriptInfo?.url || `(script ${positionInfo.scriptId})`;
+      resolvedLineColumn = sourceLineColumn(scriptInfo?.source ?? "", positionInfo.offset);
+      locationLabel = `${scriptUrl}:${resolvedLineColumn.line}:${resolvedLineColumn.column}`;
+    }
+    deoptByLocation.set(locationLabel, (deoptByLocation.get(locationLabel) ?? 0) + 1);
+    deoptByScript.set(scriptUrl, (deoptByScript.get(scriptUrl) ?? 0) + 1);
+
+    if (REACT_GRAB_SOURCE_HINT.test(scriptUrl) || REACT_GRAB_SOURCE_HINT.test(deopt.sourcePosition)) {
+      deoptsReactGrab.push({
+        ...deopt,
+        scriptUrl,
+        resolvedLineColumn,
+      });
+    }
+  }
+
+  const megamorphicByKey = new Map();
+  const polymorphicByKey = new Map();
+  for (const icRecord of icRecords) {
+    if (!icRecord.newState) continue;
+    const target = icRecord.newState.includes("MEGAMORPHIC")
+      ? megamorphicByKey
+      : icRecord.newState.includes("POLYMORPHIC")
+        ? polymorphicByKey
+        : null;
+    if (!target) continue;
+    const codeInfo = codeCreateByAddress.get(icRecord.pc);
+    const symbolName = codeInfo?.symbolName || "(unknown)";
+    const groupKey = `${icRecord.type}  ${symbolName}  key=${icRecord.key || "?"}  reason=${icRecord.slowReason || "-"}`;
+    target.set(groupKey, (target.get(groupKey) ?? 0) + 1);
+  }
+
+  const sortMapDesc = (mapValue) =>
+    Array.from(mapValue.entries())
+      .map(([label, count]) => ({ label, count }))
+      .sort((entryA, entryB) => entryB.count - entryA.count);
+
+  return {
+    totals: { deopts: deopts.length, icEvents: icRecords.length },
+    deoptByReason: sortMapDesc(deoptByReason),
+    deoptByScript: sortMapDesc(deoptByScript),
+    deoptByLocation: sortMapDesc(deoptByLocation),
+    deoptsReactGrab,
+    megamorphicGroups: sortMapDesc(megamorphicByKey),
+    polymorphicGroups: sortMapDesc(polymorphicByKey),
+  };
+};
+
+const main = async () => {
+  if (!existsSync(LOG_DIR)) {
+    console.error(`[deopt-analyze] log dir ${LOG_DIR} does not exist — run perf-deopt.mjs first.`);
+    process.exit(1);
+  }
+
+  const allEntries = await readdir(LOG_DIR);
+  const logFiles = allEntries.filter((name) => name.endsWith(".log"));
+  if (logFiles.length === 0) {
+    console.error("[deopt-analyze] no .log files found in", LOG_DIR);
+    process.exit(1);
+  }
+
+  const aggregated = {
+    codeCreateByAddress: new Map(),
+    scriptSourcesById: new Map(),
+    deopts: [],
+    icRecords: [],
+  };
+
+  for (const logFile of logFiles) {
+    const fileSummary = await summarize(resolve(LOG_DIR, logFile));
+    for (const [address, codeInfo] of fileSummary.codeCreateByAddress) {
+      aggregated.codeCreateByAddress.set(address, codeInfo);
+    }
+    for (const [scriptId, scriptInfo] of fileSummary.scriptSourcesById) {
+      aggregated.scriptSourcesById.set(scriptId, scriptInfo);
+    }
+    aggregated.deopts.push(...fileSummary.deopts);
+    aggregated.icRecords.push(...fileSummary.icRecords);
+  }
+
+  const report = buildReport(aggregated);
+
+  log(`totals: ${report.totals.deopts} deopts, ${report.totals.icEvents} IC events`);
+  log("\n=== top deopt reasons ===\n" + formatTopList(report.deoptByReason, 20));
+  log("\n=== top deopt scripts ===\n" + formatTopList(report.deoptByScript, 20));
+  log("\n=== top deopt sites (file:line:col) ===\n" + formatTopList(report.deoptByLocation, 30));
+  log(
+    `\n=== react-grab deopts: ${report.deoptsReactGrab.length} (first 25) ===\n` +
+      report.deoptsReactGrab
+        .slice(0, 25)
+        .map(
+          (entry, entryIndex) =>
+            `  ${(entryIndex + 1).toString().padStart(2, " ")}. ${entry.bailoutType}  reason=\"${entry.reason}\"\n      at ${entry.scriptUrl}` +
+            (entry.resolvedLineColumn
+              ? `:${entry.resolvedLineColumn.line}:${entry.resolvedLineColumn.column}\n      > ${entry.resolvedLineColumn.snippet}`
+              : ""),
+        )
+        .join("\n"),
+  );
+  log("\n=== top megamorphic IC sites ===\n" + formatTopList(report.megamorphicGroups, 25));
+  log("\n=== top polymorphic IC sites ===\n" + formatTopList(report.polymorphicGroups, 15));
+
+  const summaryPath = resolve(LOG_DIR, "summary.json");
+  await writeFile(summaryPath, JSON.stringify(report, null, 2));
+  log(`\nwrote ${summaryPath}`);
+
+  const humanPath = resolve(LOG_DIR, "summary.md");
+  const humanText = [
+    "# React Grab — V8 deopt + IC summary",
+    "",
+    `Captured via dexnode-equivalent --js-flags: see manifest.json.`,
+    "",
+    `- total deopts: **${report.totals.deopts}**`,
+    `- total IC events: **${report.totals.icEvents}**`,
+    `- react-grab-source deopts: **${report.deoptsReactGrab.length}**`,
+    "",
+    "## Top deopt reasons",
+    ...report.deoptByReason.slice(0, 20).map((entry) => `- \`${entry.label}\` — ${entry.count}`),
+    "",
+    "## Top deopt scripts",
+    ...report.deoptByScript.slice(0, 20).map((entry) => `- \`${entry.label}\` — ${entry.count}`),
+    "",
+    "## Top deopt sites",
+    ...report.deoptByLocation.slice(0, 30).map((entry) => `- ${entry.label} — ${entry.count}`),
+    "",
+    "## React-grab deopts (top 25)",
+    ...report.deoptsReactGrab.slice(0, 25).map((entry) => {
+      const location = entry.resolvedLineColumn
+        ? `${entry.scriptUrl}:${entry.resolvedLineColumn.line}:${entry.resolvedLineColumn.column}`
+        : entry.scriptUrl;
+      const snippet = entry.resolvedLineColumn?.snippet ?? "";
+      return `- \`${entry.bailoutType}\` — \`${entry.reason}\`\n  - ${location}\n  - \`${snippet}\``;
+    }),
+    "",
+    "## Top megamorphic IC sites",
+    ...report.megamorphicGroups.slice(0, 25).map((entry) => `- ${entry.label} — ${entry.count}`),
+    "",
+    "## Top polymorphic IC sites",
+    ...report.polymorphicGroups.slice(0, 15).map((entry) => `- ${entry.label} — ${entry.count}`),
+    "",
+  ].join("\n");
+  await writeFile(humanPath, humanText);
+  log(`wrote ${humanPath}`);
+};
+
+main().catch((error) => {
+  console.error("[deopt-analyze] fatal:", error);
+  process.exit(1);
+});

--- a/packages/react-grab/scripts/perf-deopt-analyze.mjs
+++ b/packages/react-grab/scripts/perf-deopt-analyze.mjs
@@ -13,6 +13,30 @@ const PRINT_PREFIX = "[deopt-analyze]";
 const log = (message) => console.log(`${PRINT_PREFIX} ${message}`);
 
 const REACT_GRAB_SOURCE_HINT = /react-grab|@react-grab|packages\/react-grab/i;
+const BIPPY_SOURCE_HINT = /bippy/i;
+
+const ICTYPES = new Set([
+  "LoadIC",
+  "StoreIC",
+  "KeyedLoadIC",
+  "KeyedStoreIC",
+  "LoadGlobalIC",
+  "StoreGlobalIC",
+  "StoreInArrayLiteralIC",
+  "DefineKeyedOwnIC",
+  "DefineNamedOwnIC",
+]);
+
+const IC_STATE_NAMES = {
+  X: "no_feedback",
+  "0": "uninitialized",
+  ".": "premonomorphic",
+  "1": "monomorphic",
+  "^": "recompute_handler",
+  P: "polymorphic",
+  N: "megamorphic",
+  G: "generic",
+};
 
 const parseCsvLine = (line) => {
   const parts = [];
@@ -44,218 +68,279 @@ const stripQuotes = (value) => {
   return value;
 };
 
-const summarize = async (logPath) => {
+const parseAddress = (hex) => {
+  if (!hex || typeof hex !== "string") return null;
+  return BigInt(hex);
+};
+
+const parseSourcePositionList = (text) => {
+  if (!text) return [];
+  const items = [];
+  const re = /<([^>]+)>/g;
+  let match;
+  while ((match = re.exec(text)) !== null) {
+    const raw = match[1];
+    const lastColon = raw.lastIndexOf(":");
+    const secondLastColon = raw.lastIndexOf(":", lastColon - 1);
+    if (lastColon === -1 || secondLastColon === -1) {
+      items.push({ url: raw, line: -1, column: -1 });
+      continue;
+    }
+    const column = Number(raw.slice(lastColon + 1));
+    const line = Number(raw.slice(secondLastColon + 1, lastColon));
+    const url = raw.slice(0, secondLastColon);
+    items.push({ url, line, column });
+  }
+  return items;
+};
+
+const parseFile = async (logPath) => {
   log(`parsing ${basename(logPath)} ...`);
   const text = await readFile(logPath, "utf8");
   const lines = text.split("\n");
 
-  const codeCreateByAddress = new Map();
-  const scriptSourcesById = new Map();
+  const codeIntervals = [];
   const deopts = [];
   const icRecords = [];
 
   for (const line of lines) {
     if (!line) continue;
-    const tag = line.slice(0, line.indexOf(",") === -1 ? line.length : line.indexOf(","));
-    if (
-      tag !== "code-creation" &&
-      tag !== "code-deopt" &&
-      tag !== "script-source" &&
-      tag.length > 0 &&
-      !tag.startsWith("LoadIC") &&
-      !tag.startsWith("StoreIC") &&
-      !tag.startsWith("KeyedLoadIC") &&
-      !tag.startsWith("KeyedStoreIC") &&
-      !tag.startsWith("LoadGlobalIC") &&
-      !tag.startsWith("StoreGlobalIC") &&
-      !tag.startsWith("StoreInArrayLiteralIC") &&
-      tag !== "Set" &&
-      tag !== "ic"
-    ) {
-      continue;
-    }
+    const firstCommaIndex = line.indexOf(",");
+    const tag = firstCommaIndex === -1 ? line : line.slice(0, firstCommaIndex);
 
-    const fields = parseCsvLine(line);
-
-    if (fields[0] === "script-source") {
-      const scriptId = fields[1];
-      const url = stripQuotes(fields[2] ?? "");
-      const source = stripQuotes(fields.slice(3).join(","));
-      if (scriptId) scriptSourcesById.set(scriptId, { url, source });
-      continue;
-    }
-
-    if (fields[0] === "code-creation") {
+    if (tag === "code-creation") {
+      const fields = parseCsvLine(line);
       const codeKind = fields[1];
-      const startAddress = fields[4];
-      const symbolName = stripQuotes(fields[6] ?? "");
-      const scriptId = fields[7];
-      if (startAddress) {
-        codeCreateByAddress.set(startAddress, {
-          codeKind,
-          symbolName,
-          scriptId,
-        });
+      if (codeKind === "JS" || codeKind === "LazyCompile" || codeKind === "Function" || codeKind === "Eval") {
+        const startAddress = parseAddress(fields[4]);
+        const size = Number(fields[5]);
+        const symbolName = stripQuotes(fields[6] ?? "");
+        if (startAddress !== null && Number.isFinite(size) && size > 0) {
+          codeIntervals.push({
+            start: startAddress,
+            end: startAddress + BigInt(size),
+            symbolName,
+            codeKind,
+          });
+        }
       }
       continue;
     }
 
-    if (fields[0] === "code-deopt") {
-      const [
-        ,
-        timestamp,
-        codeSize,
-        instructionStart,
-        inliningId,
-        scriptOffset,
-        bailoutType,
-        sourcePositionText,
-        deoptReasonText,
-      ] = fields;
+    if (tag === "code-deopt") {
+      const fields = parseCsvLine(line);
+      const positions = parseSourcePositionList(fields[7] ?? "");
       deopts.push({
-        timestamp: Number(timestamp),
-        codeSize: Number(codeSize),
-        instructionStart,
-        inliningId: Number(inliningId),
-        scriptOffset: Number(scriptOffset),
-        bailoutType,
-        sourcePosition: stripQuotes(sourcePositionText ?? ""),
-        reason: stripQuotes(deoptReasonText ?? ""),
+        timestamp: Number(fields[1]),
+        codeSize: Number(fields[2]),
+        instructionStart: fields[3],
+        inliningId: Number(fields[4]),
+        scriptOffset: Number(fields[5]),
+        bailoutType: fields[6],
+        rawSourcePosition: fields[7] ?? "",
+        positions,
+        reason: stripQuotes(fields[8] ?? ""),
       });
       continue;
     }
 
-    if (
-      fields[0].endsWith("IC") ||
-      fields[0] === "LoadIC" ||
-      fields[0] === "StoreIC" ||
-      fields[0] === "KeyedLoadIC" ||
-      fields[0] === "KeyedStoreIC"
-    ) {
-      const [type, pc, time, line2, column, oldState, newState, mapId, key, modifier, slowReason] =
-        fields;
+    if (ICTYPES.has(tag)) {
+      const fields = parseCsvLine(line);
       icRecords.push({
-        type,
-        pc,
-        time: Number(time),
-        line: Number(line2),
-        column: Number(column),
-        oldState,
-        newState,
-        mapId,
-        key: stripQuotes(key ?? ""),
-        modifier,
-        slowReason: stripQuotes(slowReason ?? ""),
+        type: fields[0],
+        pc: parseAddress(fields[1]),
+        time: Number(fields[2]),
+        line: Number(fields[3]),
+        column: Number(fields[4]),
+        oldState: fields[5],
+        newState: fields[6],
+        mapId: fields[7],
+        key: stripQuotes(fields[8] ?? ""),
+        modifier: fields[9] ?? "",
+        slowReason: stripQuotes(fields[10] ?? ""),
       });
       continue;
     }
   }
 
-  log(
-    `  parsed: ${deopts.length} deopts, ${icRecords.length} IC events, ${codeCreateByAddress.size} code blobs, ${scriptSourcesById.size} script sources`,
-  );
+  return { codeIntervals, deopts, icRecords };
+};
 
-  return { codeCreateByAddress, scriptSourcesById, deopts, icRecords };
+const buildCodeLookup = (codeIntervals) => {
+  const sorted = [...codeIntervals].sort((entryA, entryB) =>
+    entryA.start < entryB.start ? -1 : entryA.start > entryB.start ? 1 : 0,
+  );
+  const starts = sorted.map((entry) => entry.start);
+  const lookup = (address) => {
+    if (address === null) return null;
+    let lowIndex = 0;
+    let highIndex = sorted.length - 1;
+    while (lowIndex <= highIndex) {
+      const midIndex = (lowIndex + highIndex) >> 1;
+      const candidate = sorted[midIndex];
+      if (address < candidate.start) {
+        highIndex = midIndex - 1;
+      } else if (address >= candidate.end) {
+        lowIndex = midIndex + 1;
+      } else {
+        return candidate;
+      }
+    }
+    return null;
+  };
+  return { lookup, sorted, starts };
+};
+
+const cleanSymbolName = (symbolName) => {
+  if (!symbolName) return "(anonymous)";
+  return symbolName.replace(/^[~+]/, "").trim();
+};
+
+const extractFunctionUrl = (symbolName) => {
+  const match = / (https?:\/\/[^\s]+|file:[^\s]+|\/@fs[^\s]+)/.exec(symbolName);
+  if (!match) return null;
+  return match[1];
 };
 
 const reasonGroup = (reasonString) => reasonString || "(no-reason)";
-const positionScriptId = (sourcePosition) => {
-  const match = /^S(\d+)O(-?\d+)$/.exec(sourcePosition);
-  if (!match) return null;
-  return { scriptId: match[1], offset: Number(match[2]) };
-};
-
-const sourceLineColumn = (sourceText, offset) => {
-  if (!sourceText) return { line: -1, column: -1, snippet: "" };
-  if (offset < 0 || offset >= sourceText.length) return { line: -1, column: -1, snippet: "" };
-  let line = 1;
-  let lastNewline = -1;
-  for (let charIndex = 0; charIndex < offset; charIndex++) {
-    if (sourceText.charCodeAt(charIndex) === 10) {
-      line += 1;
-      lastNewline = charIndex;
-    }
-  }
-  const lineStart = lastNewline + 1;
-  const nextNewline = sourceText.indexOf("\n", offset);
-  const lineEnd = nextNewline === -1 ? sourceText.length : nextNewline;
-  return {
-    line,
-    column: offset - lineStart + 1,
-    snippet: sourceText.slice(lineStart, lineEnd).trim(),
-  };
-};
 
 const formatTopList = (entries, limit) =>
   entries
     .slice(0, limit)
-    .map(
-      (entry, entryIndex) =>
-        `  ${(entryIndex + 1).toString().padStart(2, " ")}. [${entry.count}]  ${entry.label}`,
-    )
+    .map((entry, entryIndex) => {
+      const indexLabel = (entryIndex + 1).toString().padStart(2, " ");
+      const countLabel = String(entry.count).padStart(5, " ");
+      return `  ${indexLabel}. [${countLabel}]  ${entry.label}`;
+    })
     .join("\n");
 
-const buildReport = ({ codeCreateByAddress, scriptSourcesById, deopts, icRecords }) => {
+const sortMapDesc = (mapValue) =>
+  Array.from(mapValue.entries())
+    .map(([label, count]) => ({ label, count }))
+    .sort((entryA, entryB) => entryB.count - entryA.count);
+
+const buildReport = ({ codeIntervals, deopts, icRecords }) => {
+  const codeLookup = buildCodeLookup(codeIntervals);
+
   const deoptByReason = new Map();
   const deoptByLocation = new Map();
   const deoptByScript = new Map();
   const deoptsReactGrab = [];
+  const deoptsBippy = [];
 
   for (const deopt of deopts) {
     const reasonKey = reasonGroup(deopt.reason);
     deoptByReason.set(reasonKey, (deoptByReason.get(reasonKey) ?? 0) + 1);
 
-    const positionInfo = positionScriptId(deopt.sourcePosition);
-    let scriptUrl = "(unknown script)";
-    let locationLabel = deopt.sourcePosition;
-    let resolvedLineColumn = null;
-    if (positionInfo) {
-      const scriptInfo = scriptSourcesById.get(positionInfo.scriptId);
-      scriptUrl = scriptInfo?.url || `(script ${positionInfo.scriptId})`;
-      resolvedLineColumn = sourceLineColumn(scriptInfo?.source ?? "", positionInfo.offset);
-      locationLabel = `${scriptUrl}:${resolvedLineColumn.line}:${resolvedLineColumn.column}`;
-    }
+    const primaryPosition = deopt.positions[0];
+    const scriptUrl = primaryPosition?.url ?? "(unknown)";
+    const locationLabel = primaryPosition
+      ? `${primaryPosition.url}:${primaryPosition.line}:${primaryPosition.column}`
+      : deopt.rawSourcePosition;
+
     deoptByLocation.set(locationLabel, (deoptByLocation.get(locationLabel) ?? 0) + 1);
     deoptByScript.set(scriptUrl, (deoptByScript.get(scriptUrl) ?? 0) + 1);
 
-    if (REACT_GRAB_SOURCE_HINT.test(scriptUrl) || REACT_GRAB_SOURCE_HINT.test(deopt.sourcePosition)) {
-      deoptsReactGrab.push({
-        ...deopt,
-        scriptUrl,
-        resolvedLineColumn,
-      });
+    if (REACT_GRAB_SOURCE_HINT.test(scriptUrl)) {
+      deoptsReactGrab.push({ ...deopt, locationLabel });
+    } else if (BIPPY_SOURCE_HINT.test(scriptUrl)) {
+      deoptsBippy.push({ ...deopt, locationLabel });
     }
   }
 
-  const megamorphicByKey = new Map();
-  const polymorphicByKey = new Map();
+  const icByLocation = new Map();
+  const icByTransition = new Map();
+  const icMegamorphicByLocation = new Map();
+  const icPolymorphicByLocation = new Map();
+  const icReactGrabMegamorphic = [];
+  const icReactGrabPolymorphic = [];
+  const icSummaryByScript = new Map();
+
   for (const icRecord of icRecords) {
-    if (!icRecord.newState) continue;
-    const target = icRecord.newState.includes("MEGAMORPHIC")
-      ? megamorphicByKey
-      : icRecord.newState.includes("POLYMORPHIC")
-        ? polymorphicByKey
-        : null;
-    if (!target) continue;
-    const codeInfo = codeCreateByAddress.get(icRecord.pc);
-    const symbolName = codeInfo?.symbolName || "(unknown)";
-    const groupKey = `${icRecord.type}  ${symbolName}  key=${icRecord.key || "?"}  reason=${icRecord.slowReason || "-"}`;
-    target.set(groupKey, (target.get(groupKey) ?? 0) + 1);
+    const codeInfo = codeLookup.lookup(icRecord.pc);
+    const cleanedSymbolName = cleanSymbolName(codeInfo?.symbolName);
+    const containingUrl = codeInfo ? extractFunctionUrl(codeInfo.symbolName) : null;
+    const baseLocationLabel = `${cleanedSymbolName}  key=${icRecord.key || "?"}  reason=${icRecord.slowReason || "-"}`;
+    const transitionLabel = `${IC_STATE_NAMES[icRecord.oldState] || icRecord.oldState}->${IC_STATE_NAMES[icRecord.newState] || icRecord.newState}`;
+
+    icByLocation.set(baseLocationLabel, (icByLocation.get(baseLocationLabel) ?? 0) + 1);
+    icByTransition.set(transitionLabel, (icByTransition.get(transitionLabel) ?? 0) + 1);
+
+    const isMegamorphic = icRecord.newState === "N";
+    const isPolymorphic = icRecord.newState === "P";
+
+    if (isMegamorphic) {
+      icMegamorphicByLocation.set(
+        baseLocationLabel,
+        (icMegamorphicByLocation.get(baseLocationLabel) ?? 0) + 1,
+      );
+    }
+    if (isPolymorphic) {
+      icPolymorphicByLocation.set(
+        baseLocationLabel,
+        (icPolymorphicByLocation.get(baseLocationLabel) ?? 0) + 1,
+      );
+    }
+
+    if (containingUrl) {
+      icSummaryByScript.set(containingUrl, (icSummaryByScript.get(containingUrl) ?? 0) + 1);
+    }
+
+    if (containingUrl && REACT_GRAB_SOURCE_HINT.test(containingUrl)) {
+      const entry = {
+        type: icRecord.type,
+        oldState: icRecord.oldState,
+        newState: icRecord.newState,
+        key: icRecord.key,
+        slowReason: icRecord.slowReason,
+        containingFunction: cleanedSymbolName,
+        containingUrl,
+        line: icRecord.line,
+        column: icRecord.column,
+      };
+      if (isMegamorphic) icReactGrabMegamorphic.push(entry);
+      if (isPolymorphic) icReactGrabPolymorphic.push(entry);
+    }
   }
 
-  const sortMapDesc = (mapValue) =>
-    Array.from(mapValue.entries())
-      .map(([label, count]) => ({ label, count }))
-      .sort((entryA, entryB) => entryB.count - entryA.count);
+  const aggregateMap = (entries, keyFn) => {
+    const accumulator = new Map();
+    for (const entry of entries) {
+      const groupKey = keyFn(entry);
+      const prior = accumulator.get(groupKey);
+      if (prior) {
+        prior.count += 1;
+      } else {
+        accumulator.set(groupKey, { ...entry, count: 1 });
+      }
+    }
+    return Array.from(accumulator.values()).sort((entryA, entryB) => entryB.count - entryA.count);
+  };
 
   return {
-    totals: { deopts: deopts.length, icEvents: icRecords.length },
+    totals: {
+      deopts: deopts.length,
+      icEvents: icRecords.length,
+      codeBlobs: codeIntervals.length,
+    },
     deoptByReason: sortMapDesc(deoptByReason),
     deoptByScript: sortMapDesc(deoptByScript),
     deoptByLocation: sortMapDesc(deoptByLocation),
     deoptsReactGrab,
-    megamorphicGroups: sortMapDesc(megamorphicByKey),
-    polymorphicGroups: sortMapDesc(polymorphicByKey),
+    deoptsBippy,
+    icByTransition: sortMapDesc(icByTransition),
+    icByLocation: sortMapDesc(icByLocation),
+    icMegamorphicByLocation: sortMapDesc(icMegamorphicByLocation),
+    icPolymorphicByLocation: sortMapDesc(icPolymorphicByLocation),
+    icSummaryByScript: sortMapDesc(icSummaryByScript),
+    icReactGrabMegamorphic: aggregateMap(
+      icReactGrabMegamorphic,
+      (entry) => `${entry.type}|${entry.containingFunction}|${entry.key}|${entry.slowReason}`,
+    ),
+    icReactGrabPolymorphic: aggregateMap(
+      icReactGrabPolymorphic,
+      (entry) => `${entry.type}|${entry.containingFunction}|${entry.key}|${entry.slowReason}`,
+    ),
   };
 };
 
@@ -272,60 +357,80 @@ const main = async () => {
     process.exit(1);
   }
 
-  const aggregated = {
-    codeCreateByAddress: new Map(),
-    scriptSourcesById: new Map(),
-    deopts: [],
-    icRecords: [],
-  };
-
+  const aggregated = { codeIntervals: [], deopts: [], icRecords: [] };
   for (const logFile of logFiles) {
-    const fileSummary = await summarize(resolve(LOG_DIR, logFile));
-    for (const [address, codeInfo] of fileSummary.codeCreateByAddress) {
-      aggregated.codeCreateByAddress.set(address, codeInfo);
-    }
-    for (const [scriptId, scriptInfo] of fileSummary.scriptSourcesById) {
-      aggregated.scriptSourcesById.set(scriptId, scriptInfo);
-    }
+    const fileSummary = await parseFile(resolve(LOG_DIR, logFile));
+    aggregated.codeIntervals.push(...fileSummary.codeIntervals);
     aggregated.deopts.push(...fileSummary.deopts);
     aggregated.icRecords.push(...fileSummary.icRecords);
   }
 
   const report = buildReport(aggregated);
 
-  log(`totals: ${report.totals.deopts} deopts, ${report.totals.icEvents} IC events`);
-  log("\n=== top deopt reasons ===\n" + formatTopList(report.deoptByReason, 20));
-  log("\n=== top deopt scripts ===\n" + formatTopList(report.deoptByScript, 20));
-  log("\n=== top deopt sites (file:line:col) ===\n" + formatTopList(report.deoptByLocation, 30));
   log(
-    `\n=== react-grab deopts: ${report.deoptsReactGrab.length} (first 25) ===\n` +
-      report.deoptsReactGrab
-        .slice(0, 25)
-        .map(
-          (entry, entryIndex) =>
-            `  ${(entryIndex + 1).toString().padStart(2, " ")}. ${entry.bailoutType}  reason=\"${entry.reason}\"\n      at ${entry.scriptUrl}` +
-            (entry.resolvedLineColumn
-              ? `:${entry.resolvedLineColumn.line}:${entry.resolvedLineColumn.column}\n      > ${entry.resolvedLineColumn.snippet}`
-              : ""),
-        )
-        .join("\n"),
+    `totals: ${report.totals.deopts} deopts, ${report.totals.icEvents} IC events, ${report.totals.codeBlobs} JS code blobs`,
   );
-  log("\n=== top megamorphic IC sites ===\n" + formatTopList(report.megamorphicGroups, 25));
-  log("\n=== top polymorphic IC sites ===\n" + formatTopList(report.polymorphicGroups, 15));
 
-  const summaryPath = resolve(LOG_DIR, "summary.json");
-  await writeFile(summaryPath, JSON.stringify(report, null, 2));
-  log(`\nwrote ${summaryPath}`);
+  log("\n=== top deopt reasons ===\n" + formatTopList(report.deoptByReason, 20));
+  log("\n=== top deopt scripts ===\n" + formatTopList(report.deoptByScript, 15));
+  log("\n=== top deopt sites (file:line:col) ===\n" + formatTopList(report.deoptByLocation, 30));
 
-  const humanPath = resolve(LOG_DIR, "summary.md");
-  const humanText = [
+  log(`\n=== react-grab deopts: ${report.deoptsReactGrab.length} ===`);
+  for (const [entryIndex, entry] of report.deoptsReactGrab.slice(0, 30).entries()) {
+    log(
+      `  ${(entryIndex + 1).toString().padStart(2, " ")}. ${entry.bailoutType}  reason="${entry.reason}"\n      at ${entry.locationLabel}`,
+    );
+  }
+
+  log(`\n=== bippy deopts: ${report.deoptsBippy.length} ===`);
+  for (const [entryIndex, entry] of report.deoptsBippy.slice(0, 15).entries()) {
+    log(
+      `  ${(entryIndex + 1).toString().padStart(2, " ")}. ${entry.bailoutType}  reason="${entry.reason}"\n      at ${entry.locationLabel}`,
+    );
+  }
+
+  log("\n=== IC state transitions (totals) ===\n" + formatTopList(report.icByTransition, 20));
+  log(
+    "\n=== top IC hot functions (any state) ===\n" + formatTopList(report.icByLocation, 25),
+  );
+  log(
+    `\n=== megamorphic IC sites in react-grab source: ${report.icReactGrabMegamorphic.length} ===`,
+  );
+  for (const [entryIndex, entry] of report.icReactGrabMegamorphic.slice(0, 25).entries()) {
+    log(
+      `  ${(entryIndex + 1).toString().padStart(2, " ")}. [${String(entry.count).padStart(5, " ")}]  ${entry.type}  ${entry.containingFunction}\n      key="${entry.key}"  reason="${entry.slowReason}"  url=${entry.containingUrl}`,
+    );
+  }
+  log(
+    `\n=== polymorphic IC sites in react-grab source: ${report.icReactGrabPolymorphic.length} ===`,
+  );
+  for (const [entryIndex, entry] of report.icReactGrabPolymorphic.slice(0, 15).entries()) {
+    log(
+      `  ${(entryIndex + 1).toString().padStart(2, " ")}. [${String(entry.count).padStart(5, " ")}]  ${entry.type}  ${entry.containingFunction}\n      key="${entry.key}"  reason="${entry.slowReason}"  url=${entry.containingUrl}`,
+    );
+  }
+
+  const writableReport = JSON.parse(
+    JSON.stringify(report, (_key, value) =>
+      typeof value === "bigint" ? value.toString() : value,
+    ),
+  );
+  const summaryJsonPath = resolve(LOG_DIR, "summary.json");
+  await writeFile(summaryJsonPath, JSON.stringify(writableReport, null, 2));
+  log(`\nwrote ${summaryJsonPath}`);
+
+  const summaryMarkdownPath = resolve(LOG_DIR, "summary.md");
+  const markdownText = [
     "# React Grab — V8 deopt + IC summary",
     "",
-    `Captured via dexnode-equivalent --js-flags: see manifest.json.`,
+    `Generated from a dexnode-equivalent --js-flags Chromium run. See manifest.json for flags.`,
     "",
     `- total deopts: **${report.totals.deopts}**`,
     `- total IC events: **${report.totals.icEvents}**`,
+    `- JS code blobs: **${report.totals.codeBlobs}**`,
     `- react-grab-source deopts: **${report.deoptsReactGrab.length}**`,
+    `- react-grab megamorphic IC sites: **${report.icReactGrabMegamorphic.length}** (${report.icReactGrabMegamorphic.reduce((accum, entry) => accum + entry.count, 0)} events)`,
+    `- react-grab polymorphic IC sites: **${report.icReactGrabPolymorphic.length}** (${report.icReactGrabPolymorphic.reduce((accum, entry) => accum + entry.count, 0)} events)`,
     "",
     "## Top deopt reasons",
     ...report.deoptByReason.slice(0, 20).map((entry) => `- \`${entry.label}\` — ${entry.count}`),
@@ -333,27 +438,33 @@ const main = async () => {
     "## Top deopt scripts",
     ...report.deoptByScript.slice(0, 20).map((entry) => `- \`${entry.label}\` — ${entry.count}`),
     "",
-    "## Top deopt sites",
-    ...report.deoptByLocation.slice(0, 30).map((entry) => `- ${entry.label} — ${entry.count}`),
+    "## React-grab deopts",
+    ...report.deoptsReactGrab.map(
+      (entry) =>
+        `- \`${entry.bailoutType}\` — \`${entry.reason}\`\n  - ${entry.locationLabel}`,
+    ),
     "",
-    "## React-grab deopts (top 25)",
-    ...report.deoptsReactGrab.slice(0, 25).map((entry) => {
-      const location = entry.resolvedLineColumn
-        ? `${entry.scriptUrl}:${entry.resolvedLineColumn.line}:${entry.resolvedLineColumn.column}`
-        : entry.scriptUrl;
-      const snippet = entry.resolvedLineColumn?.snippet ?? "";
-      return `- \`${entry.bailoutType}\` — \`${entry.reason}\`\n  - ${location}\n  - \`${snippet}\``;
-    }),
+    "## React-grab megamorphic IC sites",
+    ...report.icReactGrabMegamorphic.map(
+      (entry) =>
+        `- **${entry.count}× ${entry.type}** in \`${entry.containingFunction}\`\n  - key: \`${entry.key}\`  reason: \`${entry.slowReason || "-"}\`\n  - ${entry.containingUrl}`,
+    ),
     "",
-    "## Top megamorphic IC sites",
-    ...report.megamorphicGroups.slice(0, 25).map((entry) => `- ${entry.label} — ${entry.count}`),
+    "## React-grab polymorphic IC sites",
+    ...report.icReactGrabPolymorphic.map(
+      (entry) =>
+        `- **${entry.count}× ${entry.type}** in \`${entry.containingFunction}\`\n  - key: \`${entry.key}\`  reason: \`${entry.slowReason || "-"}\`\n  - ${entry.containingUrl}`,
+    ),
     "",
-    "## Top polymorphic IC sites",
-    ...report.polymorphicGroups.slice(0, 15).map((entry) => `- ${entry.label} — ${entry.count}`),
+    "## IC state transitions (totals)",
+    ...report.icByTransition.slice(0, 20).map((entry) => `- \`${entry.label}\` — ${entry.count}`),
+    "",
+    "## IC volume by script",
+    ...report.icSummaryByScript.slice(0, 20).map((entry) => `- ${entry.label} — ${entry.count}`),
     "",
   ].join("\n");
-  await writeFile(humanPath, humanText);
-  log(`wrote ${humanPath}`);
+  await writeFile(summaryMarkdownPath, markdownText);
+  log(`wrote ${summaryMarkdownPath}`);
 };
 
 main().catch((error) => {

--- a/packages/react-grab/scripts/perf-deopt.mjs
+++ b/packages/react-grab/scripts/perf-deopt.mjs
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+import { chromium } from "@playwright/test";
+import { spawn } from "node:child_process";
+import { mkdir, readdir, readFile, writeFile, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { dirname, resolve, basename } from "node:path";
+import { fileURLToPath } from "node:url";
+import process from "node:process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "../../..");
+const PERF_OUTPUT_DIR = resolve(__dirname, "../perf");
+const LOG_DIR = resolve(PERF_OUTPUT_DIR, "v8-log");
+
+const E2E_APP_URL = "http://localhost:5175";
+const PERF_GRID_PATH = "/?perf=grid&rows=50&cols=10";
+const SERVER_READY_TIMEOUT_MS = 60_000;
+
+const PRINT_PREFIX = "[deopt]";
+const log = (message) => console.log(`${PRINT_PREFIX} ${message}`);
+
+const DEXNODE_V8_FLAGS = [
+  "--log",
+  "--log-deopt",
+  "--log-ic",
+  "--log-maps",
+  "--log-maps-details",
+  "--log-code",
+  "--log-source-code",
+  "--prof",
+  "--log-internal-timer-events",
+  "--detailed-line-info",
+  "--no-logfile-per-isolate",
+  `--logfile=${resolve(LOG_DIR, "v8.log")}`,
+];
+
+const isServerReachable = async () => {
+  try {
+    const response = await fetch(E2E_APP_URL);
+    return response.ok || response.status < 500;
+  } catch {
+    return false;
+  }
+};
+
+const waitForServer = async (timeoutMs) => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await isServerReachable()) return true;
+    await new Promise((resolveTimer) => setTimeout(resolveTimer, 200));
+  }
+  return false;
+};
+
+const startDevServer = () => {
+  log("starting e2e-app dev server ...");
+  const child = spawn("pnpm", ["--filter", "@react-grab/e2e-app", "dev"], {
+    cwd: REPO_ROOT,
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, FORCE_COLOR: "0" },
+  });
+  child.stdout?.on("data", (chunk) => {
+    const text = chunk.toString();
+    if (text.includes("error") || text.includes("Local:")) process.stdout.write(`[dev] ${text}`);
+  });
+  child.stderr?.on("data", (chunk) => process.stderr.write(`[dev] ${chunk}`));
+  return child;
+};
+
+const stopDevServer = (child) => {
+  if (!child || child.killed) return;
+  try {
+    child.kill("SIGINT");
+  } catch {
+    // ignore
+  }
+};
+
+const driveScenarios = async (page) => {
+  log("scenario: hover_sweep (3000 pointermove dispatches)");
+  await page.evaluate(
+    async ({ sampleCount }) => {
+      const cells = Array.from(document.querySelectorAll("[data-perf-row][data-perf-column]"));
+      if (cells.length === 0) throw new Error("no perf cells found");
+
+      const api = window.__REACT_GRAB__;
+      api?.activate();
+      await new Promise((resolveTimer) => requestAnimationFrame(() => resolveTimer()));
+
+      for (let sampleIndex = 0; sampleIndex < sampleCount; sampleIndex++) {
+        const cell = cells[sampleIndex % cells.length];
+        const rect = cell.getBoundingClientRect();
+        cell.dispatchEvent(
+          new PointerEvent("pointermove", {
+            bubbles: true,
+            cancelable: true,
+            clientX: rect.left + rect.width / 2,
+            clientY: rect.top + rect.height / 2,
+            pointerId: 1,
+            pointerType: "mouse",
+            isPrimary: true,
+          }),
+        );
+      }
+      await new Promise((resolveTimer) => requestAnimationFrame(() => resolveTimer()));
+      api?.deactivate();
+    },
+    { sampleCount: 3000 },
+  );
+
+  log("scenario: scroll_invalidation (600 scrolls while frozen on a target)");
+  await page.evaluate(
+    async ({ scrollCount }) => {
+      const api = window.__REACT_GRAB__;
+      api?.activate();
+      const cells = Array.from(document.querySelectorAll("[data-perf-row][data-perf-column]"));
+      const targetCell = cells[Math.floor(cells.length / 2)];
+      const targetRect = targetCell.getBoundingClientRect();
+      targetCell.dispatchEvent(
+        new PointerEvent("pointermove", {
+          bubbles: true,
+          cancelable: true,
+          clientX: targetRect.left + targetRect.width / 2,
+          clientY: targetRect.top + targetRect.height / 2,
+          pointerId: 1,
+          pointerType: "mouse",
+          isPrimary: true,
+        }),
+      );
+      await new Promise((resolveTimer) => requestAnimationFrame(() => resolveTimer()));
+      for (let scrollIndex = 0; scrollIndex < scrollCount; scrollIndex++) {
+        window.dispatchEvent(new Event("scroll"));
+      }
+      await new Promise((resolveTimer) => requestAnimationFrame(() => resolveTimer()));
+      api?.deactivate();
+    },
+    { scrollCount: 600 },
+  );
+
+  log("scenario: get_state_amplification (10000 api.getState calls)");
+  await page.evaluate(
+    async ({ callCount }) => {
+      const api = window.__REACT_GRAB__;
+      api?.activate();
+      api?.getState();
+      for (let callIndex = 0; callIndex < callCount; callIndex++) api?.getState();
+      api?.deactivate();
+    },
+    { callCount: 10_000 },
+  );
+
+  log("scenario: viewport_burst (300 bursts of 5 scroll+resize)");
+  await page.evaluate(
+    async ({ burstCount }) => {
+      const api = window.__REACT_GRAB__;
+      api?.activate();
+      for (let burstIndex = 0; burstIndex < burstCount; burstIndex++) {
+        for (let innerIndex = 0; innerIndex < 5; innerIndex++) {
+          window.dispatchEvent(new Event("scroll"));
+          window.dispatchEvent(new Event("resize"));
+        }
+        await new Promise((resolveTimer) => requestAnimationFrame(() => resolveTimer()));
+      }
+      api?.deactivate();
+    },
+    { burstCount: 300 },
+  );
+
+  log("scenario: multi_freeze_burst (8 shift-clicked cells, 300 bursts)");
+  await page.evaluate(() => window.__REACT_GRAB__?.activate?.());
+  const cellPositions = await page.evaluate(
+    ({ elementsToFreeze }) => {
+      const cells = Array.from(document.querySelectorAll("[data-perf-row][data-perf-column]"));
+      const stride = Math.max(1, Math.floor(cells.length / elementsToFreeze));
+      const positions = [];
+      for (let cellIndex = 0; cellIndex < elementsToFreeze; cellIndex++) {
+        const cell = cells[cellIndex * stride];
+        if (!cell) break;
+        const rect = cell.getBoundingClientRect();
+        positions.push({ x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 });
+      }
+      return positions;
+    },
+    { elementsToFreeze: 8 },
+  );
+  await page.keyboard.down("Shift");
+  for (const position of cellPositions) {
+    await page.mouse.click(position.x, position.y);
+    await page.waitForTimeout(30);
+  }
+  await page.evaluate(
+    async ({ burstCount }) => {
+      for (let burstIndex = 0; burstIndex < burstCount; burstIndex++) {
+        for (let innerIndex = 0; innerIndex < 5; innerIndex++) {
+          window.dispatchEvent(new Event("scroll"));
+          window.dispatchEvent(new Event("resize"));
+        }
+        await new Promise((resolveTimer) => requestAnimationFrame(() => resolveTimer()));
+      }
+    },
+    { burstCount: 300 },
+  );
+  await page.keyboard.up("Shift");
+  await page.evaluate(() => window.__REACT_GRAB__?.deactivate?.());
+};
+
+const collectV8LogPaths = async () => {
+  const allEntries = await readdir(LOG_DIR);
+  return allEntries.filter((name) => name.endsWith(".log")).map((name) => resolve(LOG_DIR, name));
+};
+
+const main = async () => {
+  if (!existsSync(resolve(REPO_ROOT, "packages/react-grab/dist/index.js"))) {
+    log("dist missing — run `pnpm --filter react-grab build` first.");
+    process.exit(1);
+  }
+
+  await rm(LOG_DIR, { recursive: true, force: true });
+  await mkdir(LOG_DIR, { recursive: true });
+
+  let serverProcess = null;
+  const wasServerAlreadyRunning = await isServerReachable();
+  if (!wasServerAlreadyRunning) {
+    serverProcess = startDevServer();
+    const becameReady = await waitForServer(SERVER_READY_TIMEOUT_MS);
+    if (!becameReady) {
+      stopDevServer(serverProcess);
+      throw new Error("dev server failed to start within timeout");
+    }
+    log("dev server ready");
+  } else {
+    log("dev server already running, reusing");
+  }
+
+  log("launching chromium with dexnode-equivalent --js-flags ...");
+  log(`  flags: ${DEXNODE_V8_FLAGS.join(" ")}`);
+
+  const browser = await chromium.launch({
+    headless: true,
+    args: [
+      "--no-sandbox",
+      "--disable-extensions",
+      "--disable-background-networking",
+      "--disable-features=Translate,BackForwardCache",
+      "--js-flags=" + DEXNODE_V8_FLAGS.join(","),
+    ],
+  });
+
+  try {
+    const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
+    const page = await context.newPage();
+    page.on("pageerror", (error) => log(`page error: ${error.message}`));
+    page.on("console", (message) => {
+      if (message.type() === "error") log(`page console error: ${message.text()}`);
+    });
+
+    await page.goto(`${E2E_APP_URL}${PERF_GRID_PATH}`, { waitUntil: "domcontentloaded" });
+    await page.waitForFunction(() => Boolean(window.__REACT_GRAB__), null, { timeout: 10_000 });
+    await page.waitForFunction(
+      () => document.querySelectorAll("[data-perf-row][data-perf-column]").length > 100,
+      null,
+      { timeout: 10_000 },
+    );
+
+    log("warming up ...");
+    await page.evaluate(async () => {
+      window.__REACT_GRAB__?.activate?.();
+      await new Promise((resolveTimer) => setTimeout(resolveTimer, 50));
+      window.__REACT_GRAB__?.deactivate?.();
+    });
+
+    await driveScenarios(page);
+
+    log("scenarios complete; closing browser to flush v8.log ...");
+    await context.close();
+  } finally {
+    await browser.close();
+    if (serverProcess && !wasServerAlreadyRunning) stopDevServer(serverProcess);
+  }
+
+  const logPaths = await collectV8LogPaths();
+  log(`v8 log files: ${logPaths.length}`);
+  for (const logPath of logPaths) {
+    const stat = await readFile(logPath).then((buffer) => buffer.length);
+    log(`  ${basename(logPath)} — ${(stat / 1024).toFixed(1)} KiB`);
+  }
+
+  await writeFile(
+    resolve(LOG_DIR, "manifest.json"),
+    JSON.stringify(
+      {
+        capturedAt: new Date().toISOString(),
+        chromiumVersion: process.env.CHROMIUM_VERSION ?? null,
+        v8Flags: DEXNODE_V8_FLAGS,
+        logFiles: logPaths.map((logPath) => basename(logPath)),
+      },
+      null,
+      2,
+    ),
+  );
+
+  log(`done — logs in ${LOG_DIR}`);
+  log(`next: node packages/react-grab/scripts/perf-deopt-analyze.mjs`);
+};
+
+main().catch((error) => {
+  console.error("[deopt] fatal:", error);
+  process.exit(1);
+});

--- a/packages/react-grab/src/utils/get-element-at-position.ts
+++ b/packages/react-grab/src/utils/get-element-at-position.ts
@@ -7,6 +7,7 @@ import {
 import { suspendPointerEventsFreeze, resumePointerEventsFreeze } from "./pointer-events-freeze.js";
 
 interface PositionCache {
+  hasValue: boolean;
   clientX: number;
   clientY: number;
   element: Element | null;
@@ -14,12 +15,25 @@ interface PositionCache {
 }
 
 interface IFrameHoverCache {
-  element: HTMLIFrameElement;
-  rect: DOMRect;
+  isHovering: boolean;
+  element: HTMLIFrameElement | null;
+  rect: DOMRect | null;
 }
 
-let cache: PositionCache | null = null;
-let hoveredIframe: IFrameHoverCache | null = null;
+const positionCache: PositionCache = {
+  hasValue: false,
+  clientX: 0,
+  clientY: 0,
+  element: null,
+  timestamp: 0,
+};
+
+const iframeHoverCache: IFrameHoverCache = {
+  isHovering: false,
+  element: null,
+  rect: null,
+};
+
 let resumeTimerId: ReturnType<typeof setTimeout> | null = null;
 
 const isPointInsideRect = (clientX: number, clientY: number, rect: DOMRect): boolean =>
@@ -70,16 +84,25 @@ export const getElementAtPosition = (clientX: number, clientY: number): Element 
   // pending resume timer re-enable `html { pointer-events: none }`, which stops
   // the browser from dispatching pointer events into the iframe's document -
   // the source of lag on srcdoc iframes running their own React/JIT pipelines.
-  if (hoveredIframe && isPointInsideRect(clientX, clientY, hoveredIframe.rect)) {
-    return hoveredIframe.element;
+  if (
+    iframeHoverCache.isHovering &&
+    iframeHoverCache.rect &&
+    isPointInsideRect(clientX, clientY, iframeHoverCache.rect)
+  ) {
+    return iframeHoverCache.element;
   }
 
-  if (cache) {
-    const isPositionClose = isWithinThreshold(clientX, clientY, cache.clientX, cache.clientY);
-    const isWithinThrottle = now - cache.timestamp < ELEMENT_POSITION_THROTTLE_MS;
+  if (positionCache.hasValue) {
+    const isPositionClose = isWithinThreshold(
+      clientX,
+      clientY,
+      positionCache.clientX,
+      positionCache.clientY,
+    );
+    const isWithinThrottle = now - positionCache.timestamp < ELEMENT_POSITION_THROTTLE_MS;
 
     if (isPositionClose || isWithinThrottle) {
-      return cache.element;
+      return positionCache.element;
     }
   }
 
@@ -118,17 +141,30 @@ export const getElementAtPosition = (clientX: number, clientY: number): Element 
 
   scheduleResume();
 
-  hoveredIframe =
-    result instanceof HTMLIFrameElement
-      ? { element: result, rect: result.getBoundingClientRect() }
-      : null;
-  cache = { clientX, clientY, element: result, timestamp: now };
+  if (result instanceof HTMLIFrameElement) {
+    iframeHoverCache.isHovering = true;
+    iframeHoverCache.element = result;
+    iframeHoverCache.rect = result.getBoundingClientRect();
+  } else {
+    iframeHoverCache.isHovering = false;
+    iframeHoverCache.element = null;
+    iframeHoverCache.rect = null;
+  }
+
+  positionCache.hasValue = true;
+  positionCache.clientX = clientX;
+  positionCache.clientY = clientY;
+  positionCache.element = result;
+  positionCache.timestamp = now;
   return result;
 };
 
 export const clearElementPositionCache = (): void => {
   cancelScheduledResume();
   resumePointerEventsFreeze();
-  cache = null;
-  hoveredIframe = null;
+  positionCache.hasValue = false;
+  positionCache.element = null;
+  iframeHoverCache.isHovering = false;
+  iframeHoverCache.element = null;
+  iframeHoverCache.rect = null;
 };

--- a/packages/react-grab/src/utils/get-visual-viewport.ts
+++ b/packages/react-grab/src/utils/get-visual-viewport.ts
@@ -5,20 +5,31 @@ interface VisualViewportInfo {
   offsetTop: number;
 }
 
+// PERF: a single mutable singleton is returned to every caller so V8 keeps a
+// monomorphic hidden class at consumer read sites (e.g. the toolbar position
+// helpers inline this and bail out with `dependent field type constness
+// changed` if the returned object's shape transitions). Callers must consume
+// the result synchronously - never hold the reference across another
+// getVisualViewport() call.
+const viewportCache: VisualViewportInfo = {
+  width: 0,
+  height: 0,
+  offsetLeft: 0,
+  offsetTop: 0,
+};
+
 export const getVisualViewport = (): VisualViewportInfo => {
   const visualViewport = window.visualViewport;
   if (visualViewport) {
-    return {
-      width: visualViewport.width,
-      height: visualViewport.height,
-      offsetLeft: visualViewport.offsetLeft,
-      offsetTop: visualViewport.offsetTop,
-    };
+    viewportCache.width = visualViewport.width;
+    viewportCache.height = visualViewport.height;
+    viewportCache.offsetLeft = visualViewport.offsetLeft;
+    viewportCache.offsetTop = visualViewport.offsetTop;
+  } else {
+    viewportCache.width = window.innerWidth;
+    viewportCache.height = window.innerHeight;
+    viewportCache.offsetLeft = 0;
+    viewportCache.offsetTop = 0;
   }
-  return {
-    width: window.innerWidth,
-    height: window.innerHeight,
-    offsetLeft: 0,
-    offsetTop: 0,
-  };
+  return viewportCache;
 };

--- a/packages/react-grab/src/utils/toolbar-position.ts
+++ b/packages/react-grab/src/utils/toolbar-position.ts
@@ -10,6 +10,8 @@ import {
 import { getVisualViewport } from "./get-visual-viewport.js";
 import { clampToRange } from "./clamp-to-range.js";
 
+const { max: mathMax, min: mathMin } = Math;
+
 export const isHorizontalEdge = (edge: SnapEdge): boolean => edge === "top" || edge === "bottom";
 
 // Collapsed pill dimensions depend on the snap edge orientation: the LONG
@@ -33,30 +35,30 @@ export const getPositionFromEdgeAndRatio = (
   const viewportHeight = viewport.height;
 
   const minX = viewport.offsetLeft + TOOLBAR_SNAP_MARGIN_PX;
-  const maxX = Math.max(
+  const maxX = mathMax(
     minX,
     viewport.offsetLeft + viewportWidth - elementWidth - TOOLBAR_SNAP_MARGIN_PX,
   );
   const minY = viewport.offsetTop + TOOLBAR_SNAP_MARGIN_PX;
-  const maxY = Math.max(
+  const maxY = mathMax(
     minY,
     viewport.offsetTop + viewportHeight - elementHeight - TOOLBAR_SNAP_MARGIN_PX,
   );
 
   if (edge === "top" || edge === "bottom") {
-    const availableWidth = Math.max(0, viewportWidth - elementWidth - TOOLBAR_SNAP_MARGIN_PX * 2);
-    const positionX = Math.min(
+    const availableWidth = mathMax(0, viewportWidth - elementWidth - TOOLBAR_SNAP_MARGIN_PX * 2);
+    const positionX = mathMin(
       maxX,
-      Math.max(minX, viewport.offsetLeft + TOOLBAR_SNAP_MARGIN_PX + availableWidth * ratio),
+      mathMax(minX, viewport.offsetLeft + TOOLBAR_SNAP_MARGIN_PX + availableWidth * ratio),
     );
     const positionY = edge === "top" ? minY : maxY;
     return { x: positionX, y: positionY };
   }
 
-  const availableHeight = Math.max(0, viewportHeight - elementHeight - TOOLBAR_SNAP_MARGIN_PX * 2);
-  const positionY = Math.min(
+  const availableHeight = mathMax(0, viewportHeight - elementHeight - TOOLBAR_SNAP_MARGIN_PX * 2);
+  const positionY = mathMin(
     maxY,
-    Math.max(minY, viewport.offsetTop + TOOLBAR_SNAP_MARGIN_PX + availableHeight * ratio),
+    mathMax(minY, viewport.offsetTop + TOOLBAR_SNAP_MARGIN_PX + availableHeight * ratio),
   );
   const positionX = edge === "left" ? minX : maxX;
   return { x: positionX, y: positionY };
@@ -76,16 +78,16 @@ export const getRatioFromPosition = (
   if (edge === "top" || edge === "bottom") {
     const availableWidth = viewportWidth - elementWidth - TOOLBAR_SNAP_MARGIN_PX * 2;
     if (availableWidth <= 0) return TOOLBAR_DEFAULT_POSITION_RATIO;
-    return Math.max(
+    return mathMax(
       0,
-      Math.min(1, (positionX - viewport.offsetLeft - TOOLBAR_SNAP_MARGIN_PX) / availableWidth),
+      mathMin(1, (positionX - viewport.offsetLeft - TOOLBAR_SNAP_MARGIN_PX) / availableWidth),
     );
   }
   const availableHeight = viewportHeight - elementHeight - TOOLBAR_SNAP_MARGIN_PX * 2;
   if (availableHeight <= 0) return TOOLBAR_DEFAULT_POSITION_RATIO;
-  return Math.max(
+  return mathMax(
     0,
-    Math.min(1, (positionY - viewport.offsetTop - TOOLBAR_SNAP_MARGIN_PX) / availableHeight),
+    mathMin(1, (positionY - viewport.offsetTop - TOOLBAR_SNAP_MARGIN_PX) / availableHeight),
   );
 };
 
@@ -219,7 +221,7 @@ export const getSnapPosition = (
   const distanceToLeft = projectedX - viewport.offsetLeft + elementWidth / 2;
   const distanceToRight = viewport.offsetLeft + viewportWidth - projectedX - elementWidth / 2;
 
-  const minDistance = Math.min(distanceToTop, distanceToBottom, distanceToLeft, distanceToRight);
+  const minDistance = mathMin(distanceToTop, distanceToBottom, distanceToLeft, distanceToRight);
 
   const clampX = (rawX: number) =>
     clampToRange(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds an in-repo workflow to capture V8 deopt + IC information from `react-grab` as it actually runs in a real Chromium tab, **and** applies the three deopt fixes that are squarely in our source.

Because `dexnode` itself is a Node-only wrapper and `react-grab` is a browser library, this PR ports `dexnode`'s flag set to the equivalent Chromium `--js-flags` invocation. The resulting `v8.log` is byte-compatible with Microsoft's Deopt Explorer VS Code extension; an in-repo CLI summarizer is included for environments without it.

## New scripts

- `packages/react-grab/scripts/perf-deopt.mjs` — boots the `e2e-app` (`/?perf=grid&rows=50&cols=10`) and launches headless Chromium with the exact flag set `dexnode` emits for a `chrome_stable` host (`--log-deopt --log-ic --log-maps --log-maps-details --log-code --log-source-code --prof --log-internal-timer-events --detailed-line-info --no-logfile-per-isolate --logfile=…`). It then drives five scenarios (hover sweep, scroll-while-frozen, repeated `getState`, viewport invalidation bursts, multi-freeze invalidation bursts) and writes the raw `v8.log` to `packages/react-grab/perf/v8-log/`.
- `packages/react-grab/scripts/perf-deopt-analyze.mjs` — parses the log: deopt entries (`code-deopt` with inlined `<url:line:col>` source positions) and IC entries. IC `pc` addresses are resolved to their owning JS code blob via the log's `code-creation` records, so megamorphic / polymorphic hot sites are grouped by their containing function and source URL. Emits `summary.json`, `summary.md`, and a console report.
- `pnpm --filter react-grab perf:deopt` / `perf:deopt:analyze` wire those up.

## Targeted source fixes (only sites we control)

Driven directly by the capture in `packages/react-grab/perf/v8-deopt-findings.md`. Three commits, each one source file:

| file | change | site it targets |
| --- | --- | --- |
| `src/utils/get-element-at-position.ts` | `positionCache` and `iframeHoverCache` become module-level shape-stable singletons (`hasValue` / `isHovering` flag replaces the `null`/object union) | `Xr` (`freeze-updates*.js:~1303`) — removes the `cache` / `hoveredIframe` `null↔object` shape transition that fed the cache-read IC |
| `src/utils/get-visual-viewport.ts` | returns a shared mutable singleton instead of a fresh literal each call (callers already consume synchronously; comment documents the contract) | `It` (`renderer*.js:~1188` / `~1721`) — removes the `dependent field type constness changed` clusters whose root cause was the per-call literal returning different hidden classes |
| `src/utils/toolbar-position.ts` | hoists `Math.max` / `Math.min` to module-level `mathMax` / `mathMin` | `getPositionFromEdgeAndRatio` / `getSnapPosition` — eliminates the 60+ `KeyedLoadIC` events / run against the `Math` global |

### Verifiable IC-level deltas (4 runs each)

Aggregate is within run-to-run noise (±5 ms / ~7% per `perf/README.md`), but the targeted IC sites measurably moved:

| metric | before | after |
| --- | --- | --- |
| total deopts | 90 | 89 – 92 |
| total IC events | 19,876 | 19,559 – 19,690 |
| `Math` `KeyedLoadIC` events / run | 60+ | **0** |
| `dependent field type constness changed` deopts | 11 | 10 |
| distinct react-grab megamorphic IC sites | 62 | **54** |
| distinct react-grab polymorphic IC sites | 171 | **147** |

## What we did NOT change (and why)

These appear in the findings but they are not ours to fix in this PR:

- **Recursive fiber walker `$(e, t)`** at `freeze-updates*.js:~1671` (`wrong call target` + paired lazy deopt). Lives in `bippy`, not `packages/react-grab/src`.
- **Fiber finder `b(e)`** at `freeze-updates*.js:~249` (`unexpected name in keyed access` + 116× megamorphic `String.prototype.startsWith`). Also bippy.
- **Solid `createStore` proxy `get` trap** at `core*.js:70`. Owned by `solid-js`; the structural fix is to stop funneling heterogeneous targets (DOM nodes, fibers, plain options) through one store, which is a design-level change beyond this PR.
- **`incrementViewportVersion` → memo invalidation chain** (`renderer*.js` constness deopts). Already called out in `perf/README.md` — the right fix is to make store slot writes shape-stable, but that touches multiple modules and needs its own design pass.

## How to reproduce

```bash
pnpm install
pnpm build
pnpm --filter react-grab perf:deopt
pnpm --filter react-grab perf:deopt:analyze
```

Then read `packages/react-grab/perf/v8-deopt-findings.md` and the freshly-written `packages/react-grab/perf/v8-log/summary.md`. The raw `v8.log` is gitignored but can be opened directly with the Microsoft "Deopt Explorer" VS Code extension.

## Files

- **New tooling**: `packages/react-grab/scripts/perf-deopt.mjs`, `packages/react-grab/scripts/perf-deopt-analyze.mjs`
- **New docs**: `packages/react-grab/perf/v8-deopt-findings.md`, regenerated `packages/react-grab/perf/v8-log/summary.md`
- **Source fixes**: `packages/react-grab/src/utils/get-element-at-position.ts`, `packages/react-grab/src/utils/get-visual-viewport.ts`, `packages/react-grab/src/utils/toolbar-position.ts`
- **Wiring**: `packages/react-grab/package.json` (2 new scripts), `packages/react-grab/perf/README.md` (docs), `.gitignore` (exclude raw `v8.log` / `code.asm`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eba32cf7-0265-4173-9f1e-972218649bc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eba32cf7-0265-4173-9f1e-972218649bc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an in-browser V8 deopt + IC profiler for `react-grab` that mirrors `dexnode` flags in headless Chromium, plus a CLI analyzer and curated findings. Also applies three small runtime tweaks to stabilize hidden classes and hoist `Math` globals, reducing megamorphic IC sites and eliminating `Math` KeyedLoadICs.

- **New Features**
  - `perf:deopt`: launches the `e2e-app`, runs Chromium with `dexnode`-equivalent `--js-flags`, drives five scenarios, and writes `v8.log` to `packages/react-grab/perf/v8-log/`.
  - `perf:deopt:analyze`: resolves IC `pc` addresses via `code-creation` records and emits `summary.json`/`summary.md` (+ console report).
  - Adds `packages/react-grab/perf/v8-deopt-findings.md` with an updated post-fix snapshot; docs in `packages/react-grab/perf/README.md`; raw logs/asm gitignored.

- **Performance**
  - Stabilize hidden classes in `get-element-at-position.ts` and `get-visual-viewport.ts` via module-level singletons.
  - Hoist `Math.max`/`Math.min` in `toolbar-position.ts` to cut hot property lookups.
  - Results: `Math` KeyedLoadIC events → 0; react-grab megamorphic IC sites: 62 → 54; dependent-field-constness deopts: 11 → 10.

<sup>Written for commit 1a2f26a530e411abfab2785fbf461f2b5827d7ca. Summary will update on new commits. <a href="https://cubic.dev/pr/aidenybai/react-grab/pull/346?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

