### PR TITLE
fix(selection-label): hide sub-pixel seam between arrow and panel

### DIFF
--- a/packages/react-grab/src/components/selection-label/arrow.tsx
+++ b/packages/react-grab/src/components/selection-label/arrow.tsx
@@ -1,6 +1,6 @@
 import type { Component } from "solid-js";
 import type { ArrowProps } from "../../types.js";
-import { PANEL_BACKGROUND, ARROW_TIP_RADIUS_PX } from "../../constants.js";
+import { PANEL_BACKGROUND, ARROW_TIP_RADIUS_PX, ARROW_PANEL_OVERLAP_PX } from "../../constants.js";
 import { getArrowSize } from "../../utils/get-arrow-size.js";
 
 export const Arrow: Component<ArrowProps> = (props) => {
@@ -34,8 +34,8 @@ export const Arrow: Component<ArrowProps> = (props) => {
         top: isBottom() ? "0" : undefined,
         bottom: isBottom() ? undefined : "0",
         transform: isBottom()
-          ? "translateX(-50%) translateY(-100%)"
-          : "translateX(-50%) translateY(100%)",
+          ? `translateX(-50%) translateY(calc(-100% + ${ARROW_PANEL_OVERLAP_PX}px))`
+          : `translateX(-50%) translateY(calc(100% - ${ARROW_PANEL_OVERLAP_PX}px))`,
       }}
     >
       <path d={tipPath()} fill={arrowColor()} />

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -62,6 +62,12 @@ export const ARROW_MAX_LABEL_WIDTH_RATIO = 0.2;
 export const ARROW_TIP_RADIUS_PX = 1;
 export const ARROW_CENTER_PERCENT = 50;
 export const ARROW_LABEL_MARGIN_PX = 16;
+// The arrow base and the panel edge touch at the same fractional CSS
+// coordinate. Without overlap, that shared edge anti-aliases as a hairline
+// seam at certain zoom levels and devicePixelRatios. Overlapping by 1px
+// hides the seam without shifting the visual tip noticeably (both fills
+// are var(--rg-panel-bg) so the overlap is invisible).
+export const ARROW_PANEL_OVERLAP_PX = 1;
 export const LABEL_GAP_PX = 4;
 export const PREVIEW_TEXT_MAX_LENGTH = 100;
 export const PREVIEW_ATTR_VALUE_MAX_LENGTH = 15;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why a line sometimes appears between the arrow and the label

The `Arrow` SVG and the selection label panel are two separate DOM elements whose edges meet at the same CSS coordinate:

- The arrow's flat base sits at the bottom (or top) of its SVG viewBox.
- The SVG is positioned with `top: 0; transform: translateX(-50%) translateY(-100%)` (or the mirrored variant), so the SVG's edge aligns *exactly* with the panel's edge.

That shared edge frequently lands on a fractional device pixel because:

- The container uses `translateX(-50%)` over a cursor-anchored `left` that is not an integer.
- The container's `top` is computed from selection bounds + `actualArrowHeight + LABEL_GAP_PX` — none of which are guaranteed to be integers.
- Device pixel ratio and page zoom further multiply that fractional offset.

When the edge lands between two physical pixels, the browser anti-aliases the arrow's base and the panel's edge **independently**. Each one gets a partial-opacity row, but since they are two different layers (and the container has a `drop-shadow` filter applied), the seam reads as a thin hairline. Zooming in snaps the coordinate to a different sub-pixel offset and the two edges realign, which is why the line disappears under magnification — exactly the symptom reported.

This is the classic "sub-pixel seam between two flush-touching elements" bug, the same one you see in stitched image tiles and tabbed UIs.

## Fix

Overlap the arrow into the panel by 1 CSS pixel via the SVG's `translateY`:

```5:7:packages/react-grab/src/components/selection-label/arrow.tsx
import {
  PANEL_BACKGROUND,
  ARROW_TIP_RADIUS_PX,
  ARROW_PANEL_OVERLAP_PX,
} from "../../constants.js";
```

```40:42:packages/react-grab/src/components/selection-label/arrow.tsx
        transform: isBottom()
          ? `translateX(-50%) translateY(calc(-100% + ${ARROW_PANEL_OVERLAP_PX}px))`
          : `translateX(-50%) translateY(calc(100% - ${ARROW_PANEL_OVERLAP_PX}px))`,
```

Because the arrow's fill (`PANEL_BACKGROUND` → `var(--rg-panel-bg)`) is the exact color used by the panel background, the overlap is **invisible**. But it guarantees the two elements always *cover* the seam together rather than meeting at a single fractional line, so anti-aliasing has nothing to highlight.

The overlap constant lives in `constants.ts` per the workspace's magic-number rule:

```60:67:packages/react-grab/src/constants.ts
// The arrow base and the panel edge touch at the same fractional CSS
// coordinate. Without overlap, that shared edge anti-aliases as a hairline
// seam at certain zoom levels and devicePixelRatios. Overlapping by 1px
// hides the seam without shifting the visual tip noticeably (both fills
// are var(--rg-panel-bg) so the overlap is invisible).
export const ARROW_PANEL_OVERLAP_PX = 1;
```

The same `Arrow` component is reused by the context menu (`packages/react-grab/src/components/context-menu.tsx`), so that panel also benefits from the fix without further changes.

## Validation

- `pnpm build` — clean
- `pnpm typecheck` — clean
- `pnpm lint` — 0 warnings, 0 errors
- `pnpm format` — clean
- `pnpm test` — 513 Playwright E2E tests pass, including all `Visual Feedback › Selection Label` and `Visual Feedback › Arrow Direction` cases

The 1-pixel shift in the visual tip is well below perceptual threshold (and is a constant offset, not a jitter), so positioning and arrow-pointing math do not need to compensate.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98f9c32a-30c0-4896-b614-2b36cffe0c1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98f9c32a-30c0-4896-b614-2b36cffe0c1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the hairline seam between the selection label arrow and panel that showed up at certain zoom levels and DPRs. Overlaps the arrow into the panel by 1px via translateY, which is visually invisible and also applies to the shared context menu arrow.

<sup>Written for commit d38813029c768932dc1b01af7bbe41ea1f5a8cc8. Summary will update on new commits. <a href="https://cubic.dev/pr/aidenybai/react-grab/pull/367?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

