### PR TITLE
feat(react-grab): event log + session replay (devtools)

### DIFF
--- a/packages/react-grab/src/components/devtools-panel.tsx
+++ b/packages/react-grab/src/components/devtools-panel.tsx
@@ -1,0 +1,313 @@
+import { For, Show, createMemo, createSignal, onCleanup, onMount } from "solid-js";
+import { render } from "solid-js/web";
+import type { EventLog } from "../core/event-log.js";
+import type { ReactGrabAPI, ReactGrabLoggedEvent, ReactGrabSession } from "../types.js";
+
+interface DevtoolsPanelProps {
+  eventLog: EventLog;
+  api: ReactGrabAPI;
+}
+
+const MAX_VISIBLE_EVENTS = 200;
+
+const panelContainerStyle = `
+  position: fixed;
+  bottom: 12px;
+  right: 12px;
+  width: 360px;
+  max-height: 70vh;
+  z-index: 2147483646;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: #e6e6e6;
+  background: rgba(20, 20, 24, 0.94);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+`;
+
+const headerStyle = `
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  user-select: none;
+  cursor: pointer;
+`;
+
+const titleStyle = `
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  flex: 1;
+`;
+
+const badgeStyle = `
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+`;
+
+const recordingDotStyle = (isRecording: boolean): string => `
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: ${isRecording ? "#ff4d4d" : "#888"};
+  box-shadow: ${isRecording ? "0 0 6px rgba(255, 77, 77, 0.6)" : "none"};
+`;
+
+const toolbarStyle = `
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 6px 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+`;
+
+const buttonStyle = `
+  appearance: none;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: inherit;
+  padding: 3px 7px;
+  border-radius: 4px;
+  font: inherit;
+  cursor: pointer;
+`;
+
+const eventListStyle = `
+  overflow: auto;
+  flex: 1;
+  min-height: 80px;
+`;
+
+const eventRowStyle = `
+  display: grid;
+  grid-template-columns: 56px 1fr auto;
+  align-items: baseline;
+  gap: 6px;
+  padding: 3px 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+`;
+
+const timestampStyle = `
+  color: #888;
+  font-variant-numeric: tabular-nums;
+`;
+
+const nameStyle = `
+  color: #b9e3ff;
+`;
+
+const countStyle = `
+  color: #888;
+  font-variant-numeric: tabular-nums;
+`;
+
+const formatRelativeMs = (eventTimestamp: number, anchorTimestamp: number | null): string => {
+  if (anchorTimestamp === null) return "0ms";
+  const delta = eventTimestamp - anchorTimestamp;
+  if (delta < 1000) return `${delta}ms`;
+  return `${(delta / 1000).toFixed(2)}s`;
+};
+
+const summarizeArgs = (args: readonly unknown[]): string => {
+  if (args.length === 0) return "";
+  try {
+    const truncated = args.map((arg) => {
+      if (arg === null || arg === undefined) return String(arg);
+      if (typeof arg === "object") {
+        if ("__rgHandle" in (arg as Record<string, unknown>)) {
+          return `<${(arg as { __rgHandle: string }).__rgHandle}>`;
+        }
+        return JSON.stringify(arg).slice(0, 60);
+      }
+      return JSON.stringify(arg);
+    });
+    return truncated.join(", ");
+  } catch {
+    return "";
+  }
+};
+
+const DevtoolsPanel = (props: DevtoolsPanelProps): import("solid-js").JSX.Element => {
+  const [events, setEvents] = createSignal<ReactGrabLoggedEvent[]>(props.eventLog.getEvents());
+  const [isCollapsed, setIsCollapsed] = createSignal(false);
+  const [isRecording, setIsRecording] = createSignal(props.eventLog.isRecording());
+
+  onMount(() => {
+    const unsubscribe = props.eventLog.subscribe(() => {
+      setEvents(props.eventLog.getEvents());
+    });
+    onCleanup(unsubscribe);
+  });
+
+  const firstTimestamp = createMemo(() => {
+    const allEvents = events();
+    return allEvents.length > 0 ? allEvents[0].t : null;
+  });
+
+  const visibleEvents = createMemo(() => events().slice(-MAX_VISIBLE_EVENTS).reverse());
+
+  const handleCopySession = async () => {
+    const session = props.api.getSession();
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(session, null, 2));
+    } catch {}
+  };
+
+  const handleDownloadSession = () => {
+    const session = props.api.getSession();
+    const blob = new Blob([JSON.stringify(session, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `react-grab-session-${new Date().toISOString().replace(/[:.]/g, "-")}.json`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleReplayFromClipboard = async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      const session = JSON.parse(text) as ReactGrabSession;
+      await props.api.replaySession(session);
+    } catch (error) {
+      console.warn("[react-grab devtools] replay failed:", error);
+    }
+  };
+
+  const handleToggleRecording = () => {
+    const next = !isRecording();
+    props.api.setEventLogRecording(next);
+    setIsRecording(next);
+  };
+
+  const handleClear = () => {
+    props.api.clearEventLog();
+    setEvents([]);
+  };
+
+  return (
+    <div style={panelContainerStyle}>
+      <div style={headerStyle} onClick={() => setIsCollapsed((value) => !value)}>
+        <span style={recordingDotStyle(isRecording())} />
+        <span style={titleStyle}>react-grab event log</span>
+        <span style={badgeStyle}>{events().length}</span>
+        <span style={`${badgeStyle} margin-left: 4px;`}>{isCollapsed() ? "▾" : "▴"}</span>
+      </div>
+      <Show when={!isCollapsed()}>
+        <div style={toolbarStyle}>
+          <button
+            style={buttonStyle}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleToggleRecording();
+            }}
+          >
+            {isRecording() ? "pause" : "record"}
+          </button>
+          <button
+            style={buttonStyle}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleCopySession();
+            }}
+          >
+            copy
+          </button>
+          <button
+            style={buttonStyle}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleDownloadSession();
+            }}
+          >
+            download
+          </button>
+          <button
+            style={buttonStyle}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleReplayFromClipboard();
+            }}
+          >
+            replay
+          </button>
+          <button
+            style={buttonStyle}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleClear();
+            }}
+          >
+            clear
+          </button>
+        </div>
+        <div style={eventListStyle}>
+          <For each={visibleEvents()}>
+            {(loggedEvent) => (
+              <div style={eventRowStyle}>
+                <span style={timestampStyle}>
+                  {formatRelativeMs(loggedEvent.t, firstTimestamp())}
+                </span>
+                <span>
+                  <span style={nameStyle}>{loggedEvent.name}</span>
+                  <Show when={loggedEvent.args.length > 0}>
+                    <span style="color: #888;"> ({summarizeArgs(loggedEvent.args)})</span>
+                  </Show>
+                </span>
+                <Show when={loggedEvent.coalescedCount && loggedEvent.coalescedCount > 1}>
+                  <span style={countStyle}>×{loggedEvent.coalescedCount}</span>
+                </Show>
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+    </div>
+  );
+};
+
+const mountDevtoolsPanel = (eventLog: EventLog, api: ReactGrabAPI): (() => void) => {
+  if (typeof document === "undefined") return () => {};
+
+  const host = document.createElement("div");
+  host.setAttribute("data-react-grab-devtools", "");
+  host.style.position = "fixed";
+  host.style.inset = "0";
+  host.style.pointerEvents = "none";
+  host.style.zIndex = "2147483646";
+
+  const shadow = host.attachShadow({ mode: "open" });
+
+  const styleElement = document.createElement("style");
+  styleElement.textContent = `
+    :host { all: initial; }
+    * { box-sizing: border-box; }
+    button { pointer-events: auto; }
+    [data-rg-panel] { pointer-events: auto; }
+  `;
+  shadow.appendChild(styleElement);
+
+  const container = document.createElement("div");
+  container.setAttribute("data-rg-panel", "");
+  shadow.appendChild(container);
+
+  document.body.appendChild(host);
+
+  const disposeRender = render(() => <DevtoolsPanel eventLog={eventLog} api={api} />, container);
+
+  return () => {
+    disposeRender();
+    host.remove();
+  };
+};
+
+export { mountDevtoolsPanel, DevtoolsPanel };

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -189,6 +189,9 @@ export const SHIFT_SELECTION_LABEL_MIN_ANCHOR_RATIO = 0;
 export const SHIFT_SELECTION_LABEL_MAX_ANCHOR_RATIO = 1;
 export const SHIFT_SELECTION_LABEL_FALLBACK_ANCHOR_RATIO = 0;
 
