### PR TITLE
fix: prefer React fiber _debugSource for Webpack/Rspack source locations

### DIFF
--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -280,9 +280,44 @@ interface ResolvedSource {
   componentName: string | null;
 }
 
+const getSourceComponentName = (fiber: Fiber | null | undefined): string | null => {
+  if (!fiber || !isCompositeFiber(fiber)) return null;
+  const name = getDisplayName(fiber.type);
+  return name && isSourceComponentName(name) ? name : null;
+};
+
+// Bundlers like Webpack/Rspack can make bippy's owner stack resolve to
+// generated module URLs (webpack-internal://, eval sources) instead of the
+// real file. React's dev-only _debugSource points at the original JSX, so we
+// prefer it whenever it references an on-disk source file.
+const getDebugSourceFromFiber = (fiber: Fiber | null): ResolvedSource | null => {
+  let currentFiber = fiber;
+
+  while (currentFiber) {
+    const debugSource = currentFiber._debugSource;
+    if (debugSource?.fileName && isSourceFile(debugSource.fileName)) {
+      return {
+        filePath: normalizeFilePath(debugSource.fileName),
+        lineNumber: debugSource.lineNumber ?? null,
+        columnNumber: debugSource.columnNumber ?? null,
+        componentName:
+          getSourceComponentName(currentFiber) ?? getSourceComponentName(currentFiber._debugOwner),
+      };
+    }
+    currentFiber = currentFiber.return ?? currentFiber._debugOwner ?? null;
+  }
+
+  return null;
+};
+
+const getDebugSourceForElement = (element: Element): ResolvedSource | null =>
+  getDebugSourceFromFiber(getFiberFromHostInstance(findNearestFiberElement(element)));
+
 export const resolveSource = async (element: Element): Promise<ResolvedSource | null> => {
-  const resolvedElement = findNearestFiberElement(element);
-  const stack = await getStack(resolvedElement);
+  const debugSource = getDebugSourceForElement(element);
+  if (debugSource) return debugSource;
+
+  const stack = await getStack(element);
   if (!stack || stack.length === 0) return null;
 
   const sourceFrames = stack.filter((frame) => frame.fileName && isSourceFile(frame.fileName));
@@ -364,27 +399,62 @@ const getComponentNamesFromFiber = (element: Element, maxCount: number): string[
   return componentNames;
 };
 
-const formatResolvedSourceLine = (
-  frame: StackFrame,
-  filePath: string,
+// Next.js apps render from absolute paths; trimming them to a project-relative
+// "/./…" form keeps displayed locations short and consistent with its stacks.
+const NEXT_PROJECT_SOURCE_PATH_MARKERS = ["/src/app/", "/src/pages/", "/app/", "/pages/"];
+
+const formatContextFilePath = (filePath: string, isNextProject: boolean): string => {
+  const normalizedPath = normalizeFilePath(filePath);
+  if (!isNextProject || !normalizedPath.startsWith("/")) return normalizedPath;
+
+  for (const marker of NEXT_PROJECT_SOURCE_PATH_MARKERS) {
+    const markerIndex = normalizedPath.indexOf(marker);
+    if (markerIndex !== -1) return `/./${normalizedPath.slice(markerIndex + 1)}`;
+  }
+
+  return normalizedPath;
+};
+
+const formatSourceContextLine = (
   componentName: string | null,
+  filePath: string,
+  lineNumber: number | null,
+  columnNumber: number | null,
   isNextProject: boolean,
 ): string => {
-  // HACK: bundlers like Vite produce unreliable line/column numbers from
-  // owner stacks, so we only include them for Next.js where the dev server
+  const path = formatContextFilePath(filePath, isNextProject);
+  // HACK: bundlers like Vite produce unreliable line/column numbers from owner
+  // stacks, so we only include them for Next.js where the dev server
   // symbolicates frames via source maps.
   const location =
-    isNextProject && frame.lineNumber
-      ? `${normalizeFilePath(filePath)}:${frame.lineNumber}${frame.columnNumber ? `:${frame.columnNumber}` : ""}`
-      : normalizeFilePath(filePath);
+    isNextProject && lineNumber
+      ? `${path}:${lineNumber}${columnNumber ? `:${columnNumber}` : ""}`
+      : path;
   return componentName ? `\n  in ${componentName} (at ${location})` : `\n  in ${location}`;
 };
 
-const formatStackContext = (stack: StackFrame[], options: StackContextOptions = {}): string => {
+const formatResolvedSource = (source: ResolvedSource, isNextProject: boolean): string =>
+  formatSourceContextLine(
+    source.componentName,
+    source.filePath,
+    source.lineNumber,
+    source.columnNumber,
+    isNextProject,
+  );
+
+const formatStackContext = (
+  stack: StackFrame[],
+  options: StackContextOptions = {},
+  leadingSource: ResolvedSource | null = null,
+): string => {
   const { maxLines = DEFAULT_MAX_CONTEXT_LINES } = options;
   const isNextProject = checkIsNextProject();
   const lines: string[] = [];
   let previousLibraryPackage: string | null = null;
+
+  if (leadingSource) {
+    lines.push(formatResolvedSource(leadingSource, isNextProject));
+  }
 
   const emit = (line: string, libraryPackage: string | null) => {
     lines.push(line);
@@ -401,6 +471,8 @@ const formatStackContext = (stack: StackFrame[], options: StackContextOptions = 
     const componentName =
       frame.functionName && isSourceComponentName(frame.functionName) ? frame.functionName : null;
 
+    if (componentName && componentName === leadingSource?.componentName) continue;
+
     if (frame.isServer && !resolvedSource && (componentName || !frame.functionName)) {
       const tag = libraryPackage ? `${libraryPackage} at Server` : "at Server";
       emit(`\n  in ${componentName ?? "<anonymous>"} (${tag})`, libraryPackage);
@@ -416,7 +488,16 @@ const formatStackContext = (stack: StackFrame[], options: StackContextOptions = 
     }
 
     if (resolvedSource) {
-      emit(formatResolvedSourceLine(frame, resolvedSource, componentName, isNextProject), null);
+      emit(
+        formatSourceContextLine(
+          componentName,
+          resolvedSource,
+          frame.lineNumber ?? null,
+          frame.columnNumber ?? null,
+          isNextProject,
+        ),
+        null,
+      );
     }
   }
 
@@ -428,13 +509,18 @@ export const getStackContext = async (
   options: StackContextOptions = {},
 ): Promise<string> => {
   const maxLines = options.maxLines ?? DEFAULT_MAX_CONTEXT_LINES;
+  const debugSource = getDebugSourceForElement(element);
   const stack = await getStack(element);
 
   if (stack && hasFormattableFrames(stack)) {
-    return formatStackContext(stack, options);
+    return formatStackContext(stack, options, debugSource);
   }
 
-  const componentNames = getComponentNamesFromFiber(element, maxLines);
+  if (debugSource) {
+    return formatResolvedSource(debugSource, checkIsNextProject());
+  }
+
+  const componentNames = getComponentNamesFromFiber(findNearestFiberElement(element), maxLines);
   if (componentNames.length > 0) {
     return componentNames.map((name) => `\n  in ${name}`).join("");
   }

--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -6,7 +6,6 @@ import {
   hasDebugStack,
   parseStack,
   type StackFrame,
-  type FiberSource,
 } from "bippy/source";
 import {
   getFiberFromHostInstance,
@@ -282,29 +281,16 @@ interface ResolvedSource {
   componentName: string | null;
 }
 
-const getSourceComponentName = (fiber: Fiber | null | undefined): string | null => {
+const getSourceComponentName = (fiber: Fiber | undefined): string | null => {
   if (!fiber || !isCompositeFiber(fiber)) return null;
   const name = getDisplayName(fiber.type);
   return name && isSourceComponentName(name) ? name : null;
 };
 
-const toResolvedSource = (source: FiberSource, fiber: Fiber): ResolvedSource => ({
-  filePath: normalizeFilePath(source.fileName),
-  lineNumber: source.lineNumber ?? null,
-  columnNumber: source.columnNumber ?? null,
-  componentName:
-    (source.functionName && isSourceComponentName(source.functionName)
-      ? source.functionName
-      : null) ??
-    getSourceComponentName(fiber) ??
-    getSourceComponentName(fiber._debugOwner),
-});
-
 // bippy's getSource prefers React's dev-only _debugSource (the real JSX location
 // that bundlers like Webpack/Rspack drop from the owner stack) and otherwise
 // falls back to the owner stack. We only trust locations that point at a real
-// on-disk source file, so bundler-virtual URLs (webpack-internal://, eval, ...)
-// are left for the owner-stack handling below.
+// on-disk source file; bundler-virtual URLs are left to the owner-stack scan.
 const getFiberSource = async (element: Element): Promise<ResolvedSource | null> => {
   const fiber = getFiberFromHostInstance(findNearestFiberElement(element));
   if (!fiber) return null;
@@ -312,7 +298,15 @@ const getFiberSource = async (element: Element): Promise<ResolvedSource | null> 
   const source = await getSource(fiber);
   if (!source?.fileName || !isSourceFile(source.fileName)) return null;
 
-  return toResolvedSource(source, fiber);
+  return {
+    filePath: normalizeFilePath(source.fileName),
+    lineNumber: source.lineNumber ?? null,
+    columnNumber: source.columnNumber ?? null,
+    componentName:
+      (source.functionName && isSourceComponentName(source.functionName)
+        ? source.functionName
+        : null) ?? getSourceComponentName(fiber._debugOwner),
+  };
 };
 
 export const resolveSource = async (element: Element): Promise<ResolvedSource | null> => {

--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -1,10 +1,12 @@
 import {
   isSourceFile,
   getOwnerStack,
+  getSource,
   formatOwnerStack,
   hasDebugStack,
   parseStack,
   type StackFrame,
+  type FiberSource,
 } from "bippy/source";
 import {
   getFiberFromHostInstance,
@@ -286,36 +288,36 @@ const getSourceComponentName = (fiber: Fiber | null | undefined): string | null 
   return name && isSourceComponentName(name) ? name : null;
 };
 
-// Bundlers like Webpack/Rspack can make bippy's owner stack resolve to
-// generated module URLs (webpack-internal://, eval sources) instead of the
-// real file. React's dev-only _debugSource points at the original JSX, so we
-// prefer it whenever it references an on-disk source file.
-const getDebugSourceFromFiber = (fiber: Fiber | null): ResolvedSource | null => {
-  let currentFiber = fiber;
+const toResolvedSource = (source: FiberSource, fiber: Fiber): ResolvedSource => ({
+  filePath: normalizeFilePath(source.fileName),
+  lineNumber: source.lineNumber ?? null,
+  columnNumber: source.columnNumber ?? null,
+  componentName:
+    (source.functionName && isSourceComponentName(source.functionName)
+      ? source.functionName
+      : null) ??
+    getSourceComponentName(fiber) ??
+    getSourceComponentName(fiber._debugOwner),
+});
 
-  while (currentFiber) {
-    const debugSource = currentFiber._debugSource;
-    if (debugSource?.fileName && isSourceFile(debugSource.fileName)) {
-      return {
-        filePath: normalizeFilePath(debugSource.fileName),
-        lineNumber: debugSource.lineNumber ?? null,
-        columnNumber: debugSource.columnNumber ?? null,
-        componentName:
-          getSourceComponentName(currentFiber) ?? getSourceComponentName(currentFiber._debugOwner),
-      };
-    }
-    currentFiber = currentFiber.return ?? currentFiber._debugOwner ?? null;
-  }
+// bippy's getSource prefers React's dev-only _debugSource (the real JSX location
+// that bundlers like Webpack/Rspack drop from the owner stack) and otherwise
+// falls back to the owner stack. We only trust locations that point at a real
+// on-disk source file, so bundler-virtual URLs (webpack-internal://, eval, ...)
+// are left for the owner-stack handling below.
+const getFiberSource = async (element: Element): Promise<ResolvedSource | null> => {
+  const fiber = getFiberFromHostInstance(findNearestFiberElement(element));
+  if (!fiber) return null;
 
-  return null;
+  const source = await getSource(fiber);
+  if (!source?.fileName || !isSourceFile(source.fileName)) return null;
+
+  return toResolvedSource(source, fiber);
 };
 
-const getDebugSourceForElement = (element: Element): ResolvedSource | null =>
-  getDebugSourceFromFiber(getFiberFromHostInstance(findNearestFiberElement(element)));
-
 export const resolveSource = async (element: Element): Promise<ResolvedSource | null> => {
-  const debugSource = getDebugSourceForElement(element);
-  if (debugSource) return debugSource;
+  const fiberSource = await getFiberSource(element);
+  if (fiberSource) return fiberSource;
 
   const stack = await getStack(element);
   if (!stack || stack.length === 0) return null;
@@ -460,8 +462,8 @@ const formatStackContext = (
       frame.functionName && isSourceComponentName(frame.functionName) ? frame.functionName : null;
 
     // The owner stack's top frame is usually the same component the leading
-    // _debugSource line already names. Drop only that single duplicate; deeper
-    // frames sharing the name (e.g. recursive components) are kept.
+    // source line already names. Drop only that single duplicate; deeper frames
+    // sharing the name (e.g. recursive components) are kept.
     if (
       !didDedupeLeadingComponent &&
       componentName &&
@@ -509,15 +511,15 @@ export const getStackContext = async (
   options: StackContextOptions = {},
 ): Promise<string> => {
   const maxLines = options.maxLines ?? DEFAULT_MAX_CONTEXT_LINES;
-  const debugSource = getDebugSourceForElement(element);
+  const leadingSource = await getFiberSource(element);
   const stack = await getStack(element);
 
   if (stack && hasFormattableFrames(stack)) {
-    return formatStackContext(stack, options, debugSource);
+    return formatStackContext(stack, options, leadingSource);
   }
 
-  if (debugSource) {
-    return formatSourceContextLine(debugSource, checkIsNextProject());
+  if (leadingSource) {
+    return formatSourceContextLine(leadingSource, checkIsNextProject());
   }
 
   const componentNames = getComponentNamesFromFiber(findNearestFiberElement(element), maxLines);

--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -292,21 +292,27 @@ const getSourceComponentName = (fiber: Fiber | undefined): string | null => {
 // falls back to the owner stack. We only trust locations that point at a real
 // on-disk source file; bundler-virtual URLs are left to the owner-stack scan.
 const getFiberSource = async (element: Element): Promise<ResolvedSource | null> => {
+  if (!isInstrumentationActive()) return null;
+
   const fiber = getFiberFromHostInstance(findNearestFiberElement(element));
   if (!fiber) return null;
 
-  const source = await getSource(fiber);
-  if (!source?.fileName || !isSourceFile(source.fileName)) return null;
+  try {
+    const source = await getSource(fiber);
+    if (!source?.fileName || !isSourceFile(source.fileName)) return null;
 
-  return {
-    filePath: normalizeFilePath(source.fileName),
-    lineNumber: source.lineNumber ?? null,
-    columnNumber: source.columnNumber ?? null,
-    componentName:
-      (source.functionName && isSourceComponentName(source.functionName)
-        ? source.functionName
-        : null) ?? getSourceComponentName(fiber._debugOwner),
-  };
+    return {
+      filePath: normalizeFilePath(source.fileName),
+      lineNumber: source.lineNumber ?? null,
+      columnNumber: source.columnNumber ?? null,
+      componentName:
+        (source.functionName && isSourceComponentName(source.functionName)
+          ? source.functionName
+          : null) ?? getSourceComponentName(fiber._debugOwner),
+    };
+  } catch {
+    return null;
+  }
 };
 
 export const resolveSource = async (element: Element): Promise<ResolvedSource | null> => {

--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -451,6 +451,7 @@ const formatStackContext = (
   const isNextProject = checkIsNextProject();
   const lines: string[] = [];
   let previousLibraryPackage: string | null = null;
+  let didDedupeLeadingComponent = false;
 
   if (leadingSource) {
     lines.push(formatResolvedSource(leadingSource, isNextProject));
@@ -471,7 +472,17 @@ const formatStackContext = (
     const componentName =
       frame.functionName && isSourceComponentName(frame.functionName) ? frame.functionName : null;
 
-    if (componentName && componentName === leadingSource?.componentName) continue;
+    // The owner stack's top frame is usually the same component the leading
+    // _debugSource line already names. Drop only that single duplicate; deeper
+    // frames sharing the name (e.g. recursive components) are kept.
+    if (
+      !didDedupeLeadingComponent &&
+      componentName &&
+      componentName === leadingSource?.componentName
+    ) {
+      didDedupeLeadingComponent = true;
+      continue;
+    }
 
     if (frame.isServer && !resolvedSource && (componentName || !frame.functionName)) {
       const tag = libraryPackage ? `${libraryPackage} at Server` : "at Server";

--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -291,9 +291,9 @@ const getSourceComponentName = (fiber: Fiber | undefined): string | null => {
 // that bundlers like Webpack/Rspack drop from the owner stack) and otherwise
 // falls back to the owner stack. We only trust locations that point at a real
 // on-disk source file; bundler-virtual URLs are left to the owner-stack scan.
+// This reads React's own dev data, so it works without bippy instrumentation;
+// getSource can still throw while parsing owner stacks, so it is guarded.
 const getFiberSource = async (element: Element): Promise<ResolvedSource | null> => {
-  if (!isInstrumentationActive()) return null;
-
   const fiber = getFiberFromHostInstance(findNearestFiberElement(element));
   if (!fiber) return null;
 

--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -415,32 +415,19 @@ const formatContextFilePath = (filePath: string, isNextProject: boolean): string
   return normalizedPath;
 };
 
-const formatSourceContextLine = (
-  componentName: string | null,
-  filePath: string,
-  lineNumber: number | null,
-  columnNumber: number | null,
-  isNextProject: boolean,
-): string => {
-  const path = formatContextFilePath(filePath, isNextProject);
+const formatSourceContextLine = (source: ResolvedSource, isNextProject: boolean): string => {
+  const displayPath = formatContextFilePath(source.filePath, isNextProject);
   // HACK: bundlers like Vite produce unreliable line/column numbers from owner
   // stacks, so we only include them for Next.js where the dev server
   // symbolicates frames via source maps.
   const location =
-    isNextProject && lineNumber
-      ? `${path}:${lineNumber}${columnNumber ? `:${columnNumber}` : ""}`
-      : path;
-  return componentName ? `\n  in ${componentName} (at ${location})` : `\n  in ${location}`;
+    isNextProject && source.lineNumber
+      ? `${displayPath}:${source.lineNumber}${source.columnNumber ? `:${source.columnNumber}` : ""}`
+      : displayPath;
+  return source.componentName
+    ? `\n  in ${source.componentName} (at ${location})`
+    : `\n  in ${location}`;
 };
-
-const formatResolvedSource = (source: ResolvedSource, isNextProject: boolean): string =>
-  formatSourceContextLine(
-    source.componentName,
-    source.filePath,
-    source.lineNumber,
-    source.columnNumber,
-    isNextProject,
-  );
 
 const formatStackContext = (
   stack: StackFrame[],
@@ -454,7 +441,7 @@ const formatStackContext = (
   let didDedupeLeadingComponent = false;
 
   if (leadingSource) {
-    lines.push(formatResolvedSource(leadingSource, isNextProject));
+    lines.push(formatSourceContextLine(leadingSource, isNextProject));
   }
 
   const emit = (line: string, libraryPackage: string | null) => {
@@ -501,10 +488,12 @@ const formatStackContext = (
     if (resolvedSource) {
       emit(
         formatSourceContextLine(
-          componentName,
-          resolvedSource,
-          frame.lineNumber ?? null,
-          frame.columnNumber ?? null,
+          {
+            componentName,
+            filePath: resolvedSource,
+            lineNumber: frame.lineNumber ?? null,
+            columnNumber: frame.columnNumber ?? null,
+          },
           isNextProject,
         ),
         null,
@@ -528,7 +517,7 @@ export const getStackContext = async (
   }
 
   if (debugSource) {
-    return formatResolvedSource(debugSource, checkIsNextProject());
+    return formatSourceContextLine(debugSource, checkIsNextProject());
   }
 
   const componentNames = getComponentNamesFromFiber(findNearestFiberElement(element), maxLines);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes incorrect source locations in Webpack/Rspack projects, where bippy's owner stack can resolve to generated/virtual module URLs (`webpack-internal://`, `webpack://`, eval sources) instead of the real file.

This is an elegance-focused reworking of [LeonMueller-OneAndOnly#1](https://github.com/LeonMueller-OneAndOnly/react-grab/pull/1), keeping its behavior while following the repo conventions in `AGENTS.md` (arrow functions, interfaces, DRY, comments only where the "why" is non-obvious).

All changes are in `packages/react-grab/src/core/context.ts`:

- **Delegate source resolution to bippy**: instead of hand-walking `_debugSource` / `_debugOwner` / `.return`, react-grab now calls bippy's `getSource(fiber)`, which already prefers React's dev-only `_debugSource` (the real JSX location bundlers drop from the owner stack) and falls back to the owner stack. react-grab keeps only the `isSourceFile` trust guard, the `FiberSource → ResolvedSource` mapping, and the presentation policy.
- **`getStackContext` integration**: prepends the resolved source as the leading context frame while still emitting the owner stack, and falls back to it when there are no formattable stack frames.
- **Correct dedup**: drops only the single top owner-stack frame that duplicates the leading source's component, instead of every frame sharing that name — so legitimate repeats (e.g. recursive components) stay in the hierarchy.
- **Owner-stack fallback retained**: when `getSource` only yields a bundler-virtual location, react-grab still scans the owner stack for the best real source frame.
- **Nicer Next.js paths**: `formatContextFilePath` rewrites absolute paths to `/./…` relative to common Next source markers (`/src/app/`, `/app/`, `/src/pages/`, `/pages/`).

### Elegance / layering changes vs. the original PR

- Removed the hand-rolled `getDebugSourceFromFiber` fiber walk in favor of bippy's `getSource` (correct layering — bippy owns React-internals + source resolution).
- Unified all source-line formatting into a single `formatSourceContextLine` that takes a `ResolvedSource` (no wrapper aliases, no positional-argument signature).
- Extracted `getSourceComponentName` to flatten a nested ternary and apply the source-name check consistently.

### Follow-up (upstream bippy)

Filed/queued an upstream issue: bippy's `getSource` owner-stack fallback returns the first frame with a `fileName` without applying `isSourceFile`, so it can surface `webpack-internal://` / `webpack://` / eval URLs. The ideal fix is for bippy to devirtualize/skip those frames (it already maintains the URL list), which would let react-grab drop its remaining guard.

## Test plan

- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format`
- [x] Full Playwright e2e suite (537 passed; 1 unrelated flake)
- [ ] Verify correct line numbers in a Webpack/Rspack project (previously resolved to a generated source)
- [ ] Verify Next.js projects still display source-mapped locations correctly
- [ ] Verify no regression in non-bundler/dev React apps
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02cbd046-2cb0-45f5-955d-a2fba9c46e69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02cbd046-2cb0-45f5-955d-a2fba9c46e69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect source locations in Webpack/Rspack by preferring React fiber _debugSource via `bippy` `getSource`, with a safe fallback to the owner stack. Also trims Next.js absolute paths and removes instrumentation gating so source lookup works even before hooks initialize.

- **Bug Fixes**
  - Prefer `_debugSource` via `getSource` in `resolveSource` and `getStackContext`; trust only on-disk files; ignore bundler-virtual URLs (`webpack-internal://`, `webpack://`, eval); fall back to owner-stack resolution.
  - Prepend the `_debugSource` line to the context and only drop the first owner-stack frame if it repeats that component.
  - Do not gate `getFiberSource` on instrumentation; keep try/catch around `getSource` to prevent crashes before hooks initialize.

- **Refactors**
  - Delegate fiber source resolution to `bippy` `getSource` and map to internal `ResolvedSource`; use a single `formatSourceContextLine` for leading sources and stack frames.
  - Normalize Next.js absolute paths to project-relative `/./…`.

<sup>Written for commit c0b1d047d60b53abaa1f9a4edf6a439c6e51c206. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

