### PR TITLE
remove animation on the success check icon

### DIFF
--- a/packages/react-grab/src/components/selection-label/completion-view.tsx
+++ b/packages/react-grab/src/components/selection-label/completion-view.tsx
@@ -147,7 +147,7 @@ export const CompletionView: Component<CompletionViewProps> = (props) => {
           <IconCheck
             size={14}
             aria-hidden="true"
-            class="text-[var(--rg-text-primary-85)] shrink-0 animate-success-pop"
+            class="text-[var(--rg-text-primary-85)] shrink-0"
           />
           <span class="text-[var(--rg-text-primary)] text-[13px] leading-4 font-sans font-medium h-fit tabular-nums overflow-hidden text-ellipsis whitespace-nowrap min-w-0">
             {displayStatusText()}

--- a/packages/react-grab/src/styles.css
+++ b/packages/react-grab/src/styles.css
@@ -138,17 +138,6 @@
   }
 }
 
-@keyframes success-pop {
-  from {
-    transform: scale(0.85);
-    opacity: 0;
-  }
-  to {
-    transform: scale(1);
-    opacity: 1;
-  }
-}
-
 @keyframes icon-loader-spin {
   0% {
     opacity: 1;
@@ -222,11 +211,6 @@
 .animate-shake-vertical {
   --rg-shake-x: 0;
   --rg-shake-y: 1;
-}
-
-.animate-success-pop {
-  animation: success-pop 350ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
-  will-change: transform, opacity;
 }
 
 @utility press-scale {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the `animate-success-pop` pop-in animation from the check icon in `CompletionView`, so the success indicator now appears instantly without scaling/fading in.

Also drops the now-unused `@keyframes success-pop` and `.animate-success-pop` rules from `styles.css` (no other call sites).

### Files changed
- `packages/react-grab/src/components/selection-label/completion-view.tsx` — drop `animate-success-pop` from `IconCheck`.
- `packages/react-grab/src/styles.css` — remove the unused keyframes and class.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-094bb420-776e-4f6a-ba9e-116e6ed2a798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-094bb420-776e-4f6a-ba9e-116e6ed2a798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the pop-in animation from the success check icon in `CompletionView` so it appears instantly. Also remove the unused `@keyframes success-pop` and `.animate-success-pop` from `styles.css`.

<sup>Written for commit 185eb800c6130a1657d42078a42639cf924b335c. Summary will update on new commits. <a href="https://cubic.dev/pr/aidenybai/react-grab/pull/374?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

