### PR TITLE
fix(react-grab): show preview label for hovered element during shift multi-select

### DIFF
--- a/packages/react-grab/e2e/shift-multi-select.spec.ts
+++ b/packages/react-grab/e2e/shift-multi-select.spec.ts
@@ -318,6 +318,130 @@ test.describe("Shift Multi-Select", () => {
     await reactGrab.pressEscape();
   });
 
+  test("should render a copied indicator per shift-selected element after release", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.activate();
+
+    const firstItem = reactGrab.page.locator("[data-testid='todo-list'] li").nth(0);
+    const secondItem = reactGrab.page.locator("[data-testid='todo-list'] li").nth(1);
+
+    const firstBox = await firstItem.boundingBox();
+    const secondBox = await secondItem.boundingBox();
+    if (!firstBox || !secondBox) throw new Error("Could not get bounding boxes");
+
+    const firstAnchorX = firstBox.x + firstBox.width * SHIFT_LABEL_CLICK_ANCHOR_RATIO;
+    const secondAnchorX = secondBox.x + secondBox.width * SHIFT_LABEL_SECOND_CLICK_ANCHOR_RATIO;
+
+    await reactGrab.page.keyboard.up("Shift");
+    await reactGrab.page.keyboard.down("Shift");
+    await reactGrab.page.mouse.click(firstAnchorX, firstBox.y + firstBox.height / 2);
+    await reactGrab.page.waitForTimeout(120);
+    await reactGrab.page.mouse.click(secondAnchorX, secondBox.y + secondBox.height / 2);
+    await reactGrab.page.waitForTimeout(120);
+    await reactGrab.page.keyboard.up("Shift");
+
+    await expect.poll(() => reactGrab.getClipboardContent()).toContain("TodoItem");
+
+    const copiedLabelCentersBeforeScroll = await reactGrab.page.evaluate(() => {
+      const host = document.querySelector("[data-react-grab]");
+      const shadowRoot = host?.shadowRoot;
+      const labels = shadowRoot?.querySelectorAll<HTMLElement>("[data-react-grab-selection-label]");
+      return Array.from(labels ?? [])
+        .map((label) => {
+          const rect = label.getBoundingClientRect();
+          return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
+        })
+        .sort((a, b) => a.y - b.y);
+    });
+
+    expect(copiedLabelCentersBeforeScroll.length).toBe(SHIFT_LABEL_ANCHORED_COUNT);
+    expect(Math.abs(copiedLabelCentersBeforeScroll[0].x - firstAnchorX)).toBeLessThan(
+      SHIFT_LABEL_POSITION_TOLERANCE_PX,
+    );
+    expect(Math.abs(copiedLabelCentersBeforeScroll[1].x - secondAnchorX)).toBeLessThan(
+      SHIFT_LABEL_POSITION_TOLERANCE_PX,
+    );
+  });
+
+  test("should keep per-element copied indicators anchored across scroll", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.activate();
+
+    const firstItem = reactGrab.page.locator("[data-testid='todo-list'] li").nth(0);
+    const secondItem = reactGrab.page.locator("[data-testid='todo-list'] li").nth(1);
+
+    const firstBox = await firstItem.boundingBox();
+    const secondBox = await secondItem.boundingBox();
+    if (!firstBox || !secondBox) throw new Error("Could not get bounding boxes");
+
+    await reactGrab.page.keyboard.up("Shift");
+    await reactGrab.page.keyboard.down("Shift");
+    await reactGrab.page.mouse.click(
+      firstBox.x + firstBox.width / 2,
+      firstBox.y + firstBox.height / 2,
+    );
+    await reactGrab.page.waitForTimeout(120);
+    await reactGrab.page.mouse.click(
+      secondBox.x + secondBox.width / 2,
+      secondBox.y + secondBox.height / 2,
+    );
+    await reactGrab.page.waitForTimeout(120);
+    await reactGrab.page.keyboard.up("Shift");
+
+    await expect.poll(() => reactGrab.getClipboardContent()).toContain("TodoItem");
+
+    const labelCentersBeforeScroll = await reactGrab.page.evaluate(() => {
+      const host = document.querySelector("[data-react-grab]");
+      const shadowRoot = host?.shadowRoot;
+      const labels = shadowRoot?.querySelectorAll<HTMLElement>("[data-react-grab-selection-label]");
+      return Array.from(labels ?? [])
+        .map((label) => {
+          const rect = label.getBoundingClientRect();
+          return { y: rect.y + rect.height / 2 };
+        })
+        .sort((a, b) => a.y - b.y);
+    });
+
+    expect(labelCentersBeforeScroll.length).toBe(SHIFT_LABEL_ANCHORED_COUNT);
+
+    const firstElementCenterBefore = await firstItem.evaluate((node) => {
+      const rect = (node as Element).getBoundingClientRect();
+      return rect.y + rect.height / 2;
+    });
+
+    const scrollDeltaPx = 60;
+    await reactGrab.page.mouse.wheel(0, scrollDeltaPx);
+    await reactGrab.page.waitForTimeout(SHIFT_LABEL_SETTLE_DELAY_MS);
+
+    const firstElementCenterAfter = await firstItem.evaluate((node) => {
+      const rect = (node as Element).getBoundingClientRect();
+      return rect.y + rect.height / 2;
+    });
+    const elementShift = firstElementCenterAfter - firstElementCenterBefore;
+    expect(Math.abs(elementShift)).toBeGreaterThan(SHIFT_LABEL_POSITION_TOLERANCE_PX);
+
+    const labelCentersAfterScroll = await reactGrab.page.evaluate(() => {
+      const host = document.querySelector("[data-react-grab]");
+      const shadowRoot = host?.shadowRoot;
+      const labels = shadowRoot?.querySelectorAll<HTMLElement>("[data-react-grab-selection-label]");
+      return Array.from(labels ?? [])
+        .map((label) => {
+          const rect = label.getBoundingClientRect();
+          return { y: rect.y + rect.height / 2 };
+        })
+        .sort((a, b) => a.y - b.y);
+    });
+
+    expect(labelCentersAfterScroll.length).toBe(SHIFT_LABEL_ANCHORED_COUNT);
+    for (let labelIndex = 0; labelIndex < labelCentersBeforeScroll.length; labelIndex++) {
+      const expectedY = labelCentersBeforeScroll[labelIndex].y + elementShift;
+      const actualY = labelCentersAfterScroll[labelIndex].y;
+      expect(Math.abs(actualY - expectedY)).toBeLessThan(SHIFT_LABEL_POSITION_TOLERANCE_PX * 4);
+    }
+  });
+
   test("should preserve drag preview while shift multi-selecting", async ({ reactGrab }) => {
     await reactGrab.activate();
 

--- a/packages/react-grab/e2e/shift-multi-select.spec.ts
+++ b/packages/react-grab/e2e/shift-multi-select.spec.ts
@@ -88,6 +88,71 @@ test.describe("Shift Multi-Select", () => {
     await reactGrab.page.keyboard.up("Shift");
   });
 
+  test("should show a preview label for the hovered second element while shift multi-selecting", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.activate();
+
+    const firstItem = reactGrab.page.locator("[data-testid='todo-list'] li").nth(0);
+    const secondItem = reactGrab.page.locator("[data-testid='todo-list'] li").nth(1);
+
+    const firstBox = await firstItem.boundingBox();
+    const secondBox = await secondItem.boundingBox();
+    if (!firstBox || !secondBox) throw new Error("Could not get bounding boxes");
+
+    await reactGrab.page.keyboard.up("Shift");
+    await reactGrab.page.keyboard.down("Shift");
+    await reactGrab.page.mouse.click(
+      firstBox.x + firstBox.width / 2,
+      firstBox.y + firstBox.height / 2,
+    );
+    await expect.poll(() => reactGrab.getSelectionLabelBounds()).not.toBeNull();
+
+    await reactGrab.page.mouse.move(
+      secondBox.x + secondBox.width / 2,
+      secondBox.y + secondBox.height / 2,
+      { steps: SHIFT_PENDING_HOVER_STEP_COUNT },
+    );
+
+    await expect
+      .poll(async () =>
+        reactGrab.page.evaluate(() => {
+          const host = document.querySelector("[data-react-grab]");
+          const shadowRoot = host?.shadowRoot;
+          const labels = shadowRoot?.querySelectorAll<HTMLElement>(
+            "[data-react-grab-selection-label]",
+          );
+          return labels?.length ?? 0;
+        }),
+      )
+      .toBeGreaterThanOrEqual(2);
+
+    const labelVerticalCenters = await reactGrab.page.evaluate(() => {
+      const host = document.querySelector("[data-react-grab]");
+      const shadowRoot = host?.shadowRoot;
+      const labels = shadowRoot?.querySelectorAll<HTMLElement>("[data-react-grab-selection-label]");
+      return Array.from(labels ?? []).map((label) => {
+        const rect = label.getBoundingClientRect();
+        return rect.y + rect.height / 2;
+      });
+    });
+
+    const verticalSeparation = Math.abs(secondBox.y - firstBox.y);
+    const uniqueLabelCenters = Array.from(new Set(labelVerticalCenters.map((y) => Math.round(y))));
+    expect(uniqueLabelCenters.length).toBeGreaterThanOrEqual(2);
+    const maxLabelSeparation = uniqueLabelCenters.reduce(
+      (currentMax, centerA) =>
+        uniqueLabelCenters.reduce(
+          (innerMax, centerB) => Math.max(innerMax, Math.abs(centerA - centerB)),
+          currentMax,
+        ),
+      0,
+    );
+    expect(maxLabelSeparation).toBeGreaterThan(verticalSeparation / 2);
+
+    await reactGrab.page.keyboard.up("Shift");
+  });
+
   test("should keep the first shift-selected label anchored to the element", async ({
     reactGrab,
   }) => {

--- a/packages/react-grab/src/components/renderer.tsx
+++ b/packages/react-grab/src/components/renderer.tsx
@@ -67,6 +67,17 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
           )}
         </Index>
       </Show>
+      <Show when={props.pendingShiftPreviewEntry}>
+        {(pendingEntry) => (
+          <SelectionLabel
+            tagName={pendingEntry().tagName}
+            componentName={pendingEntry().componentName}
+            selectionBounds={pendingEntry().bounds}
+            mouseX={pendingEntry().mouseX}
+            visible={true}
+          />
+        )}
+      </Show>
       <Show
         when={
           props.selectionLabelVisible &&

--- a/packages/react-grab/src/components/renderer.tsx
+++ b/packages/react-grab/src/components/renderer.tsx
@@ -67,7 +67,7 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
           )}
         </Index>
       </Show>
