### PR TITLE
fix(copy): inline the full element+stack context, not just the slim preview

### DIFF
--- a/packages/react-grab/src/core/copy.ts
+++ b/packages/react-grab/src/core/copy.ts
@@ -1,4 +1,4 @@
-import { getInlineHTMLPreview, getStackContext } from "./context.js";
+import { getElementContext } from "./context.js";
 import { copyContent } from "../utils/copy-content.js";
 import { normalizeError } from "../utils/normalize-error.js";
 
@@ -16,9 +16,8 @@ interface CopyFlowHooks {
 }
 
 const formatElementReference = async (element: Element): Promise<string> => {
-  const inlinePreview = getInlineHTMLPreview(element);
-  const inlineStack = (await getStackContext(element)).replace(/\n\s+/g, " ");
-  return `[${inlinePreview}${inlineStack}]`;
+  const verboseContext = await getElementContext(element);
+  return `[${verboseContext.replace(/\s*\n\s*/g, " ").trim()}]`;
 };
 
 const buildClipboardPayload = async (elements: Element[]): Promise<string | null> => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #351.

## What was wrong

After #351, the default `Copy` emitted a slimmer reference built from `getInlineHTMLPreview()` + `getStackContext()`:

```
[<h1 class="text-xl font-bo..."> Todo List </h1> in TodoList in App]
```

That format drops child-element placeholders. The intent was to inline the **v0.1.34 verbose `Copy details`** output — i.e. include `<p ...>` style placeholders and the same attribute set, on one line — not switch to the slimmer inline preview.

For a real-world example, this is what the user expected:

```
[<div class="flex items-cent..." style=""> <p ...> GOOGLE ADS-KONTO </div> in Formik (formik) in CustomFormik (at /app/.../makeTypesafeForm.tsx:74:36) in GoogleAdsConversionSyncConfiguration (at /app/.../GoogleAdsConversionSyncConfiguration.tsx:58:104)]
```

…which is the literal v0.1.34 verbose output with newlines collapsed.

## Fix

`packages/react-grab/src/core/copy.ts`:

```19:22:packages/react-grab/src/core/copy.ts
const formatElementReference = async (element: Element): Promise<string> => {
  const verboseContext = await getElementContext(element);
  return `[${verboseContext.replace(/\s*\n\s*/g, " ").trim()}]`;
};
```

- Use `getElementContext()` — the same source the deleted `copy-details` plugin used via `generateSnippet`. It returns `getHTMLPreview(el) + getStackContext(el)`, or `getFallbackContext(el)` for non-React DOM.
- Collapse any newline + surrounding indentation runs into a single space (`\s*\n\s*` → `" "`). The old regex (`\n\s+`) missed the stray `\n` directly before `</tag>` in `getHTMLPreview`'s output.

## Verified payloads

Captured via Playwright fixture against the e2e app:

- `<h1>Todo List</h1>` (simple leaf):
  - `[<h1 class="text-xl font-bo..."> Todo List </h1> in TodoList in App]`
- `<li><span>…</span></li>` (wrapper with children):
  - `[<li> <span ...> </li> in TodoItem (at /src/App.tsx) in TodoList in App]`
- `<button>` deep inside `NestedCard`s:
  - `[<button data-testid="nested-button" class="bg-blue-500 tex..."> Nested Button </button> in NestedCard (at /src/App.tsx) in NestedCard (at /src/App.tsx) in NestedCard (at /src/App.tsx)]`

Child-element placeholders (`<span ...>`, `<p ...>`) are back, attributes match v0.1.34, all in one bracketed line.

## Tests

- `pnpm typecheck`, `pnpm lint` clean.
- Targeted e2e suites (covering every clipboard-touching test): `element-context`, `selection`, `shift-multi-select`, `keyboard-shortcuts`, `api-methods` — 69/69 passing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-860cafbd-8bc7-447f-b9d6-28fc0d993845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-860cafbd-8bc7-447f-b9d6-28fc0d993845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes default Copy to inline the full element + React stack context on one line. Restores the v0.1.34 verbose output with child-element placeholders and full attributes.

- **Bug Fixes**
  - Build the reference with `getElementContext()` instead of `getInlineHTMLPreview()` + `getStackContext()`.
  - Collapse newline/indent runs to a single space to keep the output inline.
  - Bring back `<p ...>`-style child placeholders and the full attribute set.

<sup>Written for commit 1ad6682783a1ee6dc5ec26f98d50257fb10bbf60. Summary will update on new commits. <a href="https://cubic.dev/pr/aidenybai/react-grab/pull/354?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

