### PR TITLE
fix(cli): add repository field so provenance publish succeeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "extension:build": "pnpm --filter web-extension build",
     "changeset": "changeset",
     "version": "changeset version",
-    "release": "pnpm build && changeset publish"
+    "check:provenance": "node scripts/check-publish-provenance.mjs",
+    "release": "pnpm check:provenance && pnpm build && changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@react-grab/cli",
   "version": "0.1.43",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aidenybai/react-grab.git"
+  },
   "bin": {
     "react-grab": "./bin/cli.js"
   },

--- a/scripts/check-publish-provenance.mjs
+++ b/scripts/check-publish-provenance.mjs
@@ -1,0 +1,58 @@
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const EXPECTED_REPOSITORY_URL = "git+https://github.com/aidenybai/react-grab.git";
+const WORKSPACE_GLOBS = ["packages", "apps"];
+
+const rootDirectory = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const collectPackageManifests = () => {
+  const manifests = [];
+  for (const workspaceGlob of WORKSPACE_GLOBS) {
+    const workspaceDirectory = join(rootDirectory, workspaceGlob);
+    if (!existsSync(workspaceDirectory)) continue;
+    for (const entry of readdirSync(workspaceDirectory, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const manifestPath = join(workspaceDirectory, entry.name, "package.json");
+      if (!existsSync(manifestPath)) continue;
+      manifests.push(manifestPath);
+    }
+  }
+  return manifests;
+};
+
+const offendingPackages = [];
+
+for (const manifestPath of collectPackageManifests()) {
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  if (manifest.private === true) continue;
+
+  const repositoryUrl =
+    typeof manifest.repository === "string"
+      ? manifest.repository
+      : manifest.repository?.url;
+
+  if (repositoryUrl !== EXPECTED_REPOSITORY_URL) {
+    offendingPackages.push({
+      name: manifest.name,
+      manifestPath,
+      repositoryUrl: repositoryUrl ?? "(missing)",
+    });
+  }
+}
+
+if (offendingPackages.length > 0) {
+  console.error(
+    `\nProvenance check failed. npm publish with provenance requires every publishable package to declare repository.url === "${EXPECTED_REPOSITORY_URL}".\n`,
+  );
+  for (const offendingPackage of offendingPackages) {
+    console.error(
+      `  - ${offendingPackage.name}: ${offendingPackage.repositoryUrl}\n    ${offendingPackage.manifestPath}`,
+    );
+  }
+  console.error("");
+  process.exit(1);
+}
+
+console.log("Provenance check passed: all publishable packages declare a matching repository.url.");


### PR DESCRIPTION
## Summary
- `@react-grab/cli@0.1.43` failed to publish in the [version packages run](https://github.com/aidenybai/react-grab/pull/436) with `E422 ... Error verifying sigstore provenance bundle: ... "repository.url" is ""`. The workflow sets `NPM_CONFIG_PROVENANCE: true`, which requires `package.json` `repository.url` to match the GitHub build source, but the CLI manifest had no `repository` field.
- `grab@0.1.43` and `react-grab@0.1.43` published successfully, so their `workspace:*` dep was rewritten to a `@react-grab/cli@0.1.43` that does not exist on npm — installs of the latest `grab`/`react-grab` are currently broken until the CLI publishes.
- Adds the missing `repository` field to `packages/cli/package.json` and a `check:provenance` guard wired into `release` so any publishable package missing/mismatching `repository.url` fails **before** `changeset publish` runs.

## Effect on release
- Version stays at `0.1.43` (no bump). On merge, `changeset publish` skips the already-published `grab`/`react-grab` and publishes `@react-grab/cli@0.1.43`, healing the dangling dependency.

## Test plan
- [x] `node scripts/check-publish-provenance.mjs` passes locally
- [x] `pnpm --filter @react-grab/cli build` succeeds; `npm publish --dry-run` shows correct tarball
- [ ] Merge → Publish workflow republishes `@react-grab/cli@0.1.43` with provenance
- [ ] `npm view @react-grab/cli version` reports `0.1.43`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata and a local validation script only; no runtime product or auth logic changes.
> 
> **Overview**
> Unblocks **npm provenance** publishing for `@react-grab/cli` by adding the missing `repository` field (matching the other publishable packages) so Sigstore verification can tie the tarball to the GitHub source.
> 
> Adds a **`check:provenance`** step that scans `packages/` and `apps/` manifests and fails release if any non-private package lacks or mismatches the expected `repository.url`. The root **`release`** script now runs this check before `build` and `changeset publish`, preventing another provenance-only publish failure after `grab` / `react-grab` already shipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1c9bcc6ae170a4e56e7ea807636c7e0f8d0adfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes provenance publishing for `@react-grab/cli` by adding the missing `repository` field and adds a pre-release provenance check. This unblocks `@react-grab/cli@0.1.43` and restores installs of the latest `grab` and `react-grab`.

- **Bug Fixes**
  - Added `repository.url` to `packages/cli/package.json` to match the GitHub source.
  - Added `check:provenance` and wired it into `release` to fail early if any publishable package has a missing/mismatched `repository.url`.

<sup>Written for commit d1c9bcc6ae170a4e56e7ea807636c7e0f8d0adfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

