### PR TITLE
feat(react-grab): add errors.ts for defined error classes

### DIFF
--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -13,6 +13,7 @@ import {
 } from "solid-js";
 import { render } from "solid-js/web";
 import { createGrabStore } from "./store.js";
+import { CopyFailedError } from "../errors.js";
 import {
   isKeyboardEventTriggeredByInput,
   hasTextSelectionInInput,
@@ -854,7 +855,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       } else if (pendingResults.length > 0) {
         const results = await Promise.all(pendingResults);
         if (!results.every(Boolean)) {
-          throw new Error("Failed to copy");
+          throw new CopyFailedError();
         }
       }
       void notifyElementsSelected(targetElements);

--- a/packages/react-grab/src/errors.ts
+++ b/packages/react-grab/src/errors.ts
@@ -1,0 +1,37 @@
+export class ReactGrabError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReactGrabError";
+  }
+}
+
+export class NonElementNodeError extends ReactGrabError {
+  constructor() {
+    super("Can't generate CSS selector for non-element node type.");
+    this.name = "NonElementNodeError";
+  }
+}
+
+export class SelectorTimeoutError extends ReactGrabError {
+  readonly timeoutMs: number;
+
+  constructor(timeoutMs: number) {
+    super(`Timeout: Can't find a unique selector after ${timeoutMs}ms`);
+    this.name = "SelectorTimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export class SelectorNotFoundError extends ReactGrabError {
+  constructor() {
+    super("Selector was not found.");
+    this.name = "SelectorNotFoundError";
+  }
+}
+
+export class CopyFailedError extends ReactGrabError {
+  constructor() {
+    super("Failed to copy");
+    this.name = "CopyFailedError";
+  }
+}

--- a/packages/react-grab/src/utils/find-unique-selector.ts
+++ b/packages/react-grab/src/utils/find-unique-selector.ts
@@ -1,4 +1,5 @@
 import { MAX_SELECTOR_COMBINATIONS } from "../constants.js";
+import { NonElementNodeError, SelectorNotFoundError, SelectorTimeoutError } from "../errors.js";
 
 interface SelectorNode {
   name: string;
@@ -202,7 +203,7 @@ export const findUniqueSelector = (
   attrFilter: (name: string, value: string) => boolean,
 ): string => {
   if (targetElement.nodeType !== Node.ELEMENT_NODE) {
-    throw new Error("Can't generate CSS selector for non-element node type.");
+    throw new NonElementNodeError();
   }
   if (targetElement.tagName.toLowerCase() === "html") {
     return "html";
@@ -229,7 +230,7 @@ export const findUniqueSelector = (
         if (Date.now() - startTime > timeoutMs) {
           const fallbackPath = buildFallbackPath(targetElement, rootDocument);
           if (!fallbackPath) {
-            throw new Error(`Timeout: Can't find a unique selector after ${timeoutMs}ms`);
+            throw new SelectorTimeoutError(timeoutMs);
           }
           return buildSelectorString(fallbackPath);
         }
@@ -254,7 +255,7 @@ export const findUniqueSelector = (
   }
 
   if (!foundPath) {
-    throw new Error("Selector was not found.");
+    throw new SelectorNotFoundError();
   }
 
   return buildSelectorString(foundPath);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `packages/react-grab/src/errors.ts` that centralizes the library's named error classes and refactors the existing `throw new Error(...)` sites in `src` to use them. This gives downstream code (and library consumers) a stable surface to detect specific failure modes with `instanceof` instead of matching on error message strings.

## Defined errors

All errors extend a common `ReactGrabError` base, so consumers can do a broad `instanceof ReactGrabError` check or a narrow check on the specific subclass.

- `ReactGrabError` — base class for all library-thrown errors
- `NonElementNodeError` — thrown when a CSS selector is requested for a non-element node
- `SelectorTimeoutError` — thrown when the unique selector search exceeds its time budget (carries the `timeoutMs` value)
- `SelectorNotFoundError` — thrown when no unique selector can be found
- `CopyFailedError` — thrown when one or more pending copy results report failure

## Refactored throw sites

- `packages/react-grab/src/utils/find-unique-selector.ts` — replaced the three `throw new Error(...)` calls with the corresponding named errors
- `packages/react-grab/src/core/index.tsx` — replaced `throw new Error("Failed to copy")` with `throw new CopyFailedError()`

Error messages are preserved verbatim so behavior and logs are unchanged.

## Verification

- `pnpm typecheck` — passes
- `pnpm lint` — passes
- `pnpm format` — applied

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce4de4be-d4df-4766-80ab-7b3c940a4050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce4de4be-d4df-4766-80ab-7b3c940a4050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized error classes for `react-grab` and refactored throw sites to use them. This enables clean instanceof checks while keeping messages and behavior unchanged.

- **New Features**
  - Added `errors.ts` with `ReactGrabError` base and subclasses: `NonElementNodeError`, `SelectorTimeoutError` (with `timeoutMs`), `SelectorNotFoundError`, `CopyFailedError`.
  - Updated `utils/find-unique-selector.ts` and `core/index.tsx` to throw these classes.

- **Bug Fixes**
  - CI: retry flaky e2e shard to reduce false failures.

<sup>Written for commit 934fc3ace1d0e318bff5dcc8f9a1ad55792a2697. Summary will update on new commits. <a href="https://cubic.dev/pr/aidenybai/react-grab/pull/369?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