+export const EVENT_LOG_RING_BUFFER_SIZE = 5000;
+export const EVENT_LOG_SCHEMA_VERSION = 1;
+
 export const RELEVANT_CSS_PROPERTIES = new Set([
   "display",
   "position",

--- a/packages/react-grab/src/core/event-log.ts
+++ b/packages/react-grab/src/core/event-log.ts
@@ -1,0 +1,382 @@
+import { EVENT_LOG_RING_BUFFER_SIZE, EVENT_LOG_SCHEMA_VERSION } from "../constants.js";
+import { createElementSelector } from "../utils/create-element-selector.js";
+import { isElementConnected } from "../utils/is-element-connected.js";
+import type {
+  ReactGrabLoggedEvent,
+  ReactGrabRegisteredElement,
+  ReactGrabReplayOptions,
+  ReactGrabSession,
+  ReactGrabSessionViewport,
+} from "../types.js";
+
+interface SerializedElementHandle {
+  __rgHandle: string;
+}
+
+type RegisteredElement = ReactGrabRegisteredElement;
+type LoggedEvent = ReactGrabLoggedEvent;
+type Session = ReactGrabSession;
+type ReplayOptions = ReactGrabReplayOptions;
+type SessionViewport = ReactGrabSessionViewport;
+
+interface ElementHandleRegistry {
+  toHandle: (element: Element) => string;
+  resolve: (handle: string) => Element | null;
+  registered: () => RegisteredElement[];
+  reset: () => void;
+  hydrate: (entries: RegisteredElement[]) => void;
+}
+
+interface EventLog {
+  dispatch: <Args extends unknown[]>(name: string, args: Args, timestamp?: number) => void;
+  getEvents: () => LoggedEvent[];
+  getSession: () => Session;
+  clear: () => void;
+  isRecording: () => boolean;
+  setRecording: (value: boolean) => void;
+  subscribe: (listener: (event: LoggedEvent) => void) => () => void;
+  resolveHandle: (handle: string) => Element | null;
+  hydrateRegistry: (entries: RegisteredElement[]) => void;
+}
+
+const HANDLE_PREFIX = "rg-el";
+
+const COLLAPSIBLE_ACTIONS: ReadonlySet<string> = new Set([
+  "setPointer",
+  "setDetectedElement",
+  "setInputText",
+  "setFrozenDragRect",
+  "updateContextMenuPosition",
+  "incrementViewportVersion",
+]);
+
+const argsEqual = (firstArgs: readonly unknown[], secondArgs: readonly unknown[]): boolean => {
+  if (firstArgs === secondArgs) return true;
+  if (firstArgs.length !== secondArgs.length) return false;
+  for (let index = 0; index < firstArgs.length; index += 1) {
+    if (!shallowDeepEqual(firstArgs[index], secondArgs[index])) return false;
+  }
+  return true;
+};
+
+const shallowDeepEqual = (firstValue: unknown, secondValue: unknown): boolean => {
+  if (firstValue === secondValue) return true;
+  if (firstValue === null || secondValue === null) return false;
+  if (typeof firstValue !== typeof secondValue) return false;
+  if (typeof firstValue !== "object") return false;
+  if (Array.isArray(firstValue) !== Array.isArray(secondValue)) return false;
+  if (Array.isArray(firstValue) && Array.isArray(secondValue)) {
+    if (firstValue.length !== secondValue.length) return false;
+    for (let index = 0; index < firstValue.length; index += 1) {
+      if (!shallowDeepEqual(firstValue[index], secondValue[index])) return false;
+    }
+    return true;
+  }
+  const firstObject = firstValue as Record<string, unknown>;
+  const secondObject = secondValue as Record<string, unknown>;
+  const firstKeys = Object.keys(firstObject);
+  if (firstKeys.length !== Object.keys(secondObject).length) return false;
+  for (const key of firstKeys) {
+    if (!shallowDeepEqual(firstObject[key], secondObject[key])) return false;
+  }
+  return true;
+};
+
+const createElementHandleRegistry = (): ElementHandleRegistry => {
+  const elementToHandle = new WeakMap<Element, string>();
+  const handleToWeakRef = new Map<string, WeakRef<Element>>();
+  const handleToMetadata = new Map<string, RegisteredElement>();
+  let nextHandleId = 0;
+
+  const mintHandle = (): string => {
+    nextHandleId += 1;
+    return `${HANDLE_PREFIX}-${nextHandleId}`;
+  };
+
+  const captureMetadata = (handle: string, element: Element): RegisteredElement => {
+    let selector = "";
+    try {
+      selector = createElementSelector(element);
+    } catch {
+      selector = "";
+    }
+    const entry: RegisteredElement = {
+      handle,
+      selector,
+      tagName: element.tagName?.toLowerCase?.() ?? "unknown",
+    };
+    handleToMetadata.set(handle, entry);
+    return entry;
+  };
+
+  const toHandle: ElementHandleRegistry["toHandle"] = (element) => {
+    const existing = elementToHandle.get(element);
+    if (existing) return existing;
+    const handle = mintHandle();
+    elementToHandle.set(element, handle);
+    handleToWeakRef.set(handle, new WeakRef(element));
+    captureMetadata(handle, element);
+    return handle;
+  };
+
+  const resolve: ElementHandleRegistry["resolve"] = (handle) => {
+    const weakRef = handleToWeakRef.get(handle);
+    const cached = weakRef?.deref();
+    if (cached && isElementConnected(cached)) return cached;
+
+    const metadata = handleToMetadata.get(handle);
+    if (!metadata || !metadata.selector) return null;
+    try {
+      const found = document.querySelector(metadata.selector);
+      if (found instanceof Element) {
+        elementToHandle.set(found, handle);
+        handleToWeakRef.set(handle, new WeakRef(found));
+        return found;
+      }
+    } catch {}
+    return null;
+  };
+
+  const registered: ElementHandleRegistry["registered"] = () =>
+    Array.from(handleToMetadata.values());
+
+  const reset: ElementHandleRegistry["reset"] = () => {
+    handleToWeakRef.clear();
+    handleToMetadata.clear();
+    nextHandleId = 0;
+  };
+
+  const hydrate: ElementHandleRegistry["hydrate"] = (entries) => {
+    for (const entry of entries) {
+      handleToMetadata.set(entry.handle, entry);
+      const numericPart = Number(entry.handle.slice(HANDLE_PREFIX.length + 1));
+      if (Number.isFinite(numericPart) && numericPart > nextHandleId) {
+        nextHandleId = numericPart;
+      }
+    }
+  };
+
+  return { toHandle, resolve, registered, reset, hydrate };
+};
+
+const isSerializedHandle = (value: unknown): value is SerializedElementHandle =>
+  typeof value === "object" &&
+  value !== null &&
+  typeof (value as SerializedElementHandle).__rgHandle === "string";
+
+const serializeValue = (value: unknown, registry: ElementHandleRegistry): unknown => {
+  if (value === null || value === undefined) return value;
+  if (typeof value === "boolean" || typeof value === "number" || typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "function" || typeof value === "symbol") return undefined;
+  if (typeof Element !== "undefined" && value instanceof Element) {
+    return { __rgHandle: registry.toHandle(value) };
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => serializeValue(entry, registry));
+  }
+  if (typeof value === "object") {
+    const clone: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>)) {
+      const serialized = serializeValue((value as Record<string, unknown>)[key], registry);
+      if (serialized !== undefined) clone[key] = serialized;
+    }
+    return clone;
+  }
+  return undefined;
+};
+
+type HandleResolver = (handle: string) => Element | null;
+
+const deserializeValue = (value: unknown, resolveHandle: HandleResolver): unknown => {
+  if (value === null || value === undefined) return value;
+  if (typeof value === "boolean" || typeof value === "number" || typeof value === "string") {
+    return value;
+  }
+  if (isSerializedHandle(value)) {
+    return resolveHandle(value.__rgHandle);
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => deserializeValue(entry, resolveHandle));
+  }
+  if (typeof value === "object") {
+    const clone: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>)) {
+      clone[key] = deserializeValue((value as Record<string, unknown>)[key], resolveHandle);
+    }
+    return clone;
+  }
+  return value;
+};
+
+const captureViewport = (): SessionViewport => {
+  if (typeof window === "undefined") {
+    return { width: 0, height: 0, scrollX: 0, scrollY: 0, devicePixelRatio: 1 };
+  }
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight,
+    scrollX: window.scrollX,
+    scrollY: window.scrollY,
+    devicePixelRatio: window.devicePixelRatio || 1,
+  };
+};
+
+const createEventLog = (): EventLog => {
+  const registry = createElementHandleRegistry();
+  const ringBuffer: LoggedEvent[] = [];
+  const listeners = new Set<(event: LoggedEvent) => void>();
+  let isRecordingFlag = true;
+  let firstEventTimestamp: number | null = null;
+  let lastEventTimestamp: number | null = null;
+  const createdAt = Date.now();
+
+  const dispatch: EventLog["dispatch"] = (name, args, timestamp) => {
+    if (!isRecordingFlag) return;
+    const t = timestamp ?? Date.now();
+    const serializedArgs = Array.from(args).map((arg) => serializeValue(arg, registry));
+
+    const lastEntry = ringBuffer[ringBuffer.length - 1];
+    if (lastEntry && lastEntry.name === name) {
+      const canCollapseAdjacent = COLLAPSIBLE_ACTIONS.has(name);
+      const isExactRepeat = argsEqual(lastEntry.args, serializedArgs);
+      if (canCollapseAdjacent || isExactRepeat) {
+        lastEntry.t = t;
+        lastEntry.args = serializedArgs;
+        lastEntry.coalescedCount = (lastEntry.coalescedCount ?? 1) + 1;
+        if (firstEventTimestamp === null) firstEventTimestamp = t;
+        lastEventTimestamp = t;
+        for (const listener of listeners) {
+          try {
+            listener(lastEntry);
+          } catch {}
+        }
+        return;
+      }
+    }
+
+    const entry: LoggedEvent = { t, name, args: serializedArgs };
+    ringBuffer.push(entry);
+    if (ringBuffer.length > EVENT_LOG_RING_BUFFER_SIZE) {
+      ringBuffer.shift();
+    }
+    if (firstEventTimestamp === null) firstEventTimestamp = t;
+    lastEventTimestamp = t;
+    for (const listener of listeners) {
+      try {
+        listener(entry);
+      } catch {}
+    }
+  };
+
+  const getEvents: EventLog["getEvents"] = () => ringBuffer.slice();
+
+  const getSession: EventLog["getSession"] = () => {
+    const snapshot: Session = {
+      version: EVENT_LOG_SCHEMA_VERSION,
+      createdAt,
+      startedAt: firstEventTimestamp,
+      endedAt: lastEventTimestamp,
+      userAgent: typeof navigator !== "undefined" ? navigator.userAgent : "",
+      href: typeof location !== "undefined" ? location.href : "",
+      viewport: captureViewport(),
+      elements: registry.registered().map((entry) => ({ ...entry })),
+      events: ringBuffer.map((entry) => ({
+        t: entry.t,
+        name: entry.name,
+        args: entry.args.slice(),
+        ...(entry.coalescedCount === undefined ? {} : { coalescedCount: entry.coalescedCount }),
+      })),
+    };
+    return JSON.parse(JSON.stringify(snapshot)) as Session;
+  };
+
+  const clear: EventLog["clear"] = () => {
+    ringBuffer.length = 0;
+    firstEventTimestamp = null;
+    lastEventTimestamp = null;
+    registry.reset();
+  };
+
+  const subscribe: EventLog["subscribe"] = (listener) => {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  };
+
+  return {
+    dispatch,
+    getEvents,
+    getSession,
+    clear,
+    isRecording: () => isRecordingFlag,
+    setRecording: (value) => {
+      isRecordingFlag = value;
+    },
+    subscribe,
+    resolveHandle: registry.resolve,
+    hydrateRegistry: registry.hydrate,
+  };
+};
+
+const RESET_BEFORE_REPLAY_ACTION_NAMES = [
+  "deactivate",
+  "clearGrabbedBoxes",
+  "clearLabelInstances",
+  "hideContextMenu",
+  "clearInputText",
+] as const;
+
+const replaySessionInto = async (
+  session: Session,
+  log: EventLog,
+  actions: object,
+  options: ReplayOptions = {},
+): Promise<void> => {
+  log.setRecording(false);
+  try {
+    const actionsByName = actions as Record<string, (...args: unknown[]) => unknown>;
+    for (const resetActionName of RESET_BEFORE_REPLAY_ACTION_NAMES) {
+      const resetAction = actionsByName[resetActionName];
+      if (typeof resetAction === "function") {
+        try {
+          resetAction();
+        } catch {}
+      }
+    }
+
+    log.clear();
+    log.hydrateRegistry(session.elements);
+
+    const startedAt = session.startedAt ?? 0;
+    const replayStartedAt = Date.now();
+
+    for (let index = 0; index < session.events.length; index += 1) {
+      const event = session.events[index];
+      const action = actionsByName[event.name];
+      if (typeof action !== "function") continue;
+
+      if (options.realtime && startedAt > 0) {
+        const elapsedInSession = event.t - startedAt;
+        const elapsedSinceReplay = Date.now() - replayStartedAt;
+        const waitMs = elapsedInSession - elapsedSinceReplay;
+        if (waitMs > 0) {
+          await new Promise((resolve) => setTimeout(resolve, waitMs));
+        }
+      }
+
+      const args = event.args.map((arg) => deserializeValue(arg, log.resolveHandle));
+      try {
+        action(...args);
+      } catch {}
+      options.onEvent?.(event, index);
+    }
+  } finally {
+    log.setRecording(true);
+  }
+};
+
+export { createEventLog, replaySessionInto };
+export type { EventLog };

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -13,7 +13,6 @@ import {
 import { render } from "solid-js/web";
 import { createGrabStore } from "./store.js";
 import { createEventLog, replaySessionInto } from "./event-log.js";
-import { mountDevtoolsPanel } from "../components/devtools-panel.js";
 import {
   isKeyboardEventTriggeredByInput,
   hasTextSelectionInInput,
@@ -3719,12 +3718,16 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     }, NEXTJS_REVALIDATION_DELAY_MS);
 
     if (typeof window !== "undefined" && window.__REACT_GRAB_DEVTOOLS__) {
-      try {
-        const disposeDevtools = mountDevtoolsPanel(eventLog, api);
-        onCleanup(() => disposeDevtools());
-      } catch (error) {
-        console.warn("[react-grab] devtools panel failed to mount:", error);
-      }
+      let disposeDevtools: (() => void) | undefined;
+      void import("../components/devtools-panel.js")
+        .then(({ mountDevtoolsPanel }) => {
+          if (disposed) return;
+          disposeDevtools = mountDevtoolsPanel(eventLog, api);
+        })
+        .catch((error) => {
+          console.warn("[react-grab] devtools panel failed to mount:", error);
+        });
+      onCleanup(() => disposeDevtools?.());
     }
 
     return api;

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -12,6 +12,8 @@ import {
 } from "solid-js";
 import { render } from "solid-js/web";
 import { createGrabStore } from "./store.js";
