### PR TITLE
feat: telemetry opt-out (DO_NOT_TRACK + telemetry option)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,24 @@ if (process.env.NODE_ENV === "development") {
 }
 ```
 
+## Telemetry
+
+On startup, React Grab makes a single anonymous version check to `react-grab.com` so it can warn you when a newer version is available. No personal data, source code, or page content is ever sent — only the running version. The browser extension never makes this request.
+
+To opt out:
+
+**CLI** — set the [`DO_NOT_TRACK`](https://consoledonottrack.com) environment variable:
+
+```bash
+DO_NOT_TRACK=1 npx grab@latest init
+```
+
+**Browser runtime** — set the `telemetry: false` option. With the script tag, pass it through `data-options` (e.g. `data-options='{"telemetry": false}'`). When initializing manually:
+
+```js
+import("react-grab/core").then(({ init }) => init({ telemetry: false }));
+```
+
 ## Plugins
 
 Use plugins to extend React Grab's built-in UI with context menu actions, toolbar menu items, lifecycle hooks, and theme overrides. Plugins run within React Grab.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -7,6 +7,7 @@ import { remove } from "./commands/remove.js";
 import { stop } from "./commands/stop.js";
 import { upgrade } from "./commands/upgrade.js";
 import { watch } from "./commands/watch.js";
+import { isTelemetryEnabled } from "./utils/is-telemetry-enabled.js";
 
 const VERSION = process.env.VERSION ?? "0.0.1";
 const VERSION_API_URL = "https://www.react-grab.com/api/version";
@@ -15,7 +16,9 @@ process.on("SIGINT", () => process.exit(0));
 process.on("SIGTERM", () => process.exit(0));
 
 try {
-  fetch(`${VERSION_API_URL}?source=cli&v=${VERSION}&t=${Date.now()}`).catch(() => {});
+  if (isTelemetryEnabled()) {
+    fetch(`${VERSION_API_URL}?source=cli&v=${VERSION}&t=${Date.now()}`).catch(() => {});
+  }
 } catch {}
 
 const program = new Command()

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -27,6 +27,7 @@ import {
   type ReactGrabOptions,
 } from "../utils/transform.js";
 import { formatActivationKeyDisplay } from "../utils/format-activation-key.js";
+import { isTelemetryEnabled } from "../utils/is-telemetry-enabled.js";
 
 const VERSION = process.env.VERSION ?? "0.0.1";
 const REPORT_URL = "https://react-grab.com/api/report-cli";
@@ -41,6 +42,7 @@ interface ReportConfig {
 }
 
 const reportToCli = (type: "error" | "completed", config?: ReportConfig, error?: Error): void => {
+  if (!isTelemetryEnabled()) return;
   fetch(REPORT_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/packages/cli/src/utils/is-telemetry-enabled.ts
+++ b/packages/cli/src/utils/is-telemetry-enabled.ts
@@ -1,0 +1,4 @@
+export const isTelemetryEnabled = (): boolean => {
+  const doNotTrack = process.env.DO_NOT_TRACK;
+  return doNotTrack !== "1" && doNotTrack !== "true";
+};

--- a/packages/cli/test/is-telemetry-enabled.test.ts
+++ b/packages/cli/test/is-telemetry-enabled.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, afterEach } from "vite-plus/test";
+import { isTelemetryEnabled } from "../src/utils/is-telemetry-enabled.js";
+
+const originalDoNotTrack = process.env.DO_NOT_TRACK;
+
+afterEach(() => {
+  if (originalDoNotTrack === undefined) {
+    delete process.env.DO_NOT_TRACK;
+  } else {
+    process.env.DO_NOT_TRACK = originalDoNotTrack;
+  }
+});
+
+describe("isTelemetryEnabled", () => {
+  it("is enabled when DO_NOT_TRACK is unset", () => {
+    delete process.env.DO_NOT_TRACK;
+    expect(isTelemetryEnabled()).toBe(true);
+  });
+
+  it("is disabled when DO_NOT_TRACK is 1", () => {
+    process.env.DO_NOT_TRACK = "1";
+    expect(isTelemetryEnabled()).toBe(false);
+  });
+
+  it("is disabled when DO_NOT_TRACK is true", () => {
+    process.env.DO_NOT_TRACK = "true";
+    expect(isTelemetryEnabled()).toBe(false);
+  });
+
+  it("stays enabled for explicit opt-in values", () => {
+    for (const optInValue of ["0", "false", ""]) {
+      process.env.DO_NOT_TRACK = optInValue;
+      expect(isTelemetryEnabled()).toBe(true);
+    }
+  });
+});

--- a/packages/grab/README.md
+++ b/packages/grab/README.md
@@ -124,6 +124,24 @@ if (process.env.NODE_ENV === "development") {
 }
 ```
 
