### PR TITLE
fix(cli): detect framework in monorepo subpackages with hoisted deps

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -418,6 +418,14 @@ export const init = new Command()
           Object.assign(projectInfo, newProjectInfo);
 
           const newFrameworkSpinner = spinner("Verifying framework.").start();
+          if (newProjectInfo.framework === "unknown") {
+            newFrameworkSpinner.fail("Could not detect a supported framework in this project.");
+            logger.break();
+            logger.log("React Grab supports Next.js, Vite, TanStack Start, and Webpack projects.");
+            logger.log(`Visit ${highlighter.info(DOCS_URL)} for manual setup.`);
+            logger.break();
+            process.exit(1);
+          }
           newFrameworkSpinner.succeed(
             `Verifying framework. Found ${highlighter.info(FRAMEWORK_NAMES[newProjectInfo.framework])}.`,
           );

--- a/packages/cli/src/utils/detect.ts
+++ b/packages/cli/src/utils/detect.ts
@@ -84,17 +84,13 @@ const findEnclosingMonorepoRoot = (projectRoot: string): string | null => {
 export const detectFramework = (projectRoot: string): Framework => {
   const localFramework = detectFrameworkFromDependencies(readMergedDependencies(projectRoot));
   if (localFramework !== "unknown") return localFramework;
+  return detectFrameworkFromConfigFiles(projectRoot);
+};
 
-  const configFramework = detectFrameworkFromConfigFiles(projectRoot);
-  if (configFramework !== "unknown") return configFramework;
-
+const detectFrameworkFromMonorepoRoot = (projectRoot: string): Framework => {
   const monorepoRoot = findEnclosingMonorepoRoot(projectRoot);
-  if (monorepoRoot) {
-    const rootFramework = detectFrameworkFromDependencies(readMergedDependencies(monorepoRoot));
-    if (rootFramework !== "unknown") return rootFramework;
-  }
-
-  return "unknown";
+  if (!monorepoRoot) return "unknown";
+  return detectFrameworkFromDependencies(readMergedDependencies(monorepoRoot));
 };
 
 export const detectNextRouterType = (projectRoot: string): NextRouterType => {
@@ -417,7 +413,9 @@ const detectReactGrabVersion = (projectRoot: string): string | null => {
 };
 
 export const detectProject = async (projectRoot: string = process.cwd()): Promise<ProjectInfo> => {
-  const framework = detectFramework(projectRoot);
+  const localFramework = detectFramework(projectRoot);
+  const framework =
+    localFramework === "unknown" ? detectFrameworkFromMonorepoRoot(projectRoot) : localFramework;
   const packageManager = await detectPackageManager(projectRoot);
 
   return {

--- a/packages/cli/src/utils/detect.ts
+++ b/packages/cli/src/utils/detect.ts
@@ -32,40 +32,69 @@ export const detectPackageManager = async (projectRoot: string): Promise<Package
   return "npm";
 };
 
-export const detectFramework = (projectRoot: string): Framework => {
+const CONFIG_EXTENSIONS = ["ts", "mts", "cts", "js", "mjs", "cjs"] as const;
+
+const hasConfigFile = (projectRoot: string, configBaseName: string): boolean =>
+  CONFIG_EXTENSIONS.some((extension) =>
+    existsSync(join(projectRoot, `${configBaseName}.${extension}`)),
+  );
+
+const readMergedDependencies = (projectRoot: string): Record<string, string> | null => {
   const packageJsonPath = join(projectRoot, "package.json");
-
-  if (!existsSync(packageJsonPath)) {
-    return "unknown";
-  }
-
+  if (!existsSync(packageJsonPath)) return null;
   try {
     const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
-    const allDependencies = {
+    return {
       ...packageJson.dependencies,
       ...packageJson.devDependencies,
     };
-
-    if (allDependencies["next"]) {
-      return "next";
-    }
-
-    if (allDependencies["@tanstack/react-start"]) {
-      return "tanstack";
-    }
-
-    if (allDependencies["vite"]) {
-      return "vite";
-    }
-
-    if (allDependencies["webpack"]) {
-      return "webpack";
-    }
-
-    return "unknown";
   } catch {
-    return "unknown";
+    return null;
   }
+};
+
+const detectFrameworkFromDependencies = (
+  dependencies: Record<string, string> | null,
+): Framework => {
+  if (!dependencies) return "unknown";
+  if (dependencies["next"]) return "next";
+  if (dependencies["@tanstack/react-start"]) return "tanstack";
+  if (dependencies["vite"]) return "vite";
+  if (dependencies["webpack"]) return "webpack";
+  return "unknown";
+};
+
+const detectFrameworkFromConfigFiles = (projectRoot: string): Framework => {
+  if (hasConfigFile(projectRoot, "next.config")) return "next";
+  if (hasConfigFile(projectRoot, "app.config")) return "tanstack";
+  if (hasConfigFile(projectRoot, "vite.config")) return "vite";
+  if (hasConfigFile(projectRoot, "webpack.config")) return "webpack";
+  return "unknown";
+};
+
+const findEnclosingMonorepoRoot = (projectRoot: string): string | null => {
+  let currentDirectory = dirname(projectRoot);
+  while (currentDirectory !== dirname(currentDirectory)) {
+    if (detectMonorepo(currentDirectory)) return currentDirectory;
+    currentDirectory = dirname(currentDirectory);
+  }
+  return null;
+};
+
+export const detectFramework = (projectRoot: string): Framework => {
+  const localFramework = detectFrameworkFromDependencies(readMergedDependencies(projectRoot));
+  if (localFramework !== "unknown") return localFramework;
+
+  const configFramework = detectFrameworkFromConfigFiles(projectRoot);
+  if (configFramework !== "unknown") return configFramework;
+
+  const monorepoRoot = findEnclosingMonorepoRoot(projectRoot);
+  if (monorepoRoot) {
+    const rootFramework = detectFrameworkFromDependencies(readMergedDependencies(monorepoRoot));
+    if (rootFramework !== "unknown") return rootFramework;
+  }
+
+  return "unknown";
 };
 
 export const detectNextRouterType = (projectRoot: string): NextRouterType => {
@@ -196,19 +225,9 @@ const expandWorkspacePattern = (projectRoot: string, pattern: string): string[] 
 };
 
 const hasReactDependency = (projectPath: string): boolean => {
-  const packageJsonPath = join(projectPath, "package.json");
-  if (!existsSync(packageJsonPath)) return false;
-
-  try {
-    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
-    const allDeps = {
-      ...packageJson.dependencies,
-      ...packageJson.devDependencies,
-    };
-    return Boolean(allDeps["react"] || allDeps["react-dom"]);
-  } catch {
-    return false;
-  }
+  const dependencies = readMergedDependencies(projectPath);
+  if (!dependencies) return false;
+  return Boolean(dependencies["react"] || dependencies["react-dom"]);
 };
 
 const buildReactProject = (projectPath: string): WorkspaceProject | null => {
@@ -347,20 +366,8 @@ const hasReactGrabInFile = (filePath: string): boolean => {
 };
 
 export const detectReactGrab = (projectRoot: string): boolean => {
-  const packageJsonPath = join(projectRoot, "package.json");
-
-  if (existsSync(packageJsonPath)) {
-    try {
-      const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
-      const allDependencies = {
-        ...packageJson.dependencies,
-        ...packageJson.devDependencies,
-      };
-      if (allDependencies["react-grab"]) {
-        return true;
-      }
-    } catch {}
-  }
+  const dependencies = readMergedDependencies(projectRoot);
+  if (dependencies?.["react-grab"]) return true;
 
   const filesToCheck = [
     join(projectRoot, "app", "layout.tsx"),
@@ -389,39 +396,13 @@ export const detectReactGrab = (projectRoot: string): boolean => {
 };
 
 export const detectUnsupportedFramework = (projectRoot: string): UnsupportedFramework => {
-  const packageJsonPath = join(projectRoot, "package.json");
-
-  if (!existsSync(packageJsonPath)) {
-    return null;
-  }
-
-  try {
-    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
-    const allDependencies = {
-      ...packageJson.dependencies,
-      ...packageJson.devDependencies,
-    };
-
-    if (allDependencies["@remix-run/react"] || allDependencies["remix"]) {
-      return "remix";
-    }
-
-    if (allDependencies["astro"]) {
-      return "astro";
-    }
-
-    if (allDependencies["@sveltejs/kit"]) {
-      return "sveltekit";
-    }
-
-    if (allDependencies["gatsby"]) {
-      return "gatsby";
-    }
-
-    return null;
-  } catch {
-    return null;
-  }
+  const dependencies = readMergedDependencies(projectRoot);
+  if (!dependencies) return null;
+  if (dependencies["@remix-run/react"] || dependencies["remix"]) return "remix";
+  if (dependencies["astro"]) return "astro";
+  if (dependencies["@sveltejs/kit"]) return "sveltekit";
+  if (dependencies["gatsby"]) return "gatsby";
+  return null;
 };
 
 const detectReactGrabVersion = (projectRoot: string): string | null => {

--- a/packages/cli/test/detect.test.ts
+++ b/packages/cli/test/detect.test.ts
@@ -129,7 +129,7 @@ describe("detectFramework", () => {
     expect(detectFramework("/test")).toBe("next");
   });
 
-  it("should fall back to monorepo root deps when subpackage has no framework signal", () => {
+  it("should return unknown when only the monorepo root has the framework dep", () => {
     mockExistsSync.mockImplementation((path) => {
       const pathString = String(path);
       if (pathString === "/repo/apps/web/package.json") return true;
@@ -148,7 +148,7 @@ describe("detectFramework", () => {
       return "{}";
     });
 
-    expect(detectFramework("/repo/apps/web")).toBe("vite");
+    expect(detectFramework("/repo/apps/web")).toBe("unknown");
   });
 });
 

--- a/packages/cli/test/detect.test.ts
+++ b/packages/cli/test/detect.test.ts
@@ -21,9 +21,13 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+const onlyPackageJsonExists = (): void => {
+  mockExistsSync.mockImplementation((path) => String(path).endsWith("package.json"));
+};
+
 describe("detectFramework", () => {
   it("should detect Next.js", () => {
-    mockExistsSync.mockReturnValue(true);
+    onlyPackageJsonExists();
     mockReadFileSync.mockReturnValue(
       JSON.stringify({ dependencies: { next: "14.0.0", react: "18.0.0" } }),
     );
@@ -32,21 +36,21 @@ describe("detectFramework", () => {
   });
 
   it("should detect Vite", () => {
-    mockExistsSync.mockReturnValue(true);
+    onlyPackageJsonExists();
     mockReadFileSync.mockReturnValue(JSON.stringify({ devDependencies: { vite: "5.0.0" } }));
 
     expect(detectFramework("/test")).toBe("vite");
   });
 
   it("should detect Webpack", () => {
-    mockExistsSync.mockReturnValue(true);
+    onlyPackageJsonExists();
     mockReadFileSync.mockReturnValue(JSON.stringify({ devDependencies: { webpack: "5.0.0" } }));
 
     expect(detectFramework("/test")).toBe("webpack");
   });
 
   it("should return unknown when no framework detected", () => {
-    mockExistsSync.mockReturnValue(true);
+    onlyPackageJsonExists();
     mockReadFileSync.mockReturnValue(JSON.stringify({ dependencies: { react: "18.0.0" } }));
 
     expect(detectFramework("/test")).toBe("unknown");
@@ -59,14 +63,14 @@ describe("detectFramework", () => {
   });
 
   it("should return unknown for malformed package.json", () => {
-    mockExistsSync.mockReturnValue(true);
+    onlyPackageJsonExists();
     mockReadFileSync.mockReturnValue("{ invalid json }");
 
     expect(detectFramework("/test")).toBe("unknown");
   });
 
   it("should prioritize Next.js over Vite if both are present", () => {
-    mockExistsSync.mockReturnValue(true);
+    onlyPackageJsonExists();
     mockReadFileSync.mockReturnValue(
       JSON.stringify({
         dependencies: { next: "14.0.0" },
@@ -78,7 +82,7 @@ describe("detectFramework", () => {
   });
 
   it("should detect TanStack Start", () => {
-    mockExistsSync.mockReturnValue(true);
+    onlyPackageJsonExists();
     mockReadFileSync.mockReturnValue(
       JSON.stringify({
         dependencies: { "@tanstack/react-start": "1.100.0", "@tanstack/react-router": "1.100.0" },
@@ -90,7 +94,7 @@ describe("detectFramework", () => {
   });
 
   it("should prioritize TanStack Start over Vite if both are present", () => {
-    mockExistsSync.mockReturnValue(true);
+    onlyPackageJsonExists();
     mockReadFileSync.mockReturnValue(
       JSON.stringify({
         dependencies: { "@tanstack/react-start": "1.100.0" },
@@ -99,6 +103,52 @@ describe("detectFramework", () => {
     );
 
     expect(detectFramework("/test")).toBe("tanstack");
+  });
+
+  it("should detect Vite from a config file when deps are hoisted to monorepo root", () => {
+    mockExistsSync.mockImplementation((path) => {
+      const pathString = String(path);
+      if (pathString === "/test/package.json") return true;
+      if (pathString === "/test/vite.config.ts") return true;
+      return false;
+    });
+    mockReadFileSync.mockReturnValue(JSON.stringify({ dependencies: { react: "18.0.0" } }));
+
+    expect(detectFramework("/test")).toBe("vite");
+  });
+
+  it("should detect Next.js from next.config.mjs without next in deps", () => {
+    mockExistsSync.mockImplementation((path) => {
+      const pathString = String(path);
+      if (pathString === "/test/package.json") return true;
+      if (pathString === "/test/next.config.mjs") return true;
+      return false;
+    });
+    mockReadFileSync.mockReturnValue(JSON.stringify({ dependencies: { react: "18.0.0" } }));
+
+    expect(detectFramework("/test")).toBe("next");
+  });
+
+  it("should fall back to monorepo root deps when subpackage has no framework signal", () => {
+    mockExistsSync.mockImplementation((path) => {
+      const pathString = String(path);
+      if (pathString === "/repo/apps/web/package.json") return true;
+      if (pathString === "/repo/pnpm-workspace.yaml") return true;
+      if (pathString === "/repo/package.json") return true;
+      return false;
+    });
+    mockReadFileSync.mockImplementation((path) => {
+      const pathString = String(path);
+      if (pathString === "/repo/apps/web/package.json") {
+        return JSON.stringify({ dependencies: { react: "18.0.0" } });
+      }
+      if (pathString === "/repo/package.json") {
+        return JSON.stringify({ devDependencies: { vite: "5.0.0" } });
+      }
+      return "{}";
+    });
+
+    expect(detectFramework("/repo/apps/web")).toBe("vite");
   });
 });
 

--- a/packages/cli/test/detect.test.ts
+++ b/packages/cli/test/detect.test.ts
@@ -3,6 +3,7 @@ import {
   detectFramework,
   detectMonorepo,
   detectNextRouterType,
+  detectProject,
   detectReactGrab,
   detectUnsupportedFramework,
 } from "../src/utils/detect.js";
@@ -12,13 +13,20 @@ vi.mock("node:fs", () => ({
   readFileSync: vi.fn(),
 }));
 
+vi.mock("package-manager-detector/detect", () => ({
+  detect: vi.fn(),
+}));
+
 import { existsSync, readFileSync } from "node:fs";
+import { detect as detectPackageManagerAgent } from "package-manager-detector/detect";
 
 const mockExistsSync = vi.mocked(existsSync);
 const mockReadFileSync = vi.mocked(readFileSync);
+const mockDetectPackageManagerAgent = vi.mocked(detectPackageManagerAgent);
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockDetectPackageManagerAgent.mockResolvedValue(null);
 });
 
 const onlyPackageJsonExists = (): void => {
@@ -337,5 +345,130 @@ describe("detectUnsupportedFramework", () => {
     mockReadFileSync.mockReturnValue("invalid json");
 
     expect(detectUnsupportedFramework("/test")).toBe(null);
+  });
+});
+
+describe("detectProject", () => {
+  it("should fall back to monorepo root framework when subpackage has hoisted deps", async () => {
+    mockExistsSync.mockImplementation((path) => {
+      const pathString = String(path);
+      if (pathString === "/repo/apps/web/package.json") return true;
+      if (pathString === "/repo/pnpm-workspace.yaml") return true;
+      if (pathString === "/repo/package.json") return true;
+      return false;
+    });
+    mockReadFileSync.mockImplementation((path) => {
+      const pathString = String(path);
+      if (pathString === "/repo/apps/web/package.json") {
+        return JSON.stringify({ dependencies: { react: "18.0.0" } });
+      }
+      if (pathString === "/repo/package.json") {
+        return JSON.stringify({ devDependencies: { vite: "5.0.0" } });
+      }
+      return "{}";
+    });
+
+    const project = await detectProject("/repo/apps/web");
+
+    expect(project.framework).toBe("vite");
+    expect(project.projectRoot).toBe("/repo/apps/web");
+  });
+
+  it("should prefer the subpackage's own framework dep over monorepo root", async () => {
+    mockExistsSync.mockImplementation((path) => {
+      const pathString = String(path);
+      if (pathString === "/repo/apps/web/package.json") return true;
+      if (pathString === "/repo/pnpm-workspace.yaml") return true;
+      if (pathString === "/repo/package.json") return true;
+      return false;
+    });
+    mockReadFileSync.mockImplementation((path) => {
+      const pathString = String(path);
+      if (pathString === "/repo/apps/web/package.json") {
+        return JSON.stringify({ dependencies: { next: "14.0.0", react: "18.0.0" } });
+      }
+      if (pathString === "/repo/package.json") {
+        return JSON.stringify({ devDependencies: { vite: "5.0.0" } });
+      }
+      return "{}";
+    });
+
+    const project = await detectProject("/repo/apps/web");
+
+    expect(project.framework).toBe("next");
+  });
+
+  it("should not inherit a parent's framework when the parent is not a monorepo", async () => {
+    mockExistsSync.mockImplementation((path) => {
+      const pathString = String(path);
+      if (pathString === "/parent/child/package.json") return true;
+      if (pathString === "/parent/package.json") return true;
+      return false;
+    });
+    mockReadFileSync.mockImplementation((path) => {
+      const pathString = String(path);
+      if (pathString === "/parent/child/package.json") {
+        return JSON.stringify({ dependencies: { react: "18.0.0" } });
+      }
+      if (pathString === "/parent/package.json") {
+        return JSON.stringify({ devDependencies: { vite: "5.0.0" } });
+      }
+      return "{}";
+    });
+
+    const project = await detectProject("/parent/child");
+
+    expect(project.framework).toBe("unknown");
+    expect(project.isMonorepo).toBe(false);
+  });
+
+  it("should leave framework unknown when neither subpackage nor monorepo root advertise one", async () => {
+    mockExistsSync.mockImplementation((path) => {
+      const pathString = String(path);
+      if (pathString === "/repo/apps/web/package.json") return true;
+      if (pathString === "/repo/pnpm-workspace.yaml") return true;
+      if (pathString === "/repo/package.json") return true;
+      return false;
+    });
+    mockReadFileSync.mockImplementation((path) => {
+      const pathString = String(path);
+      if (pathString === "/repo/apps/web/package.json") {
+        return JSON.stringify({ dependencies: { react: "18.0.0" } });
+      }
+      if (pathString === "/repo/package.json") {
+        return JSON.stringify({ dependencies: { typescript: "5.0.0" } });
+      }
+      return "{}";
+    });
+
+    const project = await detectProject("/repo/apps/web");
+
+    expect(project.framework).toBe("unknown");
+    expect(project.isMonorepo).toBe(false);
+  });
+
+  it("should resolve framework from local config file before falling back to monorepo root", async () => {
+    mockExistsSync.mockImplementation((path) => {
+      const pathString = String(path);
+      if (pathString === "/repo/apps/web/package.json") return true;
+      if (pathString === "/repo/apps/web/vite.config.ts") return true;
+      if (pathString === "/repo/pnpm-workspace.yaml") return true;
+      if (pathString === "/repo/package.json") return true;
+      return false;
+    });
+    mockReadFileSync.mockImplementation((path) => {
+      const pathString = String(path);
+      if (pathString === "/repo/apps/web/package.json") {
+        return JSON.stringify({ dependencies: { react: "18.0.0" } });
+      }
+      if (pathString === "/repo/package.json") {
+        return JSON.stringify({ devDependencies: { next: "14.0.0" } });
+      }
+      return "{}";
+    });
+
+    const project = await detectProject("/repo/apps/web");
+
+    expect(project.framework).toBe("vite");
   });
 });


### PR DESCRIPTION
## Summary

`npx grab init` was failing in monorepos where framework deps (`vite`, `next`, etc.) are hoisted to the root `package.json` and not redeclared in subpackages. The CLI found 2 React workspace projects, the user picked one, and detection returned `"unknown"`. The CLI then ran `spinner.succeed("Verifying framework. Found Unknown.")` and continued through the MCP prompt before crashing with `Unknown framework: unknown. Please add React Grab manually.`

<img width="985" alt="screenshot" src="https://github.com/user-attachments/assets/cli-monorepo-bug" />

### Detection upgrade

`detectFramework` now tries three signals in order:
1. Subpackage `package.json` deps (existing).
2. **New**: local config files — `next.config.*`, `app.config.*`, `vite.config.*`, `webpack.config.*` across `.ts/.mts/.cts/.js/.mjs/.cjs`.
3. **New**: walks up to the enclosing monorepo root (`pnpm-workspace.yaml`/`lerna.json`/`workspaces`) and checks its deps.

### Error UX

`init` now fails fast with the same "unsupported framework" error message when the *post-selection* subproject framework is still unknown, instead of `succeed()`-ing and limping forward.

### DRY

Extracted `readMergedDependencies` helper, reused in `hasReactDependency`, `detectReactGrab`, and `detectUnsupportedFramework` — removes 3 copies of the `existsSync → readFileSync → JSON.parse → spread deps/devDeps` block.

## Test plan

- [x] `pnpm --filter @react-grab/cli test` → 119 pass (3 new tests covering hoisted-vite-config, `next.config.mjs` without `next` in deps, and monorepo-root walk-up)
- [x] `pnpm lint` → 0 warnings, 0 errors
- [x] `pnpm typecheck` → all packages pass
- [x] `pnpm format` → clean
- [x] `pnpm build` → all packages build
- [x] `pnpm test` (root, full E2E) → 490 pass; 17 chromium failures verified pre-existing on `main` (runtime-library copy-feedback/activation tests, unrelated to CLI detection)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CLI project/framework detection and init flow control, which can affect which workspace is targeted and when `init` aborts; however the change is localized and covered by expanded unit tests.
> 
> **Overview**
> Fixes `npx grab init` in monorepos where framework deps are hoisted to the repo root by adding a monorepo-root dependency fallback in `detectProject` when a subpackage’s framework is `unknown`.
> 
> Improves framework detection by also inferring `next`/`vite`/`tanstack`/`webpack` from local config files (e.g. `next.config.*`, `vite.config.*`) and centralizes dependency parsing via `readMergedDependencies` reused across detection helpers.
> 
> Updates `init` to **fail fast** after a user selects a subproject if its framework is still `unknown`, and adds tests covering config-file detection and monorepo-root fallback/precedence rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70017c323cf3b426f5ee0cd238c4cd3e5aa1f4b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes framework detection in monorepo subpackages with hoisted deps so `npx grab init` correctly identifies `next`, `vite`, `@tanstack/react-start`, or `webpack`. Also fails fast with a clear message when the framework is still unknown.

- **Bug Fixes**
  - `detectFramework` now checks local `package.json`, then local config files (`next.config.*`, `app.config.*`, `vite.config.*`, `webpack.config.*`).
  - Monorepo root fallback runs in `detectProject` only, avoiding mislabeled utility workspaces.
  - `init` stops early instead of showing “Found Unknown” and crashing later.
  - Added tests for `detectProject` monorepo walk-up and config-file detection (with a `package-manager-detector/detect` mock).

- **Refactors**
  - Extracted `readMergedDependencies` and reused in `hasReactDependency`, `detectReactGrab`, and `detectUnsupportedFramework`.

<sup>Written for commit 70017c323cf3b426f5ee0cd238c4cd3e5aa1f4b1. Summary will update on new commits. <a href="https://cubic.dev/pr/aidenybai/react-grab/pull/372?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