+import { createEventLog, replaySessionInto } from "./event-log.js";
+import { mountDevtoolsPanel } from "../components/devtools-panel.js";
 import {
   isKeyboardEventTriggeredByInput,
   hasTextSelectionInInput,
@@ -202,9 +204,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
     const pluginRegistry = createPluginRegistry(settableOptions);
 
+    const eventLog = createEventLog();
+
     const { store, actions, pointer, viewportVersion, current } = createGrabStore({
       theme: DEFAULT_THEME,
       keyHoldDuration: pluginRegistry.store.options.keyHoldDuration ?? DEFAULT_KEY_HOLD_DURATION_MS,
+      eventLog,
     });
 
     const isHoldingKeys = createMemo(() => current().state === "holding");
@@ -3698,6 +3703,11 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       },
       getPlugins: () => pluginRegistry.getPluginNames(),
       getDisplayName: getComponentDisplayName,
+      getSession: () => eventLog.getSession(),
+      replaySession: (session, replayOptions) =>
+        replaySessionInto(session, eventLog, actions, replayOptions),
+      clearEventLog: () => eventLog.clear(),
+      setEventLogRecording: (value: boolean) => eventLog.setRecording(value),
     };
 
     for (const plugin of builtInPlugins) {
@@ -3707,6 +3717,15 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     setTimeout(() => {
       checkIsNextProject(true);
     }, NEXTJS_REVALIDATION_DELAY_MS);
+
+    if (typeof window !== "undefined" && window.__REACT_GRAB_DEVTOOLS__) {
+      try {
+        const disposeDevtools = mountDevtoolsPanel(eventLog, api);
+        onCleanup(() => disposeDevtools());
+      } catch (error) {
+        console.warn("[react-grab] devtools panel failed to mount:", error);
+      }
+    }
 
     return api;
   });

