### PR TITLE
fix(cli): detect monorepo subprojects during init + skill multiselect

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -21,6 +21,7 @@ import { getPackagesToInstall } from "../utils/install.js";
 import { logger } from "../utils/logger.js";
 import { spinner } from "../utils/spinner.js";
 import {
+  hasFrameworkEntryPoint,
   previewOptionsTransform,
   previewTransform,
   type ReactGrabOptions,
@@ -103,6 +104,22 @@ const printSubprojects = (searchRoot: string, sortedProjects: WorkspaceProject[]
     `  ${highlighter.dim("$")} npx grab@latest init -c ${relative(searchRoot, sortedProjects[0].path)}`,
   );
   logger.break();
+};
+
+const SUPPORTED_FRAMEWORKS_LINE =
+  "React Grab supports Next.js, Vite, TanStack Start, and Webpack projects.";
+
+const failWithManualSetup = (
+  failingSpinner: ReturnType<typeof spinner>,
+  message: string,
+  { listSupportedFrameworks = false } = {},
+): never => {
+  failingSpinner.fail(message);
+  logger.break();
+  if (listSupportedFrameworks) logger.log(SUPPORTED_FRAMEWORKS_LINE);
+  logger.log(`Visit ${highlighter.info(DOCS_URL)} for manual setup.`);
+  logger.break();
+  process.exit(1);
 };
 
 export const init = new Command()
@@ -347,7 +364,20 @@ export const init = new Command()
         process.exit(1);
       }
 
