### PR TITLE
fix(touch): clear stale detected element on deactivate in touch mode

### DIFF
--- a/packages/react-grab/e2e/touch-mode.spec.ts
+++ b/packages/react-grab/e2e/touch-mode.spec.ts
@@ -93,6 +93,31 @@ test.describe("Touch Mode", () => {
 
       await expect.poll(() => reactGrab.getClipboardContent(), { timeout: 5000 }).toBeTruthy();
     });
+
+    test("re-activating after touch copy should not show stale selection", async ({
+      reactGrab,
+    }) => {
+      await reactGrab.activate();
+
+      const listItem = reactGrab.page.locator("li").nth(1);
+      const itemBox = await listItem.boundingBox();
+      if (!itemBox) throw new Error("Could not get bounding box");
+      const tapX = itemBox.x + itemBox.width / 2;
+      const tapY = itemBox.y + itemBox.height / 2;
+
+      await reactGrab.touchStart(tapX, tapY);
+      await reactGrab.touchMove(tapX, tapY);
+      await reactGrab.touchEnd(tapX, tapY);
+
+      await expect.poll(() => reactGrab.getClipboardContent(), { timeout: 5000 }).toBeTruthy();
+      await expect.poll(() => reactGrab.isOverlayVisible(), { timeout: 5000 }).toBe(false);
+
+      await reactGrab.activate();
+
+      await reactGrab.page.waitForTimeout(100);
+
+      expect(await reactGrab.isSelectionBoxVisible()).toBe(false);
+    });
   });
 
   test.describe("Touch Drag Selection", () => {

--- a/packages/react-grab/src/core/store.ts
+++ b/packages/react-grab/src/core/store.ts
@@ -238,6 +238,13 @@ const createGrabStore = (input: GrabStoreInput) => {
             draft.contextMenuElement = null;
             draft.contextMenuClickOffset = null;
             draft.lastCopiedElement = null;
+            // In touch mode there is no pointer movement between taps, so a
+            // stale detectedElement from the previous interaction would
+            // render its selection box the moment the user re-activates.
+            // Mouse mode refreshes this on the next pointermove.
+            if (draft.isTouchMode) {
+              draft.detectedElement = null;
+            }
           }),
         );
       });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In touch mode, after a tap-to-copy:

1. User taps an element → copy succeeds → overlay deactivates.
2. User activates again.
3. The selection box appears over the **previously-tapped** element, before the user has touched anything new.

## Cause

`detectedElement` lives on the store and is only updated by `pointermove` or the throttled re-detect tick. Touch devices don't fire any events between taps, so the value set during the prior tap survives the deactivate/activate cycle. The moment the renderer becomes active again, `targetElement()` reads that stale element and the selection box renders over it.

Mouse mode is unaffected: the next `pointermove` refreshes `detectedElement` as soon as the cursor moves, which happens immediately after re-activation in practice.

## Fix

Clear `detectedElement` inside `actions.deactivate()` when `isTouchMode` is true. The mouse path is left alone because re-activating with the cursor already hovering over an element is intentional and feels natural there.

```225:248:packages/react-grab/src/core/store.ts
    deactivate: () => {
      batch(() => {
        setCurrent({ state: "idle" });
        setStore(
          produce((draft) => {
            ...
            draft.lastCopiedElement = null;
            // In touch mode there is no pointer movement between taps, so a
            // stale detectedElement from the previous interaction would
            // render its selection box the moment the user re-activates.
            // Mouse mode refreshes this on the next pointermove.
            if (draft.isTouchMode) {
              draft.detectedElement = null;
            }
          }),
        );
      });
    },
```

## Test

Added a regression test under `Touch Mode › Touch Selection`:

- Activate → tap → wait for clipboard + overlay close → activate again → assert `isSelectionBoxVisible` is `false`.

The test dispatches `pointerdown` + `pointermove` + `pointerup` explicitly so the bug actually reproduces (Playwright's `touchscreen.tap` skips `pointermove`, which is why the pre-existing `touch on different elements should work` test missed this).

Verified the test fails on `main` and passes with the fix. All 14 touch-mode tests pass with the fix.

## Checks

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm --filter react-grab exec playwright test e2e/touch-mode.spec.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69725db9-cd10-42f1-b8b7-9ebcf5f6af96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69725db9-cd10-42f1-b8b7-9ebcf5f6af96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a stale selection box appearing in touch mode after tap-to-copy. We now clear the previously detected element on deactivate so re-activating doesn’t render an old selection.

- **Bug Fixes**
  - Clear `detectedElement` in `deactivate()` when `isTouchMode` is true; mouse behavior unchanged.
  - Added a regression test that re-activates after a touch copy and asserts no selection box is shown.

<sup>Written for commit 43f40a9c568604fd5b3384a616df61655386c9e0. Summary will update on new commits. <a href="https://cubic.dev/pr/aidenybai/react-grab/pull/357?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

