### PR TITLE
feat(toolbar): rotate select icon to point at mouse during selection

### DIFF
--- a/packages/react-grab/e2e/selection.spec.ts
+++ b/packages/react-grab/e2e/selection.spec.ts
@@ -59,7 +59,13 @@ test.describe("Element Selection", () => {
     expect(clipboardMetadata.entries[0].content).toContain("Todo List");
   });
 
-  test("should block page text selection while grabbing", async ({ reactGrab }) => {
+  // PR #349 ("fix: keep page interactive while grabbing") intentionally
+  // stopped treating the copying state as a global selection-interaction
+  // lock so that clicks, scrolling, and native text selection on the page
+  // continue to work while React Grab finishes a slow copy hook.
+  test("should keep page interactive (allowing text selection) while a copy is pending", async ({
+    reactGrab,
+  }) => {
     await reactGrab.page.evaluate(() => {
       const api = (
         window as {
@@ -113,7 +119,7 @@ test.describe("Element Selection", () => {
     const selectedText = await reactGrab.page.evaluate(() => {
       return window.getSelection()?.toString().trim() ?? "";
     });
-    expect(selectedText).toBe("");
+    expect(selectedText).not.toBe("");
   });
 
   test("should highlight different elements when hovering", async ({ reactGrab }) => {

--- a/packages/react-grab/src/components/icons/icon-select.tsx
+++ b/packages/react-grab/src/components/icons/icon-select.tsx
@@ -1,27 +1,40 @@
 import type { Component } from "solid-js";
+import { cn } from "../../utils/cn.js";
+import { SELECT_ICON_ROTATION_TRANSITION_MS } from "../../constants.js";
 
 interface IconSelectProps {
   size?: number;
   class?: string;
+  rotationDeg?: number;
 }
 
 export const IconSelect: Component<IconSelectProps> = (props) => {
   const size = () => props.size ?? 14;
+  const rotationDeg = () => props.rotationDeg ?? 0;
 
   return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width={size()}
-      height={size()}
-      viewBox="0 0 24 24"
-      fill="currentColor"
-      class={props.class}
+    <span
+      class={cn("inline-flex items-center justify-center will-change-transform", props.class)}
+      style={{
+        transform: `rotate(${rotationDeg()}deg)`,
+        "transition-property": "transform, color",
+        "transition-duration": `${SELECT_ICON_ROTATION_TRANSITION_MS}ms`,
+        "transition-timing-function": "cubic-bezier(0.32, 0.72, 0, 1)",
+      }}
     >
-      <path
-        fill-rule="evenodd"
-        clip-rule="evenodd"
-        d="M20.8977 4.02356L21.8277 4.39121C22.3784 2.99813 21.0382 1.60206 19.6238 2.09546L3.47334 7.72936C1.38661 8.45728 1.49021 11.443 3.6224 12.0245L10.1289 13.799L11.2331 19.8724C11.638 22.0991 14.7072 22.4019 15.5393 20.2972L21.8277 4.39121L20.8977 4.02356Z"
-      />
-    </svg>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size()}
+        height={size()}
+        viewBox="0 0 24 24"
+        fill="currentColor"
+      >
+        <path
+          fill-rule="evenodd"
+          clip-rule="evenodd"
+          d="M20.8977 4.02356L21.8277 4.39121C22.3784 2.99813 21.0382 1.60206 19.6238 2.09546L3.47334 7.72936C1.38661 8.45728 1.49021 11.443 3.6224 12.0245L10.1289 13.799L11.2331 19.8724C11.638 22.0991 14.7072 22.4019 15.5393 20.2972L21.8277 4.39121L20.8977 4.02356Z"
+        />
+      </svg>
+    </span>
   );
 };

--- a/packages/react-grab/src/components/toolbar/index.tsx
+++ b/packages/react-grab/src/components/toolbar/index.tsx
@@ -12,6 +12,8 @@ import {
   TOOLBAR_DEFAULT_HEIGHT_PX,
   TOOLBAR_DEFAULT_POSITION_RATIO,
   Z_INDEX_OVERLAY,
+  SELECT_ICON_NATURAL_POINT_ANGLE_DEG,
+  SELECT_ICON_POINT_MIN_DISTANCE_PX,
 } from "../../constants.js";
 import { freezeUpdates } from "../../utils/freeze-updates.js";
 import { freezeGlobalAnimations, unfreezeGlobalAnimations } from "../../utils/freeze-animations.js";
@@ -28,6 +30,7 @@ import {
   isHorizontalEdge,
 } from "../../utils/toolbar-position.js";
 import { createToolbarDrag } from "../../utils/create-toolbar-drag.js";
+import { accumulateRotationDeg } from "../../utils/accumulate-rotation.js";
 
 interface ToolbarProps {
   isActive?: boolean;
@@ -49,6 +52,7 @@ interface FreezeHandlersOptions {
 
 export const Toolbar: Component<ToolbarProps> = (props) => {
   let containerRef: HTMLDivElement | undefined;
+  let selectButtonRef: HTMLButtonElement | undefined;
   let unfreezeUpdatesCallback: (() => void) | null = null;
 
   const savedState = loadToolbarState();
@@ -65,6 +69,7 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
   const [isCollapseAnimating, setIsCollapseAnimating] = createSignal(false);
   const [isChevronPressed, setIsChevronPressed] = createSignal(false);
   const [isToolbarHovered, setIsToolbarHovered] = createSignal(false);
+  const [selectIconRotationDeg, setSelectIconRotationDeg] = createSignal(0);
   const drag = createToolbarDrag({
     getContainerRef: () => containerRef,
     isCollapsed,
@@ -147,6 +152,38 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
           unfreezeUpdatesCallback();
           unfreezeUpdatesCallback = null;
         }
+      },
+    ),
+  );
+
+  createEffect(
+    on(
+      () => Boolean(props.isActive),
+      (isActive) => {
+        if (!isActive) {
+          setSelectIconRotationDeg(0);
+          return;
+        }
+
+        const handlePointerMove = (event: PointerEvent | MouseEvent) => {
+          if (!selectButtonRef) return;
+          const rect = selectButtonRef.getBoundingClientRect();
+          const centerX = rect.left + rect.width / 2;
+          const centerY = rect.top + rect.height / 2;
+          const dx = event.clientX - centerX;
+          const dy = event.clientY - centerY;
+          if (Math.hypot(dx, dy) < SELECT_ICON_POINT_MIN_DISTANCE_PX) return;
+          const targetAngleDeg = (Math.atan2(dy, dx) * 180) / Math.PI;
+          const desiredRotationDeg = targetAngleDeg - SELECT_ICON_NATURAL_POINT_ANGLE_DEG;
+          setSelectIconRotationDeg((previousRotationDeg) =>
+            accumulateRotationDeg(previousRotationDeg, desiredRotationDeg),
+          );
+        };
+
+        window.addEventListener("pointermove", handlePointerMove, { passive: true });
+        onCleanup(() => {
+          window.removeEventListener("pointermove", handlePointerMove);
+        });
       },
     ),
   );
@@ -594,6 +631,7 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
         }}
         selectButton={
           <button
+            ref={selectButtonRef}
             data-react-grab-ignore-events
             data-react-grab-toolbar-toggle
             aria-label={props.isActive ? "Stop selecting element" : "Select element"}
@@ -612,12 +650,10 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
           >
             <IconSelect
               size={14}
-              class={cn(
-                "transition-colors",
-                props.isActive
-                  ? "text-[var(--rg-text-primary)]"
-                  : "text-[var(--rg-text-secondary)]",
-              )}
+              rotationDeg={selectIconRotationDeg()}
+              class={
+                props.isActive ? "text-[var(--rg-text-primary)]" : "text-[var(--rg-text-secondary)]"
+              }
             />
           </button>
         }

--- a/packages/react-grab/src/components/toolbar/index.tsx
+++ b/packages/react-grab/src/components/toolbar/index.tsx
@@ -161,7 +161,13 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
       () => Boolean(props.isActive),
       (isActive) => {
         if (!isActive) {
-          setSelectIconRotationDeg(0);
+          // The accumulator can drift past ±180° while the user circles the
+          // toolbar; resetting to literal 0 would unspin those revolutions
+          // through the CSS transition. Snapping to the nearest equivalent
+          // of 0° keeps the ease-back to a shortest-path arc.
+          setSelectIconRotationDeg((previousRotationDeg) =>
+            accumulateRotationDeg(previousRotationDeg, 0),
+          );
           return;
         }
 

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -130,6 +130,14 @@ export const TOOLBAR_DEFAULT_HEIGHT_PX = 28;
 export const TOOLBAR_DEFAULT_POSITION_RATIO = 0.5;
 export const DEFAULT_ACTION_ID = "comment";
 
+// The select icon is a paper-airplane shape whose tip points toward the
+// top-right corner of its viewBox, ~45° above the +x axis. Subtracting this
+// from the mouse-relative angle yields the rotation needed to aim the tip at
+// the cursor.
+export const SELECT_ICON_NATURAL_POINT_ANGLE_DEG = -45;
+export const SELECT_ICON_ROTATION_TRANSITION_MS = 180;
+export const SELECT_ICON_POINT_MIN_DISTANCE_PX = 4;
+
 export const DRAG_SELECTION_COVERAGE_THRESHOLD = 0.75;
 export const DRAG_SELECTION_SAMPLE_SPACING_PX = 32;
 export const DRAG_SELECTION_MIN_SAMPLES_PER_AXIS = 3;

--- a/packages/react-grab/src/utils/accumulate-rotation.ts
+++ b/packages/react-grab/src/utils/accumulate-rotation.ts
@@ -1,0 +1,21 @@
+// CSS interpolates `transform: rotate(deg)` linearly between numeric values,
+// so going from 170° to -170° would visibly spin 340° instead of taking the
+// 20° shortest path. Tracking rotation as an unbounded accumulator and
+// snapping each new target to the equivalent within ±180° of the previous
+// value keeps the transition snappy while letting the icon pirouette through
+// full revolutions when the user circles the toolbar.
+export const accumulateRotationDeg = (previousDeg: number, targetDeg: number): number => {
+  const HALF_TURN_DEG = 180;
+  const FULL_TURN_DEG = 360;
+  let next = targetDeg;
+  let delta = next - previousDeg;
+  while (delta > HALF_TURN_DEG) {
+    next -= FULL_TURN_DEG;
+    delta = next - previousDeg;
+  }
+  while (delta < -HALF_TURN_DEG) {
+    next += FULL_TURN_DEG;
+    delta = next - previousDeg;
+  }
+  return next;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The select-icon in the toolbar (a paper-airplane whose tip naturally aims at the top-right corner of its viewBox) used to stay frozen in its default orientation. Now, while the user is actively selecting, the icon rotates so its tip follows the mouse cursor with a smooth animation.

## Behavior

- When `isActive` becomes `true`, the toolbar attaches a passive `pointermove` listener and computes the angle from the select button's screen-center to `event.clientX/Y` each frame.
- The icon is rotated by `targetAngle - SELECT_ICON_NATURAL_POINT_ANGLE_DEG` (the natural tip points at -45° in screen space).
- A continuous accumulator (`accumulateRotationDeg`) snaps each new target to the equivalent within ±180° of the previous value so the CSS interpolation always takes the shortest path — a full circular sweep around the toolbar pirouettes through real revolutions instead of unwinding linearly.
- A `transition: transform 180ms cubic-bezier(0.32, 0.72, 0, 1)` (the existing `ease-drawer` curve) gives the follow a smooth, slightly-weighted feel.
- When `isActive` flips back to `false`, the deactivation target is also routed through `accumulateRotationDeg`, snapping to the nearest equivalent of 0° (e.g. 720° stays at 720°, 700° → 720°). This guarantees the ease-back arc is always ≤180° regardless of how many full revolutions the user accumulated while circling the toolbar.
- A 4px dead-zone around the icon's center prevents jitter when the cursor passes directly over the toolbar.

## Implementation notes

- `IconSelect` now wraps the SVG in a `span` so the rotation transform is isolated from the SVG's own transform-box semantics. The wrapper transitions both `transform` and `color`, so the active/inactive color fade still animates.
- The natural-tip angle, transition duration, and dead-zone radius live in `constants.ts` per workspace conventions.
- The pointermove listener is registered/torn down inside a `createEffect(on(() => isActive, …))` with `onCleanup`, so it only runs while selection mode is active.

## Files

- `src/components/icons/icon-select.tsx` — accept `rotationDeg`, wrap SVG, run smooth transform/color transition.
- `src/components/toolbar/index.tsx` — track pointer, compute rotation, pass to `IconSelect`, hold a `selectButtonRef`.
- `src/utils/accumulate-rotation.ts` — shortest-path angle accumulator.
- `src/constants.ts` — `SELECT_ICON_NATURAL_POINT_ANGLE_DEG`, `SELECT_ICON_ROTATION_TRANSITION_MS`, `SELECT_ICON_POINT_MIN_DISTANCE_PX`.

## Follow-up commits in this PR

**`fix(toolbar): ease select-icon back to natural orientation via shortest path on deactivation`** — addresses [Cursor Bugbot's review](https://github.com/aidenybai/react-grab/pull/353#discussion_r3258160682). Hard-resetting the accumulator to literal 0° on deactivation could unspin accumulated revolutions through the transition; routing the reset through `accumulateRotationDeg(prev, 0)` keeps the ease-back to a single shortest-path arc.

**`test(selection): align 'page text selection while grabbing' assertion with PR #349`** — the failing `test-e2e (3, 4)` job (also red on `main` since `e7ddc85a`) was a stale assertion. PR #349 ("fix: keep page interactive while grabbing") deliberately stopped treating the `copying` state as a global selection-interaction lock, but didn't update this test. Inverted the assertion to lock in the new contract (page text selection IS allowed during a pending slow copy) and renamed the test to match PR #349's stated intent.

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm format` ✅
- All 4 Playwright shards pass locally (`--shard=1/4`, `2/4`, `3/4`, `4/4`) — 510 tests total, 0 failures.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9c180d5-f199-403d-8982-086206c6ab98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9c180d5-f199-403d-8982-086206c6ab98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The toolbar select icon now rotates to point at the mouse during selection, giving instant, clear feedback. It animates smoothly, takes the shortest path, and eases back correctly when selection ends.

- **New Features**
  - Rotates toward the cursor while `isActive`, using the button’s screen center.
  - 180ms cubic-bezier rotation; accumulator ensures shortest-path transitions.
  - 4px dead zone to reduce jitter; wrapper isolates rotation so color still animates.

- **Bug Fixes**
  - On deactivation, snap to the nearest 0° equivalent so the icon eases back along the shortest arc (no multi-spin); updated the e2e selection test to match PR #349’s interactive-copy behavior.

<sup>Written for commit 925956ba9466d0fe7ee412117dd6642d6594f5e8. Summary will update on new commits. <a href="https://cubic.dev/pr/aidenybai/react-grab/pull/353?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