+## Telemetry
+
+On startup, React Grab makes a single anonymous version check to `react-grab.com` so it can warn you when a newer version is available. No personal data, source code, or page content is ever sent — only the running version. The browser extension never makes this request.
+
+To opt out:
+
+**CLI** — set the [`DO_NOT_TRACK`](https://consoledonottrack.com) environment variable:
+
+```bash
+DO_NOT_TRACK=1 npx grab@latest init
+```
+
+**Browser runtime** — set the `telemetry: false` option. With the script tag, pass it through `data-options` (e.g. `data-options='{"telemetry": false}'`). When initializing manually:
+
+```js
+import("grab/core").then(({ init }) => init({ telemetry: false }));
+```
+
 ## Plugins
 
 Use plugins to extend React Grab's built-in UI with context menu actions, toolbar menu items, lifecycle hooks, and theme overrides. Plugins run within React Grab.

--- a/packages/grab/scripts/build.js
+++ b/packages/grab/scripts/build.js
@@ -66,6 +66,7 @@ const transformReadme = () => {
     .replace(/npx( -y)? react-grab@latest/g, "npx$1 grab@latest")
     .replace(/unpkg\.com\/react-grab/g, "unpkg.com/grab")
     .replace(/import\("react-grab"\)/g, 'import("grab")')
+    .replace(/import\("react-grab\/core"\)/g, 'import("grab/core")')
     .replace(/from "react-grab\/core"/g, 'from "grab/core"')
     .replace(/from "react-grab\/primitives"/g, 'from "grab/primitives"')
     .replace(/from "react-grab"/g, 'from "grab"');

--- a/packages/react-grab/README.md
+++ b/packages/react-grab/README.md
@@ -124,6 +124,24 @@ if (process.env.NODE_ENV === "development") {
 }
 ```
 
+## Telemetry
+
+On startup, React Grab makes a single anonymous version check to `react-grab.com` so it can warn you when a newer version is available. No personal data, source code, or page content is ever sent — only the running version. The browser extension never makes this request.
+
+To opt out:
+
+**CLI** — set the [`DO_NOT_TRACK`](https://consoledonottrack.com) environment variable:
+
+```bash
+DO_NOT_TRACK=1 npx grab@latest init
+```
+
+**Browser runtime** — set the `telemetry: false` option. With the script tag, pass it through `data-options` (e.g. `data-options='{"telemetry": false}'`). When initializing manually:
+
+```js
+import("react-grab/core").then(({ init }) => init({ telemetry: false }));
+```
+
 ## Plugins
 
 Use plugins to extend React Grab's built-in UI with context menu actions, toolbar menu items, lifecycle hooks, and theme overrides. Plugins run within React Grab.

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -194,10 +194,10 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
   }
   hasInited = true;
 
-  logIntro();
+  logIntro(initialOptions.telemetry !== false);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- need to omit enabled from settableOptions to avoid circular dependency
-  const { enabled: _enabled, ...settableOptions } = initialOptions;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- omit init-only options that aren't part of SettableOptions
+  const { enabled: _enabled, telemetry: _telemetry, ...settableOptions } = initialOptions;
 
   return createRoot((dispose) => {
     let disposed = false;

--- a/packages/react-grab/src/core/log-intro.ts
+++ b/packages/react-grab/src/core/log-intro.ts
@@ -1,7 +1,7 @@
 import { LOGO_SVG } from "./logo-svg.js";
 import { isExtensionContext } from "../utils/is-extension-context.js";
 
-export const logIntro = () => {
+export const logIntro = (telemetryEnabled: boolean) => {
   try {
     const version = process.env.VERSION;
     const logoDataUri = `data:image/svg+xml;base64,${btoa(LOGO_SVG)}`;
@@ -10,7 +10,7 @@ export const logIntro = () => {
       `background: #330039; color: #ffffff; border: 1px solid #d75fcb; padding: 4px 4px 4px 24px; border-radius: 4px; background-image: url("${logoDataUri}"); background-size: 16px 16px; background-repeat: no-repeat; background-position: 4px center; display: inline-block; margin-bottom: 4px;`,
       "",
     );
-    if (navigator.onLine && version && !isExtensionContext()) {
+    if (telemetryEnabled && navigator.onLine && version && !isExtensionContext()) {
       fetch(`https://www.react-grab.com/api/version?source=browser&v=${version}&t=${Date.now()}`, {
         referrerPolicy: "origin",
         keepalive: true,

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -355,10 +355,17 @@ export interface Options {
    * @default true
    */
   freezeReactUpdates?: boolean;
+  /**
+   * Whether to send the anonymous version check to react-grab.com on init.
+   * Set to false to skip the version-check request.
+   * @default true
+   */
+  telemetry?: boolean;
 }
 
 export interface SettableOptions extends Options {
   enabled?: never;
+  telemetry?: never;
 }
 
 export interface SourceInfo {

--- a/packages/react-grab/src/utils/get-script-options.ts
+++ b/packages/react-grab/src/utils/get-script-options.ts
@@ -27,6 +27,9 @@ const parseOptionsFromJson = (rawValue: unknown): Partial<Options> | null => {
   if (typeof rawValue.freezeReactUpdates === "boolean") {
     parsedOptions.freezeReactUpdates = rawValue.freezeReactUpdates;
   }
+  if (typeof rawValue.telemetry === "boolean") {
+    parsedOptions.telemetry = rawValue.telemetry;
+  }
 
   if (Object.keys(parsedOptions).length === 0) return null;
   return parsedOptions;


### PR DESCRIPTION
## Summary

Adds a way to disable React Grab's anonymous version checks / pings for users under strict security policies (closes #416).

- **CLI** — respects the [`DO_NOT_TRACK`](https://consoledonottrack.com) standard. When `DO_NOT_TRACK=1` (or `true`), the per-command version ping (`cli.ts`) and the `init` completion/error report (`init.ts`) are skipped. Centralized in a new `isTelemetryEnabled()` util.
- **Browser runtime** — new `telemetry?: boolean` option (default `true`). When `false`, the startup version check in `log-intro.ts` is skipped. Wired through `Options`, `data-options` parsing, and `init()`. Marked `never` on `SettableOptions` since it's init-only (like `enabled`).
- **Docs** — new `## Telemetry` section in the README documenting both opt-outs.

Out of scope (functional, not telemetry): the `upgrade` npm-registry check, user-initiated `open-file`, and the localhost Next.js stack-frame fetch. The browser extension never made the version-check request (guarded by `isExtensionContext()`).

## Usage

```bash
# CLI
DO_NOT_TRACK=1 npx grab@latest init
```

```js
// Browser, manual init (react-grab/core has no auto-init side effect)
import("react-grab/core").then(({ init }) => init({ telemetry: false }));
```

```html
<!-- Browser, script tag -->
<script src="//unpkg.com/react-grab/dist/index.global.js" data-options='{"telemetry": false}'></script>
```

## Test plan

- [x] `pnpm test:cli` — 186 passed, incl. new `is-telemetry-enabled.test.ts` (unset/`1`/`true`/opt-in values)
- [x] `pnpm build`, `pnpm typecheck`, `pnpm lint` — green
- [x] `pnpm format:check` — no new failures from this change
- [ ] Manual: `DO_NOT_TRACK=1 npx grab init` makes no request to `react-grab.com`
- [ ] Manual: `init({ telemetry: false })` suppresses the browser version check; default still pings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in privacy controls around existing network pings; default behavior unchanged and changes are well-scoped with tests for CLI env handling.
> 
> **Overview**
> Adds **telemetry opt-out** for React Grab’s anonymous version checks and CLI reporting, plus documentation.
> 
> **CLI:** New `isTelemetryEnabled()` (respects `DO_NOT_TRACK=1` or `true`) gates the startup version ping in `cli.ts` and `init` completion/error posts to `report-cli`. Unit tests cover env behavior.
> 
> **Browser:** New init-only `telemetry?: boolean` (default on) skips the version fetch in `log-intro`; it can be set via `init({ telemetry: false })` or script `data-options`. `telemetry` is excluded from `SettableOptions` like `enabled`.
> 
> **Docs / packaging:** README gains a **Telemetry** section; `grab` build README transform also rewrites `import("react-grab/core")` examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97fbdf93145873cd1a812953f840157b6fb54018. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a telemetry opt-out across the CLI and browser runtime so teams can run `react-grab` without outbound version checks under strict security policies. Defaults remain unchanged.

- **New Features**
  - CLI: Respects `DO_NOT_TRACK` (`1` or `true`) to skip the per-command version ping and `init` completion/error report, centralized via `isTelemetryEnabled()`.
  - Browser: New `telemetry?: boolean` option (default `true`). When `false`, skips the startup version check; supported via `data-options` and `init({ telemetry: false })`. Marked `never` in `SettableOptions` (init-only).
  - Docs/Tests: Added README “Telemetry” section with examples, and unit tests for `isTelemetryEnabled()`.

<sup>Written for commit 97fbdf93145873cd1a812953f840157b6fb54018. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

