### PR TITLE
fix(toolbar-menu): make hover highlight flush with dropdown edges

### DIFF
--- a/packages/react-grab/src/components/toolbar/toolbar-menu.tsx
+++ b/packages/react-grab/src/components/toolbar/toolbar-menu.tsx
@@ -87,7 +87,7 @@ export const ToolbarMenu: Component<ToolbarMenuProps> = (props) => {
           )}
           style={{ "min-width": `${TOOLBAR_MENU_MIN_WIDTH_PX}px` }}
         >
-          <div ref={highlightContainerRef} class="relative flex flex-col py-1">
+          <div ref={highlightContainerRef} class="relative flex flex-col">
             <div
               ref={highlightRef}
               class="pointer-events-none absolute opacity-0 transition-[top,left,width,height,opacity] duration-75 ease-out bg-[var(--rg-surface-hover)]"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the `py-1` vertical padding from the toolbar menu's highlight container so the hover background extends flush to the rounded top/bottom corners of the dropdown.

Previously, the wrapper around the menu items had `py-1`, leaving a 4px gap at the top and bottom of the dropdown that the hover highlight could not cover. This produced visible edges on the first and last items. Each menu button still keeps its own `py-1`, so internal text spacing is unchanged.

### Change

- `packages/react-grab/src/components/toolbar/toolbar-menu.tsx`: drop `py-1` from the highlight container.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15247cd9-c0f4-4fc8-893e-c8b0ea668599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15247cd9-c0f4-4fc8-893e-c8b0ea668599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `py-1` vertical padding from the toolbar menu’s highlight container so the hover background is flush with the dropdown’s rounded edges. Fixes visible gaps on the first and last items; item text spacing remains unchanged.

<sup>Written for commit ef04918f948d9adceaf3ba88519ca29b298ae0c1. Summary will update on new commits. <a href="https://cubic.dev/pr/aidenybai/react-grab/pull/356?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