-      <Show when={props.pendingShiftPreviewEntry}>
+      <Show when={props.selectionLabelVisible && props.pendingShiftPreviewEntry}>
         {(pendingEntry) => (
           <SelectionLabel
             tagName={pendingEntry().tagName}

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -711,6 +711,45 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       return instanceId;
     };
 
+    const createPerElementLabelInstances = (
+      entries: Array<{
+        element: Element;
+        tagName: string;
+        componentName?: string;
+        mouseX?: number;
+      }>,
+      status: SelectionLabelInstance["status"],
+    ): string[] => {
+      actions.clearLabelInstances();
+      cancelAllLabelFades();
+      const instanceIds: string[] = [];
+      for (const entry of entries) {
+        const bounds = createElementBounds(entry.element);
+        const boundsCenterX = bounds.x + bounds.width / 2;
+        const boundsHalfWidth = bounds.width / 2;
+        const mouseXOffset = entry.mouseX !== undefined ? entry.mouseX - boundsCenterX : undefined;
+        const instanceId = generateId("label");
+        const instance: SelectionLabelInstance = {
+          id: instanceId,
+          bounds,
+          tagName: entry.tagName,
+          componentName: entry.componentName,
+          status,
+          createdAt: Date.now(),
+          element: entry.element,
+          mouseX: entry.mouseX,
+          mouseXOffsetFromCenter: mouseXOffset,
+          mouseXOffsetRatio:
+            mouseXOffset !== undefined && boundsHalfWidth > 0
+              ? mouseXOffset / boundsHalfWidth
+              : undefined,
+        };
+        actions.addLabelInstance(instance);
+        instanceIds.push(instanceId);
+      }
+      return instanceIds;
+    };
+
     const clearAllLabels = () => {
       cancelAllLabelFades();
       actions.clearLabelInstances();
@@ -731,7 +770,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
     const executeCopyOperation = async (
       clipboardOperation: () => Promise<void>,
-      labelInstanceId: string | null,
+      labelInstanceIds: string[] | null,
       copiedElement?: Element,
       shouldDeactivateAfter?: boolean,
     ) => {
@@ -750,8 +789,10 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         errorMessage = normalizeErrorMessage(error, "Action failed");
       }
 
-      if (labelInstanceId) {
-        updateLabelAfterCopy(labelInstanceId, didSucceed, errorMessage);
+      if (labelInstanceIds) {
+        for (const labelInstanceId of labelInstanceIds) {
+          updateLabelAfterCopy(labelInstanceId, didSucceed, errorMessage);
+        }
       }
 
       if (current().state !== "copying") return;
@@ -942,7 +983,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           await executeCopyOperation(
             () =>
               copyElementsToClipboard(allTargetElements, extraPrompt, componentName ?? undefined),
-            labelInstanceId,
+            labelInstanceId ? [labelInstanceId] : null,
             element,
             shouldDeactivateAfter,
           );
@@ -956,6 +997,47 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
               false,
               normalizeErrorMessage(error, "Action failed"),
             );
+          }
+          if (current().state === "copying") {
+            actions.unfreeze();
+          }
+        });
+    };
+
+    const performCopyWithPerElementLabels = (options: {
+      elements: Element[];
+      labelEntries: Array<{
+        element: Element;
+        tagName: string;
+        componentName?: string;
+        mouseX?: number;
+      }>;
+      shouldDeactivateAfter?: boolean;
+      onComplete?: () => void;
+    }) => {
+      const { elements, labelEntries, shouldDeactivateAfter, onComplete } = options;
+      const primaryElement = elements[0];
+
+      clearCopyFeedbackCooldown();
+      actions.startCopy();
+
+      const labelInstanceIds = createPerElementLabelInstances(labelEntries, "copying");
+
+      void getNearestComponentName(primaryElement)
+        .then(async (componentName) => {
+          await executeCopyOperation(
+            () => copyElementsToClipboard(elements, undefined, componentName ?? undefined),
+            labelInstanceIds.length > 0 ? labelInstanceIds : null,
+            primaryElement,
+            shouldDeactivateAfter,
+          );
+          onComplete?.();
+        })
+        .catch((error) => {
+          logRecoverableError("Copy operation failed", error);
+          const normalizedMessage = normalizeErrorMessage(error, "Action failed");
+          for (const labelInstanceId of labelInstanceIds) {
+            updateLabelAfterCopy(labelInstanceId, false, normalizedMessage);
           }
           if (current().state === "copying") {
             actions.unfreeze();
@@ -1823,18 +1905,40 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
 
     const commitShiftMultiSelection = () => {
+      const accumulatedElements = store.frozenElements.filter(isElementConnected);
+
+      const perElementLabelEntries = accumulatedElements.map((element) => {
+        const tagName = getTagName(element) || "element";
+        const componentName = getComponentDisplayName(element) ?? undefined;
+        const anchorRatio = shiftSelectionLabelAnchorRatioByElement.get(element);
+        const bounds = createElementBounds(element);
+        const mouseX =
+          anchorRatio === undefined
+            ? bounds.x + bounds.width / 2
+            : bounds.x + bounds.width * anchorRatio;
+        return { element, tagName, componentName, mouseX };
+      });
+
       stopShiftMultiSelecting();
 
-      const accumulatedElements = store.frozenElements.filter(isElementConnected);
       if (accumulatedElements.length === 0) {
         actions.unfreeze();
         return;
       }
 
-      performCopyWithLabel({
-        element: accumulatedElements[0],
-        cursorX: pointer().x,
-        selectedElements: accumulatedElements,
+      if (accumulatedElements.length === 1) {
+        performCopyWithLabel({
+          element: accumulatedElements[0],
+          cursorX: perElementLabelEntries[0].mouseX,
+          selectedElements: accumulatedElements,
+          shouldDeactivateAfter: store.wasActivatedByToggle,
+        });
+        return;
+      }
+
+      performCopyWithPerElementLabels({
+        elements: accumulatedElements,
+        labelEntries: perElementLabelEntries,
         shouldDeactivateAfter: store.wasActivatedByToggle,
       });
     };

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -1243,6 +1243,17 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       return entries;
     });
 
+    const pendingShiftPreviewEntry = createMemo((): FrozenLabelEntry | null => {
+      if (isPromptMode()) return null;
+      const element = pendingShiftSelectionElement();
+      if (!element) return null;
+      void viewportVersion();
+      const tagName = getTagName(element) || "element";
+      const componentName = getComponentDisplayName(element) ?? undefined;
+      const bounds = createElementBounds(element);
+      return { tagName, componentName, bounds, mouseX: pointer().x };
+    });
+
     const cursorPosition = createMemo(() => {
       if (isCopying() || isPromptMode()) {
         void viewportVersion();
@@ -3775,6 +3786,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
                 }
                 selectionElementsCount={store.frozenElements.length}
                 frozenLabelEntries={frozenLabelEntries()}
+                pendingShiftPreviewEntry={pendingShiftPreviewEntry() ?? undefined}
                 selectionFilePath={store.selectionFilePath ?? undefined}
                 selectionLineNumber={store.selectionLineNumber ?? undefined}
                 selectionTagName={selectionTagName()}

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -359,6 +359,7 @@ export interface ReactGrabRendererProps {
   selectionShouldSnap?: boolean;
   selectionElementsCount?: number;
   frozenLabelEntries?: FrozenLabelEntry[];
+  pendingShiftPreviewEntry?: FrozenLabelEntry;
   selectionFilePath?: string;
   selectionLineNumber?: number;
   selectionTagName?: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bug

While holding `Shift` after clicking the first element, hovering a different element no longer showed a selection-label preview for that next candidate. The dashed selection box on the hovered element was still drawn, but the label stayed pinned to the first frozen element — so the user got no hint of what tag/component shift+click would actually select next.

## Root cause

In shift multi-select mode the renderer chooses between two label paths:

- `frozenLabelEntries` — only emitted when `store.frozenElements.length >= 2`.
- The "normal" `<SelectionLabel>` — gated on `frozenLabelEntries.length === 0`.

With exactly one frozen element + a pending hover, neither path knew about `pendingShiftSelectionElement()`. The normal label fell back to the first frozen element's bounds via `selectionBounds()` (cursor-anchored to the original click), so the second hovered element got no label.

## Fix

Add a dedicated `pendingShiftPreviewEntry` memo in `core/index.tsx` that returns a `FrozenLabelEntry` for the currently hovered shift-multi-select candidate (when one exists and we are not in prompt mode), and render an extra `<SelectionLabel>` for it in `renderer.tsx`. The frozen-element labels and the regular selection label are untouched; the preview is purely additive, anchored to the live pointer so it tracks the cursor on the hovered candidate. The preview is gated on `selectionLabelVisible` so it respects the same suppression rules as the other label paths (element-label theme disabled, context menu open, selection suppressed after copy).

## Per-element copied indicators

After releasing `Shift`, the commit previously produced a single "Copied" label anchored to the first element (or the drag-rect center for shift+drag); all other elements lost their label context. We now render one copied indicator per accumulated element, anchored at each element's recorded shift-click anchor ratio so each label appears where the user originally clicked. The indicators reuse the single-element label-instance pipeline, so they automatically track scroll and resize via `recomputeLabelInstance` (which re-reads each element's live bounds whenever `viewportVersion` increments).

Plumbing:

- `executeCopyOperation` now accepts an array of label instance IDs so the `copying` → `copied`/`error` transition fans out to every per-element label at once.
- `createPerElementLabelInstances` creates a batch of label instances (clearing previous instances + cancelling fades once) so each instance gets its own `element` and `mouseXOffsetRatio` for live bounds tracking.
- `performCopyWithPerElementLabels` orchestrates the per-element label flow alongside the existing single-label `performCopyWithLabel`.
- `commitShiftMultiSelection` snapshots anchor ratios before `stopShiftMultiSelecting` (which clears the anchor map) and routes multi-element commits through the new path; single-element commits keep using the existing path.

## Tests

Added regression tests in `packages/react-grab/e2e/shift-multi-select.spec.ts`:

1. `should show a preview label for the hovered second element while shift multi-selecting` — shift+clicks the first item, moves to the second, asserts at least two distinct labels are present.
2. `should render a copied indicator per shift-selected element after release` — shift+clicks two elements at known anchor ratios, releases Shift, asserts two labels appear and that each label's x center matches its recorded anchor.
3. `should keep per-element copied indicators anchored across scroll` — shift+clicks two elements, releases Shift, scrolls the page, asserts each indicator moves in lockstep with its element.

Verified the preview-label regression test fails on `main` and passes with the fix. Full `pnpm test` suite (572 e2e tests) passes; `pnpm typecheck`, `pnpm lint`, and `pnpm format` are clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb855813-ade2-4daa-a714-52b84299e542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb855813-ade2-4daa-a714-52b84299e542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the missing preview label during Shift multi-select hover and adds per-element “Copied” indicators after committing a multi-select in `react-grab`. Hovering now shows a live label for the next selection, and each selected element gets its own copied label anchored to where you clicked.

- **Bug Fixes**
  - Added `pendingShiftPreviewEntry` (from `pendingShiftSelectionElement`) and rendered an extra `SelectionLabel`; extended `ReactGrabRendererProps` with `pendingShiftPreviewEntry`.
  - Gated the preview on `selectionLabelVisible` to respect label-suppression states.
  - Added an e2e test asserting two labels appear during Shift hover.

- **New Features**
  - Render one copied indicator per shift-selected element after release, anchored to each element’s click position; indicators track scroll and resize.
  - Introduced batched label instances and fan-out copy updates for multi-select; updated commit flow to use per-element labels. Added e2e tests for anchored positions and scroll tracking.

<sup>Written for commit aa2d2805fd060530cd77bb45327c61d3b95f3a51. Summary will update on new commits. <a href="https://cubic.dev/pr/aidenybai/react-grab/pull/347?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

