### PR TITLE
fix(menu-highlight): round corners to match panel at first/last items

### DIFF
--- a/packages/react-grab/src/components/context-menu.tsx
+++ b/packages/react-grab/src/components/context-menu.tsx
@@ -10,6 +10,8 @@ import {
   ARROW_HEIGHT_PX,
   DROPDOWN_OFFSCREEN_POSITION,
   LABEL_GAP_PX,
+  MENU_HIGHLIGHT_CORNER_SHAPE,
+  MENU_PANEL_CORNER_RADIUS_PX,
   Z_INDEX_OVERLAY,
 } from "../constants.js";
 import { cn } from "../utils/cn.js";
@@ -50,7 +52,10 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
     highlightRef,
     updateHighlight,
     clearHighlight,
-  } = createMenuHighlight();
+  } = createMenuHighlight({
+    cornerRadiusPx: MENU_PANEL_CORNER_RADIUS_PX,
+    cornerShape: MENU_HIGHLIGHT_CORNER_SHAPE,
+  });
 
   const [measuredWidth, setMeasuredWidth] = createSignal(0);
   const [measuredHeight, setMeasuredHeight] = createSignal(0);
@@ -261,7 +266,7 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
             >
               <div
                 ref={highlightRef}
-                class="pointer-events-none absolute opacity-0 transition-[top,left,width,height,opacity] duration-75 ease-out bg-[var(--rg-surface-hover)]"
+                class="pointer-events-none absolute opacity-0 transition-[top,left,width,height,opacity,border-radius] duration-75 ease-out bg-[var(--rg-surface-hover)]"
               />
               <For each={menuItems()}>
                 {(item) => (

--- a/packages/react-grab/src/components/context-menu.tsx
+++ b/packages/react-grab/src/components/context-menu.tsx
@@ -53,7 +53,7 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
     updateHighlight,
     clearHighlight,
   } = createMenuHighlight({
-    cornerRadiusPx: MENU_PANEL_CORNER_RADIUS_PX,
+    bottomCornerRadiusPx: MENU_PANEL_CORNER_RADIUS_PX,
     cornerShape: MENU_HIGHLIGHT_CORNER_SHAPE,
   });
 

--- a/packages/react-grab/src/components/selection-label/arrow-navigation-menu.tsx
+++ b/packages/react-grab/src/components/selection-label/arrow-navigation-menu.tsx
@@ -1,6 +1,7 @@
 import { Show, For, createEffect } from "solid-js";
 import type { Component } from "solid-js";
 import type { ArrowNavigationItem } from "../../types.js";
+import { MENU_HIGHLIGHT_CORNER_SHAPE, MENU_PANEL_CORNER_RADIUS_PX } from "../../constants.js";
 import { createMenuHighlight } from "../../utils/create-menu-highlight.js";
 import { BottomSection } from "./bottom-section.js";
 
@@ -16,7 +17,10 @@ export const ArrowNavigationMenu: Component<ArrowNavigationMenuProps> = (props) 
     highlightRef,
     updateHighlight,
     clearHighlight,
-  } = createMenuHighlight();
+  } = createMenuHighlight({
+    bottomCornerRadiusPx: MENU_PANEL_CORNER_RADIUS_PX,
+    cornerShape: MENU_HIGHLIGHT_CORNER_SHAPE,
+  });
 
   let menuItemsRef: HTMLDivElement | undefined;
   let didPointerMove = false;
@@ -58,7 +62,7 @@ export const ArrowNavigationMenu: Component<ArrowNavigationMenuProps> = (props) 
       >
         <div
           ref={highlightRef}