--- a/packages/react-grab/src/core/noop-api.ts
+++ b/packages/react-grab/src/core/noop-api.ts
@@ -36,4 +36,18 @@ export const createNoopApi = (): ReactGrabAPI => ({
   unregisterPlugin: NOOP,
   getPlugins: () => [],
   getDisplayName: () => null,
+  getSession: () => ({
+    version: 1,
+    createdAt: 0,
+    startedAt: null,
+    endedAt: null,
+    userAgent: "",
+    href: "",
+    viewport: { width: 0, height: 0, scrollX: 0, scrollY: 0, devicePixelRatio: 1 },
+    elements: [],
+    events: [],
+  }),
+  replaySession: () => Promise.resolve(),
+  clearEventLog: NOOP,
+  setEventLogRecording: NOOP,
 });

--- a/packages/react-grab/src/core/store.ts
+++ b/packages/react-grab/src/core/store.ts
@@ -5,6 +5,7 @@ import { OFFSCREEN_POSITION } from "../constants.js";
 import { createElementBounds } from "../utils/create-element-bounds.js";
 import { getBoundsCenter } from "../utils/get-bounds-center.js";
 import { isElementConnected } from "../utils/is-element-connected.js";
+import type { EventLog } from "./event-log.js";
 
 interface FrozenDragRect {
   pageX: number;
@@ -68,6 +69,7 @@ interface GrabStore {
 interface GrabStoreInput {
   theme: Required<Theme>;
   keyHoldDuration: number;
+  eventLog?: EventLog;
 }
 
 const createInitialStore = (input: GrabStoreInput): GrabStore => ({
@@ -620,7 +622,29 @@ const createGrabStore = (input: GrabStoreInput) => {
     },
   };
 
-  return { store, actions, pointer, viewportVersion, current };
+  const wrappedActions = wrapActionsForLogging(actions, input.eventLog);
+
+  return { store, actions: wrappedActions, pointer, viewportVersion, current };
+};
+
+const wrapActionsForLogging = (
+  actions: GrabActions,
+  eventLog: EventLog | undefined,
+): GrabActions => {
+  if (!eventLog) return actions;
+  const wrapped: Record<string, unknown> = {};
+  for (const key of Object.keys(actions) as Array<keyof GrabActions>) {
+    const original = actions[key];
+    if (typeof original !== "function") {
+      wrapped[key] = original;
+      continue;
+    }
+    wrapped[key] = (...args: unknown[]) => {
+      eventLog.dispatch(key, args);
+      return (original as (...args: unknown[]) => unknown)(...args);
+    };
+  }
+  return wrapped as unknown as GrabActions;
 };
 
 export { createGrabStore };

--- a/packages/react-grab/src/index.ts
+++ b/packages/react-grab/src/index.ts
@@ -43,6 +43,7 @@ declare global {
   interface Window {
     __REACT_GRAB__?: ReactGrabAPI;
     __REACT_GRAB_DISABLED__?: boolean;
+    __REACT_GRAB_DEVTOOLS__?: boolean;
   }
 }
 

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -277,6 +277,44 @@ export interface DropdownAnchor {
   toolbarWidth: number;
 }
 
+export interface ReactGrabSessionViewport {
+  width: number;
+  height: number;
+  scrollX: number;
+  scrollY: number;
+  devicePixelRatio: number;
+}
+
+export interface ReactGrabRegisteredElement {
+  handle: string;
+  selector: string;
+  tagName: string;
+}
+
+export interface ReactGrabLoggedEvent {
+  t: number;
+  name: string;
+  args: unknown[];
+  coalescedCount?: number;
+}
+
+export interface ReactGrabSession {
+  version: number;
+  createdAt: number;
+  startedAt: number | null;
+  endedAt: number | null;
+  userAgent: string;
+  href: string;
+  viewport: ReactGrabSessionViewport;
+  elements: ReactGrabRegisteredElement[];
+  events: ReactGrabLoggedEvent[];
+}
+
+export interface ReactGrabReplayOptions {
+  realtime?: boolean;
+  onEvent?: (event: ReactGrabLoggedEvent, index: number) => void;
+}
+
 export interface ReactGrabAPI {
   activate: () => void;
   deactivate: () => void;
@@ -298,6 +336,10 @@ export interface ReactGrabAPI {
   unregisterPlugin: (name: string) => void;
   getPlugins: () => string[];
   getDisplayName: (element: Element) => string | null;
+  getSession: () => ReactGrabSession;
+  replaySession: (session: ReactGrabSession, options?: ReactGrabReplayOptions) => Promise<void>;
+  clearEventLog: () => void;
+  setEventLogRecording: (value: boolean) => void;
 }
 
 export interface OverlayBounds {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds an internal event log that records every dispatched store action so a session can be exported as JSON, pasted into a bug report, and replayed against the live store to reproduce the same UI state.

Driven by the brainstorm in the linked chat — scoped intentionally tight. No architectural rewrite, no Foldkit-ification, no plugin restructuring, no Subscriptions/Managed Resources/Submodels. Just the log and the repro mechanism.

## How

### Action proxy as the log boundary

`createGrabStore` now accepts an optional `eventLog` and wraps the returned `actions` object with a small proxy that calls `eventLog.dispatch(name, args)` before invoking the underlying action body. Internal action-to-action calls (e.g. `toggle` → `deactivate`) use the unwrapped local reference, so the log never double-counts.

### Element handles instead of live refs

Element args can't be JSON-serialized, so the log mints a stable `rg-el-N` handle the first time it sees each element. The registry keeps a `WeakMap<Element, handle>` for forward lookup, a `WeakRef<Element>` for reverse lookup, and a unique CSS selector (via the existing `createElementSelector`) as a fallback for replay.

On `replaySession`, handles are resolved by trying:
1. The cached `WeakRef` if still alive and connected.
2. `document.querySelector(selector)` against the live DOM.
3. Otherwise `null` (actions are tolerant of `null` element args today).

### Online coalescing

Without compaction, `setPointer` alone would fill the 5000-entry ring buffer in a few seconds. Dispatch checks the previous entry: if the name is in a small "idempotent setter" allowlist (`setPointer`, `setDetectedElement`, `setInputText`, `setFrozenDragRect`, `updateContextMenuPosition`, `incrementViewportVersion`) **or** the new args structurally equal the previous, the latest call replaces the prior entry and a `coalescedCount` is bumped. The dev panel renders this as `setPointer ×127`.

Things that depend on call sequence or count (`addGrabbedBox`, `toggleFrozenElement`, `increment`/`decrement` lock depth pairs, etc.) are intentionally **not** in the allowlist — they stay every call.

### Public API additions

`ReactGrabAPI` gains four methods:
- `getSession(): ReactGrabSession` — deep-cloned snapshot for export.
- `replaySession(session, options?): Promise<void>` — resets the store (`deactivate` + clears) then dispatches each event in order; `options.realtime: true` honors original timestamps via `setTimeout`.
- `clearEventLog(): void`
- `setEventLogRecording(value): void` — pause/resume without losing the buffer.

The `noop-api` stub implements the same surface.

### Optional devtools panel

Gated by `window.__REACT_GRAB_DEVTOOLS__ = true` set before `init()`. Lazy-imported only when the flag is set (mirrors the renderer's existing pattern, since `solid-js/web` touches `window` at module load and would break SSR). Mounts its own shadow root (independent of the main overlay) with inline styles and renders a floating event list. Buttons: pause/record, copy JSON, download JSON, replay from clipboard, clear. Each row shows `relativeMs · actionName(args…) · ×count`.

## What this gets you

- **Bug repros as paste-able JSON.** Hit a bug → open panel → copy → paste into an issue. Load locally and step through.
- **Tests as arrays of events.** `applyEvents(store, [...])` after a session is loaded; assert on the resulting Model.
- **Live coalesced timeline** for "what just happened" debugging.

## What this explicitly does NOT do

- Lift `Date.now()` / `document.activeElement` / `window.scroll*` reads out of action bodies. Replay reproduces the **structural** state (selection, drag, freezes, context menu) but not byte-exact timestamps inside the Model. Good enough for ~95% of repros.
- Subscriptions / Managed Resources / Submodels / Effect-style purity. Out of scope.
- Ship a UI for end users. The panel is dev-only and gated.

## Verified

- `pnpm --filter react-grab typecheck` ✓
- `pnpm --filter react-grab build` ✓
- `pnpm lint` ✓
- `pnpm format` ✓
- `pnpm test` ✓ — all 511 Playwright e2e tests pass (including SSR compatibility — initial run had 13 SSR failures from the eager devtools-panel import; fixed with the lazy import).

## Bundle impact

- Main IIFE: +0.4 kB gzip vs main (event log + handle registry inlined).
- Devtools panel: separate 2.25 kB gzip chunk, never loaded unless `__REACT_GRAB_DEVTOOLS__` is set.

## Files

- `packages/react-grab/src/core/event-log.ts` (new) — registry + ring buffer + dispatch + replay.
- `packages/react-grab/src/components/devtools-panel.tsx` (new) — gated, lazy-loaded Solid panel.
- `packages/react-grab/src/core/store.ts` — accepts `eventLog`, wraps `actions` if present.
- `packages/react-grab/src/core/index.tsx` — creates the log, exposes API methods, lazy-imports the panel when flagged.
- `packages/react-grab/src/core/noop-api.ts` — implements the new methods.
- `packages/react-grab/src/types.ts` — public types: `ReactGrabSession`, `ReactGrabLoggedEvent`, `ReactGrabReplayOptions`, etc.
- `packages/react-grab/src/index.ts` — declares `window.__REACT_GRAB_DEVTOOLS__`.
- `packages/react-grab/src/constants.ts` — `EVENT_LOG_RING_BUFFER_SIZE`, `EVENT_LOG_SCHEMA_VERSION`.

## Try it

```ts
window.__REACT_GRAB_DEVTOOLS__ = true;
// then load react-grab — a floating panel appears in the bottom-right.

// Programmatic use:
const session = window.__REACT_GRAB__.getSession();
console.log(JSON.stringify(session));

// Later, in a fresh tab:
await window.__REACT_GRAB__.replaySession(session);            // fast
await window.__REACT_GRAB__.replaySession(session, { realtime: true }); // honor original spacing
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d1501fb-5773-47e2-bcaf-10bc8af7f3b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d1501fb-5773-47e2-bcaf-10bc8af7f3b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an internal event log with session export/replay and an optional, lazy-loaded devtools panel in `react-grab` to make bug repros and debugging easy. No end-user impact by default; the devtools panel only loads when enabled and stays SSR-safe.

- New Features
  - Capture every dispatched store action via a proxy; internal action-to-action calls are not double-logged.
  - Serialize element args as stable handles (e.g., `rg-el-1`) with WeakRef and selector fallback; replay tolerates nulls.
  - Coalesce chatty setters (e.g., `setPointer`) and identical args to reduce noise; rows show ×count.
  - Export sessions as JSON and replay against the live store with optional realtime timing; store is reset before replay. Sessions include UA, URL, viewport, and a versioned schema.
  - New `ReactGrabAPI` methods: `getSession`, `replaySession(session, options?)`, `clearEventLog`, `setEventLogRecording`.
  - Optional devtools panel (shadow DOM): pause/record, copy JSON, download, replay from clipboard, clear; enable with `window.__REACT_GRAB_DEVTOOLS__ = true`.

- Bug Fixes
  - Devtools panel is lazy-imported and code-split, avoiding `window` access during SSR; loads only when `window.__REACT_GRAB_DEVTOOLS__` is true.

<sup>Written for commit 174d66bf6594fb298a9590e1c983dc0f2ec777b9. Summary will update on new commits. <a href="https://cubic.dev/pr/aidenybai/react-grab/pull/365?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

