### PR TITLE
feat(toolbar): shake vertically when minimized on left/right edge

### DIFF
--- a/packages/react-grab/src/components/toolbar/toolbar-content.tsx
+++ b/packages/react-grab/src/components/toolbar/toolbar-content.tsx
@@ -104,7 +104,7 @@ export const ToolbarContent: Component<ToolbarContentProps> = (props) => {
         "bg-[var(--rg-panel-bg)] [box-shadow:var(--rg-shadow)]",
         !props.isCollapsed && (isVertical() ? "px-1.5 gap-0 py-2" : "py-1.5 gap-0 px-2"),
         collapsedEdgeClasses(),
-        props.isShaking && "animate-shake",
+        props.isShaking && (isVertical() ? "animate-shake-vertical" : "animate-shake"),
       )}
       style={{ "transform-origin": props.transformOrigin, transform: pressSquishTransform() }}
       onAnimationEnd={props.onAnimationEnd}

--- a/packages/react-grab/src/styles.css
+++ b/packages/react-grab/src/styles.css
@@ -104,21 +104,21 @@
 @keyframes shake {
   0%,
   100% {
-    transform: translate(0, 0);
+    translate: 0 0;
   }
   15%,
   45% {
-    transform: translate(calc(-3px * var(--rg-shake-x, 1)), calc(-3px * var(--rg-shake-y, 0)));
+    translate: calc(-3px * var(--rg-shake-x, 1)) calc(-3px * var(--rg-shake-y, 0));
   }
   30%,
   60% {
-    transform: translate(calc(3px * var(--rg-shake-x, 1)), calc(3px * var(--rg-shake-y, 0)));
+    translate: calc(3px * var(--rg-shake-x, 1)) calc(3px * var(--rg-shake-y, 0));
   }
   75% {
-    transform: translate(calc(-2px * var(--rg-shake-x, 1)), calc(-2px * var(--rg-shake-y, 0)));
+    translate: calc(-2px * var(--rg-shake-x, 1)) calc(-2px * var(--rg-shake-y, 0));
   }
   90% {
-    transform: translate(calc(2px * var(--rg-shake-x, 1)), calc(2px * var(--rg-shake-y, 0)));
+    translate: calc(2px * var(--rg-shake-x, 1)) calc(2px * var(--rg-shake-y, 0));
   }
 }
 
@@ -200,7 +200,7 @@
 .animate-shake,
 .animate-shake-vertical {
   animation: shake 0.3s ease-out;
-  will-change: transform;
+  will-change: translate;
 }
 
 .animate-shake-vertical {

--- a/packages/react-grab/src/styles.css
+++ b/packages/react-grab/src/styles.css
@@ -126,6 +126,31 @@
   }
 }
 
+@keyframes shake-vertical {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  15% {
+    transform: translateY(-3px);
+  }
+  30% {
+    transform: translateY(3px);
+  }
+  45% {
+    transform: translateY(-3px);
+  }
+  60% {
+    transform: translateY(3px);
+  }
+  75% {
+    transform: translateY(-2px);
+  }
+  90% {
+    transform: translateY(2px);
+  }
+}
+
 @keyframes success-pop {
   from {
     transform: scale(0.85);
@@ -203,6 +228,11 @@
 
 .animate-shake {
   animation: shake 0.3s ease-out;
+  will-change: transform;
+}
+
+.animate-shake-vertical {
+  animation: shake-vertical 0.3s ease-out;
   will-change: transform;
 }
 

--- a/packages/react-grab/src/styles.css
+++ b/packages/react-grab/src/styles.css
@@ -108,29 +108,17 @@
   }
   15%,
   45% {
-    transform: translate(
-      calc(-3px * var(--rg-shake-x, 1)),
-      calc(-3px * var(--rg-shake-y, 0))
-    );
+    transform: translate(calc(-3px * var(--rg-shake-x, 1)), calc(-3px * var(--rg-shake-y, 0)));
   }
   30%,
   60% {
-    transform: translate(
-      calc(3px * var(--rg-shake-x, 1)),
-      calc(3px * var(--rg-shake-y, 0))
-    );
+    transform: translate(calc(3px * var(--rg-shake-x, 1)), calc(3px * var(--rg-shake-y, 0)));
   }
   75% {
-    transform: translate(
-      calc(-2px * var(--rg-shake-x, 1)),
-      calc(-2px * var(--rg-shake-y, 0))
-    );
+    transform: translate(calc(-2px * var(--rg-shake-x, 1)), calc(-2px * var(--rg-shake-y, 0)));
   }
   90% {
-    transform: translate(
-      calc(2px * var(--rg-shake-x, 1)),
-      calc(2px * var(--rg-shake-y, 0))
-    );
+    transform: translate(calc(2px * var(--rg-shake-x, 1)), calc(2px * var(--rg-shake-y, 0)));
   }
 }
 

--- a/packages/react-grab/src/styles.css
+++ b/packages/react-grab/src/styles.css
@@ -101,30 +101,24 @@
   }
 }
 