-      if (projectInfo.framework === "unknown") {
+      // A detected framework whose entry file is missing is only ambiguous in a
+      // monorepo, where the real app lives in a workspace and the root config is
+      // tooling. For a standalone project we keep the framework so previewTransform
+      // can surface its specific manual-setup guidance instead of searching elsewhere.
+      const shouldSearchForProject =
+        projectInfo.framework === "unknown" ||
+        (projectInfo.isMonorepo &&
+          !hasFrameworkEntryPoint(
+            projectInfo.projectRoot,
+            projectInfo.framework,
+            projectInfo.nextRouterType,
+          ));
+
+      if (shouldSearchForProject) {
         let searchRoot = cwd;
         let reactProjects = findReactProjects(searchRoot);
         if (reactProjects.length === 0 && cwd !== process.cwd()) {
@@ -398,23 +428,24 @@ export const init = new Command()
 
           const newFrameworkSpinner = spinner("Verifying framework.").start();
           if (newProjectInfo.framework === "unknown") {
-            newFrameworkSpinner.fail("Could not detect a supported framework in this project.");
-            logger.break();
-            logger.log("React Grab supports Next.js, Vite, TanStack Start, and Webpack projects.");
-            logger.log(`Visit ${highlighter.info(DOCS_URL)} for manual setup.`);
-            logger.break();
-            process.exit(1);
+            failWithManualSetup(
+              newFrameworkSpinner,
+              "Could not detect a supported framework in this project.",
+              { listSupportedFrameworks: true },
+            );
           }
           newFrameworkSpinner.succeed(
             `Verifying framework. Found ${highlighter.info(FRAMEWORK_NAMES[newProjectInfo.framework])}.`,
           );
+        } else if (projectInfo.framework !== "unknown") {
+          failWithManualSetup(
+            frameworkSpinner,
+            `Verifying framework. Found ${highlighter.info(FRAMEWORK_NAMES[projectInfo.framework])}, but could not find an entry file.`,
+          );
         } else {
-          frameworkSpinner.fail("Could not detect a supported framework.");
-          logger.break();
-          logger.log("React Grab supports Next.js, Vite, TanStack Start, and Webpack projects.");
-          logger.log(`Visit ${highlighter.info(DOCS_URL)} for manual setup.`);
-          logger.break();
-          process.exit(1);
+          failWithManualSetup(frameworkSpinner, "Could not detect a supported framework.", {
+            listSupportedFrameworks: true,
+          });
         }
       } else {
         frameworkSpinner.succeed(

--- a/packages/cli/src/utils/detect-agents.ts
+++ b/packages/cli/src/utils/detect-agents.ts
@@ -1,0 +1,52 @@
+import { accessSync, constants, statSync } from "node:fs";
+import { delimiter, join } from "node:path";
+import {
+  type SkillAgentType,
+  detectInstalledSkillAgents,
+  getSkillAgentTypes,
+} from "agent-install/skill";
+
+// PATH binaries used as a supplementary detection signal on top of
+// agent-install's filesystem detection. This catches users who installed a
+// CLI but have not run it yet (no ~/.claude / ~/.cursor / etc. on disk).
+// Only agents whose CLI ships an obvious binary name are listed; FS-only
+// agents rely entirely on agent-install. "universal" is a synthetic install
+// target with no binary or config dir.
+const PATH_BINARIES: Partial<Record<SkillAgentType, readonly string[]>> = {
+  "claude-code": ["claude"],
+  codex: ["codex"],
+  cursor: ["cursor", "cursor-agent"],
+  droid: ["droid"],
+  "gemini-cli": ["gemini"],
+  "github-copilot": ["copilot"],
+  opencode: ["opencode"],
+  pi: ["pi", "omegon"],
+};
+
+const isCommandAvailable = (command: string): boolean => {
+  const pathDirectories = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
+  for (const directory of pathDirectories) {
+    const binaryPath = join(directory, command);
+    try {
+      if (statSync(binaryPath).isFile()) {
+        accessSync(binaryPath, constants.X_OK);
+        return true;
+      }
+    } catch {}
+  }
+  return false;
+};
+
+// Union of agent-install's filesystem-detected agents (~/.claude, ~/.cursor,
+// etc.) with a supplementary $PATH binary scan that catches agents installed
+// but not yet run (no config dir on disk). Order follows getSkillAgentTypes()
+// for deterministic UI; the synthetic "universal" type is filtered out because
+// it is not a user-facing agent.
+export const detectAvailableAgents = async (): Promise<SkillAgentType[]> => {
+  const installedAgents = new Set(await detectInstalledSkillAgents());
+  return getSkillAgentTypes().filter((agent) => {
+    if (agent === "universal") return false;
+    if (installedAgents.has(agent)) return true;
+    return PATH_BINARIES[agent]?.some(isCommandAvailable) ?? false;
+  });
+};

--- a/packages/cli/src/utils/install-skill.ts
+++ b/packages/cli/src/utils/install-skill.ts
@@ -4,12 +4,12 @@ import { fileURLToPath } from "node:url";
 import {
   type SkillAgentType,
   add,
-  detectInstalledSkillAgents,
   getCanonicalSkillsDir,
   getSkillAgentConfig,
   getSkillAgentDir,
   isUniversalSkillAgent,
 } from "agent-install/skill";
+import { detectAvailableAgents } from "./detect-agents.js";
 import { highlighter } from "./highlighter.js";
 import { logger } from "./logger.js";
 import { prompts } from "./prompts.js";
@@ -34,26 +34,34 @@ const installedSkillDir = (agent: SkillAgentType): string =>
   );
 
 export const promptSkillInstall = async ({ yes = false } = {}): Promise<boolean> => {
-  const agents = await detectInstalledSkillAgents();
-  if (agents.length === 0) {
+  const detectedAgents = await detectAvailableAgents();
+  if (detectedAgents.length === 0) {
     logger.warn("No supported agents detected.");
     return false;
   }
 
+  let selectedAgents = detectedAgents;
   if (!yes) {
-    const { confirmed } = await prompts({
-      type: "confirm",
-      name: "confirmed",
-      message: `Install the React Grab skill for ${highlighter.info(agents.map(agentLabel).join(", "))}?`,
-      initial: true,
+    const { agents } = await prompts({
+      type: "multiselect",
+      name: "agents",
+      message: "Install the React Grab skill for:",
+      choices: detectedAgents.map((agent) => ({
+        title: agentLabel(agent),
+        value: agent,
+        selected: true,
+      })),
+      instructions: false,
+      min: 1,
     });
-    if (!confirmed) return false;
+    selectedAgents = agents ?? [];
+    if (selectedAgents.length === 0) return false;
   }
 
   const installSpinner = spinner("Installing React Grab skill.").start();
   const { installed, failed } = await add({
     source: SKILL_SOURCE,
-    agents,
+    agents: selectedAgents,
     global: true,
     mode: "copy",
   });
@@ -72,7 +80,7 @@ export const promptSkillInstall = async ({ yes = false } = {}): Promise<boolean>
 };
 
 export const removeSkill = async (): Promise<number> => {
-  const agents = await detectInstalledSkillAgents();
+  const agents = await detectAvailableAgents();
   const agentsWithSkill = agents.filter((agent) => existsSync(installedSkillDir(agent)));
   // Universal agents share one canonical dir, so delete each distinct dir once.
   for (const skillDir of new Set(agentsWithSkill.map(installedSkillDir))) {

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -1,5 +1,6 @@
 import basePrompts, { type PromptObject, type Answers } from "prompts";
 import { logger } from "./logger.js";
+import { unrefStdin } from "./unref-stdin.js";
 
 const onCancel = () => {
   logger.break();
@@ -11,5 +12,7 @@ const onCancel = () => {
 export const prompts = <T extends string = string>(
   questions: PromptObject<T> | PromptObject<T>[],
 ): Promise<Answers<T>> => {
-  return basePrompts(questions, { onCancel });
+  // HACK: each prompt re-refs stdin and never unrefs it on close, so re-unref
+  // once it settles or the one-shot CLI hangs. See `unref-stdin.ts` for why.
+  return basePrompts(questions, { onCancel }).finally(unrefStdin);
 };

--- a/packages/cli/src/utils/transform.ts
+++ b/packages/cli/src/utils/transform.ts
@@ -484,6 +484,26 @@ const transformTanStack = (
   };
 };
 
+export const hasFrameworkEntryPoint = (
+  projectRoot: string,
+  framework: Framework,
+  nextRouterType: NextRouterType,
+): boolean => {
+  switch (framework) {
+    case "next":
+      return nextRouterType === "app"
+        ? findLayoutFile(projectRoot) !== null
+        : findDocumentFile(projectRoot) !== null;
+    case "vite":
+    case "webpack":
+      return findEntryFile(projectRoot) !== null;
+    case "tanstack":
+      return findTanStackRootFile(projectRoot) !== null;
+    default:
+      return false;
+  }
+};
+
 export const previewTransform = (
   projectRoot: string,
   framework: Framework,

--- a/packages/cli/src/utils/unref-stdin.ts
+++ b/packages/cli/src/utils/unref-stdin.ts
@@ -1,0 +1,19 @@
+// HACK: this is a one-shot CLI, but when stdin (fd 0) is an inherited pipe or
+// socket Node keeps the event loop alive for as long as that handle is open —
+// even though the only thing that ever reads stdin is an interactive prompt.
+// When the CLI is spawned by a parent that holds the stdin write-end open (eval
+// runners, CI harnesses, editor integrations), the command finishes yet the
+// process never exits: the inherited `Socket fd=0` refs the loop. Unref-ing fd
+// 0 makes an idle pipe/socket incapable of holding the process open.
+//
+// We MUST NOT unref an interactive TTY. A real terminal is the only case that
+// shows prompts, and `prompts` never re-refs an unref'd stdin handle: its base
+// element does `readline.createInterface(...)` + `setRawMode(true)` but never
+// `resume()`, none of which re-ref the libuv handle. Unref-ing a TTY would let
+// the event loop drain while a prompt is still waiting for input — the CLI
+// would render the prompt and then exit by itself before the user can answer.
+// Guarding on `isTTY` keeps the one-shot exit fix without breaking prompts.
+export const unrefStdin = (): void => {
+  if (process.stdin.isTTY) return;
+  process.stdin.unref?.();
+};

--- a/packages/cli/test/detect-agents.test.ts
+++ b/packages/cli/test/detect-agents.test.ts
@@ -1,0 +1,74 @@
+import { vi, describe, expect, it, beforeEach } from "vite-plus/test";
+
+vi.mock("node:fs", () => ({
+  statSync: vi.fn(),
+  accessSync: vi.fn(),
+  constants: { X_OK: 1 },
+}));
+
+vi.mock("agent-install/skill", () => ({
+  detectInstalledSkillAgents: vi.fn(),
+  getSkillAgentTypes: vi.fn(),
+}));
+
+import { statSync, accessSync } from "node:fs";
+import { detectInstalledSkillAgents, getSkillAgentTypes } from "agent-install/skill";
+import { detectAvailableAgents } from "../src/utils/detect-agents.js";
+
+const mockStatSync = vi.mocked(statSync);
+const mockAccessSync = vi.mocked(accessSync);
+const mockDetectInstalled = vi.mocked(detectInstalledSkillAgents);
+const mockGetTypes = vi.mocked(getSkillAgentTypes);
+
+const toPosixPath = (path: unknown): string => `${path}`.replace(/\\/g, "/");
+
+// `path.join` uses `\` on Windows; normalize so the POSIX binary paths match.
+const binaryPresent = (binaryPath: string) => {
+  mockStatSync.mockImplementation((path) => {
+    if (toPosixPath(path) === binaryPath) return { isFile: () => true } as never;
+    throw new Error("ENOENT");
+  });
+  mockAccessSync.mockImplementation((path) => {
+    if (toPosixPath(path) !== binaryPath) throw new Error("EACCES");
+  });
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.PATH = "/usr/bin";
+  mockGetTypes.mockReturnValue(["claude-code", "cursor", "codex", "universal"] as never);
+});
+
+describe("detectAvailableAgents", () => {
+  it("detects an agent from a PATH binary even with no config dir", async () => {
+    mockDetectInstalled.mockResolvedValue([]);
+    binaryPresent("/usr/bin/claude");
+
+    expect(await detectAvailableAgents()).toEqual(["claude-code"]);
+  });
+
+  it("unions PATH-detected and filesystem-detected agents in canonical order", async () => {
+    mockDetectInstalled.mockResolvedValue(["cursor"] as never);
+    binaryPresent("/usr/bin/claude");
+
+    expect(await detectAvailableAgents()).toEqual(["claude-code", "cursor"]);
+  });
+
+  it("filters out the synthetic universal agent", async () => {
+    mockDetectInstalled.mockResolvedValue(["universal"] as never);
+    mockStatSync.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+
+    expect(await detectAvailableAgents()).toEqual([]);
+  });
+
+  it("returns nothing when no agents are found anywhere", async () => {
+    mockDetectInstalled.mockResolvedValue([]);
+    mockStatSync.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+
+    expect(await detectAvailableAgents()).toEqual([]);
+  });
+});

--- a/packages/cli/test/transform.test.ts
+++ b/packages/cli/test/transform.test.ts
@@ -25,33 +25,38 @@ beforeEach(() => {
 });
 
 describe("hasFrameworkEntryPoint", () => {
+  // `path.join` emits `\` on Windows, so normalize to `/` before matching the
+  // POSIX-style suffixes below.
+  const pathEndsWith = (path: unknown, suffix: string): boolean =>
+    `${path}`.replace(/\\/g, "/").endsWith(suffix);
+
   it("returns true when a Vite entry file exists", () => {
-    mockExistsSync.mockImplementation((path) => String(path).endsWith("src/main.tsx"));
+    mockExistsSync.mockImplementation((path) => pathEndsWith(path, "src/main.tsx"));
     expect(hasFrameworkEntryPoint("/app", "vite", "unknown")).toBe(true);
   });
 
   it("returns false for Vite when only a config file exists (monorepo root tooling)", () => {
-    mockExistsSync.mockImplementation((path) => String(path).endsWith("vite.config.ts"));
+    mockExistsSync.mockImplementation((path) => pathEndsWith(path, "vite.config.ts"));
     expect(hasFrameworkEntryPoint("/repo", "vite", "unknown")).toBe(false);
   });
 
   it("returns true for a Webpack entry file", () => {
-    mockExistsSync.mockImplementation((path) => String(path).endsWith("src/index.tsx"));
+    mockExistsSync.mockImplementation((path) => pathEndsWith(path, "src/index.tsx"));
     expect(hasFrameworkEntryPoint("/app", "webpack", "unknown")).toBe(true);
   });
 
   it("returns true for Next.js App Router when layout exists", () => {
-    mockExistsSync.mockImplementation((path) => String(path).endsWith("app/layout.tsx"));
+    mockExistsSync.mockImplementation((path) => pathEndsWith(path, "app/layout.tsx"));
     expect(hasFrameworkEntryPoint("/app", "next", "app")).toBe(true);
   });
 
   it("returns false for Next.js App Router when only _document exists (matches transform)", () => {
-    mockExistsSync.mockImplementation((path) => String(path).endsWith("pages/_document.tsx"));
+    mockExistsSync.mockImplementation((path) => pathEndsWith(path, "pages/_document.tsx"));
     expect(hasFrameworkEntryPoint("/app", "next", "app")).toBe(false);
   });
 
   it("returns true for Next.js Pages Router when _document exists", () => {
-    mockExistsSync.mockImplementation((path) => String(path).endsWith("pages/_document.tsx"));
+    mockExistsSync.mockImplementation((path) => pathEndsWith(path, "pages/_document.tsx"));
     expect(hasFrameworkEntryPoint("/app", "next", "pages")).toBe(true);
   });
 
@@ -61,7 +66,7 @@ describe("hasFrameworkEntryPoint", () => {
   });
 
   it("returns true for TanStack Start when the root route exists", () => {
-    mockExistsSync.mockImplementation((path) => String(path).endsWith("src/routes/__root.tsx"));
+    mockExistsSync.mockImplementation((path) => pathEndsWith(path, "src/routes/__root.tsx"));
     expect(hasFrameworkEntryPoint("/app", "tanstack", "unknown")).toBe(true);
   });
 

--- a/packages/cli/test/transform.test.ts
+++ b/packages/cli/test/transform.test.ts
@@ -1,5 +1,9 @@
 import { vi, describe, expect, it, beforeEach } from "vite-plus/test";
-import { previewTransform, applyTransform } from "../src/utils/transform.js";
+import {
+  hasFrameworkEntryPoint,
+  previewTransform,
+  applyTransform,
+} from "../src/utils/transform.js";
 
 vi.mock("node:fs", () => ({
   existsSync: vi.fn(),
@@ -18,6 +22,53 @@ const mockAccessSync = vi.mocked(accessSync);
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+describe("hasFrameworkEntryPoint", () => {
+  it("returns true when a Vite entry file exists", () => {
+    mockExistsSync.mockImplementation((path) => String(path).endsWith("src/main.tsx"));
+    expect(hasFrameworkEntryPoint("/app", "vite", "unknown")).toBe(true);
+  });
+
+  it("returns false for Vite when only a config file exists (monorepo root tooling)", () => {
+    mockExistsSync.mockImplementation((path) => String(path).endsWith("vite.config.ts"));
+    expect(hasFrameworkEntryPoint("/repo", "vite", "unknown")).toBe(false);
+  });
+
+  it("returns true for a Webpack entry file", () => {
+    mockExistsSync.mockImplementation((path) => String(path).endsWith("src/index.tsx"));
+    expect(hasFrameworkEntryPoint("/app", "webpack", "unknown")).toBe(true);
+  });
+
+  it("returns true for Next.js App Router when layout exists", () => {
+    mockExistsSync.mockImplementation((path) => String(path).endsWith("app/layout.tsx"));
+    expect(hasFrameworkEntryPoint("/app", "next", "app")).toBe(true);
+  });
+
+  it("returns false for Next.js App Router when only _document exists (matches transform)", () => {
+    mockExistsSync.mockImplementation((path) => String(path).endsWith("pages/_document.tsx"));
+    expect(hasFrameworkEntryPoint("/app", "next", "app")).toBe(false);
+  });
+
+  it("returns true for Next.js Pages Router when _document exists", () => {
+    mockExistsSync.mockImplementation((path) => String(path).endsWith("pages/_document.tsx"));
+    expect(hasFrameworkEntryPoint("/app", "next", "pages")).toBe(true);
+  });
+
+  it("returns false for Next.js when neither layout nor document exist", () => {
+    mockExistsSync.mockReturnValue(false);
+    expect(hasFrameworkEntryPoint("/repo", "next", "unknown")).toBe(false);
+  });
+
+  it("returns true for TanStack Start when the root route exists", () => {
+    mockExistsSync.mockImplementation((path) => String(path).endsWith("src/routes/__root.tsx"));
+    expect(hasFrameworkEntryPoint("/app", "tanstack", "unknown")).toBe(true);
+  });
+
+  it("returns false for an unknown framework", () => {
+    mockExistsSync.mockReturnValue(true);
+    expect(hasFrameworkEntryPoint("/app", "unknown", "unknown")).toBe(false);
+  });
 });
 
 describe("previewTransform - Next.js App Router", () => {

--- a/packages/cli/test/unref-stdin.test.ts
+++ b/packages/cli/test/unref-stdin.test.ts
@@ -1,0 +1,29 @@
+import { vi, describe, expect, it, afterEach } from "vite-plus/test";
+import { unrefStdin } from "../src/utils/unref-stdin.js";
+
+const originalIsTTY = process.stdin.isTTY;
+
+afterEach(() => {
+  Object.defineProperty(process.stdin, "isTTY", { value: originalIsTTY, configurable: true });
+  vi.restoreAllMocks();
+});
+
+describe("unrefStdin", () => {
+  it("does not unref an interactive TTY", () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    const unref = vi.spyOn(process.stdin, "unref").mockImplementation(() => process.stdin);
+
+    unrefStdin();
+
+    expect(unref).not.toHaveBeenCalled();
+  });
+
+  it("unrefs a non-TTY (inherited pipe) stdin", () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+    const unref = vi.spyOn(process.stdin, "unref").mockImplementation(() => process.stdin);
+
+    unrefStdin();
+
+    expect(unref).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- **Fix monorepo `init` failure.** Running `npx grab init` at a monorepo root whose only framework signal was a tooling config (e.g. a root `vite.config.ts` used by vite-plus) detected "Vite", then failed with `Could not find entry file (src/index.tsx, src/main.tsx, etc.)` instead of offering the real apps in `apps/*`. The workspace-selection flow only ran for `framework === "unknown"`, so a false-positive root config bypassed it entirely. Init now falls through to workspace-project selection whenever a **monorepo** root has no usable entry point, via a new `hasFrameworkEntryPoint` helper that mirrors exactly what `previewTransform` requires per framework/router. Standalone (non-monorepo) projects keep their framework so `previewTransform` can still surface its framework-specific manual-setup guidance.
- **Skill install is now a multiselect** (each detected agent pre-selected, `min: 1`) instead of an all-or-nothing confirm — matching react-doctor's installer UX.
- **PATH-augmented agent detection** (`detect-agents.ts`): unions agent-install's filesystem detection with a `$PATH` binary scan, so agents that are installed but haven't created a config dir yet are still detected (fixes false "No supported agents detected").
- **`prompts` now unrefs an inherited (non-TTY) stdin** on settle, preventing the one-shot CLI from hanging when spawned by a parent that holds stdin open. TTY is never unref'd, so interactive prompts are unaffected.

## Details

- `hasFrameworkEntryPoint(projectRoot, framework, nextRouterType)` in `transform.ts` returns whether the file the transform would edit actually exists (next: `app`→layout, else→`_document`; vite/webpack→entry; tanstack→root route).
- `init.ts` gate: `framework === "unknown" || (isMonorepo && !hasFrameworkEntryPoint(...))`. Scoping to monorepos avoids accidentally `chdir`-ing a standalone project into an unrelated parent/sibling.
- Replaced the dangerously generic `agent` PATH binary with the specific `cursor-agent`.
- Deduped the repeated "supported frameworks" failure messaging into a `failWithManualSetup` helper.

## Test plan

- [x] `pnpm --filter @react-grab/cli build`
- [x] `pnpm --filter @react-grab/cli lint` (0 warnings/errors)
- [x] `pnpm --filter @react-grab/cli test` — 140 passed (added `hasFrameworkEntryPoint`, `detectAvailableAgents`, `unrefStdin` tests)
- [x] Manual: `node packages/cli/dist/cli.js init -y --skip-install -c <monorepo>` now discovers `apps/web` + `apps/website-rd` instead of failing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to CLI init/detect/prompt UX and skill installation; no runtime app, auth, or data-path changes.
> 
> **Overview**
> **Monorepo `init`** no longer stops at a root-only framework config (e.g. root `vite.config.ts`) with a missing entry file. In monorepos, init now searches workspace apps when `hasFrameworkEntryPoint` says the detected framework has nothing to patch—the same files `previewTransform` would edit. Standalone repos still get framework-specific manual-setup errors instead of being `chdir`'d elsewhere. Repeated failure copy is centralized in `failWithManualSetup`.
> 
> **Skill install** uses a **multiselect** of detected agents (all pre-selected, minimum one) instead of a single confirm-for-all prompt. Detection is widened via `detectAvailableAgents`, which unions `agent-install` filesystem checks with executable names on `$PATH` (so CLIs installed but never run still show up). `removeSkill` uses the same detector.
> 
> **CLI exit** — wrapped `prompts` call `unrefStdin` in `finally` so inherited non-TTY stdin does not keep the one-shot process alive after prompts; TTY stdin is left alone.
> 
> Tests cover `hasFrameworkEntryPoint`, agent detection, and `unrefStdin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e79cb1d875e35d85a6122ffde9decc7bced01023. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CLI init in monorepos that only have tooling configs by detecting missing framework entry points and offering workspace selection. Also adds skill install multiselect and improves agent detection and prompt shutdown behavior.

- **Bug Fixes**
  - Init at monorepo root now falls back to workspace selection when no entry file exists, using `hasFrameworkEntryPoint` (avoids false positives from root configs like vite).
  - Clear manual-setup path on framework detection failures via `failWithManualSetup`.
  - `prompts` now unrefs inherited non-TTY stdin on settle to prevent hangs; TTY is untouched.
  - Tests: normalize path separators in `hasFrameworkEntryPoint` cases for Windows.

- **New Features**
  - Skill install uses a multiselect with detected agents preselected (min: 1).
  - PATH-augmented agent detection via `detectAvailableAgents`: unions `agent-install/skill` filesystem checks with `$PATH` binaries (e.g., `cursor`/`cursor-agent`, `claude`).

<sup>Written for commit e79cb1d875e35d85a6122ffde9decc7bced01023. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