-          class="pointer-events-none absolute opacity-0 transition-[top,left,width,height,opacity] duration-75 ease-out bg-[var(--rg-surface-hover)]"
+          class="pointer-events-none absolute opacity-0 transition-[top,left,width,height,opacity,border-radius] duration-75 ease-out bg-[var(--rg-surface-hover)]"
         />
         <For each={props.items}>
           {(item, itemIndex) => (

--- a/packages/react-grab/src/components/toolbar/toolbar-menu.tsx
+++ b/packages/react-grab/src/components/toolbar/toolbar-menu.tsx
@@ -31,7 +31,8 @@ export const ToolbarMenu: Component<ToolbarMenuProps> = (props) => {
     updateHighlight,
     clearHighlight,
   } = createMenuHighlight({
-    cornerRadiusPx: MENU_PANEL_CORNER_RADIUS_PX,
+    topCornerRadiusPx: MENU_PANEL_CORNER_RADIUS_PX,
+    bottomCornerRadiusPx: MENU_PANEL_CORNER_RADIUS_PX,
     cornerShape: MENU_HIGHLIGHT_CORNER_SHAPE,
   });
 

--- a/packages/react-grab/src/components/toolbar/toolbar-menu.tsx
+++ b/packages/react-grab/src/components/toolbar/toolbar-menu.tsx
@@ -3,6 +3,8 @@ import type { Component } from "solid-js";
 import type { ContextMenuAction, DropdownAnchor } from "../../types.js";
 import {
   DROPDOWN_EDGE_TRANSFORM_ORIGIN,
+  MENU_HIGHLIGHT_CORNER_SHAPE,
+  MENU_PANEL_CORNER_RADIUS_PX,
   TOOLBAR_MENU_MIN_WIDTH_PX,
   Z_INDEX_OVERLAY,
 } from "../../constants.js";
@@ -28,7 +30,10 @@ export const ToolbarMenu: Component<ToolbarMenuProps> = (props) => {
     highlightRef,
     updateHighlight,
     clearHighlight,
-  } = createMenuHighlight();
+  } = createMenuHighlight({
+    cornerRadiusPx: MENU_PANEL_CORNER_RADIUS_PX,
+    cornerShape: MENU_HIGHLIGHT_CORNER_SHAPE,
+  });
 
   const dropdown = createAnchoredDropdown(
     () => containerRef,
@@ -90,7 +95,7 @@ export const ToolbarMenu: Component<ToolbarMenuProps> = (props) => {
           <div ref={highlightContainerRef} class="relative flex flex-col">
             <div
               ref={highlightRef}
-              class="pointer-events-none absolute opacity-0 transition-[top,left,width,height,opacity] duration-75 ease-out bg-[var(--rg-surface-hover)]"
+              class="pointer-events-none absolute opacity-0 transition-[top,left,width,height,opacity,border-radius] duration-75 ease-out bg-[var(--rg-surface-hover)]"
             />
             <For each={props.actions}>
               {(action) => {

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -134,6 +134,9 @@ export const TOOLBAR_DEFAULT_HEIGHT_PX = 28;
 export const TOOLBAR_DEFAULT_POSITION_RATIO = 0.5;
 export const DEFAULT_ACTION_ID = "comment";
 
+export const MENU_PANEL_CORNER_RADIUS_PX = 14;
+export const MENU_HIGHLIGHT_CORNER_SHAPE = "superellipse(1.25)";
+
 // The select icon is a paper-airplane shape whose tip points toward the
 // top-right corner of its viewBox, ~45° above the +x axis. Subtracting this
 // from the mouse-relative angle yields the rotation needed to aim the tip at

--- a/packages/react-grab/src/utils/create-menu-highlight.ts
+++ b/packages/react-grab/src/utils/create-menu-highlight.ts
@@ -10,6 +10,11 @@ interface AnimatedBoundsFollowerController {
   hideFollower: () => void;
 }
 
+interface MenuHighlightOptions {
+  cornerRadiusPx?: number;
+  cornerShape?: string;
+}
+
 interface MenuHighlightController {
   containerRef: (containerElement: HTMLElement) => void;
   highlightRef: (highlightElement: HTMLElement) => void;
@@ -67,13 +72,66 @@ const createAnimatedBoundsFollower = ({
   };
 };
 
-export const createMenuHighlight = (): MenuHighlightController => {
+const isActionableSibling = (node: Element, follower: HTMLElement | undefined): boolean =>
+  node !== follower && node instanceof HTMLElement;
+
+const getActionableSiblings = (
+  parent: HTMLElement,
+  follower: HTMLElement | undefined,
+): HTMLElement[] => {
+  const siblings: HTMLElement[] = [];
+  for (const child of Array.from(parent.children)) {
+    if (isActionableSibling(child, follower)) {
+      siblings.push(child as HTMLElement);
+    }
+  }
+  return siblings;
+};
+
+export const createMenuHighlight = (
+  options: MenuHighlightOptions = {},
+): MenuHighlightController => {
+  const { cornerRadiusPx, cornerShape } = options;
+  let followerElement: HTMLElement | undefined;
+  let didApplyCornerShape = false;
+
+  const applyEdgeRadii = (targetElement: HTMLElement): void => {
+    if (!followerElement || cornerRadiusPx === undefined) return;
+    const parent = targetElement.parentElement;
+    if (!parent) return;
+    const siblings = getActionableSiblings(parent, followerElement);
+    const isFirst = siblings[0] === targetElement;
+    const isLast = siblings[siblings.length - 1] === targetElement;
+    const topRadius = isFirst ? `${cornerRadiusPx}px` : "0px";
+    const bottomRadius = isLast ? `${cornerRadiusPx}px` : "0px";
+    followerElement.style.borderTopLeftRadius = topRadius;
+    followerElement.style.borderTopRightRadius = topRadius;
+    followerElement.style.borderBottomLeftRadius = bottomRadius;
+    followerElement.style.borderBottomRightRadius = bottomRadius;
+    if (cornerShape && !didApplyCornerShape) {
+      followerElement.style.setProperty("corner-shape", cornerShape);
+      didApplyCornerShape = true;
+    }
+  };
+
   const {
     containerRef,
-    followerRef: highlightRef,
-    followElement: updateHighlight,
+    followerRef: baseFollowerRef,
+    followElement: baseFollowElement,
     hideFollower: clearHighlight,
   } = createAnimatedBoundsFollower();
+
+  const highlightRef = (highlightElement: HTMLElement): void => {
+    followerElement = highlightElement;
+    baseFollowerRef(highlightElement);
+  };
+
+  const updateHighlight = (targetElement: HTMLElement | undefined): void => {
+    baseFollowElement(targetElement);
+    if (targetElement) {
+      applyEdgeRadii(targetElement);
+    }
+  };
 
   return {
     containerRef,

--- a/packages/react-grab/src/utils/create-menu-highlight.ts
+++ b/packages/react-grab/src/utils/create-menu-highlight.ts
@@ -11,7 +11,8 @@ interface AnimatedBoundsFollowerController {
 }
 
 interface MenuHighlightOptions {
-  cornerRadiusPx?: number;
+  topCornerRadiusPx?: number;
+  bottomCornerRadiusPx?: number;
   cornerShape?: string;
 }
 
@@ -91,19 +92,21 @@ const getActionableSiblings = (
 export const createMenuHighlight = (
   options: MenuHighlightOptions = {},
 ): MenuHighlightController => {
-  const { cornerRadiusPx, cornerShape } = options;
+  const { topCornerRadiusPx, bottomCornerRadiusPx, cornerShape } = options;
+  const hasEdgeRadii = topCornerRadiusPx !== undefined || bottomCornerRadiusPx !== undefined;
   let followerElement: HTMLElement | undefined;
   let didApplyCornerShape = false;
 
   const applyEdgeRadii = (targetElement: HTMLElement): void => {
-    if (!followerElement || cornerRadiusPx === undefined) return;
+    if (!followerElement || !hasEdgeRadii) return;
     const parent = targetElement.parentElement;
     if (!parent) return;
     const siblings = getActionableSiblings(parent, followerElement);
     const isFirst = siblings[0] === targetElement;
     const isLast = siblings[siblings.length - 1] === targetElement;
-    const topRadius = isFirst ? `${cornerRadiusPx}px` : "0px";
-    const bottomRadius = isLast ? `${cornerRadiusPx}px` : "0px";
+    const topRadius = isFirst && topCornerRadiusPx !== undefined ? `${topCornerRadiusPx}px` : "0px";
+    const bottomRadius =
+      isLast && bottomCornerRadiusPx !== undefined ? `${bottomCornerRadiusPx}px` : "0px";
     followerElement.style.borderTopLeftRadius = topRadius;
     followerElement.style.borderTopRightRadius = topRadius;
     followerElement.style.borderBottomLeftRadius = bottomRadius;
@@ -123,6 +126,7 @@ export const createMenuHighlight = (
 
   const highlightRef = (highlightElement: HTMLElement): void => {
     followerElement = highlightElement;
+    didApplyCornerShape = false;
     baseFollowerRef(highlightElement);
   };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The hover highlight in the toolbar menu and context menu had visibly square bottom corners that did not match the panel's rounded curve. The highlight was a plain `<div>` with a background color, and the panel relied on `overflow-hidden` + `rounded-[14px]` + `[corner-shape:superellipse(1.25)]` to clip the corners. The superellipse `corner-shape` clipping is not honored consistently, leaving the square highlight corners visible past the panel curve. The context menu's panel didn't use `overflow-hidden` at all, so the issue was worse there.

### Fix

- Extend `createMenuHighlight` with a `cornerRadiusPx` and `cornerShape` option.
- When the highlight follows an actionable item, detect whether the item is the first or last sibling (excluding the highlight element itself) and apply matching `border-top-*-radius` / `border-bottom-*-radius` directly on the highlight, with the same `corner-shape: superellipse(1.25)` as the panel.
- Both `toolbar-menu` and `context-menu` pass the panel's `14px` corner radius so the highlight curves line up exactly with the panel curve at the top and bottom items.
- Add `border-radius` to the existing highlight transition so the radii animate alongside the slide between items (square middle items → rounded first/last).

### Test plan

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm test` (all 513 Playwright tests passing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bbbfd4a-47a0-4f0d-8bb5-9a5a6fc4044c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bbbfd4a-47a0-4f0d-8bb5-9a5a6fc4044c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rounds the menu hover highlight at the first/last items to match the panel curve across toolbar, context, and arrow-navigation menus. Border radius now animates with the highlight.

- **Bug Fixes**
  - Extended `createMenuHighlight` with `topCornerRadiusPx`, `bottomCornerRadiusPx`, and `cornerShape`; apply edge radii on first/last items and set `corner-shape: superellipse(1.25)`; reset when the ref remounts.
  - Updated `toolbar-menu` (top+bottom) and `context-menu`/`arrow-navigation-menu` (bottom-only) to pass `MENU_PANEL_CORNER_RADIUS_PX` (14) and `MENU_HIGHLIGHT_CORNER_SHAPE`; added `border-radius` to the highlight transition.

<sup>Written for commit ab3b810313d8de753ed69415b87ab2235b6c24a1. Summary will update on new commits. <a href="https://cubic.dev/pr/aidenybai/react-grab/pull/371?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

