### PR TITLE
perf(core): scope plugin hook tracking to relevant state

### DIFF
--- a/packages/react-grab/src/components/icons/icon-select.tsx
+++ b/packages/react-grab/src/components/icons/icon-select.tsx
@@ -17,7 +17,7 @@ export const IconSelect: Component<IconSelectProps> = (props) => {
       class={cn("inline-flex items-center justify-center will-change-transform", props.class)}
       style={{
         transform: `rotate(${rotationDeg()}deg)`,
-        "transition-property": "transform, color",
+        "transition-property": "transform",
         "transition-duration": `${SELECT_ICON_ROTATION_TRANSITION_MS}ms`,
         "transition-timing-function": "cubic-bezier(0.32, 0.72, 0, 1)",
       }}

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -9,6 +9,7 @@ import {
   createResource,
   on,
   mapArray,
+  untrack,
 } from "solid-js";
 import { render } from "solid-js/web";
 import { createGrabStore } from "./store.js";
@@ -107,6 +108,7 @@ import type {
   ToolbarState,
   CommentItem,
   DropdownAnchor,
+  ElementLabelVariant,
 } from "../types.js";
 import { DEFAULT_THEME } from "./theme.js";
 import { createPluginRegistry } from "./plugin-registry.js";
@@ -1405,11 +1407,18 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
     createEffect(
       on(
-        () => [isPromptMode(), pointer().x, pointer().y, targetElement()] as const,
-        ([inputMode, x, y, target]) => {
+        () => {
+          const inputMode = isPromptMode();
+          return {
+            inputMode,
+            position: inputMode ? pointer() : untrack(pointer),
+            target: inputMode ? targetElement() : untrack(targetElement),
+          };
+        },
+        ({ inputMode, position, target }) => {
           pluginRegistry.hooks.onPromptModeChange(inputMode, {
-            x,
-            y,
+            x: position.x,
+            y: position.y,
             targetElement: target,
           });
         },
@@ -1436,17 +1445,19 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
     createEffect(
       on(
-        () =>
-          [
-            labelVisible(),
+        () => {
+          const visible = labelVisible();
+          return [
+            visible,
             labelVariant(),
-            cursorPosition(),
-            targetElement(),
+            visible ? cursorPosition() : untrack(cursorPosition),
+            visible ? targetElement() : untrack(targetElement),
             store.selectionFilePath,
             store.selectionLineNumber,
-          ] as const,
+          ] as const;
+        },
         ([visible, variant, position, element, filePath, lineNumber]) => {
-          pluginRegistry.hooks.onElementLabel(Boolean(visible), variant, {
+          pluginRegistry.hooks.onElementLabel(visible, variant, {
             x: position.x,
             y: position.y,
             content: "",
@@ -3111,7 +3122,9 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         isDraggingBeyondThreshold(),
     );
 
-    const labelVariant = createMemo(() => (isCopying() ? "processing" : "hover"));
+    const labelVariant = createMemo<ElementLabelVariant>(() =>
+      isCopying() ? "processing" : "hover",
+    );
 
     const labelVisible = createMemo(() => {
       if (!isThemeEnabled()) return false;


### PR DESCRIPTION
## Summary

- `onPromptModeChange` no longer re-fires on every pointer/target update when prompt mode is inactive; pointer/target signals are `untrack`ed unless `isPromptMode()` is true.
- `onElementLabel` applies the same gating: cursor position and target element are only tracked when `labelVisible()` is true. The hook still fires once on the hide transition with the last-known position.
- Type `labelVariant` explicitly as `ElementLabelVariant` and drop the now-redundant `Boolean(visible)` coercion.
- Drop `color` from the toolbar select icon's `transition-property` so only the rotation animates.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] Verify in playground: prompt-mode hook fires on toggle + while in prompt mode, but not on pointer moves outside it
- [ ] Verify element-label hook fires on show/hide and while visible, but not on pointer moves while hidden
- [ ] Visual check on toolbar select icon hover → processing → success color transitions


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Solid reactivity dependencies for plugin hooks (`onPromptModeChange`, `onElementLabel`), which may alter when plugins receive updates and could surface subtle regressions in integrations.
> 
> **Overview**
> **Reduces unnecessary plugin hook updates** by scoping Solid signal tracking to only when the relevant UI state is active/visible. `onPromptModeChange` now `untrack`s pointer/target updates while prompt mode is inactive, and `onElementLabel` similarly only tracks cursor/target while the label is visible (still emitting once on hide with the last-known data).
> 
> Also tightens typing by explicitly typing `labelVariant` as `ElementLabelVariant`, and adjusts the toolbar select icon animation so only `transform` (rotation) transitions (removing `color` from `transition-property`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 561b03e2bd1e118c99a38f2f0fff182a23bc4d4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes plugin hook tracking to active states to cut unnecessary updates and improve responsiveness. Only track pointer/target during prompt mode or when the element label is visible, plus minor typing and icon animation tweaks.

- **Refactors**
  - Gate `onPromptModeChange`: untrack pointer/target unless `isPromptMode()` is true.
  - Gate `onElementLabel`: track position/target only when `labelVisible()` is true; still fires once on hide with last-known position.
  - Type `labelVariant` as `ElementLabelVariant`; remove `Boolean(visible)` coercion.
  - Icon: drop color from transition so only rotation animates.

<sup>Written for commit 561b03e2bd1e118c99a38f2f0fff182a23bc4d4a. Summary will update on new commits. <a href="https://cubic.dev/pr/aidenybai/react-grab/pull/368?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