-@property --rg-shake-px {
-  syntax: "<length>";
-  inherits: false;
-  initial-value: 0px;
-}
-
 @keyframes shake {
   0%,
   100% {
-    --rg-shake-px: 0px;
+    transform: translate(0, 0);
   }
   15%,
   45% {
-    --rg-shake-px: -3px;
+    transform: translate(calc(-3px * var(--rg-shake-x, 1)), calc(-3px * var(--rg-shake-y, 0)));
   }
   30%,
   60% {
-    --rg-shake-px: 3px;
+    transform: translate(calc(3px * var(--rg-shake-x, 1)), calc(3px * var(--rg-shake-y, 0)));
   }
   75% {
-    --rg-shake-px: -2px;
+    transform: translate(calc(-2px * var(--rg-shake-x, 1)), calc(-2px * var(--rg-shake-y, 0)));
   }
   90% {
-    --rg-shake-px: 2px;
+    transform: translate(calc(2px * var(--rg-shake-x, 1)), calc(2px * var(--rg-shake-y, 0)));
   }
 }
 
@@ -205,15 +199,13 @@
 
 .animate-shake,
 .animate-shake-vertical {
-  translate: calc(var(--rg-shake-axis-x, 1) * var(--rg-shake-px))
-    calc(var(--rg-shake-axis-y, 0) * var(--rg-shake-px));
   animation: shake 0.3s ease-out;
-  will-change: translate;
+  will-change: transform;
 }
 
 .animate-shake-vertical {
-  --rg-shake-axis-x: 0;
-  --rg-shake-axis-y: 1;
+  --rg-shake-x: 0;
+  --rg-shake-y: 1;
 }
 
 .animate-success-pop {

--- a/packages/react-grab/src/styles.css
+++ b/packages/react-grab/src/styles.css
@@ -101,24 +101,30 @@
   }
 }
 
+@property --rg-shake-px {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0px;
+}
+
 @keyframes shake {
   0%,
   100% {
-    transform: translate(0, 0);
+    --rg-shake-px: 0px;
   }
   15%,
   45% {
-    transform: translate(calc(-3px * var(--rg-shake-x, 1)), calc(-3px * var(--rg-shake-y, 0)));
+    --rg-shake-px: -3px;
   }
   30%,
   60% {
-    transform: translate(calc(3px * var(--rg-shake-x, 1)), calc(3px * var(--rg-shake-y, 0)));
+    --rg-shake-px: 3px;
   }
   75% {
-    transform: translate(calc(-2px * var(--rg-shake-x, 1)), calc(-2px * var(--rg-shake-y, 0)));
+    --rg-shake-px: -2px;
   }
   90% {
-    transform: translate(calc(2px * var(--rg-shake-x, 1)), calc(2px * var(--rg-shake-y, 0)));
+    --rg-shake-px: 2px;
   }
 }
 
@@ -199,13 +205,15 @@
 
 .animate-shake,
 .animate-shake-vertical {
+  translate: calc(var(--rg-shake-axis-x, 1) * var(--rg-shake-px))
+    calc(var(--rg-shake-axis-y, 0) * var(--rg-shake-px));
   animation: shake 0.3s ease-out;
-  will-change: transform;
+  will-change: translate;
 }
 
 .animate-shake-vertical {
-  --rg-shake-x: 0;
-  --rg-shake-y: 1;
+  --rg-shake-axis-x: 0;
+  --rg-shake-axis-y: 1;
 }
 
 .animate-success-pop {

--- a/packages/react-grab/src/styles.css
+++ b/packages/react-grab/src/styles.css
@@ -104,50 +104,33 @@
 @keyframes shake {
   0%,
   100% {
-    transform: translateX(0);
+    transform: translate(0, 0);
   }
-  15% {
-    transform: translateX(-3px);
-  }
-  30% {
-    transform: translateX(3px);
-  }
+  15%,
   45% {
-    transform: translateX(-3px);
+    transform: translate(
+      calc(-3px * var(--rg-shake-x, 1)),
+      calc(-3px * var(--rg-shake-y, 0))
+    );
   }
+  30%,
   60% {
-    transform: translateX(3px);
+    transform: translate(
+      calc(3px * var(--rg-shake-x, 1)),
+      calc(3px * var(--rg-shake-y, 0))
+    );
   }
   75% {
-    transform: translateX(-2px);
+    transform: translate(
+      calc(-2px * var(--rg-shake-x, 1)),
+      calc(-2px * var(--rg-shake-y, 0))
+    );
   }
   90% {
-    transform: translateX(2px);
-  }
-}
-
-@keyframes shake-vertical {
-  0%,
-  100% {
-    transform: translateY(0);
-  }
-  15% {
-    transform: translateY(-3px);
-  }
-  30% {
-    transform: translateY(3px);
-  }
-  45% {
-    transform: translateY(-3px);
-  }
-  60% {
-    transform: translateY(3px);
-  }
-  75% {
-    transform: translateY(-2px);
-  }
-  90% {
-    transform: translateY(2px);
+    transform: translate(
+      calc(2px * var(--rg-shake-x, 1)),
+      calc(2px * var(--rg-shake-y, 0))
+    );
   }
 }
 
@@ -226,14 +209,15 @@
   will-change: transform;
 }
 
