### PR TITLE
feat(selection-label): dim more-options ellipsis icon

### DIFF
--- a/packages/react-grab/src/components/selection-label/completion-view.tsx
+++ b/packages/react-grab/src/components/selection-label/completion-view.tsx
@@ -18,7 +18,7 @@ const MoreOptionsButton: Component<MoreOptionsButtonProps> = (props) => {
     <button
       data-react-grab-ignore-events
       data-react-grab-more-options
-      class="flex items-center justify-center size-4 rounded-sm cursor-pointer bg-transparent hover:bg-[var(--rg-surface-hover)] text-[var(--rg-text-secondary)] hover:text-[var(--rg-text-primary)] border-none outline-none p-0 shrink-0 press-scale"
+      class="group flex items-center justify-center size-4 rounded-sm cursor-pointer bg-transparent hover:bg-[var(--rg-surface-hover)] text-[var(--rg-text-secondary)] hover:text-[var(--rg-text-primary)] border-none outline-none p-0 shrink-0 press-scale"
       // The on: prefix attaches a native event listener (rather than using
       // SolidJS delegation) so stopImmediatePropagation can beat both
       // delegated handlers and document-level capture listeners.
@@ -30,7 +30,7 @@ const MoreOptionsButton: Component<MoreOptionsButtonProps> = (props) => {
         props.onClick();
       }}
     >
-      <IconEllipsis size={14} />
+      <IconEllipsis size={14} class="opacity-60 group-hover:opacity-100 transition-opacity" />
     </button>
   );
 };

--- a/packages/react-grab/src/components/selection-label/completion-view.tsx
+++ b/packages/react-grab/src/components/selection-label/completion-view.tsx
@@ -30,7 +30,7 @@ const MoreOptionsButton: Component<MoreOptionsButtonProps> = (props) => {
         props.onClick();
       }}
     >
-      <IconEllipsis size={14} class="opacity-60 group-hover:opacity-100 transition-opacity" />
+      <IconEllipsis size={14} class="opacity-50 group-hover:opacity-100 transition-opacity" />
     </button>
   );
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Makes the "more options" ellipsis icon (`…` button) on the selection label's completion view a bit dimmer in its resting state, while still brightening up on hover.

## Change

In `packages/react-grab/src/components/selection-label/completion-view.tsx`, the `MoreOptionsButton` now:

- Adds the `group` utility to the button so children can react to its hover state.
- Renders `<IconEllipsis>` with `opacity-50 group-hover:opacity-100 transition-opacity`, so the icon sits at 50% opacity by default and smoothly returns to full opacity when the button is hovered.

The button still picks up `var(--rg-text-secondary)` → `var(--rg-text-primary)` on hover and keeps its hover background, press-scale, and click handlers intact — only the visual weight of the icon at rest changes.

## Verification

- `pnpm --filter react-grab typecheck` passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73f3c165-c44b-44f5-be8a-378d353e4e2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73f3c165-c44b-44f5-be8a-378d353e4e2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dims the “more options” ellipsis icon in the selection label completion view to 50% opacity at rest, returning to full on hover for clearer visual hierarchy. Adds `group` to the button and sets `opacity-50 group-hover:opacity-100 transition-opacity` on `IconEllipsis`; no behavior changes.

<sup>Written for commit 4ca824ac18ae8775888f783621813b07e5c20cbc. Summary will update on new commits. <a href="https://cubic.dev/pr/aidenybai/react-grab/pull/366?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

