### PR TITLE
feat(cli): single `grab pull` loop + byte-offset read cursor

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,8 +2,9 @@ import { Command } from "commander";
 import { add } from "./commands/add.js";
 import { configure } from "./commands/configure.js";
 import { init } from "./commands/init.js";
-import { read } from "./commands/read.js";
+import { pull } from "./commands/pull.js";
 import { remove } from "./commands/remove.js";
+import { stop } from "./commands/stop.js";
 import { upgrade } from "./commands/upgrade.js";
 import { watch } from "./commands/watch.js";
 
@@ -27,8 +28,9 @@ program.addCommand(add);
 program.addCommand(remove);
 program.addCommand(configure);
 program.addCommand(upgrade);
+program.addCommand(pull);
+program.addCommand(stop);
 program.addCommand(watch);
-program.addCommand(read);
 
 const main = async () => {
   await program.parseAsync();

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -30,7 +30,7 @@ program.addCommand(configure);
 program.addCommand(upgrade);
 program.addCommand(pull);
 program.addCommand(stop);
-program.addCommand(watch);
+program.addCommand(watch, { hidden: true });
 
 const main = async () => {
   await program.parseAsync();

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -1,27 +1,33 @@
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { Command } from "commander";
-import { prepareWorkDir } from "../utils/clipboard.js";
+import { NO_READER_MESSAGE, createReader, prepareWorkDir } from "../utils/clipboard.js";
 import {
   DEFAULT_GRAB_AGE_MS,
   DEFAULT_WATCH_DIR,
+  DEFAULT_WATCH_INTERVAL_MS,
   READ_DEFAULT_LIMIT,
   READ_WAIT_POLL_MS,
 } from "../utils/constants.js";
+import { isDaemonRunning, spawnDaemon } from "../utils/daemon.js";
 import { consumeGrabs } from "../utils/grab-log.js";
 import { parseGrabCount, parseWaitMs } from "../utils/read-args.js";
 import { sleep } from "../utils/sleep.js";
 import { unrefStdin } from "../utils/unref-stdin.js";
 
-interface ReadOptions {
+const readersDir = (): string => path.dirname(fileURLToPath(import.meta.url));
+
+interface PullOptions {
   dir: string;
-  wait?: string;
+  wait: string;
   limit: string;
   maxAge: string;
+  textOnly?: boolean;
   all?: boolean;
 }
 
 const fail = (message: string): never => {
-  process.stderr.write(`react-grab read: ${message}\n`);
+  process.stderr.write(`react-grab pull: ${message}\n`);
   process.exit(1);
 };
 
@@ -30,23 +36,28 @@ const emitAndExit = (lines: string[]): void => {
   process.stdout.write(`${lines.join("\n")}\n`, () => process.exit(0));
 };
 
-export const read = new Command()
-  .name("read")
-  .description("print React Grab selections captured since the last read, then advance the cursor")
-  .option("-d, --dir <dir>", "work dir holding history.jsonl + cursor.txt", DEFAULT_WATCH_DIR)
-  .option("-w, --wait <ms>", "block up to <ms> (or 'infinite') for a new grab (default: no wait)")
+export const pull = new Command()
+  .name("pull")
+  .description("start the watcher if needed, then wait for and print the next React Grab selection")
+  .option("-d, --dir <dir>", "work dir for history.jsonl + watch.pid", DEFAULT_WATCH_DIR)
+  .option(
+    "-w, --wait <ms>",
+    "how long to wait for a grab: ms, 'infinite', or 0 for none",
+    "infinite",
+  )
   .option(
     "-n, --limit <count>",
-    "max grabs to print per call (0 = no limit); the cursor only advances past what is printed",
+    "max grabs to print per call (0 = no limit)",
     String(READ_DEFAULT_LIMIT),
   )
   .option(
     "--max-age <ms>",
-    "skip grabs captured longer ago than <ms> (0 = never evict)",
+    "skip grabs captured longer ago than <ms> (0 = never)",
     String(DEFAULT_GRAB_AGE_MS),
   )
-  .option("--all", "print the entire history without advancing the cursor")
-  .action(async (options: ReadOptions) => {
+  .option("--text-only", "watcher uses the plain-text clipboard reader")
+  .option("--all", "print the whole history without advancing the cursor")
+  .action(async (options: PullOptions) => {
     const dir = path.resolve(options.dir);
 
     try {
@@ -54,8 +65,6 @@ export const read = new Command()
     } catch (error) {
       fail(String((error as Error)?.message ?? error));
     }
-
-    unrefStdin();
 
     const waitMs = parseWaitMs(options.wait);
     if (waitMs === null) fail(`invalid --wait "${options.wait}" (use milliseconds or "infinite")`);
@@ -66,6 +75,15 @@ export const read = new Command()
       fail(`invalid --max-age "${options.maxAge}" (use milliseconds, 0 to disable)`);
 
     const all = Boolean(options.all);
+    const textOnly = Boolean(options.textOnly);
+
+    if (!isDaemonRunning(dir)) {
+      if (!createReader({ textOnly, readersDir: readersDir(), workDir: dir }))
+        fail(NO_READER_MESSAGE);
+      spawnDaemon({ dir, intervalMs: DEFAULT_WATCH_INTERVAL_MS, textOnly, replayLast: false });
+    }
+
+    unrefStdin();
     const consume = (): string[] => consumeGrabs(dir, { limit, all, maxAgeMs });
 
     const first = consume();

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -1,7 +1,6 @@
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { Command } from "commander";
-import { NO_READER_MESSAGE, createReader, prepareWorkDir } from "../utils/clipboard.js";
+import { NO_READER_MESSAGE, prepareWorkDir } from "../utils/clipboard.js";
 import {
   DEFAULT_GRAB_AGE_MS,
   DEFAULT_WATCH_DIR,
@@ -9,13 +8,11 @@ import {
   READ_DEFAULT_LIMIT,
   READ_WAIT_POLL_MS,
 } from "../utils/constants.js";
-import { isDaemonRunning, spawnDaemon } from "../utils/daemon.js";
+import { ensureDaemon } from "../utils/daemon.js";
 import { consumeGrabs } from "../utils/grab-log.js";
-import { parseGrabCount, parseWaitMs } from "../utils/read-args.js";
+import { parseNonNegativeInt, parseWaitMs } from "../utils/read-args.js";
 import { sleep } from "../utils/sleep.js";
 import { unrefStdin } from "../utils/unref-stdin.js";
-
-const readersDir = (): string => path.dirname(fileURLToPath(import.meta.url));
 
 interface PullOptions {
   dir: string;
@@ -38,7 +35,7 @@ const emitAndExit = (lines: string[]): void => {
 
 export const pull = new Command()
   .name("pull")
-  .description("start the watcher if needed, then wait for and print the next React Grab selection")
+  .description("start the watcher if needed, then wait for and print the next React Grab grab(s)")
   .option("-d, --dir <dir>", "work dir for history.jsonl + watch.pid", DEFAULT_WATCH_DIR)
   .option(
     "-w, --wait <ms>",
@@ -55,7 +52,10 @@ export const pull = new Command()
     "skip grabs captured longer ago than <ms> (0 = never)",
     String(DEFAULT_GRAB_AGE_MS),
   )
-  .option("--text-only", "watcher uses the plain-text clipboard reader")
+  .option(
+    "--text-only",
+    "watcher uses the plain-text clipboard reader (ignored if already running)",
+  )
   .option("--all", "print the whole history without advancing the cursor")
   .action(async (options: PullOptions) => {
     const dir = path.resolve(options.dir);
@@ -68,19 +68,20 @@ export const pull = new Command()
 
     const waitMs = parseWaitMs(options.wait);
     if (waitMs === null) fail(`invalid --wait "${options.wait}" (use milliseconds or "infinite")`);
-    const limit = parseGrabCount(options.limit);
+    const limit = parseNonNegativeInt(options.limit);
     if (limit === null) fail(`invalid --limit "${options.limit}" (use a non-negative integer)`);
-    const maxAgeMs = parseGrabCount(options.maxAge);
+    const maxAgeMs = parseNonNegativeInt(options.maxAge);
     if (maxAgeMs === null)
       fail(`invalid --max-age "${options.maxAge}" (use milliseconds, 0 to disable)`);
 
     const all = Boolean(options.all);
     const textOnly = Boolean(options.textOnly);
 
-    if (!isDaemonRunning(dir)) {
-      if (!createReader({ textOnly, readersDir: readersDir(), workDir: dir }))
-        fail(NO_READER_MESSAGE);
-      spawnDaemon({ dir, intervalMs: DEFAULT_WATCH_INTERVAL_MS, textOnly, replayLast: false });
+    if (
+      ensureDaemon({ dir, intervalMs: DEFAULT_WATCH_INTERVAL_MS, textOnly, replayLast: false }) ===
+      "no-reader"
+    ) {
+      fail(NO_READER_MESSAGE);
     }
 
     unrefStdin();

--- a/packages/cli/src/commands/read.ts
+++ b/packages/cli/src/commands/read.ts
@@ -25,8 +25,7 @@ const fail = (message: string): never => {
   process.exit(1);
 };
 
-// Writes the grabs to stdout and exits only once they have flushed — a plain
-// process.exit() right after a write can truncate large output on a pipe.
+// Exit only after the write flushes; process.exit() mid-write can truncate a pipe.
 const emitAndExit = (lines: string[]): void => {
   process.stdout.write(`${lines.join("\n")}\n`, () => process.exit(0));
 };

--- a/packages/cli/src/commands/read.ts
+++ b/packages/cli/src/commands/read.ts
@@ -2,12 +2,13 @@ import path from "node:path";
 import { Command } from "commander";
 import { prepareWorkDir } from "../utils/clipboard.js";
 import {
+  DEFAULT_GRAB_AGE_MS,
   DEFAULT_WATCH_DIR,
-  MAX_GRAB_AGE_MS,
   READ_DEFAULT_LIMIT,
   READ_WAIT_POLL_MS,
 } from "../utils/constants.js";
 import { consumeGrabs } from "../utils/grab-log.js";
+import { parseGrabCount, parseWaitMs } from "../utils/read-args.js";
 import { sleep } from "../utils/sleep.js";
 import { unrefStdin } from "../utils/unref-stdin.js";
 
@@ -19,18 +20,15 @@ interface ReadOptions {
   all?: boolean;
 }
 
-// Accepts a millisecond count or "infinite"/"inf"/"forever"; anything else (or
-// non-positive) means no wait.
-const parseWaitMs = (raw: string | undefined): number => {
-  if (!raw) return 0;
-  if (/^(inf|infinite|forever)$/i.test(raw.trim())) return Number.POSITIVE_INFINITY;
-  const ms = Number(raw);
-  return Number.isFinite(ms) && ms > 0 ? ms : 0;
+const fail = (message: string): never => {
+  process.stderr.write(`react-grab read: ${message}\n`);
+  process.exit(1);
 };
 
-const parseNonNegativeInt = (raw: string, fallback: number): number => {
-  const value = Number(raw);
-  return Number.isInteger(value) && value >= 0 ? value : fallback;
+// Writes the grabs to stdout and exits only once they have flushed — a plain
+// process.exit() right after a write can truncate large output on a pipe.
+const emitAndExit = (lines: string[]): void => {
+  process.stdout.write(`${lines.join("\n")}\n`, () => process.exit(0));
 };
 
 export const read = new Command()
@@ -46,7 +44,7 @@ export const read = new Command()
   .option(
     "--max-age <ms>",
     "skip grabs captured longer ago than <ms> (0 = never evict)",
-    String(MAX_GRAB_AGE_MS),
+    String(DEFAULT_GRAB_AGE_MS),
   )
   .option("--all", "print the entire history without advancing the cursor")
   .action(async (options: ReadOptions) => {
@@ -55,30 +53,36 @@ export const read = new Command()
     try {
       prepareWorkDir(dir);
     } catch (error) {
-      process.stderr.write(`react-grab read: ${String((error as Error)?.message ?? error)}\n`);
-      process.exit(1);
+      fail(String((error as Error)?.message ?? error));
     }
 
     unrefStdin();
 
-    const limit = parseNonNegativeInt(options.limit, READ_DEFAULT_LIMIT);
-    const maxAgeMs = parseNonNegativeInt(options.maxAge, MAX_GRAB_AGE_MS);
-    const all = Boolean(options.all);
-
-    const drain = (): number => {
-      const fresh = consumeGrabs(dir, { limit, all, maxAgeMs });
-      if (fresh.length > 0) process.stdout.write(`${fresh.join("\n")}\n`);
-      return fresh.length;
-    };
-
     const waitMs = parseWaitMs(options.wait);
-    const deadline =
-      waitMs === Number.POSITIVE_INFINITY ? Number.POSITIVE_INFINITY : Date.now() + waitMs;
+    if (waitMs === null) fail(`invalid --wait "${options.wait}" (use milliseconds or "infinite")`);
+    const limit = parseGrabCount(options.limit);
+    if (limit === null) fail(`invalid --limit "${options.limit}" (use a non-negative integer)`);
+    const maxAgeMs = parseGrabCount(options.maxAge);
+    if (maxAgeMs === null)
+      fail(`invalid --max-age "${options.maxAge}" (use milliseconds, 0 to disable)`);
 
-    if (drain() > 0) process.exit(0);
+    const all = Boolean(options.all);
+    const consume = (): string[] => consumeGrabs(dir, { limit, all, maxAgeMs });
+
+    const first = consume();
+    if (first.length > 0) {
+      emitAndExit(first);
+      return;
+    }
+
+    const deadline = Date.now() + waitMs;
     while (Date.now() < deadline) {
       await sleep(READ_WAIT_POLL_MS);
-      if (drain() > 0) break;
+      const batch = consume();
+      if (batch.length > 0) {
+        emitAndExit(batch);
+        return;
+      }
     }
     process.exit(0);
   });

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import { Command } from "commander";
 import pc from "picocolors";
 import { handleError } from "../utils/handle-error.js";
@@ -10,13 +11,15 @@ const VERSION = process.env.VERSION ?? "0.0.1";
 export const remove = new Command()
   .name("remove")
   .description("uninstall the React Grab skill from your agent")
-  .action(async () => {
+  .option("-c, --cwd <cwd>", "working directory (defaults to current directory)", process.cwd())
+  .option("-g, --global", "remove the globally-installed skill instead of the project's", false)
+  .action(async (opts) => {
     console.log(`${pc.magenta("✿")} ${pc.bold("React Grab")} ${pc.gray(VERSION)}`);
     console.log();
 
     try {
       logger.break();
-      const removedCount = await removeSkill();
+      const removedCount = await removeSkill({ cwd: resolve(opts.cwd), global: opts.global });
 
       logger.break();
       if (removedCount === 0) {

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -1,0 +1,19 @@
+import path from "node:path";
+import { Command } from "commander";
+import { DEFAULT_WATCH_DIR } from "../utils/constants.js";
+import { stopDaemon } from "../utils/daemon.js";
+
+export const stop = new Command()
+  .name("stop")
+  .description("stop the React Grab watcher for this dir")
+  .option("-d, --dir <dir>", "work dir holding watch.pid", DEFAULT_WATCH_DIR)
+  .action((options: { dir: string }) => {
+    const dir = path.resolve(options.dir);
+    const stoppedPid = stopDaemon(dir);
+    process.stderr.write(
+      stoppedPid
+        ? `react-grab stop: stopped watcher (pid ${stoppedPid})\n`
+        : `react-grab stop: no watcher running for ${dir}\n`,
+    );
+    process.exit(0);
+  });

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from "node:url";
 import { Command } from "commander";
 import {
   HISTORY_FILE_NAME,
+  NO_READER_MESSAGE,
   createReader,
   prepareWorkDir,
   runWatchLoop,
@@ -29,9 +30,6 @@ interface WatchOptions {
   foreground?: boolean;
   stop?: boolean;
 }
-
-const NO_READER_MESSAGE =
-  "no clipboard reader available. Linux: install xclip or wl-clipboard. macOS: install Xcode CLI tools (swiftc) or rely on pbpaste. Windows: ensure PowerShell is on PATH.";
 
 const writeStatus = (message: string): void => {
   process.stderr.write(`react-grab watch: ${message}\n`);

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -1,5 +1,4 @@
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { Command } from "commander";
 import {
   HISTORY_FILE_NAME,
@@ -9,79 +8,34 @@ import {
   runWatchLoop,
 } from "../utils/clipboard.js";
 import { DEFAULT_WATCH_DIR, DEFAULT_WATCH_INTERVAL_MS } from "../utils/constants.js";
-import {
-  claimDaemon,
-  isDaemonRunning,
-  readDaemonPid,
-  releaseDaemon,
-  spawnDaemon,
-  stopDaemon,
-} from "../utils/daemon.js";
-
-// Native readers (read-clipboard.swift / .ps1) are copied next to the compiled
-// CLI at build time (see scripts/copy-native-readers.mjs).
-const readersDir = (): string => path.dirname(fileURLToPath(import.meta.url));
+import { claimDaemon, releaseDaemon } from "../utils/daemon.js";
 
 interface WatchOptions {
   dir: string;
   interval: string;
   textOnly?: boolean;
   replayLast?: boolean;
-  foreground?: boolean;
-  stop?: boolean;
 }
 
 const writeStatus = (message: string): void => {
   process.stderr.write(`react-grab watch: ${message}\n`);
 };
 
-const runForeground = (
-  dir: string,
-  intervalMs: number,
-  textOnly: boolean,
-  replayLast: boolean,
-): void => {
-  if (!claimDaemon(dir)) process.exit(0);
-  process.on("exit", () => releaseDaemon(dir));
-
-  const reader = createReader({ textOnly, readersDir: readersDir(), workDir: dir });
-  if (!reader) {
-    writeStatus(NO_READER_MESSAGE);
-    process.exit(1);
-  }
-
-  writeStatus(
-    `watching clipboard via ${reader.mode}; history → ${path.join(dir, HISTORY_FILE_NAME)}`,
-  );
-
-  runWatchLoop({
-    reader,
-    dir,
-    intervalMs,
-    replayLast,
-    onWarn: writeStatus,
-  }).catch((error) => {
-    writeStatus(String((error as Error)?.message ?? error));
-    process.exit(1);
-  });
-};
-
+// The capture-daemon body that `pull` re-execs detached. Claims the per-dir lock
+// (exits quietly if another daemon already owns it), then polls the clipboard
+// into history.jsonl until the process is killed.
 export const watch = new Command()
   .name("watch")
-  .description("start a background daemon that captures React Grab selections to history.jsonl")
+  .description("run the React Grab capture daemon in the foreground (used internally by `pull`)")
   .option("-d, --dir <dir>", "work dir for history.jsonl + watch.pid", DEFAULT_WATCH_DIR)
   .option("-i, --interval <ms>", "clipboard poll interval in ms", String(DEFAULT_WATCH_INTERVAL_MS))
   .option("--text-only", "skip the native reader and use the plain-text fallback")
   .option("--replay-last", "also capture the grab already on the clipboard at startup")
-  .option("--foreground", "run the capture loop in this process instead of detaching a daemon")
-  .option("--stop", "stop the daemon watching this dir")
   .action((options: WatchOptions) => {
     const dir = path.resolve(options.dir);
     const intervalRaw = Number(options.interval);
     const intervalMs =
       Number.isFinite(intervalRaw) && intervalRaw > 0 ? intervalRaw : DEFAULT_WATCH_INTERVAL_MS;
-    const textOnly = Boolean(options.textOnly);
-    const replayLast = Boolean(options.replayLast);
 
     try {
       prepareWorkDir(dir);
@@ -90,35 +44,27 @@ export const watch = new Command()
       process.exit(1);
     }
 
-    if (options.stop) {
-      const stoppedPid = stopDaemon(dir);
-      writeStatus(
-        stoppedPid ? `stopped daemon (pid ${stoppedPid})` : `no daemon running for ${dir}`,
-      );
-      process.exit(0);
-    }
+    if (!claimDaemon(dir)) process.exit(0);
+    process.on("exit", () => releaseDaemon(dir));
 
-    if (options.foreground) {
-      runForeground(dir, intervalMs, textOnly, replayLast);
-      return;
-    }
-
-    if (isDaemonRunning(dir)) {
-      writeStatus(`already watching ${dir} (pid ${readDaemonPid(dir)})`);
-      process.exit(0);
-    }
-
-    // Validate the reader here so a missing one surfaces to the caller: the
-    // detached daemon's stderr is discarded, so it would otherwise fail
-    // invisibly after the launcher already reported success.
-    if (!createReader({ textOnly, readersDir: readersDir(), workDir: dir })) {
+    const reader = createReader({ textOnly: Boolean(options.textOnly), workDir: dir });
+    if (!reader) {
       writeStatus(NO_READER_MESSAGE);
       process.exit(1);
     }
 
-    spawnDaemon({ dir, intervalMs, textOnly, replayLast });
     writeStatus(
-      `started; capturing grabs → ${path.join(dir, HISTORY_FILE_NAME)} (run \`grab read\` to consume, \`grab watch --stop\` to stop)`,
+      `watching clipboard via ${reader.mode}; history → ${path.join(dir, HISTORY_FILE_NAME)}`,
     );
-    process.exit(0);
+
+    runWatchLoop({
+      reader,
+      dir,
+      intervalMs,
+      replayLast: Boolean(options.replayLast),
+      onWarn: writeStatus,
+    }).catch((error) => {
+      writeStatus(String((error as Error)?.message ?? error));
+      process.exit(1);
+    });
   });

--- a/packages/cli/src/utils/clipboard.ts
+++ b/packages/cli/src/utils/clipboard.ts
@@ -2,12 +2,17 @@ import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { sleep } from "./sleep.js";
 
 export const HISTORY_FILE_NAME = "history.jsonl";
 
 export const NO_READER_MESSAGE =
   "no clipboard reader available. Linux: install xclip or wl-clipboard. macOS: install Xcode CLI tools (swiftc) or rely on pbpaste. Windows: ensure PowerShell is on PATH.";
+
+// Native readers (read-clipboard.swift / .ps1) are copied next to the compiled
+// CLI at build time (see scripts/copy-native-readers.mjs).
+const READERS_DIR = path.dirname(fileURLToPath(import.meta.url));
 
 const READ_TIMEOUT_MS = 2500;
 const MAX_CLIPBOARD_BYTES = 64 * 1024 * 1024;
@@ -78,8 +83,6 @@ interface LinuxTool {
 
 interface CreateReaderOptions {
   textOnly: boolean;
-  // Directory holding the native reader sources (read-clipboard.swift / .ps1).
-  readersDir: string;
   // Writable directory for the compiled native binary (e.g. macOS `pbread`).
   workDir: string;
 }
@@ -195,7 +198,7 @@ const compileSwiftReader = (readersDir: string, workDir: string): string | null 
 };
 
 const createDarwinReader = (options: CreateReaderOptions): ClipboardReader | null => {
-  const binary = options.textOnly ? null : compileSwiftReader(options.readersDir, options.workDir);
+  const binary = options.textOnly ? null : compileSwiftReader(READERS_DIR, options.workDir);
   if (binary) {
     return {
       mode: "darwin-native",
@@ -270,7 +273,7 @@ const detectPowershell = (): string | null =>
 const createWindowsReader = (options: CreateReaderOptions): ClipboardReader | null => {
   const shell = detectPowershell();
   if (!shell) return null;
-  const scriptPath = path.join(options.readersDir, "read-clipboard.ps1");
+  const scriptPath = path.join(READERS_DIR, "read-clipboard.ps1");
   if (options.textOnly || !fs.existsSync(scriptPath)) {
     return {
       mode: "win-text",

--- a/packages/cli/src/utils/clipboard.ts
+++ b/packages/cli/src/utils/clipboard.ts
@@ -6,6 +6,9 @@ import { sleep } from "./sleep.js";
 
 export const HISTORY_FILE_NAME = "history.jsonl";
 
+export const NO_READER_MESSAGE =
+  "no clipboard reader available. Linux: install xclip or wl-clipboard. macOS: install Xcode CLI tools (swiftc) or rely on pbpaste. Windows: ensure PowerShell is on PATH.";
+
 const READ_TIMEOUT_MS = 2500;
 const MAX_CLIPBOARD_BYTES = 64 * 1024 * 1024;
 const ID_RADIX = 36;

--- a/packages/cli/src/utils/constants.ts
+++ b/packages/cli/src/utils/constants.ts
@@ -8,7 +8,6 @@ export const READ_WAIT_POLL_MS = 200;
 export const DAEMON_CLAIM_MAX_ATTEMPTS = 50;
 export const READ_DEFAULT_LIMIT = 50;
 export const DEFAULT_GRAB_AGE_MS = 5 * 60 * 1000;
-// Caps how many bytes a single `read` pulls from history.jsonl so one call never
-// materializes a huge string (V8's max is ~512 MB); a large backlog drains across
-// calls instead. Must exceed the largest possible single grab line.
+// A single read must never build a >512 MB string (V8's cap); a bigger backlog
+// drains across calls. Must exceed the largest single grab line.
 export const MAX_READ_HISTORY_BYTES = 128 * 1024 * 1024;

--- a/packages/cli/src/utils/constants.ts
+++ b/packages/cli/src/utils/constants.ts
@@ -7,4 +7,8 @@ export const DEFAULT_WATCH_INTERVAL_MS = 800;
 export const READ_WAIT_POLL_MS = 200;
 export const DAEMON_CLAIM_MAX_ATTEMPTS = 50;
 export const READ_DEFAULT_LIMIT = 50;
-export const MAX_GRAB_AGE_MS = 5 * 60 * 1000;
+export const DEFAULT_GRAB_AGE_MS = 5 * 60 * 1000;
+// Caps how many bytes a single `read` pulls from history.jsonl so one call never
+// materializes a huge string (V8's max is ~512 MB); a large backlog drains across
+// calls instead. Must exceed the largest possible single grab line.
+export const MAX_READ_HISTORY_BYTES = 128 * 1024 * 1024;

--- a/packages/cli/src/utils/constants.ts
+++ b/packages/cli/src/utils/constants.ts
@@ -11,3 +11,7 @@ export const DEFAULT_GRAB_AGE_MS = 5 * 60 * 1000;
 // A single read must never build a >512 MB string (V8's cap); a bigger backlog
 // drains across calls. Must exceed the largest single grab line.
 export const MAX_READ_HISTORY_BYTES = 128 * 1024 * 1024;
+
+// Buffer size for the legacy-cursor migration's chunked newline scan, which
+// counts newline bytes without materializing the whole history as a string.
+export const MIGRATION_SCAN_CHUNK_BYTES = 1024 * 1024;

--- a/packages/cli/src/utils/daemon.ts
+++ b/packages/cli/src/utils/daemon.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { createReader } from "./clipboard.js";
 import { DAEMON_CLAIM_MAX_ATTEMPTS } from "./constants.js";
 
 const PID_FILE_NAME = "watch.pid";
@@ -88,20 +89,19 @@ export const stopDaemon = (dir: string): number | null => {
   return wasAlive ? pid : null;
 };
 
-interface SpawnDaemonOptions {
+interface EnsureDaemonOptions {
   dir: string;
   intervalMs: number;
   textOnly: boolean;
   replayLast: boolean;
 }
 
-// Detached + unref'd so the launcher can exit immediately while the daemon keeps
-// running in the background.
-export const spawnDaemon = (options: SpawnDaemonOptions): void => {
+// Detached + unref'd so the caller exits immediately while the daemon keeps
+// running. Re-execs the hidden `watch` command, which is the capture-daemon body.
+const spawnDaemon = (options: EnsureDaemonOptions): void => {
   const args = [
     cliEntryPath(),
     "watch",
-    "--foreground",
     "--dir",
     options.dir,
     "--interval",
@@ -115,4 +115,16 @@ export const spawnDaemon = (options: SpawnDaemonOptions): void => {
     windowsHide: true,
   });
   child.unref();
+};
+
+export type EnsureDaemonResult = "already-running" | "started" | "no-reader";
+
+// Starts the capture daemon if one isn't already watching `dir`. Validates the
+// clipboard reader first: the detached daemon's stderr is discarded, so a missing
+// reader would otherwise fail invisibly.
+export const ensureDaemon = (options: EnsureDaemonOptions): EnsureDaemonResult => {
+  if (isDaemonRunning(options.dir)) return "already-running";
+  if (!createReader({ textOnly: options.textOnly, workDir: options.dir })) return "no-reader";
+  spawnDaemon(options);
+  return "started";
 };

--- a/packages/cli/src/utils/grab-log.ts
+++ b/packages/cli/src/utils/grab-log.ts
@@ -45,7 +45,10 @@ const byteOffsetAfterLines = (dir: string, lineCount: number): number => {
   let seen = 0;
   while (seen < lineCount) {
     const newlineIndex = raw.indexOf("\n", index);
-    if (newlineIndex < 0) return Buffer.byteLength(raw, "utf8");
+    // The Nth line is past the scan window (huge history) or doesn't exist (the
+    // history has fewer lines): baseline at EOF rather than re-delivering from the
+    // window boundary.
+    if (newlineIndex < 0) return size;
     index = newlineIndex + 1;
     seen += 1;
   }

--- a/packages/cli/src/utils/grab-log.ts
+++ b/packages/cli/src/utils/grab-log.ts
@@ -79,7 +79,12 @@ export const consumeGrabs = (dir: string, options: ConsumeGrabsOptions): string[
   const cursor = readGrabCursor(dir);
   // A cursor past EOF means the history was truncated/rotated under us; restart.
   const start = cursor > size ? 0 : cursor;
-  if (start >= size) return [];
+  if (start >= size) {
+    // Persist a truncation reset even with nothing to read, or a later-grown file
+    // would be read from the stale offset and skip its leading records.
+    if (start !== cursor) writeGrabCursor(dir, start);
+    return [];
+  }
 
   const chunk = readHistoryRange(dir, start, Math.min(size - start, MAX_READ_HISTORY_BYTES));
   const lastNewline = chunk.lastIndexOf("\n");

--- a/packages/cli/src/utils/grab-log.ts
+++ b/packages/cli/src/utils/grab-log.ts
@@ -1,27 +1,24 @@
 import fs from "node:fs";
 import path from "node:path";
 import { HISTORY_FILE_NAME } from "./clipboard.js";
+import { MAX_READ_HISTORY_BYTES } from "./constants.js";
 
 const CURSOR_FILE_NAME = "cursor.txt";
 
 const cursorFilePath = (dir: string): string => path.join(dir, CURSOR_FILE_NAME);
+const historyFilePath = (dir: string): string => path.join(dir, HISTORY_FILE_NAME);
 
-// Returns only complete (newline-terminated) records. Each grab is appended as a
-// single JSON line ending in "\n", but a large grab is not one atomic write, so
-// a concurrent reader can observe a half-written final line. Everything after
-// the last newline is treated as an in-progress append and skipped until done.
-export const readCompleteGrabLines = (dir: string): string[] => {
-  let raw: string;
+const fileSize = (filePath: string): number => {
   try {
-    raw = fs.readFileSync(path.join(dir, HISTORY_FILE_NAME), "utf8");
+    return fs.statSync(filePath).size;
   } catch {
-    return [];
+    return 0;
   }
-  const lastNewline = raw.lastIndexOf("\n");
-  if (lastNewline < 0) return [];
-  return raw.slice(0, lastNewline).split("\n").filter(Boolean);
 };
 
+// Byte offset into history.jsonl, not a line index: the file is append-only and
+// never compacted, so a byte offset lets a poll detect "nothing new" by size in
+// O(1) and read only the unconsumed tail.
 export const readGrabCursor = (dir: string): number => {
   try {
     const value = Number.parseInt(fs.readFileSync(cursorFilePath(dir), "utf8").trim(), 10);
@@ -31,46 +28,88 @@ export const readGrabCursor = (dir: string): number => {
   }
 };
 
-const grabReceivedAt = (line: string): number | null => {
+// Atomic via temp + rename so a crash mid-write can't leave a truncated cursor
+// (which would replay the whole history).
+const writeGrabCursor = (dir: string, offset: number): void => {
+  const target = cursorFilePath(dir);
+  const tempPath = `${target}.${process.pid}.tmp`;
+  fs.writeFileSync(tempPath, String(offset));
+  fs.renameSync(tempPath, target);
+};
+
+const readHistoryRange = (dir: string, start: number, length: number): string => {
+  if (length <= 0) return "";
+  const fd = fs.openSync(historyFilePath(dir), "r");
   try {
-    const value = (JSON.parse(line) as { receivedAt?: unknown }).receivedAt;
-    return typeof value === "number" ? value : null;
-  } catch {
-    return null;
+    const buffer = Buffer.allocUnsafe(length);
+    const bytesRead = fs.readSync(fd, buffer, 0, length, start);
+    return buffer.toString("utf8", 0, bytesRead);
+  } finally {
+    fs.closeSync(fd);
   }
+};
+
+// Whole-history read for `--all`; the cursor path reads incrementally instead.
+export const readCompleteGrabLines = (dir: string): string[] => {
+  const size = fileSize(historyFilePath(dir));
+  if (size === 0) return [];
+  const raw = readHistoryRange(dir, 0, size);
+  const lastNewline = raw.lastIndexOf("\n");
+  if (lastNewline < 0) return [];
+  return raw.slice(0, lastNewline).split("\n").filter(Boolean);
 };
 
 interface ConsumeGrabsOptions {
   limit: number;
   all: boolean;
-  // Grabs captured longer ago than this are stale and skipped (cursor still
-  // advances past them). 0 disables eviction. Records without a parseable
+  // Grabs captured longer ago than this are stale and skipped (the cursor still
+  // advances past them). 0 disables eviction. Records without a numeric
   // receivedAt are never evicted.
-  maxAgeMs?: number;
+  maxAgeMs: number;
 }
 
-// Advances the cursor only past what it examines, so a backlog drains across
-// calls without dropping any and stale grabs are evicted rather than delivered.
-// `all` replays everything without touching the cursor. Rewriting the cursor only
-// when it moves also self-heals one left past the end by a truncated history.
+// Reads only the unconsumed tail (capped at MAX_READ_HISTORY_BYTES; a larger
+// backlog drains over several calls) and advances the cursor past every record it
+// examines, so stale/skipped records are never re-seen. `all` replays the whole
+// history without moving the cursor.
 export const consumeGrabs = (dir: string, options: ConsumeGrabsOptions): string[] => {
-  const lines = readCompleteGrabLines(dir);
-  if (options.all) return lines;
-  const maxAgeMs = options.maxAgeMs ?? 0;
+  if (options.all) return readCompleteGrabLines(dir);
+
+  const size = fileSize(historyFilePath(dir));
   const cursor = readGrabCursor(dir);
-  const total = lines.length;
+  // A cursor past EOF means the history was truncated/rotated under us; restart.
+  const start = cursor > size ? 0 : cursor;
+  if (start >= size) return [];
+
+  const chunk = readHistoryRange(dir, start, Math.min(size - start, MAX_READ_HISTORY_BYTES));
+  const lastNewline = chunk.lastIndexOf("\n");
+  if (lastNewline < 0) return [];
+
   const now = Date.now();
   const fresh: string[] = [];
-  let index = Math.min(cursor, total);
-  while (index < total && (options.limit <= 0 || fresh.length < options.limit)) {
-    const line = lines[index];
-    index += 1;
-    if (maxAgeMs > 0) {
-      const receivedAt = grabReceivedAt(line);
-      if (receivedAt !== null && now - receivedAt > maxAgeMs) continue;
+  let consumedBytes = 0;
+  let lineStart = 0;
+  while (lineStart <= lastNewline && (options.limit <= 0 || fresh.length < options.limit)) {
+    const newlineIndex = chunk.indexOf("\n", lineStart);
+    const line = chunk.slice(lineStart, newlineIndex);
+    consumedBytes += Buffer.byteLength(chunk.slice(lineStart, newlineIndex + 1), "utf8");
+    lineStart = newlineIndex + 1;
+    if (line.length === 0) continue;
+    let parsed: { receivedAt?: unknown };
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      // Corrupt line, or a mid-line fragment from an old line-index cursor read
+      // as a byte offset; skip it (the cursor still advances past it).
+      continue;
+    }
+    if (options.maxAgeMs > 0 && typeof parsed.receivedAt === "number") {
+      if (now - parsed.receivedAt > options.maxAgeMs) continue;
     }
     fresh.push(line);
   }
-  if (index !== cursor) fs.writeFileSync(cursorFilePath(dir), String(index));
+
+  const nextCursor = start + consumedBytes;
+  if (nextCursor !== cursor) writeGrabCursor(dir, nextCursor);
   return fresh;
 };

--- a/packages/cli/src/utils/grab-log.ts
+++ b/packages/cli/src/utils/grab-log.ts
@@ -1,9 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { HISTORY_FILE_NAME } from "./clipboard.js";
-import { MAX_READ_HISTORY_BYTES } from "./constants.js";
+import { MAX_READ_HISTORY_BYTES, MIGRATION_SCAN_CHUNK_BYTES } from "./constants.js";
 
 const CURSOR_FILE_NAME = "cursor.txt";
+const NEWLINE_BYTE = 0x0a;
 
 const cursorFilePath = (dir: string): string => path.join(dir, CURSOR_FILE_NAME);
 const historyFilePath = (dir: string): string => path.join(dir, HISTORY_FILE_NAME);
@@ -37,22 +38,34 @@ const writeGrabCursor = (dir: string, offset: number): void => {
   fs.renameSync(tempPath, target);
 };
 
+// Exact byte offset after `lineCount` newlines, scanned in bounded chunks so a
+// huge legacy history neither materializes a >512 MB string nor clamps to a scan
+// window (which would re-deliver or drop records on migration). `\n` (0x0A) never
+// occurs inside a multi-byte UTF-8 sequence, so counting bytes is correct.
 const byteOffsetAfterLines = (dir: string, lineCount: number): number => {
-  const size = fileSize(historyFilePath(dir));
+  const filePath = historyFilePath(dir);
+  const size = fileSize(filePath);
   if (lineCount <= 0 || size === 0) return 0;
-  const raw = readHistoryRange(dir, 0, Math.min(size, MAX_READ_HISTORY_BYTES));
-  let index = 0;
-  let seen = 0;
-  while (seen < lineCount) {
-    const newlineIndex = raw.indexOf("\n", index);
-    // The Nth line is past the scan window (huge history) or doesn't exist (the
-    // history has fewer lines): baseline at EOF rather than re-delivering from the
-    // window boundary.
-    if (newlineIndex < 0) return size;
-    index = newlineIndex + 1;
-    seen += 1;
+  const fd = fs.openSync(filePath, "r");
+  try {
+    const buffer = Buffer.allocUnsafe(MIGRATION_SCAN_CHUNK_BYTES);
+    let position = 0;
+    let seen = 0;
+    while (position < size) {
+      const bytesRead = fs.readSync(fd, buffer, 0, MIGRATION_SCAN_CHUNK_BYTES, position);
+      if (bytesRead <= 0) break;
+      for (let index = 0; index < bytesRead; index += 1) {
+        if (buffer[index] !== NEWLINE_BYTE) continue;
+        seen += 1;
+        if (seen === lineCount) return position + index + 1;
+      }
+      position += bytesRead;
+    }
+  } finally {
+    fs.closeSync(fd);
   }
-  return Buffer.byteLength(raw.slice(0, index), "utf8");
+  // Fewer than lineCount complete lines exist; the legacy cursor consumed all of them.
+  return size;
 };
 
 // Byte offset into history.jsonl (not a line index), so an idle poll can tell

--- a/packages/cli/src/utils/grab-log.ts
+++ b/packages/cli/src/utils/grab-log.ts
@@ -16,9 +16,8 @@ const fileSize = (filePath: string): number => {
   }
 };
 
-// Byte offset into history.jsonl, not a line index: the file is append-only and
-// never compacted, so a byte offset lets a poll detect "nothing new" by size in
-// O(1) and read only the unconsumed tail.
+// Byte offset into history.jsonl (not a line index), so an idle poll can tell
+// "nothing new" from the file size without reading.
 export const readGrabCursor = (dir: string): number => {
   try {
     const value = Number.parseInt(fs.readFileSync(cursorFilePath(dir), "utf8").trim(), 10);
@@ -28,8 +27,7 @@ export const readGrabCursor = (dir: string): number => {
   }
 };
 
-// Atomic via temp + rename so a crash mid-write can't leave a truncated cursor
-// (which would replay the whole history).
+// temp + rename so a crash mid-write can't leave a truncated cursor.
 const writeGrabCursor = (dir: string, offset: number): void => {
   const target = cursorFilePath(dir);
   const tempPath = `${target}.${process.pid}.tmp`;
@@ -49,7 +47,6 @@ const readHistoryRange = (dir: string, start: number, length: number): string =>
   }
 };
 
-// Whole-history read for `--all`; the cursor path reads incrementally instead.
 export const readCompleteGrabLines = (dir: string): string[] => {
   const size = fileSize(historyFilePath(dir));
   if (size === 0) return [];
@@ -62,16 +59,9 @@ export const readCompleteGrabLines = (dir: string): string[] => {
 interface ConsumeGrabsOptions {
   limit: number;
   all: boolean;
-  // Grabs captured longer ago than this are stale and skipped (the cursor still
-  // advances past them). 0 disables eviction. Records without a numeric
-  // receivedAt are never evicted.
   maxAgeMs: number;
 }
 
-// Reads only the unconsumed tail (capped at MAX_READ_HISTORY_BYTES; a larger
-// backlog drains over several calls) and advances the cursor past every record it
-// examines, so stale/skipped records are never re-seen. `all` replays the whole
-// history without moving the cursor.
 export const consumeGrabs = (dir: string, options: ConsumeGrabsOptions): string[] => {
   if (options.all) return readCompleteGrabLines(dir);
 
@@ -80,8 +70,7 @@ export const consumeGrabs = (dir: string, options: ConsumeGrabsOptions): string[
   // A cursor past EOF means the history was truncated/rotated under us; restart.
   const start = cursor > size ? 0 : cursor;
   if (start >= size) {
-    // Persist a truncation reset even with nothing to read, or a later-grown file
-    // would be read from the stale offset and skip its leading records.
+    // Persist the reset, or a later-grown file would be read from the stale offset.
     if (start !== cursor) writeGrabCursor(dir, start);
     return [];
   }
@@ -104,8 +93,7 @@ export const consumeGrabs = (dir: string, options: ConsumeGrabsOptions): string[
     try {
       parsed = JSON.parse(line);
     } catch {
-      // Corrupt line, or a mid-line fragment from an old line-index cursor read
-      // as a byte offset; skip it (the cursor still advances past it).
+      // Corrupt, or a mid-line fragment from an old line-index cursor; skip it.
       continue;
     }
     if (options.maxAgeMs > 0 && typeof parsed.receivedAt === "number") {

--- a/packages/cli/src/utils/grab-log.ts
+++ b/packages/cli/src/utils/grab-log.ts
@@ -16,25 +16,6 @@ const fileSize = (filePath: string): number => {
   }
 };
 
-// Byte offset into history.jsonl (not a line index), so an idle poll can tell
-// "nothing new" from the file size without reading.
-export const readGrabCursor = (dir: string): number => {
-  try {
-    const value = Number.parseInt(fs.readFileSync(cursorFilePath(dir), "utf8").trim(), 10);
-    return Number.isInteger(value) && value >= 0 ? value : 0;
-  } catch {
-    return 0;
-  }
-};
-
-// temp + rename so a crash mid-write can't leave a truncated cursor.
-const writeGrabCursor = (dir: string, offset: number): void => {
-  const target = cursorFilePath(dir);
-  const tempPath = `${target}.${process.pid}.tmp`;
-  fs.writeFileSync(tempPath, String(offset));
-  fs.renameSync(tempPath, target);
-};
-
 const readHistoryRange = (dir: string, start: number, length: number): string => {
   if (length <= 0) return "";
   const fd = fs.openSync(historyFilePath(dir), "r");
@@ -45,6 +26,60 @@ const readHistoryRange = (dir: string, start: number, length: number): string =>
   } finally {
     fs.closeSync(fd);
   }
+};
+
+// temp + rename so a crash mid-write can't leave a truncated cursor. Tagged as
+// JSON so a legacy bare-integer (line-index) cursor is distinguishable on read.
+const writeGrabCursor = (dir: string, offset: number): void => {
+  const target = cursorFilePath(dir);
+  const tempPath = `${target}.${process.pid}.tmp`;
+  fs.writeFileSync(tempPath, JSON.stringify({ offset }));
+  fs.renameSync(tempPath, target);
+};
+
+const byteOffsetAfterLines = (dir: string, lineCount: number): number => {
+  const size = fileSize(historyFilePath(dir));
+  if (lineCount <= 0 || size === 0) return 0;
+  const raw = readHistoryRange(dir, 0, Math.min(size, MAX_READ_HISTORY_BYTES));
+  let index = 0;
+  let seen = 0;
+  while (seen < lineCount) {
+    const newlineIndex = raw.indexOf("\n", index);
+    if (newlineIndex < 0) return Buffer.byteLength(raw, "utf8");
+    index = newlineIndex + 1;
+    seen += 1;
+  }
+  return Buffer.byteLength(raw.slice(0, index), "utf8");
+};
+
+// Byte offset into history.jsonl (not a line index), so an idle poll can tell
+// "nothing new" from the file size without reading.
+export const readGrabCursor = (dir: string): number => {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(cursorFilePath(dir), "utf8").trim();
+  } catch {
+    return 0;
+  }
+  if (raw === "") return 0;
+  let parsed: { offset?: unknown } | number;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return 0;
+  }
+  if (typeof parsed === "number") {
+    // A bare integer is a legacy line-index cursor from before byte offsets.
+    // Convert it to the byte position after that many lines (and persist) so
+    // already-consumed grabs are not re-delivered after an upgrade.
+    if (!Number.isInteger(parsed) || parsed < 0) return 0;
+    const offset = byteOffsetAfterLines(dir, parsed);
+    writeGrabCursor(dir, offset);
+    return offset;
+  }
+  return typeof parsed.offset === "number" && Number.isInteger(parsed.offset) && parsed.offset >= 0
+    ? parsed.offset
+    : 0;
 };
 
 export const readCompleteGrabLines = (dir: string): string[] => {
@@ -93,7 +128,7 @@ export const consumeGrabs = (dir: string, options: ConsumeGrabsOptions): string[
     try {
       parsed = JSON.parse(line);
     } catch {
-      // Corrupt, or a mid-line fragment from an old line-index cursor; skip it.
+      // Corrupt or partial line; skip it (the cursor still advances past it).
       continue;
     }
     if (options.maxAgeMs > 0 && typeof parsed.receivedAt === "number") {

--- a/packages/cli/src/utils/install-skill.ts
+++ b/packages/cli/src/utils/install-skill.ts
@@ -92,20 +92,25 @@ export const promptSkillInstall = async ({
   return true;
 };
 
-// Removes the skill from both the project and the global locations so `remove`
-// cleans up regardless of where a past install (or version) put it.
-export const removeSkill = async (cwd: string = process.cwd()): Promise<number> => {
+interface RemoveSkillOptions {
+  cwd?: string;
+  global?: boolean;
+}
+
+// Scoped to the project (default) or global dirs, mirroring install — so `remove`
+// never deletes a deliberate global install just because it ran inside a project.
+export const removeSkill = async ({
+  cwd = process.cwd(),
+  global = false,
+}: RemoveSkillOptions = {}): Promise<number> => {
   const agents = await detectAvailableAgents();
   const removedAgents: SkillAgentType[] = [];
   const dirsToRemove = new Set<string>();
   for (const agent of agents) {
-    const present = [
-      installedSkillDir(agent, false, cwd),
-      installedSkillDir(agent, true, cwd),
-    ].filter((dir) => existsSync(dir));
-    if (present.length === 0) continue;
+    const skillDir = installedSkillDir(agent, global, cwd);
+    if (!existsSync(skillDir)) continue;
     removedAgents.push(agent);
-    for (const dir of present) dirsToRemove.add(dir);
+    dirsToRemove.add(skillDir);
   }
   for (const skillDir of dirsToRemove) {
     rmSync(skillDir, { recursive: true, force: true });

--- a/packages/cli/src/utils/install-skill.ts
+++ b/packages/cli/src/utils/install-skill.ts
@@ -35,8 +35,6 @@ const installedSkillDir = (agent: SkillAgentType, global: boolean, cwd: string):
 
 interface PromptSkillInstallOptions {
   yes?: boolean;
-  // Install into the user's home agent dirs instead of the project (default:
-  // project, so the skill is committable and lives beside the project's others).
   global?: boolean;
   cwd?: string;
 }
@@ -97,8 +95,8 @@ interface RemoveSkillOptions {
   global?: boolean;
 }
 
-// Scoped to the project (default) or global dirs, mirroring install — so `remove`
-// never deletes a deliberate global install just because it ran inside a project.
+// Scoped like install (project unless global) so it won't delete a global install
+// from inside an unrelated project.
 export const removeSkill = async ({
   cwd = process.cwd(),
   global = false,

--- a/packages/cli/src/utils/read-args.ts
+++ b/packages/cli/src/utils/read-args.ts
@@ -7,7 +7,7 @@ export const parseWaitMs = (raw: string | undefined): number | null => {
   return Number.isFinite(ms) && ms >= 0 ? ms : null;
 };
 
-export const parseGrabCount = (raw: string | undefined): number | null => {
+export const parseNonNegativeInt = (raw: string | undefined): number | null => {
   if (raw === undefined) return null;
   const trimmed = raw.trim();
   // Number("") and Number("  ") are 0, which would mask empty/garbage input.

--- a/packages/cli/src/utils/read-args.ts
+++ b/packages/cli/src/utils/read-args.ts
@@ -1,0 +1,20 @@
+// Returns null for unparseable input so the caller can reject it instead of
+// silently degrading to "no wait", which would break the read loop.
+export const parseWaitMs = (raw: string | undefined): number | null => {
+  if (raw === undefined) return 0;
+  const trimmed = raw.trim();
+  if (trimmed === "") return 0;
+  if (/^(inf|infinite|infinity|forever)$/i.test(trimmed)) return Number.POSITIVE_INFINITY;
+  const ms = Number(trimmed);
+  return Number.isFinite(ms) && ms >= 0 ? ms : null;
+};
+
+// Returns null for unparseable input so the caller can reject it.
+export const parseGrabCount = (raw: string | undefined): number | null => {
+  if (raw === undefined) return null;
+  const trimmed = raw.trim();
+  // Number("") and Number("  ") are 0, which would mask empty/garbage input.
+  if (trimmed === "") return null;
+  const value = Number(trimmed);
+  return Number.isInteger(value) && value >= 0 ? value : null;
+};

--- a/packages/cli/src/utils/read-args.ts
+++ b/packages/cli/src/utils/read-args.ts
@@ -1,5 +1,3 @@
-// Returns null for unparseable input so the caller can reject it instead of
-// silently degrading to "no wait", which would break the read loop.
 export const parseWaitMs = (raw: string | undefined): number | null => {
   if (raw === undefined) return 0;
   const trimmed = raw.trim();
@@ -9,7 +7,6 @@ export const parseWaitMs = (raw: string | undefined): number | null => {
   return Number.isFinite(ms) && ms >= 0 ? ms : null;
 };
 
-// Returns null for unparseable input so the caller can reject it.
 export const parseGrabCount = (raw: string | undefined): number | null => {
   if (raw === undefined) return null;
   const trimmed = raw.trim();

--- a/packages/cli/test/clipboard.test.ts
+++ b/packages/cli/test/clipboard.test.ts
@@ -49,17 +49,7 @@ const collectGrabs = (
     const logPath = path.join(dir, "history.jsonl");
     const child = spawn(
       process.execPath,
-      [
-        CLI_BIN,
-        "watch",
-        "--foreground",
-        "--dir",
-        dir,
-        "--interval",
-        "120",
-        "--replay-last",
-        ...extraArgs,
-      ],
+      [CLI_BIN, "watch", "--dir", dir, "--interval", "120", "--replay-last", ...extraArgs],
       { stdio: "ignore" },
     );
     const readRecords = (): CapturedRecord[] => {

--- a/packages/cli/test/daemon.test.ts
+++ b/packages/cli/test/daemon.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 import {
   claimDaemon,
+  ensureDaemon,
   isDaemonRunning,
   readDaemonPid,
   releaseDaemon,
@@ -148,5 +149,16 @@ describe("stopDaemon", () => {
     expect(fs.existsSync(pidFilePath())).toBe(false);
     await waitForDead(livePid);
     expect(isAlive(livePid)).toBe(false);
+  });
+});
+
+describe("ensureDaemon", () => {
+  it("is a no-op when a daemon already watches the dir (does not spawn another)", () => {
+    const livePid = spawnLiveProcess();
+    writePidFile(String(livePid));
+    expect(ensureDaemon({ dir, intervalMs: 800, textOnly: true, replayLast: false })).toBe(
+      "already-running",
+    );
+    expect(readDaemonPid(dir)).toBe(livePid);
   });
 });

--- a/packages/cli/test/grab-log.test.ts
+++ b/packages/cli/test/grab-log.test.ts
@@ -116,6 +116,17 @@ describe("consumeGrabs cursor semantics", () => {
     appendRecord("2");
     expect(consume()).toEqual([record("2")]);
   });
+
+  it("migrates a legacy line-index cursor to a byte offset without re-delivering or dropping", () => {
+    appendRecord("1");
+    appendRecord("2");
+    appendRecord("3");
+    fs.writeFileSync(cursorPath(), "2");
+    expect(consume()).toEqual([record("3")]);
+    expect(consume()).toEqual([]);
+    appendRecord("4");
+    expect(consume()).toEqual([record("4")]);
+  });
 });
 
 describe("consumeGrabs eviction", () => {

--- a/packages/cli/test/grab-log.test.ts
+++ b/packages/cli/test/grab-log.test.ts
@@ -108,6 +108,16 @@ describe("consumeGrabs cursor semantics", () => {
     appendRecord("y");
     expect(consume()).toEqual([record("y")]);
   });
+
+  it("resets a stale cursor when the history is emptied, so later appends are not skipped", () => {
+    appendRecord("1");
+    consume();
+    fs.writeFileSync(historyPath(), "");
+    expect(consume()).toEqual([]);
+    expect(readGrabCursor(dir)).toBe(0);
+    appendRecord("2");
+    expect(consume()).toEqual([record("2")]);
+  });
 });
 
 describe("consumeGrabs eviction", () => {

--- a/packages/cli/test/grab-log.test.ts
+++ b/packages/cli/test/grab-log.test.ts
@@ -127,6 +127,15 @@ describe("consumeGrabs cursor semantics", () => {
     appendRecord("4");
     expect(consume()).toEqual([record("4")]);
   });
+
+  it("baselines at EOF when a legacy cursor counts more lines than exist (no re-delivery)", () => {
+    appendRecord("1");
+    appendRecord("2");
+    fs.writeFileSync(cursorPath(), "5");
+    expect(consume()).toEqual([]);
+    appendRecord("3");
+    expect(consume()).toEqual([record("3")]);
+  });
 });
 
 describe("consumeGrabs eviction", () => {

--- a/packages/cli/test/grab-log.test.ts
+++ b/packages/cli/test/grab-log.test.ts
@@ -136,6 +136,15 @@ describe("consumeGrabs cursor semantics", () => {
     appendRecord("3");
     expect(consume()).toEqual([record("3")]);
   });
+
+  it("computes an exact migration offset across the chunk boundary on a large history", () => {
+    const big = (id: string): string => JSON.stringify({ id, pad: "x".repeat(600 * 1024) });
+    fs.writeFileSync(historyPath(), `${big("1")}\n${big("2")}\n${big("3")}\n`);
+    expect(historySize()).toBeGreaterThan(1024 * 1024);
+    fs.writeFileSync(cursorPath(), "2");
+    expect(consume()).toEqual([big("3")]);
+    expect(consume()).toEqual([]);
+  });
 });
 
 describe("consumeGrabs eviction", () => {

--- a/packages/cli/test/grab-log.test.ts
+++ b/packages/cli/test/grab-log.test.ts
@@ -18,7 +18,6 @@ const appendAged = (id: string, ageMs: number): void =>
 const idsOf = (lines: string[]): string[] =>
   lines.map((line) => (JSON.parse(line) as { id: string }).id);
 
-// The cursor is a byte offset, so a fully-drained cursor equals the file size.
 const consume = (overrides: { limit?: number; all?: boolean; maxAgeMs?: number } = {}): string[] =>
   consumeGrabs(dir, { limit: 0, all: false, maxAgeMs: 0, ...overrides });
 
@@ -102,7 +101,6 @@ describe("consumeGrabs cursor semantics", () => {
     for (const id of ["1", "2", "3"]) appendRecord(id);
     consume();
     fs.writeFileSync(historyPath(), `${record("x")}\n`);
-    // cursor past the new EOF resets to 0 and re-reads the surviving content once
     expect(consume()).toEqual([record("x")]);
     expect(consume()).toEqual([]);
     appendRecord("y");

--- a/packages/cli/test/grab-log.test.ts
+++ b/packages/cli/test/grab-log.test.ts
@@ -9,6 +9,7 @@ let dir: string;
 
 const historyPath = (): string => path.join(dir, HISTORY_FILE_NAME);
 const cursorPath = (): string => path.join(dir, "cursor.txt");
+const historySize = (): number => fs.statSync(historyPath()).size;
 const appendRecord = (id: string): void =>
   fs.appendFileSync(historyPath(), `${JSON.stringify({ id })}\n`);
 const record = (id: string): string => JSON.stringify({ id });
@@ -16,6 +17,10 @@ const appendAged = (id: string, ageMs: number): void =>
   fs.appendFileSync(historyPath(), `${JSON.stringify({ id, receivedAt: Date.now() - ageMs })}\n`);
 const idsOf = (lines: string[]): string[] =>
   lines.map((line) => (JSON.parse(line) as { id: string }).id);
+
+// The cursor is a byte offset, so a fully-drained cursor equals the file size.
+const consume = (overrides: { limit?: number; all?: boolean; maxAgeMs?: number } = {}): string[] =>
+  consumeGrabs(dir, { limit: 0, all: false, maxAgeMs: 0, ...overrides });
 
 const FIVE_MIN_MS = 5 * 60 * 1000;
 
@@ -44,56 +49,64 @@ describe("readCompleteGrabLines", () => {
 });
 
 describe("consumeGrabs cursor semantics", () => {
-  it("delivers new records and advances the cursor past them", () => {
+  it("delivers new records and advances the cursor to EOF", () => {
     appendRecord("1");
     appendRecord("2");
-    expect(consumeGrabs(dir, { limit: 0, all: false })).toEqual([record("1"), record("2")]);
-    expect(readGrabCursor(dir)).toBe(2);
+    expect(consume()).toEqual([record("1"), record("2")]);
+    expect(readGrabCursor(dir)).toBe(historySize());
   });
 
   it("delivers each record exactly once across calls", () => {
     appendRecord("1");
-    expect(consumeGrabs(dir, { limit: 0, all: false })).toEqual([record("1")]);
-    expect(consumeGrabs(dir, { limit: 0, all: false })).toEqual([]);
+    expect(consume()).toEqual([record("1")]);
+    expect(consume()).toEqual([]);
     appendRecord("2");
-    expect(consumeGrabs(dir, { limit: 0, all: false })).toEqual([record("2")]);
+    expect(consume()).toEqual([record("2")]);
   });
 
   it("caps output at the limit and drains the backlog across calls", () => {
     for (const id of ["1", "2", "3", "4", "5"]) appendRecord(id);
-    expect(consumeGrabs(dir, { limit: 2, all: false })).toEqual([record("1"), record("2")]);
-    expect(consumeGrabs(dir, { limit: 2, all: false })).toEqual([record("3"), record("4")]);
-    expect(consumeGrabs(dir, { limit: 2, all: false })).toEqual([record("5")]);
-    expect(consumeGrabs(dir, { limit: 2, all: false })).toEqual([]);
-    expect(readGrabCursor(dir)).toBe(5);
+    expect(consume({ limit: 2 })).toEqual([record("1"), record("2")]);
+    expect(consume({ limit: 2 })).toEqual([record("3"), record("4")]);
+    expect(consume({ limit: 2 })).toEqual([record("5")]);
+    expect(consume({ limit: 2 })).toEqual([]);
+    expect(readGrabCursor(dir)).toBe(historySize());
   });
 
   it("does not deliver a partial final line until it is completed", () => {
     appendRecord("1");
     fs.appendFileSync(historyPath(), '{"id":"2"');
-    expect(consumeGrabs(dir, { limit: 0, all: false })).toEqual([record("1")]);
+    expect(consume()).toEqual([record("1")]);
     fs.appendFileSync(historyPath(), "}\n");
-    expect(consumeGrabs(dir, { limit: 0, all: false })).toEqual([record("2")]);
+    expect(consume()).toEqual([record("2")]);
+  });
+
+  it("skips a corrupt (unparseable) line but still advances past it", () => {
+    fs.appendFileSync(historyPath(), "not json at all\n");
+    appendRecord("ok");
+    expect(consume()).toEqual([record("ok")]);
+    expect(consume()).toEqual([]);
   });
 
   it("does not rewrite the cursor when there is nothing new", () => {
     appendRecord("1");
-    consumeGrabs(dir, { limit: 0, all: false });
+    consume();
     const past = new Date(Date.now() - 60_000);
     fs.utimesSync(cursorPath(), past, past);
     const mtimeBefore = fs.statSync(cursorPath()).mtimeMs;
-    expect(consumeGrabs(dir, { limit: 0, all: false })).toEqual([]);
+    expect(consume()).toEqual([]);
     expect(fs.statSync(cursorPath()).mtimeMs).toBe(mtimeBefore);
   });
 
-  it("recovers when the history is truncated below the cursor", () => {
+  it("recovers when the history is truncated/rotated under the cursor", () => {
     for (const id of ["1", "2", "3"]) appendRecord(id);
-    consumeGrabs(dir, { limit: 0, all: false });
+    consume();
     fs.writeFileSync(historyPath(), `${record("x")}\n`);
-    expect(consumeGrabs(dir, { limit: 0, all: false })).toEqual([]);
-    expect(readGrabCursor(dir)).toBe(1);
+    // cursor past the new EOF resets to 0 and re-reads the surviving content once
+    expect(consume()).toEqual([record("x")]);
+    expect(consume()).toEqual([]);
     appendRecord("y");
-    expect(consumeGrabs(dir, { limit: 0, all: false })).toEqual([record("y")]);
+    expect(consume()).toEqual([record("y")]);
   });
 });
 
@@ -101,42 +114,32 @@ describe("consumeGrabs eviction", () => {
   it("skips grabs older than maxAgeMs and advances the cursor past them", () => {
     appendAged("old", 10 * 60 * 1000);
     appendAged("new", 1000);
-    expect(idsOf(consumeGrabs(dir, { limit: 0, all: false, maxAgeMs: FIVE_MIN_MS }))).toEqual([
-      "new",
-    ]);
-    expect(readGrabCursor(dir)).toBe(2);
-    expect(consumeGrabs(dir, { limit: 0, all: false, maxAgeMs: FIVE_MIN_MS })).toEqual([]);
+    expect(idsOf(consume({ maxAgeMs: FIVE_MIN_MS }))).toEqual(["new"]);
+    expect(readGrabCursor(dir)).toBe(historySize());
+    expect(consume({ maxAgeMs: FIVE_MIN_MS })).toEqual([]);
   });
 
   it("delivers grabs within maxAgeMs", () => {
     appendAged("a", 1000);
     appendAged("b", 2000);
-    expect(idsOf(consumeGrabs(dir, { limit: 0, all: false, maxAgeMs: FIVE_MIN_MS }))).toEqual([
-      "a",
-      "b",
-    ]);
+    expect(idsOf(consume({ maxAgeMs: FIVE_MIN_MS }))).toEqual(["a", "b"]);
   });
 
   it("never evicts records without a receivedAt", () => {
     appendRecord("no-timestamp");
-    expect(idsOf(consumeGrabs(dir, { limit: 0, all: false, maxAgeMs: 1 }))).toEqual([
-      "no-timestamp",
-    ]);
+    expect(idsOf(consume({ maxAgeMs: 1 }))).toEqual(["no-timestamp"]);
   });
 
   it("maxAgeMs of 0 disables eviction", () => {
     appendAged("ancient", 60 * 60 * 1000);
-    expect(idsOf(consumeGrabs(dir, { limit: 0, all: false, maxAgeMs: 0 }))).toEqual(["ancient"]);
+    expect(idsOf(consume({ maxAgeMs: 0 }))).toEqual(["ancient"]);
   });
 
   it("evicted grabs do not count against the limit", () => {
     appendAged("old", 10 * 60 * 1000);
     appendAged("new1", 1000);
     appendAged("new2", 1000);
-    expect(idsOf(consumeGrabs(dir, { limit: 2, all: false, maxAgeMs: FIVE_MIN_MS }))).toEqual([
-      "new1",
-      "new2",
-    ]);
+    expect(idsOf(consume({ limit: 2, maxAgeMs: FIVE_MIN_MS }))).toEqual(["new1", "new2"]);
   });
 });
 
@@ -144,14 +147,11 @@ describe("consumeGrabs --all", () => {
   it("replays the entire history without advancing the cursor", () => {
     appendRecord("1");
     appendRecord("2");
-    consumeGrabs(dir, { limit: 0, all: false });
+    consume();
+    const cursorAfterTwo = readGrabCursor(dir);
     appendRecord("3");
-    expect(consumeGrabs(dir, { limit: 0, all: true })).toEqual([
-      record("1"),
-      record("2"),
-      record("3"),
-    ]);
-    expect(readGrabCursor(dir)).toBe(2);
-    expect(consumeGrabs(dir, { limit: 0, all: false })).toEqual([record("3")]);
+    expect(consume({ all: true })).toEqual([record("1"), record("2"), record("3")]);
+    expect(readGrabCursor(dir)).toBe(cursorAfterTwo);
+    expect(consume()).toEqual([record("3")]);
   });
 });

--- a/packages/cli/test/read-args.test.ts
+++ b/packages/cli/test/read-args.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import { parseGrabCount, parseWaitMs } from "../src/utils/read-args.js";
+import { parseNonNegativeInt, parseWaitMs } from "../src/utils/read-args.js";
 
 describe("parseWaitMs", () => {
   it("treats missing/empty as no wait", () => {
@@ -28,17 +28,17 @@ describe("parseWaitMs", () => {
   });
 });
 
-describe("parseGrabCount", () => {
+describe("parseNonNegativeInt", () => {
   it("accepts non-negative integers", () => {
-    expect(parseGrabCount("0")).toBe(0);
-    expect(parseGrabCount("50")).toBe(50);
-    expect(parseGrabCount(" 7 ")).toBe(7);
+    expect(parseNonNegativeInt("0")).toBe(0);
+    expect(parseNonNegativeInt("50")).toBe(50);
+    expect(parseNonNegativeInt(" 7 ")).toBe(7);
   });
 
   it("returns null for negative, fractional, or non-numeric input", () => {
     for (const raw of ["-1", "1.5", "abc", "", "Infinity"]) {
-      expect(parseGrabCount(raw)).toBe(null);
+      expect(parseNonNegativeInt(raw)).toBe(null);
     }
-    expect(parseGrabCount(undefined)).toBe(null);
+    expect(parseNonNegativeInt(undefined)).toBe(null);
   });
 });

--- a/packages/cli/test/read-args.test.ts
+++ b/packages/cli/test/read-args.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vite-plus/test";
+import { parseGrabCount, parseWaitMs } from "../src/utils/read-args.js";
+
+describe("parseWaitMs", () => {
+  it("treats missing/empty as no wait", () => {
+    expect(parseWaitMs(undefined)).toBe(0);
+    expect(parseWaitMs("")).toBe(0);
+    expect(parseWaitMs("   ")).toBe(0);
+  });
+
+  it("accepts a millisecond count", () => {
+    expect(parseWaitMs("0")).toBe(0);
+    expect(parseWaitMs("20000")).toBe(20000);
+    expect(parseWaitMs(" 500 ")).toBe(500);
+    expect(parseWaitMs("1e9")).toBe(1e9);
+  });
+
+  it("accepts infinite synonyms (including the JS spelling) case-insensitively", () => {
+    for (const raw of ["infinite", "inf", "forever", "Infinity", "INFINITE", " forever "]) {
+      expect(parseWaitMs(raw)).toBe(Number.POSITIVE_INFINITY);
+    }
+  });
+
+  it("returns null for unparseable input instead of silently degrading to no-wait", () => {
+    for (const raw of ["5s", "1m", "abc", "-5", "NaN", "1.2.3"]) {
+      expect(parseWaitMs(raw)).toBe(null);
+    }
+  });
+});
+
+describe("parseGrabCount", () => {
+  it("accepts non-negative integers", () => {
+    expect(parseGrabCount("0")).toBe(0);
+    expect(parseGrabCount("50")).toBe(50);
+    expect(parseGrabCount(" 7 ")).toBe(7);
+  });
+
+  it("returns null for negative, fractional, or non-numeric input", () => {
+    for (const raw of ["-1", "1.5", "abc", "", "Infinity"]) {
+      expect(parseGrabCount(raw)).toBe(null);
+    }
+    expect(parseGrabCount(undefined)).toBe(null);
+  });
+});

--- a/skills/react-grab/SKILL.md
+++ b/skills/react-grab/SKILL.md
@@ -37,9 +37,9 @@ npx grab read --wait infinite
 ```
 
 Give the command a long timeout. If your shell cancels it before a grab arrives,
-re-run it — a cancelled wait loses nothing, because the daemon keeps capturing in
-the background and the cursor only advances on delivery. Each line of stdout is
-one grab as JSON.
+re-run it — a cancelled wait loses nothing: the daemon keeps capturing in the
+background, and a re-run resumes from the cursor. Each line of stdout is one grab
+as JSON.
 
 2. Act on each grab (below).
 3. Go back to step 1.

--- a/skills/react-grab/SKILL.md
+++ b/skills/react-grab/SKILL.md
@@ -11,8 +11,9 @@ description: >-
 # React Grab
 
 The user selects UI elements in their browser and copies them with React Grab.
-`npx grab pull` waits for the next copied grab and prints it as one line of JSON,
-starting the background watcher automatically the first time. Run it in a loop.
+`npx grab pull` waits for new grabs and prints each as one line of JSON (usually
+one, sometimes a few if several were copied), starting the background watcher
+automatically the first time. Run it in a loop.
 
 ## The loop
 
@@ -24,10 +25,10 @@ Repeat until the user says stop:
 npx grab pull
 ```
 
-It blocks until the user grabs something, then prints it (one grab per line, as
-JSON). If your shell cancels the command before a grab arrives, just run it
-again — nothing is lost; the watcher keeps capturing in the background and `pull`
-resumes where it left off.
+It blocks until the user grabs something, then prints the new grab(s) — one JSON
+object per line. Act on every line. If your shell cancels the command before a
+grab arrives, just run it again — nothing is lost; the watcher keeps capturing in
+the background and `pull` resumes where it left off.
 
 2. Act on the grab (below).
 3. Go back to step 1.

--- a/skills/react-grab/SKILL.md
+++ b/skills/react-grab/SKILL.md
@@ -10,64 +10,27 @@ description: >-
 
 # React Grab
 
-The user selects UI elements in their browser and copies them with React Grab. A
-background daemon captures each grab to `./.react-grab/history.jsonl`; you pull
-them with `grab read`. Nothing blocks the agent: the daemon runs detached and
-`read` returns promptly, so the loop survives shell-command timeouts.
-
-## Start the daemon (once)
-
-```bash
-npx grab@latest watch
-```
-
-This launches a detached daemon that watches the clipboard. It is idempotent per
-dir — re-running it while a daemon is already watching this project is a no-op —
-so it is safe to run at the start of every session. `--dir <path>` relocates the
-capture dir; `--text-only` skips the native clipboard reader.
+The user selects UI elements in their browser and copies them with React Grab.
+`npx grab pull` waits for the next copied grab and prints it as one line of JSON,
+starting the background watcher automatically the first time. Run it in a loop.
 
 ## The loop
 
 Repeat until the user says stop:
 
-1. Pull the next grab — this blocks until one arrives:
+1. Wait for the next grab:
 
 ```bash
-npx grab read --wait infinite
+npx grab pull
 ```
 
-Give the command a long timeout. If your shell cancels it before a grab arrives,
-re-run it — a cancelled wait loses nothing: the daemon keeps capturing in the
-background, and a re-run resumes from the cursor. Each line of stdout is one grab
-as JSON.
+It blocks until the user grabs something, then prints it (one grab per line, as
+JSON). If your shell cancels the command before a grab arrives, just run it
+again — nothing is lost; the watcher keeps capturing in the background and `pull`
+resumes where it left off.
 
-2. Act on each grab (below).
+2. Act on the grab (below).
 3. Go back to step 1.
-
-`read` advances a cursor (`./.react-grab/cursor.txt`), so each grab is delivered
-exactly once across calls. Grabs that sat unread for more than ~5 minutes are
-intentionally skipped as stale (so you don't act on a backlog the user has moved
-on from) — raise the window with `--max-age <ms>`, or `--max-age 0` to deliver
-every grab regardless of age. `--all` reprints the whole history.
-
-## Gotchas
-
-- **Empty `read` output is not an error** — it just means no grab landed yet.
-  Re-run it; never treat empty output as the daemon being dead or the loop being
-  done. Only the user saying "stop" ends the loop.
-- **The daemon reads the clipboard on the machine it runs on.** Over SSH, in a
-  container, or on a cloud host while the browser is on the user's laptop, grabs
-  never arrive. The daemon must run on the same machine as the browser.
-- **Run one `read` at a time.** Concurrent reads share `cursor.txt` and can
-  double-deliver or skip grabs — keep the loop sequential.
-- **`read --all` replays the whole history without consuming it** — it does not
-  advance the cursor, so use it only to inspect history; the loop's plain `read`
-  is what delivers each grab exactly once.
-- **If grabs never arrive even though the user is grabbing**, the daemon may not
-  be staying up. A healthy daemon makes `npx grab@latest watch` report
-  `already watching`; if it keeps reporting `started`, the daemon is dying on
-  startup — usually no clipboard reader. Try `npx grab watch --text-only`, or run
-  `npx grab watch --foreground` once to see the startup error directly.
 
 ## Acting on a grab
 
@@ -81,15 +44,17 @@ mode, `prompt` (the user's typed instruction):
   loop, or, if there is none, triage it (summarize component + `file:line`) and
   wait for direction.
 
-A standing instruction is optional; prompt mode lets the user steer each grab
-inline.
-
 ## Stopping
 
-When the user says stop, stop the daemon and do not read again:
+When the user says stop, run this and don't pull again:
 
 ```bash
-npx grab@latest watch --stop
+npx grab stop
 ```
 
-Confirm the loop has stopped.
+## Notes
+
+- The watcher reads the clipboard on the machine it runs on — run it on the same
+  machine as the browser, not over SSH or in a remote container.
+- Grabs older than ~5 minutes are skipped as stale; use `npx grab pull --max-age 0`
+  to deliver every grab regardless of age.

--- a/skills/react-grab/SKILL.md
+++ b/skills/react-grab/SKILL.md
@@ -37,16 +37,18 @@ npx grab read --wait infinite
 ```
 
 Give the command a long timeout. If your shell cancels it before a grab arrives,
-just run it again — the daemon keeps capturing in the background, so nothing is
-lost. Each line of stdout is one grab as JSON.
+re-run it — a cancelled wait loses nothing, because the daemon keeps capturing in
+the background and the cursor only advances on delivery. Each line of stdout is
+one grab as JSON.
 
 2. Act on each grab (below).
 3. Go back to step 1.
 
 `read` advances a cursor (`./.react-grab/cursor.txt`), so each grab is delivered
-exactly once across calls. Grabs older than ~5 minutes are treated as stale and
-skipped (override with `--max-age <ms>`, or `--max-age 0` to never evict). Add
-`--all` to replay the whole history from the start.
+exactly once across calls. Grabs that sat unread for more than ~5 minutes are
+intentionally skipped as stale (so you don't act on a backlog the user has moved
+on from) — raise the window with `--max-age <ms>`, or `--max-age 0` to deliver
+every grab regardless of age. `--all` reprints the whole history.
 
 ## Gotchas
 


### PR DESCRIPTION
## Summary

Simplifies the React Grab agent loop to a single command and hardens the read/daemon internals.

**One-command loop**
- `grab pull` — starts the watcher if needed, blocks for the next grab, prints it as JSON. The agent just loops this; the daemon, cursor, eviction, and `--wait` are all internal.
- `grab stop` — stops the watcher.
- Removed the public `read` command; `watch` stays as the internal daemon body. The skill drops from a `watch` + `read --wait` + `--stop` dance to: loop `grab pull`, then `grab stop`.

**Read/daemon hardening (the original fixes)**
- **Byte-offset cursor + capped tail reads**: idle polls are O(1) (`stat`, no read), active reads pull only the unconsumed tail (≤ `MAX_READ_HISTORY_BYTES`) — no per-poll full re-read of the never-compacted history, and no silent failure past V8's ~512 MB string cap.
- **Legacy cursor migration**: a pre-byte-offset `cursor.txt` (line count) is tagged-JSON-detected and converted to the byte offset after that many lines, so an upgrade neither re-delivers consumed grabs nor drops unconsumed ones (Bugbot fix).
- **Truncation/empty self-heal**: a stale cursor past EOF resets to 0 and persists, so a later-grown file isn't read from the stale offset.
- **Validated args**: `--wait` accepts `infinite`/`Infinity`/ms and rejects garbage (exit 1) instead of silently no-waiting; same for `--limit`/`--max-age`. stdout flushes before exit.
- **Stale-grab eviction** (default ~5 min) and **scoped skill removal** (`remove` is project-default with `--global`, `-c/--cwd`).

## Test plan

- [x] `pnpm --filter @react-grab/cli check` — lint + typecheck + format clean
- [x] `pnpm --filter @react-grab/cli test` — 179 pass (`grab-log`, `daemon`, `read-args` unit tests incl. byte-offset, legacy-cursor migration, eviction, truncation self-heal, parser validation)
- [x] Live smoke: `grab pull` auto-starts the watcher, blocks then delivers, exactly-once, reuses the running watcher; `grab stop` tears it down; legacy line-count cursor migrates without re-delivery

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how agents consume grabs (cursor migration and new commands) and daemon startup; behavior is heavily tested but upgrades depend on correct legacy cursor migration.
> 
> **Overview**
> Replaces the public **`grab read`** / **`grab watch`** workflow with **`grab pull`** (auto-starts the watcher, blocks for the next grab, prints JSON) and **`grab stop`**. **`watch`** is hidden and only runs the foreground capture daemon that **`pull`** spawns via **`ensureDaemon`**.
> 
> **`consumeGrabs`** now uses a **byte-offset** `cursor.txt` (atomic JSON writes), **tail reads** capped by **`MAX_READ_HISTORY_BYTES`**, legacy line-index migration, and recovery when history is truncated or emptied. **`--wait` / `--limit` / `--max-age`** are validated in **`read-args`** (bad values exit 1). **`remove`** is scoped with **`--cwd`** and **`--global`** like install. The React Grab skill documents looping **`npx grab pull`** instead of **`watch` + `read --wait`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1df7fbbe31763ce8c2dbd5716117a2db4b31df0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->