### PR TITLE
Round selection label corners and arrow tip

### DIFF
--- a/apps/storybook/stories/selection-label.stories.tsx
+++ b/apps/storybook/stories/selection-label.stories.tsx
@@ -44,8 +44,6 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-// Idle — what the user sees on hover before any action.
-
 export const Idle: Story = {
   args: { tagName: "button", componentName: "Button" },
 };
@@ -91,8 +89,6 @@ export const IdleArrowNavigation: Story = {
   },
 };
 
-// Comment / prompt mode — what shows after pressing the comment shortcut.
-
 export const PromptEmpty: Story = {
   args: {
     tagName: "div",
@@ -130,8 +126,6 @@ export const PendingDismiss: Story = {
     inputValue: "tweak the spacing",
   },
 };
-
-// Status — copy lifecycle (defaults to "Grabbing…" and "Copied" status text).
 
 export const Copying: Story = {
   args: {

--- a/apps/storybook/stories/selection-label.stories.tsx
+++ b/apps/storybook/stories/selection-label.stories.tsx
@@ -91,10 +91,6 @@ export const IdleArrowNavigation: Story = {
   },
 };
 
-export const IdleHiddenArrow: Story = {
-  args: { tagName: "div", componentName: "Card", hideArrow: true },
-};
-
 // Comment / prompt mode — what shows after pressing the comment shortcut.
 
 export const PromptEmpty: Story = {

--- a/apps/storybook/stories/selection-label.stories.tsx
+++ b/apps/storybook/stories/selection-label.stories.tsx
@@ -44,24 +44,18 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+// Idle — what the user sees on hover before any action.
+
 export const Idle: Story = {
   args: { tagName: "button", componentName: "Button" },
 };
 
-export const IdleWithFilePath: Story = {
-  args: {
-    tagName: "div",
-    componentName: "Header",
-    filePath: "src/components/Header.tsx",
-  },
+export const IdleTagOnly: Story = {
+  args: { tagName: "section", componentName: undefined },
 };
 
 export const IdleMultiElement: Story = {
   args: { tagName: "div", componentName: undefined, elementsCount: 3 },
-};
-
-export const IdleTagOnly: Story = {
-  args: { tagName: "section", componentName: undefined },
 };
 
 export const IdleLongComponentName: Story = {
@@ -70,6 +64,38 @@ export const IdleLongComponentName: Story = {
     componentName: "SuperLongComponentNameThatShouldDefinitelyTruncate",
   },
 };
+
+export const IdleWithFilePath: Story = {
+  args: {
+    tagName: "div",
+    componentName: "Header",
+    filePath: "src/components/Header.tsx",
+    onOpen: noop,
+  },
+};
+
+export const IdleArrowNavigation: Story = {
+  args: {
+    tagName: "button",
+    componentName: "Button",
+    arrowNavigationState: {
+      isVisible: true,
+      activeIndex: 1,
+      items: [
+        { tagName: "div", componentName: "Card" },
+        { tagName: "button", componentName: "Button" },
+        { tagName: "span" },
+      ],
+    },
+    onArrowNavigationSelect: noop,
+  },
+};
+
+export const IdleHiddenArrow: Story = {
+  args: { tagName: "div", componentName: "Card", hideArrow: true },
+};
+
+// Comment / prompt mode — what shows after pressing the comment shortcut.
 
 export const PromptEmpty: Story = {
   args: {
@@ -105,15 +131,17 @@ export const PendingDismiss: Story = {
     componentName: "Header",
     isPromptMode: true,
     isPendingDismiss: true,
+    inputValue: "tweak the spacing",
   },
 };
+
+// Status — copy lifecycle (defaults to "Grabbing…" and "Copied" status text).
 
 export const Copying: Story = {
   args: {
     tagName: "input",
     componentName: "TextField",
     status: "copying",
-    statusText: "Grabbing…",
   },
 };
 
@@ -125,7 +153,7 @@ export const Copied: Story = {
   },
 };
 
-export const ErrorState: Story = {
+export const Error: Story = {
   args: {
     tagName: "dialog",
     componentName: "Modal",

--- a/packages/react-grab/src/components/context-menu.tsx
+++ b/packages/react-grab/src/components/context-menu.tsx
@@ -234,7 +234,7 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
 
         <div
           class={cn(
-            "contain-layout flex flex-col justify-center items-start rounded-[10px] antialiased w-fit h-fit min-w-[100px] [font-synthesis:none] [corner-shape:superellipse(1.25)]",
+            "contain-layout flex flex-col justify-center items-start rounded-[14px] antialiased w-fit h-fit min-w-[100px] [font-synthesis:none] [corner-shape:superellipse(1.25)]",
             "bg-[var(--rg-panel-bg)]",
           )}
         >

--- a/packages/react-grab/src/components/selection-label/arrow.tsx
+++ b/packages/react-grab/src/components/selection-label/arrow.tsx
@@ -10,10 +10,6 @@ export const Arrow: Component<ArrowProps> = (props) => {
   const arrowWidth = () => arrowSize() * 2;
   const arrowHeight = () => arrowSize();
 
-  // Triangle has a 90° apex (base = 2 * size, height = size), so the two edges
-  // meet at right angles. For a tangent-arc corner radius `r` on a 90° vertex,
-  // the tangent points sit `r` away from the apex along each edge, which is
-  // `r / sqrt(2)` in both x and y when the edges are at 45° from vertical.
   const tipPath = () => {
     const totalWidth = arrowWidth();
     const totalHeight = arrowHeight();

--- a/packages/react-grab/src/components/selection-label/arrow.tsx
+++ b/packages/react-grab/src/components/selection-label/arrow.tsx
@@ -1,17 +1,39 @@
 import type { Component } from "solid-js";
 import type { ArrowProps } from "../../types.js";
-import { PANEL_BACKGROUND } from "../../constants.js";
+import { PANEL_BACKGROUND, ARROW_TIP_RADIUS_PX } from "../../constants.js";
 import { getArrowSize } from "../../utils/get-arrow-size.js";
 
 export const Arrow: Component<ArrowProps> = (props) => {
   const arrowColor = () => props.color ?? PANEL_BACKGROUND;
   const isBottom = () => props.position === "bottom";
   const arrowSize = () => getArrowSize(props.labelWidth ?? 0);
+  const arrowWidth = () => arrowSize() * 2;
+  const arrowHeight = () => arrowSize();
+
+  // Triangle has a 90° apex (base = 2 * size, height = size), so the two edges
+  // meet at right angles. For a tangent-arc corner radius `r` on a 90° vertex,
+  // the tangent points sit `r` away from the apex along each edge, which is
+  // `r / sqrt(2)` in both x and y when the edges are at 45° from vertical.
+  const tipPath = () => {
+    const totalWidth = arrowWidth();
+    const totalHeight = arrowHeight();
+    const tipRadius = ARROW_TIP_RADIUS_PX;
+    const tangentOffset = tipRadius * Math.SQRT1_2;
+    const halfWidth = totalWidth / 2;
+
+    if (isBottom()) {
+      return `M0 ${totalHeight} L${halfWidth - tangentOffset} ${tangentOffset} A${tipRadius} ${tipRadius} 0 0 1 ${halfWidth + tangentOffset} ${tangentOffset} L${totalWidth} ${totalHeight} Z`;
+    }
+    return `M0 0 L${halfWidth - tangentOffset} ${totalHeight - tangentOffset} A${tipRadius} ${tipRadius} 0 0 0 ${halfWidth + tangentOffset} ${totalHeight - tangentOffset} L${totalWidth} 0 Z`;
+  };
 
   return (
-    <div
+    <svg
       data-react-grab-arrow
-      class="absolute w-0 h-0 z-10"
+      class="absolute block z-10"
+      width={arrowWidth()}
+      height={arrowHeight()}
+      viewBox={`0 0 ${arrowWidth()} ${arrowHeight()}`}
       style={{
         left: `calc(${props.leftPercent}% + ${props.leftOffsetPx}px)`,
         top: isBottom() ? "0" : undefined,
@@ -19,11 +41,9 @@ export const Arrow: Component<ArrowProps> = (props) => {
         transform: isBottom()
           ? "translateX(-50%) translateY(-100%)"
           : "translateX(-50%) translateY(100%)",
-        "border-left": `${arrowSize()}px solid transparent`,
-        "border-right": `${arrowSize()}px solid transparent`,
-        "border-bottom": isBottom() ? `${arrowSize()}px solid ${arrowColor()}` : undefined,
-        "border-top": isBottom() ? undefined : `${arrowSize()}px solid ${arrowColor()}`,
       }}
-    />
+    >
+      <path d={tipPath()} fill={arrowColor()} />
+    </svg>
   );
 };

--- a/packages/react-grab/src/components/selection-label/arrow.tsx
+++ b/packages/react-grab/src/components/selection-label/arrow.tsx
@@ -17,14 +17,13 @@ export const Arrow: Component<ArrowProps> = (props) => {
   const tipPath = () => {
     const totalWidth = arrowWidth();
     const totalHeight = arrowHeight();
-    const tipRadius = ARROW_TIP_RADIUS_PX;
-    const tangentOffset = tipRadius * Math.SQRT1_2;
+    const tangentOffset = ARROW_TIP_RADIUS_PX * Math.SQRT1_2;
     const halfWidth = totalWidth / 2;
+    const baseY = isBottom() ? totalHeight : 0;
+    const tipY = isBottom() ? tangentOffset : totalHeight - tangentOffset;
+    const sweepFlag = isBottom() ? 1 : 0;
 
-    if (isBottom()) {
-      return `M0 ${totalHeight} L${halfWidth - tangentOffset} ${tangentOffset} A${tipRadius} ${tipRadius} 0 0 1 ${halfWidth + tangentOffset} ${tangentOffset} L${totalWidth} ${totalHeight} Z`;
-    }
-    return `M0 0 L${halfWidth - tangentOffset} ${totalHeight - tangentOffset} A${tipRadius} ${tipRadius} 0 0 0 ${halfWidth + tangentOffset} ${totalHeight - tangentOffset} L${totalWidth} 0 Z`;
+    return `M0 ${baseY} L${halfWidth - tangentOffset} ${tipY} A${ARROW_TIP_RADIUS_PX} ${ARROW_TIP_RADIUS_PX} 0 0 ${sweepFlag} ${halfWidth + tangentOffset} ${tipY} L${totalWidth} ${baseY} Z`;
   };
 
   return (

--- a/packages/react-grab/src/components/selection-label/completion-view.tsx
+++ b/packages/react-grab/src/components/selection-label/completion-view.tsx
@@ -102,7 +102,7 @@ export const CompletionView: Component<CompletionViewProps> = (props) => {
     <div
       data-react-grab-completion
       class={cn(
-        "contain-layout shrink-0 flex flex-col justify-center items-end rounded-[10px] antialiased w-fit h-fit max-w-[280px] transition-opacity duration-100 ease-out [font-synthesis:none] [corner-shape:superellipse(1.25)]",
+        "contain-layout shrink-0 flex flex-col justify-center items-end rounded-full antialiased w-fit h-fit max-w-[280px] transition-opacity duration-100 ease-out [font-synthesis:none]",
         "bg-[var(--rg-panel-bg)]",
       )}
       style={{ opacity: isFading() ? 0 : 1 }}

--- a/packages/react-grab/src/components/selection-label/index.tsx
+++ b/packages/react-grab/src/components/selection-label/index.tsx
@@ -415,7 +415,7 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
             "contain-layout flex items-center gap-[5px] antialiased w-fit h-fit p-0 [font-synthesis:none]",
             isSinglePanelLine()
               ? "rounded-full"
-              : "rounded-[10px] [corner-shape:superellipse(1.25)]",
+              : "rounded-[14px] [corner-shape:superellipse(1.25)]",
             "bg-[var(--rg-panel-bg)]",
             isShaking() && "animate-shake",
           )}

--- a/packages/react-grab/src/components/selection-label/index.tsx
+++ b/packages/react-grab/src/components/selection-label/index.tsx
@@ -337,10 +337,8 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
   const isArrowNavigationVisible = () => Boolean(props.arrowNavigationState?.isVisible);
 
   const isSinglePanelLine = createMemo(() => {
-    if (props.error) return false;
-    if (props.isPendingDismiss) return false;
-    if (canInteract() && props.isPromptMode) return false;
-    if (canInteract() && !props.isPromptMode && isArrowNavigationVisible()) return false;
+    if (props.error || props.isPendingDismiss) return false;
+    if (canInteract() && (props.isPromptMode || isArrowNavigationVisible())) return false;
     return true;
   });
 

--- a/packages/react-grab/src/components/selection-label/index.tsx
+++ b/packages/react-grab/src/components/selection-label/index.tsx
@@ -404,7 +404,7 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
         <div
           ref={panelRef}
           class={cn(
-            "contain-layout flex items-center gap-[5px] rounded-[10px] antialiased w-fit h-fit p-0 [font-synthesis:none] [corner-shape:superellipse(1.25)]",
+            "contain-layout flex items-center gap-[5px] rounded-full antialiased w-fit h-fit p-0 [font-synthesis:none]",
             "bg-[var(--rg-panel-bg)]",
             isShaking() && "animate-shake",
           )}

--- a/packages/react-grab/src/components/selection-label/index.tsx
+++ b/packages/react-grab/src/components/selection-label/index.tsx
@@ -336,6 +336,14 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
 
   const isArrowNavigationVisible = () => Boolean(props.arrowNavigationState?.isVisible);
 
+  const isSinglePanelLine = createMemo(() => {
+    if (props.error) return false;
+    if (props.isPendingDismiss) return false;
+    if (canInteract() && props.isPromptMode) return false;
+    if (canInteract() && !props.isPromptMode && isArrowNavigationVisible()) return false;
+    return true;
+  });
+
   const handleTagClick = (event: MouseEvent) => {
     event.stopImmediatePropagation();
     if (props.filePath && props.onOpen) {
@@ -404,7 +412,10 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
         <div
           ref={panelRef}
           class={cn(
-            "contain-layout flex items-center gap-[5px] rounded-full antialiased w-fit h-fit p-0 [font-synthesis:none]",
+            "contain-layout flex items-center gap-[5px] antialiased w-fit h-fit p-0 [font-synthesis:none]",
+            isSinglePanelLine()
+              ? "rounded-full"
+              : "rounded-[10px] [corner-shape:superellipse(1.25)]",
             "bg-[var(--rg-panel-bg)]",
             isShaking() && "animate-shake",
           )}

--- a/packages/react-grab/src/components/toolbar/toolbar-menu.tsx
+++ b/packages/react-grab/src/components/toolbar/toolbar-menu.tsx
@@ -82,7 +82,7 @@ export const ToolbarMenu: Component<ToolbarMenuProps> = (props) => {
       >
         <div
           class={cn(
-            "contain-layout flex flex-col rounded-[10px] antialiased w-fit h-fit overflow-hidden [font-synthesis:none] [corner-shape:superellipse(1.25)]",
+            "contain-layout flex flex-col rounded-[14px] antialiased w-fit h-fit overflow-hidden [font-synthesis:none] [corner-shape:superellipse(1.25)]",
             "bg-[var(--rg-panel-bg)]",
           )}
           style={{ "min-width": `${TOOLBAR_MENU_MIN_WIDTH_PX}px` }}

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -59,6 +59,7 @@ export const FROZEN_GLOW_EDGE_PX = 50;
 export const ARROW_HEIGHT_PX = 8;
 export const ARROW_MIN_SIZE_PX = 4;
 export const ARROW_MAX_LABEL_WIDTH_RATIO = 0.2;
+export const ARROW_TIP_RADIUS_PX = 1;
 export const ARROW_CENTER_PERCENT = 50;
 export const ARROW_LABEL_MARGIN_PX = 16;
 export const LABEL_GAP_PX = 4;

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -445,6 +445,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
     let selectionSourceRequestVersion = 0;
     let componentNameRequestVersion = 0;
+    let contextMenuComponentNameRequestVersion = 0;
     let componentNameDebounceTimerId: number | null = null;
     let keyboardSelectedElement: Element | null = null;
     let pendingDefaultActionId: string | null = null;
@@ -3153,17 +3154,38 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       return getTagName(element) || undefined;
     });
 
-    const [contextMenuComponentName] = createResource(
-      () => ({
-        element: store.contextMenuElement,
-        frozenCount: store.frozenElements.length,
-      }),
-      async ({ element, frozenCount }) => {
-        if (!element) return undefined;
-        if (frozenCount > 1) return undefined;
-        const name = await getNearestComponentName(element);
-        return name ?? undefined;
-      },
+    const [contextMenuComponentName, setContextMenuComponentName] = createSignal<
+      string | undefined
+    >(undefined);
+
+    createEffect(
+      on(
+        () => ({
+          element: store.contextMenuElement,
+          frozenCount: store.frozenElements.length,
+        }),
+        ({ element, frozenCount }) => {
+          const currentVersion = ++contextMenuComponentNameRequestVersion;
+
+          if (!element || frozenCount > 1) {
+            setContextMenuComponentName(undefined);
+            return;
+          }
+
+          const fallbackComponentName = getComponentDisplayName(element) ?? undefined;
+          setContextMenuComponentName(fallbackComponentName);
+
+          getNearestComponentName(element)
+            .then((name) => {
+              if (contextMenuComponentNameRequestVersion !== currentVersion) return;
+              setContextMenuComponentName(name ?? fallbackComponentName);
+            })
+            .catch(() => {
+              if (contextMenuComponentNameRequestVersion !== currentVersion) return;
+              setContextMenuComponentName(fallbackComponentName);
+            });
+        },
+      ),
     );
 
     const [contextMenuFilePath] = createResource(

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -18,6 +18,7 @@ import {
   hasTextSelectionOnPage,
 } from "../utils/is-keyboard-event-triggered-by-input.js";
 import { mountRoot } from "../utils/mount-root.js";
+import { createComponentNameForElement } from "../utils/create-component-name-for-element.js";
 import { watchAppTheme } from "../utils/detect-app-theme.js";
 import {
   nativeCancelAnimationFrame,
@@ -444,16 +445,14 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       isCopyFeedbackCooldownActive = false;
     };
     let selectionSourceRequestVersion = 0;
-    let componentNameRequestVersion = 0;
-    let contextMenuComponentNameRequestVersion = 0;
     let componentNameDebounceTimerId: number | null = null;
     let keyboardSelectedElement: Element | null = null;
     let pendingDefaultActionId: string | null = null;
     const [isPendingContextMenuSelect, setIsPendingContextMenuSelect] = createSignal(false);
     const [debouncedElementForComponentName, setDebouncedElementForComponentName] =
       createSignal<Element | null>(null);
-    const [resolvedComponentName, setResolvedComponentName] = createSignal<string | undefined>(
-      undefined,
+    const [resolvedComponentName, setResolvedComponentName] = createComponentNameForElement(
+      debouncedElementForComponentName,
     );
     const [arrowNavigationElements, setArrowNavigationElements] = createSignal<Element[]>([]);
     const [arrowNavigationActiveIndex, setArrowNavigationActiveIndex] = createSignal(0);
@@ -3000,33 +2999,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       return getTagName(element) || undefined;
     });
 
-    createEffect(
-      on(
-        () => debouncedElementForComponentName(),
-        (element) => {
-          const currentVersion = ++componentNameRequestVersion;
-
-          if (!element) {
-            setResolvedComponentName(undefined);
-            return;
-          }
-
-          const fallbackComponentName = getComponentDisplayName(element) ?? undefined;
-          setResolvedComponentName(fallbackComponentName);
-
-          getNearestComponentName(element)
-            .then((name) => {
-              if (componentNameRequestVersion !== currentVersion) return;
-              setResolvedComponentName(name ?? fallbackComponentName);
-            })
-            .catch(() => {
-              if (componentNameRequestVersion !== currentVersion) return;
-              setResolvedComponentName(fallbackComponentName);
-            });
-        },
-      ),
-    );
-
     const selectionLabelVisible = createMemo(() => {
       if (store.contextMenuPosition !== null) return false;
       if (!isElementLabelThemeEnabled()) return false;
@@ -3154,38 +3126,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       return getTagName(element) || undefined;
     });
 
-    const [contextMenuComponentName, setContextMenuComponentName] = createSignal<
-      string | undefined
-    >(undefined);
-
-    createEffect(
-      on(
-        () => ({
-          element: store.contextMenuElement,
-          frozenCount: store.frozenElements.length,
-        }),
-        ({ element, frozenCount }) => {
-          const currentVersion = ++contextMenuComponentNameRequestVersion;
-
-          if (!element || frozenCount > 1) {
-            setContextMenuComponentName(undefined);
-            return;
-          }
-
-          const fallbackComponentName = getComponentDisplayName(element) ?? undefined;
-          setContextMenuComponentName(fallbackComponentName);
-
-          getNearestComponentName(element)
-            .then((name) => {
-              if (contextMenuComponentNameRequestVersion !== currentVersion) return;
-              setContextMenuComponentName(name ?? fallbackComponentName);
-            })
-            .catch(() => {
-              if (contextMenuComponentNameRequestVersion !== currentVersion) return;
-              setContextMenuComponentName(fallbackComponentName);
-            });
-        },
-      ),
+    const [contextMenuComponentName] = createComponentNameForElement(() =>
+      store.frozenElements.length > 1 ? null : store.contextMenuElement,
     );
 
     const [contextMenuFilePath] = createResource(

--- a/packages/react-grab/src/utils/create-component-name-for-element.ts
+++ b/packages/react-grab/src/utils/create-component-name-for-element.ts
@@ -2,12 +2,6 @@ import { createEffect, createSignal, on } from "solid-js";
 import type { Accessor, Setter } from "solid-js";
 import { getComponentDisplayName, getNearestComponentName } from "../core/context.js";
 
-// Seeds the result synchronously with `getComponentDisplayName` so consumers
-// (e.g. the selection label and context menu tag badges) render the component
-// name immediately, then upgrades to the nearest user-defined source-component
-// name once the async stack walk in `getNearestComponentName` settles. A
-// monotonically increasing request version guards against late responses from a
-// previous source overwriting the current one.
 export const createComponentNameForElement = (
   source: Accessor<Element | null>,
 ): [Accessor<string | undefined>, Setter<string | undefined>] => {

--- a/packages/react-grab/src/utils/create-component-name-for-element.ts
+++ b/packages/react-grab/src/utils/create-component-name-for-element.ts
@@ -1,0 +1,42 @@
+import { createEffect, createSignal, on } from "solid-js";
+import type { Accessor, Setter } from "solid-js";
+import { getComponentDisplayName, getNearestComponentName } from "../core/context.js";
+
+// Seeds the result synchronously with `getComponentDisplayName` so consumers
+// (e.g. the selection label and context menu tag badges) render the component
+// name immediately, then upgrades to the nearest user-defined source-component
+// name once the async stack walk in `getNearestComponentName` settles. A
+// monotonically increasing request version guards against late responses from a
+// previous source overwriting the current one.
+export const createComponentNameForElement = (
+  source: Accessor<Element | null>,
+): [Accessor<string | undefined>, Setter<string | undefined>] => {
+  const [componentName, setComponentName] = createSignal<string | undefined>(undefined);
+  let requestVersion = 0;
+
+  createEffect(
+    on(source, (element) => {
+      const currentVersion = ++requestVersion;
+
+      if (!element) {
+        setComponentName(undefined);
+        return;
+      }
+
+      const fallbackComponentName = getComponentDisplayName(element) ?? undefined;
+      setComponentName(fallbackComponentName);
+
+      getNearestComponentName(element)
+        .then((name) => {
+          if (requestVersion !== currentVersion) return;
+          setComponentName(name ?? fallbackComponentName);
+        })
+        .catch(() => {
+          if (requestVersion !== currentVersion) return;
+          setComponentName(fallbackComponentName);
+        });
+    }),
+  );
+
+  return [componentName, setComponentName];
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Fully round the selection label with `rounded-full` only when the panel is a single line (idle tag badge, copying spinner, completion view).
- Multi-line states (prompt mode with textarea, arrow-nav menu, error view, discard prompt) use `rounded-[14px]` + `corner-shape: superellipse(1.25)` — a slight bump from the previous 10px for a softer look.
- Replace the CSS-border triangle arrow with an inline SVG so the pointer chevron's tip can be slightly rounded (~1px tangent-arc), giving it a softer point while leaving the base flush against the panel.
- Show the component name in the context menu's tag badge by reusing the selection label's sync-fallback + async-resolve pattern. Previously `contextMenuComponentName` was a `createResource` that returned `undefined` until `getNearestComponentName` settled, so the badge would render just the tag name. It now seeds the badge with `getComponentDisplayName` synchronously (e.g. `NestedCard.button`) and then upgrades to the nearest source-component name when ready.
- Extract that resolve pattern into `createComponentNameForElement` so the selection label and context menu share one implementation, including an internal request-version counter that guards against late async responses overwriting the current selection.
- Tidy the `SelectionLabel` storybook stories: fix `IdleWithFilePath` to include `onOpen` (otherwise the tag wasn't actually clickable), fix `PendingDismiss` to include an `inputValue` (you only land in the discard prompt after typing something), drop the redundant `statusText: "Grabbing…"` override from `Copying`, rename `ErrorState` → `Error`, and add stories for `IdleArrowNavigation` (stacked-element menu) and `IdleHiddenArrow` (frozen-label variant). Stories are now grouped Idle / Prompt / Status.

## Notes

- Arrow size, positioning, transforms and the `data-react-grab-arrow` selector are preserved, so e2e fixtures and tests that rely on the arrow's bounding rect (e.g. `visual-feedback.spec.ts`) keep passing.
- Tip radius lives in `ARROW_TIP_RADIUS_PX` in `constants.ts` for easy tuning later.
- The same `Arrow` component is also used by the context menu, so the slight tip rounding applies there too.
- Single-line vs multi-line is computed from the panel's logical state (not measured height) to avoid a measure → restyle feedback loop.

## Verification

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- Playwright: `visual-feedback`, `prompt-mode`, `shift-multi-select`, `toolbar`, `toolbar-selection-hover`, `viewport`, `context-menu` specs (all passing).
- Manual screenshots of all 15 storybook stories confirmed each renders the intended state.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11809710-d779-4d0d-9dd9-23e381fbce55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11809710-d779-4d0d-9dd9-23e381fbce55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rounded the single-line selection label and completion view into pills, switched the arrow to a rounded-tip SVG, and aligned panel radii for a softer, consistent look. The context menu tag now shows a component name immediately and refines it asynchronously.

- **New Features**
  - Context menu tag shows the component display name instantly, then upgrades to the nearest component name asynchronously.

- **Refactors**
  - Selection label is `rounded-full` only for single-line; multi-line states (prompt, arrow nav, error, discard) use `rounded-[14px]` with `[corner-shape:superellipse(1.25)]`. Completion view is pill-shaped. Context menu and toolbar menus now use the same 14px radius.
  - Replaced the CSS triangle with an inline SVG (~1px rounded tip), preserving transforms and `data-react-grab-arrow`.
  - Extracted component-name resolution into `createComponentNameForElement` shared by the selection label and context menu.
  - Storybook: grouped selection label stories, added missing `onOpen`, added arrow-navigation example, removed the fake HiddenArrow story, and removed redundant comments across code and stories.

<sup>Written for commit 692c1ca0b0954ee0e11e11e19829f496e308f912. Summary will update on new commits. <a href="https://cubic.dev/pr/aidenybai/react-grab/pull/359?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

