### PR TITLE
chore: remove verified dead code

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,12 +35,10 @@
     "agent-install": "^0.0.5",
     "commander": "^14.0.3",
     "ignore": "^7.0.5",
-    "jsonc-parser": "^3.3.1",
     "ora": "^9.4.0",
     "package-manager-detector": "^1.6.0",
     "picocolors": "^1.1.1",
     "prompts": "^2.4.2",
-    "smol-toml": "^1.6.1",
     "tinyexec": "^1.1.2"
   },
   "devDependencies": {

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -173,13 +173,8 @@ export const MOUNT_ROOT_RECHECK_DELAY_MS = 1000;
 // Must match the CSS exit transition on dropdown components or the DOM
 // unmounts mid-animation.
 export const DROPDOWN_ANIMATION_DURATION_MS = 120;
-export const DROPDOWN_HOVER_OPEN_DELAY_MS = 200;
 export const DROPDOWN_VIEWPORT_PADDING_PX = 8;
 export const DROPDOWN_ANCHOR_GAP_PX = 8;
-export const SAFE_POLYGON_BUFFER_PX = 8;
-export const DROPDOWN_ICON_SIZE_PX = 11;
-export const DROPDOWN_MIN_WIDTH_PX = 180;
-export const DROPDOWN_MAX_WIDTH_PX = 280;
 export const TOOLBAR_MENU_MIN_WIDTH_PX = 100;
 export const DROPDOWN_OFFSCREEN_POSITION = { left: -9999, top: -9999 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,9 +303,6 @@ importers:
       ignore:
         specifier: ^7.0.5
         version: 7.0.5
-      jsonc-parser:
-        specifier: ^3.3.1
-        version: 3.3.1
       ora:
         specifier: ^9.4.0
         version: 9.4.0
@@ -318,9 +315,6 @@ importers:
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
-      smol-toml:
-        specifier: ^1.6.1
-        version: 1.6.1
       tinyexec:
         specifier: ^1.1.2
         version: 1.1.2
@@ -6835,10 +6829,6 @@ packages:
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
-
-  smol-toml@1.6.1:
-    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
-    engines: {node: '>= 18'}
 
   socks-proxy-agent@8.0.5:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
@@ -14274,8 +14264,6 @@ snapshots:
       is-fullwidth-code-point: 5.1.0
 
   smart-buffer@4.2.0: {}
-
-  smol-toml@1.6.1: {}
 
   socks-proxy-agent@8.0.5:
     dependencies:


### PR DESCRIPTION
## Summary
- Remove two unused CLI dependencies, `jsonc-parser` and `smol-toml`, from `packages/cli/package.json` (and regenerate the lockfile). `jsonc-parser` correctly remains in `pnpm-lock.yaml` as a transitive dep of `agent-install`.
- Remove five unused dropdown constants from `packages/react-grab/src/constants.ts`: `DROPDOWN_HOVER_OPEN_DELAY_MS`, `SAFE_POLYGON_BUFFER_PX`, `DROPDOWN_ICON_SIZE_PX`, `DROPDOWN_MIN_WIDTH_PX`, `DROPDOWN_MAX_WIDTH_PX`.

All removals were verified dead: repo-wide grep found zero references, the constants are not re-exported via a barrel nor part of any published entrypoint, and neither dep is referenced in source or build/config scripts.

## Test plan
- [ ] `pnpm install --frozen-lockfile` succeeds (lockfile is internally consistent)
- [ ] `pnpm build`
- [ ] `pnpm typecheck`
- [ ] `pnpm lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and constant removals only; no runtime logic or public API behavior changes.
> 
> **Overview**
> Removes unused dependencies from **`@react-grab/cli`**: `jsonc-parser` and `smol-toml` are dropped from `packages/cli/package.json`, with **`pnpm-lock.yaml`** updated accordingly.
> 
> Also deletes five unused dropdown tuning constants from **`packages/react-grab/src/constants.ts`** (`DROPDOWN_HOVER_OPEN_DELAY_MS`, `SAFE_POLYGON_BUFFER_PX`, `DROPDOWN_ICON_SIZE_PX`, `DROPDOWN_MIN_WIDTH_PX`, `DROPDOWN_MAX_WIDTH_PX`). Remaining dropdown-related exports are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2622049ad71f76925dc8ec511cadc77a1bcd8ff7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed verified dead code to reduce install footprint and trim unused dropdown config. No behavior changes.

- **Refactors**
  - CLI: removed `jsonc-parser` and `smol-toml` from `packages/cli`; regenerated `pnpm-lock.yaml`. `jsonc-parser` remains as a transitive dep of `agent-install`.
  - React: deleted unused constants from `packages/react-grab/src/constants.ts` (DROPDOWN_HOVER_OPEN_DELAY_MS, SAFE_POLYGON_BUFFER_PX, DROPDOWN_ICON_SIZE_PX, DROPDOWN_MIN_WIDTH_PX, DROPDOWN_MAX_WIDTH_PX).

<sup>Written for commit 2622049ad71f76925dc8ec511cadc77a1bcd8ff7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

