### PR TITLE
fix: keep page interactive while grabbing

### DIFF
--- a/apps/website-v2/app/page.tsx
+++ b/apps/website-v2/app/page.tsx
@@ -816,7 +816,7 @@ export default function Home() {
       </Section>
 
       <Section title="Resizable">
-        <ResizablePanelGroup direction="horizontal" className="min-h-[120px] rounded-lg border">
+        <ResizablePanelGroup orientation="horizontal" className="min-h-[120px] rounded-lg border">
           <ResizablePanel defaultSize={50}>
             <div className="flex h-full items-center justify-center p-4">
               <span className="text-sm font-semibold">Panel A</span>

--- a/apps/website-v2/middleware.ts
+++ b/apps/website-v2/middleware.ts
@@ -1,5 +1,0 @@
-export { proxy as middleware } from "./proxy";
-
-export const config = {
-  matcher: ["/", "/llm.txt"],
-};

--- a/apps/website-v2/proxy.ts
+++ b/apps/website-v2/proxy.ts
@@ -26,3 +26,7 @@ export const proxy = (request: NextRequest) => {
 
   return response;
 };
+
+export const config = {
+  matcher: ["/", "/llm.txt"],
+};

--- a/packages/react-grab/package.json
+++ b/packages/react-grab/package.json
@@ -94,7 +94,7 @@
   },
   "dependencies": {
     "@react-grab/cli": "workspace:*",
-    "bippy": "^0.5.40"
+    "bippy": "^0.5.41"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -241,7 +241,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     });
     const isCopying = createMemo(() => current().state === "copying");
     const isSelectionInteractionLocked = createMemo(
-      () => isCopying() || store.selectionInteractionLockDepth > 0,
+      () => store.selectionInteractionLockDepth > 0,
     );
     const didJustCopy = createMemo(() => current().state === "justCopied");
     const isPromptMode = createMemo(() => {
@@ -2758,11 +2758,11 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         if (isEventFromOverlay(event, "data-react-grab-ignore-events")) return;
         if (store.contextMenuPosition !== null) return;
 
-        if (isRendererActive() || isCopying() || didJustDrag()) {
+        if (isRendererActive() || didJustDrag()) {
           event.preventDefault();
           event.stopImmediatePropagation();
 
-          if (store.wasActivatedByToggle && !isCopying() && !isPromptMode() && !event.shiftKey) {
+          if (store.wasActivatedByToggle && !isPromptMode() && !event.shiftKey) {
             if (!isHoldingKeys()) {
               deactivateRenderer();
             } else {
@@ -2941,7 +2941,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         if (isPromptMode() || isEventFromOverlay(event, "data-react-grab-ignore-events")) {
           return;
         }
-        if (isRendererActive() || isCopying()) {
+        if (isRendererActive()) {
           event.preventDefault();
         }
       },

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -2213,6 +2213,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     const handleEnterKeyActivation = (event: KeyboardEvent): boolean => {
       if (!isEnterCode(event.code)) return false;
       if (isKeyboardEventTriggeredByInput(event)) return false;
+      if (isCopying()) return false;
       if (isSelectionInteractionLocked()) return false;
 
       const copiedElement = store.lastCopiedElement;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -369,8 +369,8 @@ importers:
         specifier: workspace:*
         version: link:../cli
       bippy:
-        specifier: ^0.5.40
-        version: 0.5.40(react@19.2.6)
+        specifier: ^0.5.41
+        version: 0.5.41(react@19.2.6)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -4023,8 +4023,8 @@ packages:
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
-  bippy@0.5.40:
-    resolution: {integrity: sha512-3QPSDG5tgd7FCIkcKsUqmbGdlHxBxP7II5drXPNp1I0rpA9+4+/VjQOigDTbzeqTi6Xkaf1Dq7x4E8vbOuwOkA==}
+  bippy@0.5.41:
+    resolution: {integrity: sha512-jCP2pXXLhXqPrAN+iSEFZmLI4uUM4fjSqajh0K+TmM062VehfDT3ZJNkrTGyN701Z5XMejs9qAudSqkMGhSMKg==}
     peerDependencies:
       react: 19.2.6
 
@@ -11295,7 +11295,7 @@ snapshots:
 
   bignumber.js@9.3.1: {}
 
-  bippy@0.5.40(react@19.2.6):
+  bippy@0.5.41(react@19.2.6):
     dependencies:
       react: 19.2.6
 


### PR DESCRIPTION
## Summary
- Stop treating pending copy/grabbing work as a global selection interaction lock.
- Allow normal page click/copy events while React Grab copy work is pending.
- Upgrade to `bippy@0.5.41` for stronger source-map caching and fewer repeated dev-server fetches.

## Test plan
- `nr build`
- `pnpm typecheck`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global interaction-blocking conditions while `react-grab` is in the `copying` state, which can affect click/keyboard/clipboard event handling across the page. Risk is moderate because it touches core input interception logic, though the diff is small and scoped.
> 
> **Overview**
> Keeps pages interactive during `react-grab` copy operations by *stopping* `copying` from acting as a global selection-interaction lock, and by no longer preventing normal window `click`/document `copy` events solely due to `isCopying()`.
> 
> Adds a guard to ignore Enter-based activation while `copying` is in progress to avoid racing/interrupting pending copy results.
> 
> Website misc fixes: switches `ResizablePanelGroup` to use `orientation` (from `direction`), and moves Next.js middleware `config.matcher` from `middleware.ts` into `proxy.ts` while removing the standalone `middleware.ts` export.
> 
> Upgrades `bippy` from `^0.5.40` to `^0.5.41` (lockfile updated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22231bfacc586ddc05c27dde152e2236e245b015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep pages interactive while grabbing/copying in `react-grab` by removing the global "copying" lock, so clicks and copy work normally. Also updates the website to the new Next proxy entrypoint and the current resizable panel API.

- **Bug Fixes**
  - Skip Enter activation during copy to avoid discarding pending results.
  - Website: move Next proxy matcher to `apps/website-v2/proxy.ts` and remove `middleware.ts`; switch `ResizablePanelGroup` to `orientation="horizontal"`.

- **Dependencies**
  - Upgrade `bippy` to `^0.5.41` for stronger source-map caching and fewer repeated dev-server fetches.

<sup>Written for commit 22231bfacc586ddc05c27dde152e2236e245b015. Summary will update on new commits. <a href="https://cubic.dev/pr/aidenybai/react-grab/pull/349?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

