### PR TITLE
Fix style toolbar switch from comment discard

### DIFF
--- a/packages/react-grab/e2e/edit-panel.spec.ts
+++ b/packages/react-grab/e2e/edit-panel.spec.ts
@@ -89,6 +89,24 @@ test.describe("Style Panel", () => {
       ).toEqual([]);
     });
 
+    test("hovering a style row keeps row height stable", async ({ reactGrab }) => {
+      await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      const beforeRows = await getPropertyRowBounds(reactGrab.page);
+      const targetRow = beforeRows.find((row) => !row.isActive);
+      expect(targetRow).toBeTruthy();
+
+      await reactGrab.page.mouse.move(
+        targetRow!.left + targetRow!.width / 2,
+        targetRow!.top + targetRow!.height / 2,
+      );
+      await expect.poll(() => getActivePropertyKey(reactGrab.page)).toBe(targetRow!.key);
+
+      const afterRows = await getPropertyRowBounds(reactGrab.page);
+      const afterTargetRow = afterRows.find((row) => row.key === targetRow!.key);
+      expect(afterTargetRow).toBeTruthy();
+      expect(Math.abs(afterTargetRow!.height - targetRow!.height)).toBeLessThan(0.5);
+    });
+
     test("S opens Style from the context menu", async ({ reactGrab }) => {
       await reactGrab.activate();
       await reactGrab.hoverElement(BUTTON_SELECTOR);

--- a/packages/react-grab/e2e/edit-panel.spec.ts
+++ b/packages/react-grab/e2e/edit-panel.spec.ts
@@ -91,20 +91,22 @@ test.describe("Style Panel", () => {
 
     test("hovering a style row keeps row height stable", async ({ reactGrab }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      await reactGrab.page.waitForTimeout(IDLE_BUFFER_MS);
       const beforeRows = await getPropertyRowBounds(reactGrab.page);
-      const targetRow = beforeRows.find((row) => !row.isActive);
-      expect(targetRow).toBeTruthy();
+      const targetRowIndex = beforeRows.findIndex((row) => !row.isActive);
+      const targetRow = beforeRows[targetRowIndex];
+      if (!targetRow) throw new Error("Expected an inactive style row");
 
       await reactGrab.page.mouse.move(
-        targetRow!.left + targetRow!.width / 2,
-        targetRow!.top + targetRow!.height / 2,
+        targetRow.left + targetRow.width / 2,
+        targetRow.top + targetRow.height / 2,
       );
-      await expect.poll(() => getActivePropertyKey(reactGrab.page)).toBe(targetRow!.key);
+      await expect.poll(() => getActivePropertyKey(reactGrab.page)).toBe(targetRow.key);
 
       const afterRows = await getPropertyRowBounds(reactGrab.page);
-      const afterTargetRow = afterRows.find((row) => row.key === targetRow!.key);
-      expect(afterTargetRow).toBeTruthy();
-      expect(Math.abs(afterTargetRow!.height - targetRow!.height)).toBeLessThan(0.5);
+      const afterTargetRow = afterRows[targetRowIndex];
+      if (!afterTargetRow) throw new Error("Expected hovered style row to remain visible");
+      expect(Math.abs(afterTargetRow.height - targetRow.height)).toBeLessThan(0.5);
     });
 
     test("S opens Style from the context menu", async ({ reactGrab }) => {

--- a/packages/react-grab/e2e/prompt-mode.spec.ts
+++ b/packages/react-grab/e2e/prompt-mode.spec.ts
@@ -177,6 +177,16 @@ test.describe("Prompt Mode", () => {
       const isPendingDismiss = await reactGrab.isPendingDismissVisible();
       expect(isPendingDismiss).toBe(false);
     });
+
+    test("empty input outside click should cancel without confirmation", async ({ reactGrab }) => {
+      await reactGrab.registerCommentAction();
+      await reactGrab.enterPromptMode("li:first-child");
+
+      await reactGrab.page.mouse.click(10, 10);
+
+      await expect.poll(() => reactGrab.isOverlayVisible(), { timeout: 2000 }).toBe(false);
+      expect(await reactGrab.isPendingDismissVisible()).toBe(false);
+    });
   });
 
   test.describe("Prompt Mode with Selection", () => {

--- a/packages/react-grab/e2e/prompt-mode.spec.ts
+++ b/packages/react-grab/e2e/prompt-mode.spec.ts
@@ -177,16 +177,6 @@ test.describe("Prompt Mode", () => {
       const isPendingDismiss = await reactGrab.isPendingDismissVisible();
       expect(isPendingDismiss).toBe(false);
     });
-
-    test("empty input outside click should cancel without confirmation", async ({ reactGrab }) => {
-      await reactGrab.registerCommentAction();
-      await reactGrab.enterPromptMode("li:first-child");
-
-      await reactGrab.page.mouse.click(10, 10);
-
-      await expect.poll(() => reactGrab.isOverlayVisible(), { timeout: 2000 }).toBe(false);
-      expect(await reactGrab.isPendingDismissVisible()).toBe(false);
-    });
   });
 
   test.describe("Prompt Mode with Selection", () => {

--- a/packages/react-grab/e2e/toolbar-actions.spec.ts
+++ b/packages/react-grab/e2e/toolbar-actions.spec.ts
@@ -193,6 +193,24 @@ test.describe("Toolbar Action Buttons", () => {
       expect(await reactGrab.getToolbarActionPressed("edit")).toBe(true);
     });
 
+    test("Style button switches from API comment selection mode", async ({ reactGrab }) => {
+      await waitForToolbar(reactGrab);
+      await reactGrab.page.evaluate(() => {
+        window.__REACT_GRAB__?.comment();
+      });
+      await expect
+        .poll(() => reactGrab.getToolbarActionPressed("comment"), { timeout: 2000 })
+        .toBe(true);
+
+      await reactGrab.clickToolbarAction("edit");
+      await reactGrab.hoverElement(BUTTON_SELECTOR);
+      await reactGrab.waitForSelectionBox();
+      await reactGrab.clickElement(BUTTON_SELECTOR);
+
+      await expect.poll(() => isEditPanelVisible(reactGrab.page), { timeout: 2000 }).toBe(true);
+      expect(await reactGrab.getToolbarActionPressed("edit")).toBe(true);
+    });
+
     test("keyboard shortcut switches a pending toolbar selection to style mode", async ({
       reactGrab,
     }) => {

--- a/packages/react-grab/e2e/toolbar-actions.spec.ts
+++ b/packages/react-grab/e2e/toolbar-actions.spec.ts
@@ -67,7 +67,9 @@ test.describe("Toolbar Action Buttons", () => {
       await reactGrab.clickToolbarAction("comment");
 
       expect(await reactGrab.isOverlayVisible()).toBe(true);
-      await expect.poll(() => reactGrab.getToolbarActionPressed("comment"), { timeout: 2000 }).toBe(true);
+      await expect
+        .poll(() => reactGrab.getToolbarActionPressed("comment"), { timeout: 2000 })
+        .toBe(true);
       expect(await reactGrab.getToolbarActionPressed("copy")).toBe(false);
       expect(await reactGrab.getToolbarActionPressed("edit")).toBe(false);
     });

--- a/packages/react-grab/e2e/toolbar-actions.spec.ts
+++ b/packages/react-grab/e2e/toolbar-actions.spec.ts
@@ -97,9 +97,7 @@ test.describe("Toolbar Action Buttons", () => {
       expect(await reactGrab.getToolbarActionPressed("edit")).toBe(false);
     });
 
-    test("context menu Comment marks only the Comment button as pressed", async ({
-      reactGrab,
-    }) => {
+    test("context menu Comment marks only the Comment button as pressed", async ({ reactGrab }) => {
       await waitForToolbar(reactGrab);
       await reactGrab.activate();
       await reactGrab.hoverElement(BUTTON_SELECTOR);

--- a/packages/react-grab/e2e/toolbar-actions.spec.ts
+++ b/packages/react-grab/e2e/toolbar-actions.spec.ts
@@ -153,6 +153,26 @@ test.describe("Toolbar Action Buttons", () => {
       expect(await reactGrab.getToolbarActionPressed("edit")).toBe(true);
     });
 
+    test("Style shortcut opens the style panel from a comment discard prompt", async ({
+      reactGrab,
+    }) => {
+      await waitForToolbar(reactGrab);
+      await reactGrab.clickToolbarAction("comment");
+      await reactGrab.hoverElement(BUTTON_SELECTOR);
+      await reactGrab.waitForSelectionBox();
+      await reactGrab.clickElement(BUTTON_SELECTOR);
+      await reactGrab.typeInInput("Discard this comment");
+      await reactGrab.page.mouse.click(10, 10);
+      await expect.poll(() => reactGrab.isPendingDismissVisible(), { timeout: 2000 }).toBe(true);
+
+      await reactGrab.page.keyboard.press("s");
+
+      await expect.poll(() => isEditPanelVisible(reactGrab.page), { timeout: 2000 }).toBe(true);
+      await expect.poll(() => reactGrab.isPromptModeActive(), { timeout: 2000 }).toBe(false);
+      expect(await reactGrab.getInputValue()).toBe("");
+      expect(await reactGrab.getToolbarActionPressed("edit")).toBe(true);
+    });
+
     test("Style button opens from a context-menu comment after pending toolbar selection", async ({
       reactGrab,
     }) => {

--- a/packages/react-grab/e2e/toolbar-actions.spec.ts
+++ b/packages/react-grab/e2e/toolbar-actions.spec.ts
@@ -116,5 +116,25 @@ test.describe("Toolbar Action Buttons", () => {
 
       await expect.poll(() => isEditPanelVisible(reactGrab.page), { timeout: 2000 }).toBe(true);
     });
+
+    test("Style button opens the style panel from a comment discard prompt", async ({
+      reactGrab,
+    }) => {
+      await waitForToolbar(reactGrab);
+      await reactGrab.clickToolbarAction("comment");
+      await reactGrab.hoverElement(BUTTON_SELECTOR);
+      await reactGrab.waitForSelectionBox();
+      await reactGrab.clickElement(BUTTON_SELECTOR);
+      await reactGrab.typeInInput("Discard this comment");
+      await reactGrab.page.mouse.click(10, 10);
+      await expect.poll(() => reactGrab.isPendingDismissVisible(), { timeout: 2000 }).toBe(true);
+
+      await reactGrab.clickToolbarAction("edit");
+
+      await expect.poll(() => isEditPanelVisible(reactGrab.page), { timeout: 2000 }).toBe(true);
+      await expect.poll(() => reactGrab.isPromptModeActive(), { timeout: 2000 }).toBe(false);
+      expect(await reactGrab.getInputValue()).toBe("");
+      expect(await reactGrab.getToolbarActionPressed("edit")).toBe(true);
+    });
   });
 });

--- a/packages/react-grab/e2e/toolbar-actions.spec.ts
+++ b/packages/react-grab/e2e/toolbar-actions.spec.ts
@@ -96,6 +96,22 @@ test.describe("Toolbar Action Buttons", () => {
       expect(await reactGrab.getToolbarActionPressed("comment")).toBe(false);
       expect(await reactGrab.getToolbarActionPressed("edit")).toBe(false);
     });
+
+    test("context menu Comment marks only the Comment button as pressed", async ({
+      reactGrab,
+    }) => {
+      await waitForToolbar(reactGrab);
+      await reactGrab.activate();
+      await reactGrab.hoverElement(BUTTON_SELECTOR);
+      await reactGrab.waitForSelectionBox();
+      await reactGrab.rightClickElement(BUTTON_SELECTOR);
+      await reactGrab.clickContextMenuItem("Comment");
+
+      await expect.poll(() => reactGrab.isPromptModeActive(), { timeout: 2000 }).toBe(true);
+      expect(await reactGrab.getToolbarActionPressed("comment")).toBe(true);
+      expect(await reactGrab.getToolbarActionPressed("copy")).toBe(false);
+      expect(await reactGrab.getToolbarActionPressed("edit")).toBe(false);
+    });
   });
 
   test.describe("Mode activation", () => {
@@ -137,6 +153,41 @@ test.describe("Toolbar Action Buttons", () => {
       await expect.poll(() => reactGrab.isPromptModeActive(), { timeout: 2000 }).toBe(false);
       expect(await reactGrab.getInputValue()).toBe("");
       expect(await reactGrab.getToolbarActionPressed("edit")).toBe(true);
+    });
+
+    test("Style button opens from a context-menu comment after pending toolbar selection", async ({
+      reactGrab,
+    }) => {
+      await waitForToolbar(reactGrab);
+      await reactGrab.clickToolbarAction("edit");
+      await reactGrab.hoverElement(BUTTON_SELECTOR);
+      await reactGrab.waitForSelectionBox();
+      await reactGrab.rightClickElement(BUTTON_SELECTOR);
+      await reactGrab.clickContextMenuItem("Comment");
+      await reactGrab.typeInInput("Discard this context comment");
+      await reactGrab.page.mouse.click(10, 10);
+      await expect.poll(() => reactGrab.isPendingDismissVisible(), { timeout: 2000 }).toBe(true);
+
+      await reactGrab.clickToolbarAction("edit");
+
+      await expect.poll(() => isEditPanelVisible(reactGrab.page), { timeout: 2000 }).toBe(true);
+      await expect.poll(() => reactGrab.isPromptModeActive(), { timeout: 2000 }).toBe(false);
+      expect(await reactGrab.getToolbarActionPressed("edit")).toBe(true);
+    });
+
+    test("keyboard shortcut switches a pending toolbar selection to style mode", async ({
+      reactGrab,
+    }) => {
+      await waitForToolbar(reactGrab);
+      await reactGrab.clickToolbarAction("comment");
+      await reactGrab.hoverElement(BUTTON_SELECTOR);
+      await reactGrab.waitForSelectionBox();
+
+      await reactGrab.page.keyboard.press("s");
+
+      await expect.poll(() => isEditPanelVisible(reactGrab.page), { timeout: 2000 }).toBe(true);
+      expect(await reactGrab.getToolbarActionPressed("edit")).toBe(true);
+      expect(await reactGrab.getToolbarActionPressed("comment")).toBe(false);
     });
   });
 });

--- a/packages/react-grab/src/components/edit-panel/property-list.tsx
+++ b/packages/react-grab/src/components/edit-panel/property-list.tsx
@@ -223,18 +223,20 @@ export const PropertyList: Component<PropertyListProps> = (props) => {
                   </div>
                 }
               >
-                <ActivePropertyControl
-                  property={property()}
-                  activeKey={props.activeKey}
-                  onStep={props.onStep}
-                  onCommit={props.onCommit}
-                  onEditComplete={props.onEditComplete}
-                  onInvalidCommit={props.onInvalidCommit}
-                  onInteract={props.onInteract}
-                  onColorPickerRegister={props.onColorPickerRegister}
-                  showLabel
-                  tailwindLabel={props.activeTailwindLabel}
-                />
+                <div class="flex items-center w-full min-h-[24px]">
+                  <ActivePropertyControl
+                    property={property()}
+                    activeKey={props.activeKey}
+                    onStep={props.onStep}
+                    onCommit={props.onCommit}
+                    onEditComplete={props.onEditComplete}
+                    onInvalidCommit={props.onInvalidCommit}
+                    onInteract={props.onInteract}
+                    onColorPickerRegister={props.onColorPickerRegister}
+                    showLabel
+                    tailwindLabel={props.activeTailwindLabel}
+                  />
+                </div>
               </Show>
             </button>
           );

--- a/packages/react-grab/src/components/edit-panel/property-list.tsx
+++ b/packages/react-grab/src/components/edit-panel/property-list.tsx
@@ -156,7 +156,7 @@ export const PropertyList: Component<PropertyListProps> = (props) => {
               type="button"
               role="menuitem"
               tabindex={-1}
-              class="relative z-1 contain-layout block w-full px-0 py-0 cursor-pointer text-left border-none bg-transparent min-h-[24px]"
+              class="relative z-1 contain-layout block w-full h-[24px] px-0 py-0 cursor-pointer text-left border-none bg-transparent"
               onPointerEnter={() => {
                 maybeActivateHoveredIndex(propertyIndex, "enter");
               }}
@@ -190,7 +190,7 @@ export const PropertyList: Component<PropertyListProps> = (props) => {
               <Show
                 when={isActive()}
                 fallback={
-                  <div class="flex items-center justify-between w-full px-2 py-1 gap-2 min-h-[24px]">
+                  <div class="flex items-center justify-between w-full h-[24px] px-2 gap-2">
                     <span class="text-[13px] leading-4 font-sans font-medium text-[var(--rg-text-primary)] truncate min-w-0">
                       {property().label}
                     </span>
@@ -223,7 +223,7 @@ export const PropertyList: Component<PropertyListProps> = (props) => {
                   </div>
                 }
               >
-                <div class="flex items-center w-full min-h-[24px]">
+                <div class="flex items-center w-full h-[24px]">
                   <ActivePropertyControl
                     property={property()}
                     activeKey={props.activeKey}

--- a/packages/react-grab/src/components/toolbar/index.tsx
+++ b/packages/react-grab/src/components/toolbar/index.tsx
@@ -729,7 +729,9 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
               wrapperClass={actionButtonWrapperClass()}
               onClick={handleComment}
               {...createFreezeHandlers(COMMENT_ACTION_ID)}
-              icon={<IconComment size={14} class={actionIconClass(isActionActive(COMMENT_ACTION_ID))} />}
+              icon={
+                <IconComment size={14} class={actionIconClass(isActionActive(COMMENT_ACTION_ID))} />
+              }
               tooltipVisible={isTooltipVisible(COMMENT_ACTION_ID)}
               tooltipPosition={tooltipPosition()}
               tooltip="Comment"

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -3445,6 +3445,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         },
         customEnterPromptMode: () => {
           clearAllLabels();
+          clearPendingToolbarSelection();
+          setActiveActionId(COMMENT_ACTION_ID);
           actions.clearInputText();
           actions.enterPromptMode(position, element);
           deferHideContextMenu();

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -2311,6 +2311,13 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       const action = findShortcutAction(pluginRegistry.store.actions, event);
       if (!action) return false;
 
+      if (isPromptMode()) {
+        if (!runActionForCurrentSelection(action.id)) return false;
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        return true;
+      }
+
       const position = { x: pointer().x, y: pointer().y };
       clearPendingToolbarSelection();
       action.onAction(buildImmediateActionContext(element, position));

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -112,7 +112,7 @@ import type {
   DropdownAnchor,
   ElementLabelVariant,
 } from "../types.js";
-import { createEditModeController } from "./edit-mode.js";
+import { createEditModeController, type EditModeOverrides } from "./edit-mode.js";
 import { DEFAULT_THEME } from "./theme.js";
 import { createPluginRegistry } from "./plugin-registry.js";
 import { createArrowNavigator } from "./arrow-navigation.js";
@@ -493,7 +493,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       if (editMode.isOpen()) return EDIT_ACTION_ID;
       if (isCommentMode()) return COMMENT_ACTION_ID;
       if (isPendingContextMenuSelect()) return pendingToolbarActionId();
-      if (isActivated()) return pendingToolbarActionId() ?? DEFAULT_ACTION_ID;
+      if (isActivated()) return DEFAULT_ACTION_ID;
       return null;
     });
     const [arrowNavigationElements, setArrowNavigationElements] = createSignal<Element[]>([]);
@@ -1589,8 +1589,21 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       }
       const element = store.frozenElement || targetElement();
       if (!element) return;
-      editMode.trigger(element, { x: pointer().x, y: pointer().y });
+      openEditMode(element, { x: pointer().x, y: pointer().y });
     };
+
+    const openEditMode = (
+      element: Element,
+      position: Position,
+      overrides: EditModeOverrides = {},
+    ): boolean => editMode.trigger(element, position, overrides);
+
+    const currentSelectionEditOverrides = (element: Element): EditModeOverrides => ({
+      filePath: store.selectionFilePath ?? undefined,
+      lineNumber: store.selectionLineNumber ?? undefined,
+      componentName: resolvedComponentName(),
+      tagName: getTagName(element) || undefined,
+    });
 
     const clearPendingToolbarSelection = () => {
       pendingDefaultActionId = null;
@@ -1617,12 +1630,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       }
 
       if (actionId === EDIT_ACTION_ID) {
-        const didOpen = editMode.trigger(element, position, {
-          filePath: store.selectionFilePath ?? undefined,
-          lineNumber: store.selectionLineNumber ?? undefined,
-          componentName: resolvedComponentName(),
-          tagName: getTagName(element) || undefined,
-        });
+        const didOpen = openEditMode(element, position, currentSelectionEditOverrides(element));
         if (!didOpen) return true;
         actions.clearInputText();
         actions.exitPromptMode();
@@ -1682,7 +1690,13 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     const runPendingDefaultAction = (element: Element, position: Position) => {
       const actionId = pendingDefaultActionId;
       pendingDefaultActionId = null;
+      setPendingToolbarActionId(null);
       if (!actionId) return;
+
+      if (actionId === EDIT_ACTION_ID) {
+        openEditMode(element, position, currentSelectionEditOverrides(element));
+        return;
+      }
 
       const action = pluginRegistry.store.actions.find(
         (registeredAction) => registeredAction.id === actionId,
@@ -3395,7 +3409,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       };
 
       const enterEditModeAction = () => {
-        const didOpen = editMode.trigger(element, position, {
+        const didOpen = openEditMode(element, position, {
           filePath,
           lineNumber,
           componentName,

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -1647,6 +1647,13 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         if (toolbarActiveActionId() !== actionId && isPromptMode()) {
           if (runActionForCurrentSelection(actionId)) return;
         }
+        if (toolbarActiveActionId() !== actionId && store.pendingCommentMode) {
+          actions.setPendingCommentMode(false);
+          pendingDefaultActionId = actionId;
+          setPendingToolbarActionId(actionId);
+          setIsPendingContextMenuSelect(true);
+          return;
+        }
         if (toolbarActiveActionId() !== actionId && isPendingContextMenuSelect()) {
           pendingDefaultActionId = actionId;
           setPendingToolbarActionId(actionId);
@@ -1675,7 +1682,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     const openContextMenu = (element: Element, position: Position) => {
       stopShiftMultiSelecting();
       dismissAllPopups();
-      clearPendingToolbarSelection();
       actions.showContextMenu(position, element);
       clearArrowNavigation();
       pluginRegistry.hooks.onContextMenu(element, position);
@@ -2319,7 +2325,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       }
 
       const position = { x: pointer().x, y: pointer().y };
-      clearPendingToolbarSelection();
       action.onAction(buildImmediateActionContext(element, position));
 
       event.preventDefault();

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -2512,6 +2512,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           isEventFromOverlay(event, "data-react-grab-ignore-events") && !isEnterToActivateInput;
 
         if (isPromptMode() || isFromOverlay) {
+          if (isPromptMode() && !isFromReactGrabInput && tryHandleBareKeyShortcut(event)) return;
+
           if (event.key === "Escape") {
             if (isPromptMode()) {
               handleInputCancel();

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -1557,12 +1557,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       actions.clearLastCopied();
       if (!isPromptMode()) return;
 
-      if (store.inputText.trim() === "") {
-        actions.clearInputText();
-        deactivateRenderer();
-        return;
-      }
-
       if (isPendingDismiss()) {
         actions.clearInputText();
         deactivateRenderer();

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -483,12 +483,19 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     let keyboardSelectedElement: Element | null = null;
     let pendingDefaultActionId: string | null = null;
     const [isPendingContextMenuSelect, setIsPendingContextMenuSelect] = createSignal(false);
-    const [activeActionId, setActiveActionId] = createSignal<string | null>(null);
+    const [pendingToolbarActionId, setPendingToolbarActionId] = createSignal<string | null>(null);
     const [debouncedElementForComponentName, setDebouncedElementForComponentName] =
       createSignal<Element | null>(null);
     const [resolvedComponentName, setResolvedComponentName] = createComponentNameForElement(
       debouncedElementForComponentName,
     );
+    const toolbarActiveActionId = createMemo(() => {
+      if (editMode.isOpen()) return EDIT_ACTION_ID;
+      if (isCommentMode()) return COMMENT_ACTION_ID;
+      if (isPendingContextMenuSelect()) return pendingToolbarActionId();
+      if (isActivated()) return pendingToolbarActionId() ?? DEFAULT_ACTION_ID;
+      return null;
+    });
     const [arrowNavigationElements, setArrowNavigationElements] = createSignal<Element[]>([]);
     const [arrowNavigationActiveIndex, setArrowNavigationActiveIndex] = createSignal(0);
 
@@ -1477,7 +1484,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       clearArrowNavigation();
       keyboardSelectedElement = null;
       setIsPendingContextMenuSelect(false);
-      setActiveActionId(null);
+      setPendingToolbarActionId(null);
       if (wasDragging) {
         document.body.style.userSelect = "";
       }
@@ -1589,6 +1596,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       pendingDefaultActionId = null;
       setIsPendingContextMenuSelect(false);
       actions.setPendingCommentMode(false);
+      setPendingToolbarActionId(null);
     };
 
     const runActionForCurrentSelection = (actionId: string): boolean => {
@@ -1619,7 +1627,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         actions.clearInputText();
         actions.exitPromptMode();
         clearPendingToolbarSelection();
-        setActiveActionId(EDIT_ACTION_ID);
         return true;
       }
 
@@ -1635,12 +1642,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         // While still choosing an element, clicking a different action switches
         // the pending action in place instead of tearing down selection mode;
         // clicking the already-active action toggles selection off.
-        if (activeActionId() !== actionId && isPromptMode()) {
+        if (toolbarActiveActionId() !== actionId && isPromptMode()) {
           if (runActionForCurrentSelection(actionId)) return;
         }
-        if (activeActionId() !== actionId && isPendingContextMenuSelect()) {
+        if (toolbarActiveActionId() !== actionId && isPendingContextMenuSelect()) {
           pendingDefaultActionId = actionId;
-          setActiveActionId(actionId);
+          setPendingToolbarActionId(actionId);
           return;
         }
         deactivateRenderer();
@@ -1648,7 +1655,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       }
       if (!isEnabled()) return;
       pendingDefaultActionId = actionId;
-      setActiveActionId(actionId);
+      setPendingToolbarActionId(actionId);
       setIsPendingContextMenuSelect(true);
       toggleActivate();
     };
@@ -1659,7 +1666,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
     const enterCommentModeForElement = (element: Element, positionX: number, positionY: number) => {
       clearPendingToolbarSelection();
-      setActiveActionId(COMMENT_ACTION_ID);
       actions.clearInputText();
       actions.enterPromptMode({ x: positionX, y: positionY }, element);
     };
@@ -2285,7 +2291,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       );
       if (!opened) return false;
       clearPendingToolbarSelection();
-      setActiveActionId(EDIT_ACTION_ID);
       event.preventDefault();
       event.stopImmediatePropagation();
       return true;
@@ -3365,7 +3370,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
       const copyAction = () => {
         clearPendingToolbarSelection();
-        setActiveActionId(DEFAULT_ACTION_ID);
         onBeforeCopy?.();
         performCopyWithLabel({
           element,
@@ -3379,7 +3383,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       const defaultEnterPromptMode = () => {
         clearAllLabels();
         clearPendingToolbarSelection();
-        setActiveActionId(COMMENT_ACTION_ID);
         onBeforePrompt?.();
         preparePromptMode(element, position.x, position.y);
         actions.setPointer({ x: position.x, y: position.y });
@@ -3400,7 +3403,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         });
         if (didOpen) {
           clearPendingToolbarSelection();
-          setActiveActionId(EDIT_ACTION_ID);
         }
         hideContextMenuAction();
       };
@@ -3461,7 +3463,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         customEnterPromptMode: () => {
           clearAllLabels();
           clearPendingToolbarSelection();
-          setActiveActionId(COMMENT_ACTION_ID);
           actions.clearInputText();
           actions.enterPromptMode(position, element);
           deferHideContextMenu();
@@ -3659,7 +3660,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
                 isActive={isActivated()}
                 onToggleActive={handleToggleActive}
                 onActivateAction={handleActivateAction}
-                activeActionId={activeActionId()}
+                activeActionId={toolbarActiveActionId()}
                 enabled={isEnabled()}
                 shakeCount={toolbarShakeCount()}
                 onToolbarStateChange={(state) => {

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -1577,6 +1577,30 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       editMode.trigger(element, { x: pointer().x, y: pointer().y });
     };
 
+    const runActionForCurrentSelection = (actionId: string): boolean => {
+      const element = store.frozenElement || targetElement();
+      if (!element) return false;
+
+      const position = { x: pointer().x, y: pointer().y };
+      actions.clearInputText();
+      actions.exitPromptMode();
+      actions.setPendingCommentMode(false);
+      setIsPendingContextMenuSelect(false);
+      setActiveActionId(actionId);
+
+      const action = pluginRegistry.store.actions.find(
+        (registeredAction) => registeredAction.id === actionId,
+      );
+      if (!action) {
+        handleSetDefaultAction(DEFAULT_ACTION_ID);
+        openContextMenu(element, position);
+        return true;
+      }
+
+      action.onAction(buildImmediateActionContext(element, position));
+      return true;
+    };
+
     const handleActivateAction = (actionId: string) => {
       if (isActivated()) {
         // While still choosing an element, clicking a different action switches
@@ -1586,6 +1610,9 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           pendingDefaultActionId = actionId;
           setActiveActionId(actionId);
           return;
+        }
+        if (activeActionId() !== actionId && isPromptMode()) {
+          if (runActionForCurrentSelection(actionId)) return;
         }
         deactivateRenderer();
         return;

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -1548,6 +1548,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       actions.clearLastCopied();
       if (!isPromptMode()) return;
 
+      if (store.inputText.trim() === "") {
+        actions.clearInputText();
+        deactivateRenderer();
+        return;
+      }
+
       if (isPendingDismiss()) {
         actions.clearInputText();
         deactivateRenderer();
@@ -1577,6 +1583,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       editMode.trigger(element, { x: pointer().x, y: pointer().y });
     };
 
+    const clearPendingToolbarSelection = () => {
+      pendingDefaultActionId = null;
+      setIsPendingContextMenuSelect(false);
+      actions.setPendingCommentMode(false);
+    };
+
     const runActionForCurrentSelection = (actionId: string): boolean => {
       const element = store.frozenElement || targetElement();
       if (!element) return false;
@@ -1584,8 +1596,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       const position = { x: pointer().x, y: pointer().y };
       actions.clearInputText();
       actions.exitPromptMode();
-      actions.setPendingCommentMode(false);
-      setIsPendingContextMenuSelect(false);
+      clearPendingToolbarSelection();
       setActiveActionId(actionId);
 
       const action = pluginRegistry.store.actions.find(
@@ -1606,13 +1617,13 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         // While still choosing an element, clicking a different action switches
         // the pending action in place instead of tearing down selection mode;
         // clicking the already-active action toggles selection off.
+        if (activeActionId() !== actionId && isPromptMode()) {
+          if (runActionForCurrentSelection(actionId)) return;
+        }
         if (activeActionId() !== actionId && isPendingContextMenuSelect()) {
           pendingDefaultActionId = actionId;
           setActiveActionId(actionId);
           return;
-        }
-        if (activeActionId() !== actionId && isPromptMode()) {
-          if (runActionForCurrentSelection(actionId)) return;
         }
         deactivateRenderer();
         return;
@@ -1629,7 +1640,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
 
     const enterCommentModeForElement = (element: Element, positionX: number, positionY: number) => {
-      actions.setPendingCommentMode(false);
+      clearPendingToolbarSelection();
+      setActiveActionId(COMMENT_ACTION_ID);
       actions.clearInputText();
       actions.enterPromptMode({ x: positionX, y: positionY }, element);
     };
@@ -1637,6 +1649,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     const openContextMenu = (element: Element, position: Position) => {
       stopShiftMultiSelecting();
       dismissAllPopups();
+      clearPendingToolbarSelection();
       actions.showContextMenu(position, element);
       clearArrowNavigation();
       pluginRegistry.hooks.onContextMenu(element, position);
@@ -2253,6 +2266,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         { initialSearchQuery: event.key },
       );
       if (!opened) return false;
+      clearPendingToolbarSelection();
+      setActiveActionId(EDIT_ACTION_ID);
       event.preventDefault();
       event.stopImmediatePropagation();
       return true;
@@ -2266,6 +2281,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       if (!action) return false;
 
       const position = { x: pointer().x, y: pointer().y };
+      clearPendingToolbarSelection();
+      setActiveActionId(action.id);
       action.onAction(buildImmediateActionContext(element, position));
 
       event.preventDefault();
@@ -3330,6 +3347,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         : actions.hideContextMenu;
 
       const copyAction = () => {
+        clearPendingToolbarSelection();
+        setActiveActionId(DEFAULT_ACTION_ID);
         onBeforeCopy?.();
         performCopyWithLabel({
           element,
@@ -3342,6 +3361,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
       const defaultEnterPromptMode = () => {
         clearAllLabels();
+        clearPendingToolbarSelection();
+        setActiveActionId(COMMENT_ACTION_ID);
         onBeforePrompt?.();
         preparePromptMode(element, position.x, position.y);
         actions.setPointer({ x: position.x, y: position.y });
@@ -3354,12 +3375,16 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       };
 
       const enterEditModeAction = () => {
-        editMode.trigger(element, position, {
+        const didOpen = editMode.trigger(element, position, {
           filePath,
           lineNumber,
           componentName,
           tagName,
         });
+        if (didOpen) {
+          clearPendingToolbarSelection();
+          setActiveActionId(EDIT_ACTION_ID);
+        }
         hideContextMenuAction();
       };
 

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -1596,20 +1596,36 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       if (!element) return false;
 
       const position = { x: pointer().x, y: pointer().y };
-      actions.clearInputText();
-      actions.exitPromptMode();
-      clearPendingToolbarSelection();
-      setActiveActionId(actionId);
-
       const action = pluginRegistry.store.actions.find(
         (registeredAction) => registeredAction.id === actionId,
       );
       if (!action) {
+        actions.clearInputText();
+        actions.exitPromptMode();
+        clearPendingToolbarSelection();
         handleSetDefaultAction(DEFAULT_ACTION_ID);
         openContextMenu(element, position);
         return true;
       }
 
+      if (actionId === EDIT_ACTION_ID) {
+        const didOpen = editMode.trigger(element, position, {
+          filePath: store.selectionFilePath ?? undefined,
+          lineNumber: store.selectionLineNumber ?? undefined,
+          componentName: resolvedComponentName(),
+          tagName: getTagName(element) || undefined,
+        });
+        if (!didOpen) return true;
+        actions.clearInputText();
+        actions.exitPromptMode();
+        clearPendingToolbarSelection();
+        setActiveActionId(EDIT_ACTION_ID);
+        return true;
+      }
+
+      actions.clearInputText();
+      actions.exitPromptMode();
+      clearPendingToolbarSelection();
       action.onAction(buildImmediateActionContext(element, position));
       return true;
     };
@@ -2284,7 +2300,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
       const position = { x: pointer().x, y: pointer().y };
       clearPendingToolbarSelection();
-      setActiveActionId(action.id);
       action.onAction(buildImmediateActionContext(element, position));
 
       event.preventDefault();

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -80,6 +80,8 @@ import {
   NEXTJS_REVALIDATION_DELAY_MS,
   TOOLBAR_DEFAULT_POSITION_RATIO,
   DEFAULT_ACTION_ID,
+  COMMENT_ACTION_ID,
+  EDIT_ACTION_ID,
   EDIT_PANEL_POINTER_ANCHOR_WIDTH_PX,
 } from "../constants.js";
 import { getBoundsCenter } from "../utils/get-bounds-center.js";

--- a/scripts/check-publish-provenance.mjs
+++ b/scripts/check-publish-provenance.mjs
@@ -29,9 +29,7 @@ for (const manifestPath of collectPackageManifests()) {
   if (manifest.private === true) continue;
 
   const repositoryUrl =
-    typeof manifest.repository === "string"
-      ? manifest.repository
-      : manifest.repository?.url;
+    typeof manifest.repository === "string" ? manifest.repository : manifest.repository?.url;
 
   if (repositoryUrl !== EXPECTED_REPOSITORY_URL) {
     offendingPackages.push({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Allow toolbar actions and shortcuts to switch out of an existing comment discard prompt on the current selection
- Preserve discard-prompt cancellation behavior; do not bypass or remove the discard prompt flow
- Derive toolbar active action from actual mode (`prompt` -> Comment, open edit panel -> Style, pending action/default -> Copy) instead of manually syncing it through each entry path
- Keep pending toolbar action ids scoped to pending-selection flows and preserve them until the selected action succeeds or is consumed
- Reuse a single edit-opening helper across toolbar, prompt-switch, and context-menu paths
- Gate prompt-to-Style switching so the draft is discarded only after the edit panel successfully opens
- Stabilize style/edit-panel row hover height so rows do not shift when becoming active
- Add e2e regressions for prompt discard via button and shortcut, API comment selection switching, context-menu prompt entry, stale pending selection, shortcut switching, and style-row hover height stability

## Testing
- `pnpm dlx --package @antfu/ni nr build`
- `pnpm dlx --package @antfu/ni nr --filter react-grab test -- e2e/toolbar-actions.spec.ts e2e/edit-panel.spec.ts --grep "API comment|Style shortcut opens|hovering a style row"`
- `pnpm dlx --package @antfu/ni nr test`
- `pnpm dlx --package @antfu/ni nr lint`
- `pnpm dlx --package @antfu/ni nr typecheck`
- `pnpm dlx --package @antfu/ni nr format`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83d276ec-481f-4040-8bed-3c718b18472e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83d276ec-481f-4040-8bed-3c718b18472e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes toolbar/prompt transitions in `react-grab`, locks Style row height, and enables action shortcuts inside the discard prompt. Style now opens on the current selection from a discard prompt or pending selection via the Style button or "s"; discard confirmation remains cancelable.

- **Bug Fixes**
  - Enable action shortcuts during prompt and discard; switch to Style on the current selection; derive toolbar active action from mode; preserve pending toolbar action until it succeeds, then clear; align context‑menu prompt state.
  - Gate prompt→Style so drafts discard only after the edit panel opens; apply current‑selection overrides; fall back to the context menu if the action is missing; stabilize Style row height; add e2e for context‑menu Comment pressed state, discard→Style via click/shortcut, pending→Style via toolbar and "s", API comment→Style switch, and row‑height stability.

<sup>Written for commit ab655b30333c6bf06ada0ceba36ba64ee4483cf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