-.animate-shake {
+.animate-shake,
+.animate-shake-vertical {
   animation: shake 0.3s ease-out;
   will-change: transform;
 }
 
 .animate-shake-vertical {
-  animation: shake-vertical 0.3s ease-out;
-  will-change: transform;
+  --rg-shake-x: 0;
+  --rg-shake-y: 1;
 }
 
 .animate-success-pop {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When the React Grab toolbar is minimized as a vertical pill against the left or right edge of the viewport, the "shake" feedback animation now wiggles up and down instead of left and right.

## Why

The existing `@keyframes shake` translated on the X axis, which works well for the horizontal pill on the top/bottom edges. On the left/right edges the pill is oriented vertically and pinned flush against the viewport wall — shaking it horizontally pushed the pill into (or away from) the wall, which looked awkward and partially clipped against the edge.

The fix mirrors the existing animation along the pill's long axis so the bounce stays in the natural visible direction regardless of orientation.

## Approach

Rather than duplicate the keyframe with `translateX` / `translateY` variants, a single `@keyframes shake` is parameterised by an axis unit vector via CSS custom properties:

```css
@keyframes shake {
  0%, 100%  { translate: 0 0; }
  15%, 45%  { translate: calc(-3px * var(--rg-shake-x, 1)) calc(-3px * var(--rg-shake-y, 0)); }
  30%, 60%  { translate: calc( 3px * var(--rg-shake-x, 1)) calc( 3px * var(--rg-shake-y, 0)); }
  75%       { translate: calc(-2px * var(--rg-shake-x, 1)) calc(-2px * var(--rg-shake-y, 0)); }
  90%       { translate: calc( 2px * var(--rg-shake-x, 1)) calc( 2px * var(--rg-shake-y, 0)); }
}
```

Default fallbacks `(1, 0)` preserve the original horizontal shake for every existing caller (e.g. the selection label). `.animate-shake-vertical` only flips the axis vector — it doesn't redefine the animation — so the keyframe stops aren't duplicated.

A couple of design notes called out during bot review and worth recording:

- **`translate` longhand, not `transform: translate(...)`.** The toolbar panel applies an inline `transform: scale(...)` press-squish while the chevron is pressed. Animating `transform` in the shake keyframes would override that whole property and the squish would disappear under a shake. Using the standalone `translate` CSS property keeps the two composable — shake translates the element, any inline `transform: scale(...)` still applies on top. (Bot: cubic.)
- **No `@property` registration.** A seemingly cleaner alternative would be to register a typed `--rg-shake-px` via `@property` and animate just the magnitude. The toolbar mounts inside a Shadow DOM (`mountRoot` calls `attachShadow`), and `@property` declarations inside a shadow-root stylesheet are silently ignored by every current browser; the variable would step-jump between values, regressing the shake to discrete frames. Instead, each keyframe stop resolves to a typed `translate: <length> <length>` at parse time, so the browser interpolates the resolved property smoothly without needing `@property`. (Bot: Cursor Bugbot.)

## Changes

- `packages/react-grab/src/styles.css`
  - One `@keyframes shake` animating the `translate` longhand, driven by `--rg-shake-x` / `--rg-shake-y` (defaults `1, 0`).
  - `.animate-shake` and `.animate-shake-vertical` share the same animation rule; the vertical variant only overrides the axis vector.
- `packages/react-grab/src/components/toolbar/toolbar-content.tsx`
  - Picks `animate-shake-vertical` when the toolbar is on a vertical edge (`left` / `right`), otherwise `animate-shake`.

The selection label keeps the existing shake behaviour via the default axis fallback — no changes needed there.

## Verification

- `pnpm typecheck` — passes
- `pnpm lint` — passes
- `pnpm format:check packages/react-grab/src/styles.css` — passes
- Build runs as part of typecheck pipeline — succeeds
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-013c6f4a-d4f8-4a9c-8bf5-cc44fe114be0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-013c6f4a-d4f8-4a9c-8bf5-cc44fe114be0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the minimized toolbar shake vertically on left/right edges to avoid clipping, while keeping horizontal shake on top/bottom. The shake uses one keyframe with axis variables and the CSS `translate` longhand so it composes with inline `transform: scale()` and still interpolates smoothly in Shadow DOM.

- New Features
  - In `packages/react-grab/src/components/toolbar/toolbar-content.tsx`, choose `animate-shake-vertical` on `left`/`right` edges; otherwise `animate-shake`.

- Refactors
  - In `packages/react-grab/src/styles.css`, unify to a single `@keyframes shake` using `translate` with `calc()` and `--rg-shake-x`/`--rg-shake-y` (default `(1, 0)`); `.animate-shake-vertical` flips to `(0, 1)`.
  - Use `will-change: translate`; remove the previous `@property` amplitude approach and avoid `transform` in keyframes so the shake composes with inline scale.

<sup>Written for commit c255e5ade15b7dc99cf737dda48d7f9fc0a9efab. Summary will update on new commits. <a href="https://cubic.dev/pr/aidenybai/react-grab/pull/355?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

