### PR TITLE
feat(react-grab): add hover tooltips to toolbar action buttons

### DIFF
--- a/packages/react-grab/src/components/toolbar/index.tsx
+++ b/packages/react-grab/src/components/toolbar/index.tsx
@@ -77,11 +77,16 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
   const [isChevronPressed, setIsChevronPressed] = createSignal(false);
   const [isToolbarHovered, setIsToolbarHovered] = createSignal(false);
   const [selectIconRotationDeg, setSelectIconRotationDeg] = createSignal(0);
+  const [hoveredActionId, setHoveredActionId] = createSignal<string | null>(null);
   const drag = createToolbarDrag({
     getContainerRef: () => containerRef,
     isCollapsed,
     getExpandedDimensions: () => expandedDimensions,
     onDragStart: () => {
+      // Pointer capture during a drag suppresses the button's mouseleave, so
+      // clear the hover here or the tooltip flashes at the snapped position
+      // once isDragging/isSnapping settle.
+      setHoveredActionId(null);
       if (unfreezeUpdatesCallback) {
         unfreezeUpdatesCallback();
         unfreezeUpdatesCallback = null;
@@ -119,7 +124,6 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
   const isCopyActive = () =>
     Boolean(props.isActive) && (props.activeActionId ?? DEFAULT_ACTION_ID) === DEFAULT_ACTION_ID;
 
-  const [hoveredActionId, setHoveredActionId] = createSignal<string | null>(null);
   const isTooltipVisible = (actionId: string) =>
     hoveredActionId() === actionId &&
     !props.isActive &&

--- a/packages/react-grab/src/components/toolbar/index.tsx
+++ b/packages/react-grab/src/components/toolbar/index.tsx
@@ -119,13 +119,37 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
   const isCopyActive = () =>
     Boolean(props.isActive) && (props.activeActionId ?? DEFAULT_ACTION_ID) === DEFAULT_ACTION_ID;
 
+  const [hoveredActionId, setHoveredActionId] = createSignal<string | null>(null);
+  const isTooltipVisible = (actionId: string) =>
+    hoveredActionId() === actionId &&
+    !props.isActive &&
+    !isCollapsed() &&
+    !drag.isDragging() &&
+    !drag.isSnapping() &&
+    !props.isContextMenuOpen;
+  const tooltipPosition = (): "top" | "bottom" | "left" | "right" => {
+    switch (snapEdge()) {
+      case "top":
+        return "bottom";
+      case "bottom":
+        return "top";
+      case "left":
+        return "right";
+      case "right":
+        return "left";
+      default:
+        return "top";
+    }
+  };
+
   const stopEventPropagation = (event: Event) => {
     event.stopImmediatePropagation();
   };
 
-  const createFreezeHandlers = (options?: FreezeHandlersOptions) => ({
+  const createFreezeHandlers = (actionId: string, options?: FreezeHandlersOptions) => ({
     onMouseEnter: (event: MouseEvent) => {
       if (drag.isDragging()) return;
+      setHoveredActionId(actionId);
       if (options?.shouldFreezeInteractions !== false && !unfreezeUpdatesCallback) {
         unfreezeUpdatesCallback = freezeUpdates();
         freezeGlobalAnimations();
@@ -134,6 +158,7 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
       options?.onHoverChange?.(true);
     },
     onMouseLeave: () => {
+      setHoveredActionId((current) => (current === actionId ? null : current));
       if (
         options?.shouldFreezeInteractions !== false &&
         !props.isActive &&
@@ -253,11 +278,10 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
   );
   const handleStyle = drag.createDragAwareHandler(() => props.onActivateAction?.(EDIT_ACTION_ID));
 
-  const actionButtonClass = () =>
-    cn(
-      "group contain-layout flex items-center justify-center cursor-pointer interactive-scale a11y-hitbox",
-      buttonSpacingClass(),
-    );
+  const actionButtonClass =
+    "group contain-layout flex items-center justify-center cursor-pointer interactive-scale a11y-hitbox";
+  const actionButtonWrapperClass = () =>
+    cn("relative contain-layout flex items-center justify-center", buttonSpacingClass());
   const actionIconClass = (isActive: boolean) =>
     isActive
       ? "text-[var(--rg-text-primary)]"
@@ -666,46 +690,58 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
         }}
         actionButtons={
           <>
-            <button
-              ref={selectButtonRef}
-              data-react-grab-ignore-events
-              data-react-grab-toolbar-toggle
-              data-react-grab-toolbar-action={DEFAULT_ACTION_ID}
-              aria-label={isCopyActive() ? "Stop selecting element" : "Copy element"}
-              aria-pressed={isCopyActive()}
-              type="button"
-              class={actionButtonClass()}
+            <ToolbarActionButton
+              actionId={DEFAULT_ACTION_ID}
+              isToggle
+              ref={(element) => (selectButtonRef = element)}
+              label={isCopyActive() ? "Stop selecting element" : "Copy element"}
+              isActive={isCopyActive()}
+              class={actionButtonClass}
+              wrapperClass={actionButtonWrapperClass()}
               onClick={handleToggle}
-              on:contextmenu={(event: MouseEvent) => {
+              onContextMenu={(event) => {
                 event.preventDefault();
                 event.stopPropagation();
+                setHoveredActionId(null);
                 props.onToggleToolbarMenu?.();
               }}
-              {...createFreezeHandlers()}
-            >
-              <IconSelect
-                size={14}
-                rotationDeg={selectIconRotationDeg()}
-                class={actionIconClass(isCopyActive())}
-              />
-            </button>
+              {...createFreezeHandlers(DEFAULT_ACTION_ID)}
+              icon={
+                <IconSelect
+                  size={14}
+                  rotationDeg={selectIconRotationDeg()}
+                  class={actionIconClass(isCopyActive())}
+                />
+              }
+              tooltipVisible={isTooltipVisible(DEFAULT_ACTION_ID)}
+              tooltipPosition={tooltipPosition()}
+              tooltip="Copy"
+            />
             <ToolbarActionButton
               actionId={COMMENT_ACTION_ID}
               label="Comment on element"
               isActive={isActionActive(COMMENT_ACTION_ID)}
-              class={actionButtonClass()}
+              class={actionButtonClass}
+              wrapperClass={actionButtonWrapperClass()}
               onClick={handleComment}
-              {...createFreezeHandlers()}
+              {...createFreezeHandlers(COMMENT_ACTION_ID)}
               icon={<IconComment size={14} class={actionIconClass(isActionActive(COMMENT_ACTION_ID))} />}
+              tooltipVisible={isTooltipVisible(COMMENT_ACTION_ID)}
+              tooltipPosition={tooltipPosition()}
+              tooltip="Comment"
             />
             <ToolbarActionButton
               actionId={EDIT_ACTION_ID}
               label="Style element"
               isActive={isActionActive(EDIT_ACTION_ID)}
-              class={actionButtonClass()}
+              class={actionButtonClass}
+              wrapperClass={actionButtonWrapperClass()}
               onClick={handleStyle}
-              {...createFreezeHandlers()}
+              {...createFreezeHandlers(EDIT_ACTION_ID)}
               icon={<IconStyle size={14} class={actionIconClass(isActionActive(EDIT_ACTION_ID))} />}
+              tooltipVisible={isTooltipVisible(EDIT_ACTION_ID)}
+              tooltipPosition={tooltipPosition()}
+              tooltip="Style"
             />
           </>
         }

--- a/packages/react-grab/src/components/toolbar/toolbar-action-button.tsx
+++ b/packages/react-grab/src/components/toolbar/toolbar-action-button.tsx
@@ -1,28 +1,46 @@
-import type { Component, JSX } from "solid-js";
+import { Show, type Component, type JSX } from "solid-js";
+import { Tooltip } from "../tooltip.jsx";
 
 interface ToolbarActionButtonProps {
   actionId: string;
   label: string;
   isActive?: boolean;
+  isToggle?: boolean;
   class?: string;
+  wrapperClass?: string;
+  ref?: (element: HTMLButtonElement) => void;
   onClick?: (event: MouseEvent) => void;
+  onContextMenu?: (event: MouseEvent) => void;
   onMouseEnter?: (event: MouseEvent) => void;
   onMouseLeave?: (event: MouseEvent) => void;
   icon: JSX.Element;
+  tooltip?: JSX.Element;
+  tooltipVisible?: boolean;
+  tooltipPosition?: "top" | "bottom" | "left" | "right";
 }
 
 export const ToolbarActionButton: Component<ToolbarActionButtonProps> = (props) => (
-  <button
-    data-react-grab-ignore-events
-    data-react-grab-toolbar-action={props.actionId}
-    aria-label={props.label}
-    aria-pressed={Boolean(props.isActive)}
-    type="button"
-    class={props.class}
-    onClick={props.onClick}
-    onMouseEnter={props.onMouseEnter}
-    onMouseLeave={props.onMouseLeave}
-  >
-    {props.icon}
-  </button>
+  <div class={props.wrapperClass}>
+    <button
+      ref={props.ref}
+      data-react-grab-ignore-events
+      data-react-grab-toolbar-toggle={props.isToggle ? "" : undefined}
+      data-react-grab-toolbar-action={props.actionId}
+      aria-label={props.label}
+      aria-pressed={Boolean(props.isActive)}
+      type="button"
+      class={props.class}
+      onClick={props.onClick}
+      on:contextmenu={(event) => props.onContextMenu?.(event)}
+      onMouseEnter={props.onMouseEnter}
+      onMouseLeave={props.onMouseLeave}
+    >
+      {props.icon}
+    </button>
+    <Show when={props.tooltip}>
+      <Tooltip visible={Boolean(props.tooltipVisible)} position={props.tooltipPosition ?? "top"}>
+        {props.tooltip}
+      </Tooltip>
+    </Show>
+  </div>
 );

--- a/packages/react-grab/src/components/tooltip.tsx
+++ b/packages/react-grab/src/components/tooltip.tsx
@@ -1,0 +1,89 @@
+import { createSignal, createEffect, on, onCleanup, Show } from "solid-js";
+import type { Component, JSX } from "solid-js";
+import { cn } from "../utils/cn.js";
+import { TOOLTIP_DELAY_MS, TOOLTIP_GRACE_PERIOD_MS, Z_INDEX_OVERLAY } from "../constants.js";
+
+let lastCloseTimestamp = 0;
+
+const wasTooltipRecentlyVisible = () => {
+  return Date.now() - lastCloseTimestamp < TOOLTIP_GRACE_PERIOD_MS;
+};
+
+interface TooltipProps {
+  visible: boolean;
+  position: "top" | "bottom" | "left" | "right";
+  children: JSX.Element;
+}
+
+export const Tooltip: Component<TooltipProps> = (props) => {
+  const [delayedVisible, setDelayedVisible] = createSignal(false);
+  const [shouldAnimate, setShouldAnimate] = createSignal(true);
+  let delayTimeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  createEffect(
+    on(
+      () => props.visible,
+      (isVisible) => {
+        if (delayTimeoutId !== undefined) {
+          clearTimeout(delayTimeoutId);
+          delayTimeoutId = undefined;
+        }
+
+        if (isVisible) {
+          // Reopening within the grace period skips the delay and the fade so
+          // moving between adjacent buttons reads as one continuous tooltip.
+          if (wasTooltipRecentlyVisible()) {
+            setShouldAnimate(false);
+            setDelayedVisible(true);
+          } else {
+            setShouldAnimate(true);
+            delayTimeoutId = setTimeout(() => {
+              setDelayedVisible(true);
+            }, TOOLTIP_DELAY_MS);
+          }
+        } else {
+          if (delayedVisible()) {
+            lastCloseTimestamp = Date.now();
+          }
+          setDelayedVisible(false);
+        }
+      },
+    ),
+  );
+
+  onCleanup(() => {
+    if (delayTimeoutId !== undefined) {
+      clearTimeout(delayTimeoutId);
+    }
+    if (delayedVisible()) {
+      lastCloseTimestamp = Date.now();
+    }
+  });
+
+  const positionStyle = (): Record<string, string> => {
+    const isHorizontal = props.position === "top" || props.position === "bottom";
+    if (isHorizontal) {
+      return { left: "50%", translate: "-50%", "z-index": `${Z_INDEX_OVERLAY}` };
+    }
+    return { top: "50%", translate: "0 -50%", "z-index": `${Z_INDEX_OVERLAY}` };
+  };
+
+  return (
+    <Show when={delayedVisible()}>
+      <div
+        class={cn(
+          "absolute whitespace-nowrap px-1.5 py-0.5 rounded-[8px] text-[10px] font-sans font-medium leading-4 pointer-events-none [corner-shape:superellipse(1.25)]",
+          "bg-[var(--rg-panel-bg)] text-[var(--rg-text-primary)] [box-shadow:var(--rg-shadow)]",
+          props.position === "top" && "bottom-full mb-2.5",
+          props.position === "bottom" && "top-full mt-2.5",
+          props.position === "left" && "right-full mr-2.5",
+          props.position === "right" && "left-full ml-2.5",
+          shouldAnimate() && "animate-tooltip-fade-in",
+        )}
+        style={positionStyle()}
+      >
+        {props.children}
+      </div>
+    </Show>
+  );
+};

--- a/packages/react-grab/src/components/tooltip.tsx
+++ b/packages/react-grab/src/components/tooltip.tsx
@@ -72,7 +72,7 @@ export const Tooltip: Component<TooltipProps> = (props) => {
     <Show when={delayedVisible()}>
       <div
         class={cn(
-          "absolute whitespace-nowrap px-1.5 py-0.5 rounded-[8px] text-[10px] font-sans font-medium leading-4 pointer-events-none [corner-shape:superellipse(1.25)]",
+          "absolute whitespace-nowrap px-2 py-0.5 rounded-full text-[10px] font-sans font-medium leading-4 pointer-events-none",
           "bg-[var(--rg-panel-bg)] text-[var(--rg-text-primary)] [box-shadow:var(--rg-shadow)]",
           props.position === "top" && "bottom-full mb-2.5",
           props.position === "bottom" && "top-full mt-2.5",

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -136,6 +136,9 @@ export const DEFAULT_ACTION_ID = "copy";
 export const COMMENT_ACTION_ID = "comment";
 export const EDIT_ACTION_ID = "edit";
 
+export const TOOLTIP_DELAY_MS = 400;
+export const TOOLTIP_GRACE_PERIOD_MS = 800;
+
 export const MENU_PANEL_CORNER_RADIUS_PX = 14;
 export const MENU_HIGHLIGHT_CORNER_SHAPE = "superellipse(1.25)";
 

--- a/packages/react-grab/src/styles.css
+++ b/packages/react-grab/src/styles.css
@@ -321,6 +321,22 @@
   will-change: translate;
 }
 
+@keyframes tooltip-fade-in {
+  from {
+    opacity: 0;
+    transform: scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.animate-tooltip-fade-in {
+  animation: tooltip-fade-in 100ms ease-out;
+  will-change: transform, opacity;
+}
+
 .animate-shake-vertical {
   --rg-shake-x: 0;
   --rg-shake-y: 1;


### PR DESCRIPTION
## Summary
- Re-adds hover tooltips to the toolbar's Copy / Comment / Style buttons (ports the `tooltip.tsx` primitive that was removed back in #313). Each button shows its label on hover after a ~400ms delay, with an 800ms grace period so moving between adjacent buttons reads as one continuous tooltip.
- Tooltips are styled with the toolbar's own theme tokens (`--rg-panel-bg`, `--rg-text-primary`, `--rg-shadow`) and `font-sans font-medium`, so they match the toolbar in light/dark and stay visually consistent with the right-click menu. They're suppressed during active selection (and while collapsed/dragging/snapping/context-menu-open).
- Refactor: the Copy button now routes through the shared `ToolbarActionButton` (extended with `ref` / `isToggle` / `onContextMenu`) instead of a hand-inlined copy of the wrapper+tooltip structure.

## Notes
- Tooltip labels are intentionally short ("Copy" / "Comment" / "Style"), no keyboard shortcut.
- The three toolbar buttons remain hardcoded (consistent with #426); tooltip labels are not yet derived from the plugin action registry — a known, accepted trade-off rather than threading the action list into the toolbar.

## Test plan
- [x] `pnpm --filter react-grab build`, `typecheck`, and `pnpm lint` all pass
- [x] Toolbar e2e suites pass (`toolbar-actions`, `toolbar`, `toolbar-menu`) — drag handle, right-click menu, and active-state behavior unaffected by the Copy-button refactor
- [ ] Manual: hover each button → correct label appears after a short delay; tooltips hidden during selection; theme-matched styling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only toolbar/tooltip behavior with guarded visibility; Copy refactor preserves existing toggle, context menu, and freeze-on-hover semantics.
> 
> **Overview**
> Adds **hover tooltips** to the toolbar Copy, Comment, and Style actions via a new `Tooltip` component (~400ms show delay, ~800ms grace period so hopping between buttons feels continuous). Tooltips use toolbar theme tokens, flip to the side opposite the snapped edge, and stay hidden while selecting, collapsed, dragging/snapping, or when the context menu is open.
> 
> The **Copy** control is refactored onto shared `ToolbarActionButton` (with `ref`, `isToggle`, `onContextMenu`, and a relative wrapper for tooltip positioning). Hover state is tracked per action and cleared on drag start and right-click so tooltips do not flash after snaps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8800e9841f9414382ef12daf498bd96a8e0a359a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hover tooltips to the `react-grab` toolbar buttons (Copy, Comment, Style) to improve discoverability. Tooltips match the toolbar theme, are fully rounded, use a 400ms delay with an 800ms grace period, and the Copy button now uses `ToolbarActionButton` without behavior changes.

- **New Features**
  - Reintroduces `tooltip.tsx`; shows short labels after 400ms with an 800ms grace period; fully rounded pill styling with theme tokens and a fade-in animation.
  - Positions opposite the snapped edge; hidden while selecting, collapsed, dragging/snapping, or when the context menu is open.

- **Bug Fixes**
  - Clears hovered action on drag start to prevent a tooltip flash after snapping (pointer capture can suppress mouseleave).

<sup>Written for commit 8800e9841f9414382ef12daf498bd96a8e0a359a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

