### PR TITLE
Deslop core, delete dead code, fix copy/freeze bugs

### DIFF
--- a/packages/cli/src/utils/clipboard.ts
+++ b/packages/cli/src/utils/clipboard.ts
@@ -23,7 +23,7 @@ const PICKLE_ALIGN_BYTES = 4;
 const SIGNATURE_SCAN_CHARS = 32 * 1024;
 
 export const GRAB_MIME = "application/x-react-grab";
-export const CHROMIUM_CUSTOM_FORMAT = "chromium/x-web-custom-data";
+const CHROMIUM_CUSTOM_FORMAT = "chromium/x-web-custom-data";
 
 // React Grab plain-text payloads always carry a component-stack frame such as
 // "in LoginForm (at components/login-form.tsx:46:19)". Used to recognize a grab

--- a/packages/react-grab/src/components/context-menu.tsx
+++ b/packages/react-grab/src/components/context-menu.tsx
@@ -389,7 +389,6 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
                 }
               }}
               shrink
-              forceShowIcon={props.hasFilePath}
             />
           </div>
           <BottomSection>

--- a/packages/react-grab/src/components/edit-panel/color-picker.tsx
+++ b/packages/react-grab/src/components/edit-panel/color-picker.tsx
@@ -1,6 +1,7 @@
 import { createSignal, onCleanup, onMount, Show, type Component } from "solid-js";
 import { IME_COMPOSING_KEY_CODE } from "../../constants.js";
 import { parseAnyColor } from "../../utils/parse-any-color.js";
+import { EDIT_LABEL_CLASS } from "./constants.js";
 
 // Native <input type="color"> only accepts `#rrggbb` (no alpha, no
 // shorthand). Strip the alpha byte if present so the picker opens at
@@ -18,7 +19,6 @@ interface ColorPickerProps {
   emphasized?: boolean;
 }
 
-const LABEL_CLASS = "text-[13px] leading-4 font-medium";
 const HEX_CLASS = "text-[12px] leading-4 font-medium tabular-nums uppercase";
 
 export const ColorPicker: Component<ColorPickerProps> = (props) => {
@@ -86,7 +86,7 @@ export const ColorPicker: Component<ColorPickerProps> = (props) => {
     <div class="flex items-center gap-2 w-full px-2 h-[20px]">
       <Show when={props.label}>
         {(text) => (
-          <span class={`${LABEL_CLASS} text-[var(--rg-text-primary)] truncate min-w-0`}>
+          <span class={`${EDIT_LABEL_CLASS} text-[var(--rg-text-primary)] truncate min-w-0`}>
             {text()}
           </span>
         )}
@@ -164,10 +164,10 @@ export const ColorPicker: Component<ColorPickerProps> = (props) => {
             const pickedRgb = event.currentTarget.value;
             const originalAlpha = props.value.length === 9 ? props.value.slice(7) : "";
             const preservedAlpha = originalAlpha.toLowerCase() === "00" ? "" : originalAlpha;
-            const next = pickedRgb + preservedAlpha;
+            const nextColorValue = pickedRgb + preservedAlpha;
             props.onInteract?.();
-            if (next && next.toLowerCase() !== props.value.toLowerCase()) {
-              props.onCommit(next);
+            if (nextColorValue && nextColorValue.toLowerCase() !== props.value.toLowerCase()) {
+              props.onCommit(nextColorValue);
             }
           }}
         />

--- a/packages/react-grab/src/components/edit-panel/constants.ts
+++ b/packages/react-grab/src/components/edit-panel/constants.ts
@@ -1,3 +1,5 @@
+export const EDIT_LABEL_CLASS = "text-[13px] leading-4 font-medium";
+
 export const HIDDEN_FOCUS_PRESERVING_STYLE = {
   position: "absolute" as const,
   opacity: 0,

--- a/packages/react-grab/src/components/edit-panel/cycle-control.tsx
+++ b/packages/react-grab/src/components/edit-panel/cycle-control.tsx
@@ -1,6 +1,7 @@
 import { Show, type Component } from "solid-js";
 import type { EnumEditableOption } from "../../types.js";
 import { pickNextOption } from "../../utils/pick-next-option.js";
+import { EDIT_LABEL_CLASS } from "./constants.js";
 import { StepArrow } from "./step-arrow.js";
 
 interface CycleControlProps {
@@ -11,8 +12,6 @@ interface CycleControlProps {
   onCommit: (value: string) => void;
 }
 
-const LABEL_CLASS = "text-[13px] leading-4 font-medium";
-
 export const CycleControl: Component<CycleControlProps> = (props) => {
   const currentLabel = () => {
     const match = props.options.find((option) => option.value === props.value);
@@ -20,14 +19,14 @@ export const CycleControl: Component<CycleControlProps> = (props) => {
   };
 
   const advance = (direction: 1 | -1) => {
-    const next = pickNextOption(props.options, props.value, direction);
-    if (next) props.onCommit(next.value);
+    const nextOption = pickNextOption(props.options, props.value, direction);
+    if (nextOption) props.onCommit(nextOption.value);
   };
 
   return (
     <div class="flex items-center gap-2 w-full px-2 h-[20px]">
       <Show when={props.label}>
-        <span class={`${LABEL_CLASS} text-[var(--rg-text-primary)] truncate min-w-0`}>
+        <span class={`${EDIT_LABEL_CLASS} text-[var(--rg-text-primary)] truncate min-w-0`}>
           {props.label}
         </span>
       </Show>

--- a/packages/react-grab/src/components/edit-panel/discard-confirmation.ts
+++ b/packages/react-grab/src/components/edit-panel/discard-confirmation.ts
@@ -1,7 +1,7 @@
 import { createSignal, onCleanup, type Accessor } from "solid-js";
 import { EDIT_DISCARD_PROMPT_IDLE_MS } from "../../constants.js";
 
-export interface DiscardConfirmation {
+interface DiscardConfirmation {
   isPending: Accessor<boolean>;
   show: () => void;
   hide: () => void;

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -500,7 +500,6 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
                     isClickable={false}
                     onClick={() => {}}
                     shrink
-                    forceShowIcon={false}
                   />
                   <Show when={hasPendingTweaks()}>
                     <button

--- a/packages/react-grab/src/components/edit-panel/step-arrow.tsx
+++ b/packages/react-grab/src/components/edit-panel/step-arrow.tsx
@@ -3,10 +3,7 @@ import type { Component } from "solid-js";
 interface StepArrowProps {
   direction: "left" | "right";
   active: boolean;
-  disabled?: boolean;
   onPointerDown?: () => void;
-  onPointerUp?: () => void;
-  onPointerLeave?: () => void;
 }
 
 const ARROW_BLOCK_LEFT_PATH =
@@ -20,14 +17,10 @@ const ACTIVE_TRANSLATE_PX = 2;
 const ACTIVE_SCALE = 1.12;
 
 export const StepArrow: Component<StepArrowProps> = (props) => {
-  const fill = () => (props.disabled ? IDLE_COLOR : props.active ? ACTIVE_COLOR : IDLE_COLOR);
+  const fill = () => (props.active ? ACTIVE_COLOR : IDLE_COLOR);
   const translateX = () =>
-    props.active && !props.disabled
-      ? props.direction === "left"
-        ? -ACTIVE_TRANSLATE_PX
-        : ACTIVE_TRANSLATE_PX
-      : 0;
-  const scale = () => (props.active && !props.disabled ? ACTIVE_SCALE : 1);
+    props.active ? (props.direction === "left" ? -ACTIVE_TRANSLATE_PX : ACTIVE_TRANSLATE_PX) : 0;
+  const scale = () => (props.active ? ACTIVE_SCALE : 1);
   const path = () => (props.direction === "left" ? ARROW_BLOCK_LEFT_PATH : ARROW_BLOCK_RIGHT_PATH);
 
   return (
@@ -38,14 +31,12 @@ export const StepArrow: Component<StepArrowProps> = (props) => {
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       aria-hidden="true"
-      onPointerDown={props.disabled ? undefined : props.onPointerDown}
-      onPointerUp={props.onPointerUp}
-      onPointerLeave={props.onPointerLeave}
+      onPointerDown={props.onPointerDown}
       style={{
         width: "16px",
         height: "16px",
         "flex-shrink": "0",
-        cursor: props.disabled ? "default" : "pointer",
+        cursor: "pointer",
         transform: `translateX(${translateX()}px) scale(${scale()})`,
         transition: props.active
           ? "transform 30ms cubic-bezier(0, 0, 0.2, 1)"
@@ -58,11 +49,7 @@ export const StepArrow: Component<StepArrowProps> = (props) => {
         fill-rule="evenodd"
         clip-rule="evenodd"
         style={{
-          transition: props.disabled
-            ? "fill 200ms ease"
-            : props.active
-              ? "fill 50ms ease"
-              : "fill 300ms ease",
+          transition: props.active ? "fill 50ms ease" : "fill 300ms ease",
         }}
       />
     </svg>

--- a/packages/react-grab/src/components/edit-panel/tailwind-autoapply.ts
+++ b/packages/react-grab/src/components/edit-panel/tailwind-autoapply.ts
@@ -128,7 +128,7 @@ interface TailwindAutoApplyOptions {
   setIsCompact: (value: boolean) => void;
 }
 
-export interface TailwindAutoApplyController {
+interface TailwindAutoApplyController {
   readonly isInlineNumericEdit: Accessor<boolean>;
   isInlineNumericDraft: (query: string) => boolean;
   tryApplyNumericValue: (query: string) => boolean;

--- a/packages/react-grab/src/components/edit-panel/tweak-store.ts
+++ b/packages/react-grab/src/components/edit-panel/tweak-store.ts
@@ -14,7 +14,7 @@ interface CreateTweakStoreOptions {
   searchQuery: () => string;
 }
 
-export interface TweakStore {
+interface TweakStore {
   filteredProperties: () => EditableProperty[];
   applyTweak: (property: EditableProperty, nextValue: number | string) => void;
   buildPendingEdits: () => PendingEdit[];

--- a/packages/react-grab/src/components/edit-panel/value-stepper.tsx
+++ b/packages/react-grab/src/components/edit-panel/value-stepper.tsx
@@ -12,6 +12,7 @@ import {
 } from "../../constants.js";
 import { formatDisplayValue } from "../../utils/format-css-value.js";
 import { Slot } from "../slot.js";
+import { EDIT_LABEL_CLASS } from "./constants.js";
 import { StepArrow } from "./step-arrow.js";
 
 interface ValueStepperProps {
@@ -36,7 +37,6 @@ const HASH_MARK_PERCENTS = Array.from(
 );
 
 const VALUE_CLASS = "text-[12px] leading-4 font-medium tabular-nums";
-const LABEL_CLASS = "text-[13px] leading-4 font-medium";
 const INLINE_VALUE_PATTERN = /^(-?(?:\d+\.?\d*|\.\d+))\s*([a-zA-Z%]*)$/;
 
 export const ValueStepper: Component<ValueStepperProps> = (props) => {
@@ -45,7 +45,6 @@ export const ValueStepper: Component<ValueStepperProps> = (props) => {
   const [isDragging, setIsDragging] = createSignal(false);
   const [isHovered, setIsHovered] = createSignal(false);
   const isEditing = () => draftText() !== null;
-  let trackElement: HTMLDivElement | undefined;
   let valueTextElement: HTMLSpanElement | undefined;
   let dragState: {
     startX: number;
@@ -228,7 +227,6 @@ export const ValueStepper: Component<ValueStepperProps> = (props) => {
   return (
     <div class="flex items-center gap-1 w-full px-1">
       <div
-        ref={trackElement}
         role="slider"
         aria-label={props.label ?? "Value"}
         aria-valuemin={props.min}
@@ -295,7 +293,7 @@ export const ValueStepper: Component<ValueStepperProps> = (props) => {
         <div class="relative z-10 flex items-center justify-between w-full px-2 pointer-events-none">
           <Show when={props.label}>
             {(text) => (
-              <span class={`${LABEL_CLASS} text-[var(--rg-text-primary)] truncate min-w-0`}>
+              <span class={`${EDIT_LABEL_CLASS} text-[var(--rg-text-primary)] truncate min-w-0`}>
                 {text()}
               </span>
             )}

--- a/packages/react-grab/src/components/selection-label/index.tsx
+++ b/packages/react-grab/src/components/selection-label/index.tsx
@@ -462,11 +462,6 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
                   onClick={handleTagClick}
                   onHoverChange={handleTagHoverChange}
                   shrink
-                  forceShowIcon={
-                    isArrowNavigationVisible()
-                      ? Boolean(props.filePath && props.onOpen)
-                      : Boolean(props.isContextMenuOpen)
-                  }
                 />
               </div>
               <Show when={props.arrowNavigationState?.isVisible}>
@@ -488,7 +483,6 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
                   isClickable={Boolean(props.filePath && props.onOpen)}
                   onClick={handleTagClick}
                   onHoverChange={handleTagHoverChange}
-                  forceShowIcon
                 />
               </div>
               <BottomSection>

--- a/packages/react-grab/src/components/toolbar/index.tsx
+++ b/packages/react-grab/src/components/toolbar/index.tsx
@@ -220,10 +220,10 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
           const rect = selectButtonRef.getBoundingClientRect();
           const centerX = rect.left + rect.width / 2;
           const centerY = rect.top + rect.height / 2;
-          const dx = event.clientX - centerX;
-          const dy = event.clientY - centerY;
-          if (Math.hypot(dx, dy) < SELECT_ICON_POINT_MIN_DISTANCE_PX) return;
-          const targetAngleDeg = (Math.atan2(dy, dx) * 180) / Math.PI;
+          const deltaX = event.clientX - centerX;
+          const deltaY = event.clientY - centerY;
+          if (Math.hypot(deltaX, deltaY) < SELECT_ICON_POINT_MIN_DISTANCE_PX) return;
+          const targetAngleDeg = (Math.atan2(deltaY, deltaX) * 180) / Math.PI;
           const desiredRotationDeg = targetAngleDeg - SELECT_ICON_NATURAL_POINT_ANGLE_DEG;
           setSelectIconRotationDeg((previousRotationDeg) =>
             accumulateRotationDeg(previousRotationDeg, desiredRotationDeg),
@@ -297,16 +297,19 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
     let newRatio = positionRatio();
 
     if (wasCollapsed) {
-      const { position: newPos, ratio } = getExpandedFromCollapsed(currentPosition(), snapEdge());
+      const { position: expandedPosition, ratio } = getExpandedFromCollapsed(
+        currentPosition(),
+        snapEdge(),
+      );
       newRatio = ratio;
-      setPosition(newPos);
+      setPosition(expandedPosition);
       setPositionRatio(newRatio);
     } else if (rect) {
       expandedDimensions = { width: rect.width, height: rect.height };
     }
 
     setIsCollapseAnimating(true);
-    setIsCollapsed((prev) => !prev);
+    setIsCollapsed((previousCollapsed) => !previousCollapsed);
 
     saveAndNotify({
       edge: snapEdge(),
@@ -480,11 +483,11 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
           const collapsedPos = currentPosition();
           setIsCollapseAnimating(true);
           setIsCollapsed(state.collapsed);
-          const { position: newPos, ratio: newRatio } = getExpandedFromCollapsed(
+          const { position: expandedPosition, ratio: newRatio } = getExpandedFromCollapsed(
             collapsedPos,
             state.edge,
           );
-          setPosition(newPos);
+          setPosition(expandedPosition);
           setPositionRatio(newRatio);
           clearTimeout(collapseAnimationTimeout);
           collapseAnimationTimeout = setTimeout(() => {
@@ -669,11 +672,11 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
         onPanelClick={(event) => {
           if (isCollapsed()) {
             event.stopPropagation();
-            const { position: newPos, ratio: newRatio } = getExpandedFromCollapsed(
+            const { position: expandedPosition, ratio: newRatio } = getExpandedFromCollapsed(
               currentPosition(),
               snapEdge(),
             );
-            setPosition(newPos);
+            setPosition(expandedPosition);
             setPositionRatio(newRatio);
             setIsCollapseAnimating(true);
             setIsCollapsed(false);

--- a/packages/react-grab/src/components/toolbar/toolbar-content.tsx
+++ b/packages/react-grab/src/components/toolbar/toolbar-content.tsx
@@ -15,7 +15,6 @@ interface ToolbarContentProps {
   onCollapsePointerUp?: (event: PointerEvent) => void;
   onCollapsePointerLeave?: (event: PointerEvent) => void;
   actionButtons?: JSX.Element;
-  collapseButton?: JSX.Element;
   transformOrigin?: string;
 }
 
@@ -144,7 +143,7 @@ export const ToolbarContent: Component<ToolbarContentProps> = (props) => {
           </div>
         </div>
       </div>
-      {props.collapseButton ?? defaultCollapseButton()}
+      {defaultCollapseButton()}
     </div>
   );
 };

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -195,7 +195,6 @@ export const EDIT_TRANSPARENT_COLOR_HEX = "#00000000";
 export const EDIT_ROOT_FONT_SIZE_PX = 16;
 export const EDIT_PANEL_MIN_WIDTH_PX = 200;
 export const EDIT_PANEL_MAX_WIDTH_PX = 320;
-export const EDIT_PANEL_POINTER_ANCHOR_WIDTH_PX = 0;
 export const EDIT_SHIFT_STEP_MULTIPLIER = 10;
 // Idle window after the last control-interact pulse before the
 // transient-interaction signal clears. Must comfortably exceed the

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -683,7 +683,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       let didCopy = true;
       if (unhandledElements.length > 0) {
         didCopy = await copyResolvedElements(unhandledElements, extraPrompt, resolvedComponentName);
-      } else if (pendingResults.length > 0) {
+      }
+      if (pendingResults.length > 0) {
         const results = await Promise.all(pendingResults);
         if (!results.every(Boolean)) {
           throw new CopyFailedError();

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -60,7 +60,6 @@ import { getTagName } from "../utils/get-tag-name.js";
 import {
   ARROW_KEYS,
   FEEDBACK_DURATION_MS,
-  FADE_COMPLETE_BUFFER_MS,
   KEYDOWN_SPAM_TIMEOUT_MS,
   DRAG_THRESHOLD_PX,
   ELEMENT_DETECTION_THROTTLE_MS,
@@ -82,7 +81,6 @@ import {
   DEFAULT_ACTION_ID,
   COMMENT_ACTION_ID,
   EDIT_ACTION_ID,
-  EDIT_PANEL_POINTER_ANCHOR_WIDTH_PX,
 } from "../constants.js";
 import { getBoundsCenter } from "../utils/get-bounds-center.js";
 import { hideFromThirdParties } from "../utils/hide-from-third-parties.js";
@@ -113,8 +111,8 @@ import type {
   ElementLabelVariant,
 } from "../types.js";
 import { createEditModeController, type EditModeOverrides } from "./edit-mode.js";
-import { DEFAULT_THEME } from "./theme.js";
 import { createPluginRegistry } from "./plugin-registry.js";
+import { createLabelController } from "./label-controller.js";
 import { createArrowNavigator } from "./arrow-navigation.js";
 import { getRequiredModifiers, setupKeyboardEventClaimer } from "./keyboard-handlers.js";
 import { createAutoScroller, getAutoScrollDirection } from "./auto-scroll.js";
@@ -172,6 +170,15 @@ interface BuildActionContextOptions {
   customEnterPromptMode?: () => void;
 }
 
+interface LabeledCopyOptions {
+  primaryElement: Element;
+  targetElements: Element[];
+  labelInstanceIds: string[];
+  extraPrompt?: string;
+  shouldDeactivateAfter?: boolean;
+  onComplete?: () => void;
+}
+
 let hasInited = false;
 const toolbarStateChangeCallbacks = new Set<(state: ToolbarState) => void>();
 
@@ -208,7 +215,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     const pluginRegistry = createPluginRegistry(settableOptions);
 
     const { store, actions, pointer, viewportVersion, current } = createGrabStore({
-      theme: DEFAULT_THEME,
       keyHoldDuration: pluginRegistry.store.options.keyHoldDuration ?? DEFAULT_KEY_HOLD_DURATION_MS,
     });
 
@@ -231,9 +237,9 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     // pointerup) does not flash the selection bounds off and back on.
     const isActivelyDragging = createMemo(() => {
       if (!isDragging()) return false;
-      const dx = Math.abs(pointer().x + window.scrollX - store.dragStart.x);
-      const dy = Math.abs(pointer().y + window.scrollY - store.dragStart.y);
-      return dx > DRAG_THRESHOLD_PX || dy > DRAG_THRESHOLD_PX;
+      const deltaX = Math.abs(pointer().x + window.scrollX - store.dragStart.x);
+      const deltaY = Math.abs(pointer().y + window.scrollY - store.dragStart.y);
+      return deltaX > DRAG_THRESHOLD_PX || deltaY > DRAG_THRESHOLD_PX;
     });
     const isDragRepositioning = createMemo(() => {
       const currentState = current();
@@ -579,155 +585,11 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       );
     };
 
-    const labelFadeTimeouts = new Map<string, number>();
-
-    const cancelLabelFade = (instanceId: string) => {
-      const existingTimeout = labelFadeTimeouts.get(instanceId);
-      if (existingTimeout !== undefined) {
-        window.clearTimeout(existingTimeout);
-        labelFadeTimeouts.delete(instanceId);
-      }
-    };
-
-    const cancelAllLabelFades = () => {
-      for (const timeoutId of labelFadeTimeouts.values()) {
-        window.clearTimeout(timeoutId);
-      }
-      labelFadeTimeouts.clear();
-    };
-
-    const scheduleLabelFade = (instanceId: string) => {
-      cancelLabelFade(instanceId);
-
-      const timeoutId = window.setTimeout(() => {
-        labelFadeTimeouts.delete(instanceId);
-        actions.updateLabelInstance(instanceId, "fading");
-        setTimeout(() => {
-          labelFadeTimeouts.delete(instanceId);
-          actions.removeLabelInstance(instanceId);
-        }, FADE_COMPLETE_BUFFER_MS);
-      }, FEEDBACK_DURATION_MS);
-
-      labelFadeTimeouts.set(instanceId, timeoutId);
-    };
-
-    const handleLabelInstanceHoverChange = (instanceId: string, isHovered: boolean) => {
-      if (isHovered) {
-        cancelLabelFade(instanceId);
-      } else {
-        const instance = store.labelInstances.find(
-          (labelInstance) => labelInstance.id === instanceId,
-        );
-        if (instance && instance.status === "copied") {
-          scheduleLabelFade(instanceId);
-        }
-      }
-    };
-
-    const createLabelInstance = (
-      bounds: OverlayBounds,
-      tagName: string,
-      componentName: string | undefined,
-      status: SelectionLabelInstance["status"],
-      options?: {
-        element?: Element;
-        mouseX?: number;
-        elements?: Element[];
-        boundsMultiple?: OverlayBounds[];
-        hideArrow?: boolean;
-      },
-    ): string => {
-      actions.clearLabelInstances();
-      cancelAllLabelFades();
-      const instanceId = generateId("label");
-      const boundsCenterX = bounds.x + bounds.width / 2;
-      const boundsHalfWidth = bounds.width / 2;
-      const mouseX = options?.mouseX;
-      const mouseXOffset = mouseX !== undefined ? mouseX - boundsCenterX : undefined;
-
-      const instance: SelectionLabelInstance = {
-        id: instanceId,
-        bounds,
-        boundsMultiple: options?.boundsMultiple,
-        tagName,
-        componentName,
-        status,
-        createdAt: Date.now(),
-        element: options?.element,
-        elements: options?.elements,
-        mouseX,
-        mouseXOffsetFromCenter: mouseXOffset,
-        mouseXOffsetRatio:
-          mouseXOffset !== undefined && boundsHalfWidth > 0
-            ? mouseXOffset / boundsHalfWidth
-            : undefined,
-        hideArrow: options?.hideArrow,
-      };
-      actions.addLabelInstance(instance);
-      return instanceId;
-    };
-
-    const createPerElementLabelInstances = (
-      entries: Array<{
-        element: Element;
-        tagName: string;
-        componentName?: string;
-        mouseX?: number;
-      }>,
-      status: SelectionLabelInstance["status"],
-    ): string[] => {
-      actions.clearLabelInstances();
-      cancelAllLabelFades();
-      const instanceIds: string[] = [];
-      for (const entry of entries) {
-        const bounds = createElementBounds(entry.element);
-        const boundsCenterX = bounds.x + bounds.width / 2;
-        const boundsHalfWidth = bounds.width / 2;
-        const mouseXOffset = entry.mouseX !== undefined ? entry.mouseX - boundsCenterX : undefined;
-        const instanceId = generateId("label");
-        const instance: SelectionLabelInstance = {
-          id: instanceId,
-          bounds,
-          tagName: entry.tagName,
-          componentName: entry.componentName,
-          status,
-          createdAt: Date.now(),
-          element: entry.element,
-          mouseX: entry.mouseX,
-          mouseXOffsetFromCenter: mouseXOffset,
-          mouseXOffsetRatio:
-            mouseXOffset !== undefined && boundsHalfWidth > 0
-              ? mouseXOffset / boundsHalfWidth
-              : undefined,
-        };
-        actions.addLabelInstance(instance);
-        instanceIds.push(instanceId);
-      }
-      return instanceIds;
-    };
-
-    const clearAllLabels = () => {
-      cancelAllLabelFades();
-      actions.clearLabelInstances();
-    };
-
-    const updateLabelAfterCopy = (
-      labelInstanceId: string,
-      didSucceed: boolean,
-      errorMessage?: string,
-    ) => {
-      if (didSucceed) {
-        actions.updateLabelInstance(labelInstanceId, "copied");
-      } else {
-        actions.updateLabelInstance(labelInstanceId, "error", errorMessage || "Unknown error");
-      }
-      scheduleLabelFade(labelInstanceId);
-    };
+    const labelController = createLabelController(actions, () => store.labelInstances);
 
     const executeCopyOperation = async (
-      clipboardOperation: () => Promise<void>,
+      clipboardOperation: () => Promise<boolean>,
       labelInstanceIds: string[] | null,
-      copiedElement?: Element,
       shouldDeactivateAfter?: boolean,
     ) => {
       clearCopyFeedbackCooldown();
@@ -739,22 +601,22 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       let errorMessage: string | undefined;
 
       try {
-        await clipboardOperation();
-        didSucceed = true;
+        didSucceed = await clipboardOperation();
+        if (!didSucceed) errorMessage = "Failed to copy";
       } catch (error) {
         errorMessage = normalizeErrorMessage(error, "Action failed");
       }
 
       if (labelInstanceIds) {
         for (const labelInstanceId of labelInstanceIds) {
-          updateLabelAfterCopy(labelInstanceId, didSucceed, errorMessage);
+          labelController.updateAfterCopy(labelInstanceId, didSucceed, errorMessage);
         }
       }
 
       if (current().state !== "copying") return;
 
       if (didSucceed) {
-        actions.completeCopy(copiedElement);
+        actions.completeCopy();
       }
 
       if (shouldDeactivateAfter) {
@@ -799,8 +661,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       targetElements: Element[],
       extraPrompt?: string,
       resolvedComponentName?: string,
-    ): Promise<void> => {
-      if (targetElements.length === 0) return;
+    ): Promise<boolean> => {
+      if (targetElements.length === 0) return false;
 
       const unhandledElements: Element[] = [];
       const pendingResults: Promise<boolean>[] = [];
@@ -817,8 +679,10 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         }
       }
       await waitUntilNextFrame();
+
+      let didCopy = true;
       if (unhandledElements.length > 0) {
-        await copyResolvedElements(unhandledElements, extraPrompt, resolvedComponentName);
+        didCopy = await copyResolvedElements(unhandledElements, extraPrompt, resolvedComponentName);
       } else if (pendingResults.length > 0) {
         const results = await Promise.all(pendingResults);
         if (!results.every(Boolean)) {
@@ -826,6 +690,34 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         }
       }
       void notifyElementsSelected(targetElements);
+      return didCopy;
+    };
+
+    const runLabeledCopy = (copy: LabeledCopyOptions) => {
+      void getNearestComponentName(copy.primaryElement)
+        .then(async (componentName) => {
+          await executeCopyOperation(
+            () =>
+              copyElementsToClipboard(
+                copy.targetElements,
+                copy.extraPrompt,
+                componentName ?? undefined,
+              ),
+            copy.labelInstanceIds.length > 0 ? copy.labelInstanceIds : null,
+            copy.shouldDeactivateAfter,
+          );
+          copy.onComplete?.();
+        })
+        .catch((error) => {
+          logRecoverableError("Copy operation failed", error);
+          const normalizedMessage = normalizeErrorMessage(error, "Action failed");
+          for (const labelInstanceId of copy.labelInstanceIds) {
+            labelController.updateAfterCopy(labelInstanceId, false, normalizedMessage);
+          }
+          if (current().state === "copying") {
+            actions.unfreeze();
+          }
+        });
     };
 
     const performCopyWithLabel = (options: CopyWithLabelOptions) => {
@@ -855,37 +747,21 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       actions.startCopy();
 
       const labelInstanceId = tagName
-        ? createLabelInstance(selectionBounds, tagName, undefined, "copying", {
+        ? labelController.createInstance(selectionBounds, tagName, undefined, "copying", {
             element,
             mouseX: labelCursorX,
             elements: selectedElements,
           })
         : null;
 
-      void getNearestComponentName(element)
-        .then(async (componentName) => {
-          await executeCopyOperation(
-            () =>
-              copyElementsToClipboard(allTargetElements, extraPrompt, componentName ?? undefined),
-            labelInstanceId ? [labelInstanceId] : null,
-            element,
-            shouldDeactivateAfter,
-          );
-          onComplete?.();
-        })
-        .catch((error) => {
-          logRecoverableError("Copy operation failed", error);
-          if (labelInstanceId) {
-            updateLabelAfterCopy(
-              labelInstanceId,
-              false,
-              normalizeErrorMessage(error, "Action failed"),
-            );
-          }
-          if (current().state === "copying") {
-            actions.unfreeze();
-          }
-        });
+      runLabeledCopy({
+        primaryElement: element,
+        targetElements: allTargetElements,
+        labelInstanceIds: labelInstanceId ? [labelInstanceId] : [],
+        extraPrompt,
+        shouldDeactivateAfter,
+        onComplete,
+      });
     };
 
     const performCopyWithPerElementLabels = (options: {
@@ -905,28 +781,15 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       clearCopyFeedbackCooldown();
       actions.startCopy();
 
-      const labelInstanceIds = createPerElementLabelInstances(labelEntries, "copying");
+      const labelInstanceIds = labelController.createPerElementInstances(labelEntries, "copying");
 
-      void getNearestComponentName(primaryElement)
-        .then(async (componentName) => {
-          await executeCopyOperation(
-            () => copyElementsToClipboard(elements, undefined, componentName ?? undefined),
-            labelInstanceIds.length > 0 ? labelInstanceIds : null,
-            primaryElement,
-            shouldDeactivateAfter,
-          );
-          onComplete?.();
-        })
-        .catch((error) => {
-          logRecoverableError("Copy operation failed", error);
-          const normalizedMessage = normalizeErrorMessage(error, "Action failed");
-          for (const labelInstanceId of labelInstanceIds) {
-            updateLabelAfterCopy(labelInstanceId, false, normalizedMessage);
-          }
-          if (current().state === "copying") {
-            actions.unfreeze();
-          }
-        });
+      runLabeledCopy({
+        primaryElement,
+        targetElements: elements,
+        labelInstanceIds,
+        shouldDeactivateAfter,
+        onComplete,
+      });
     };
 
     const targetElement = createMemo(() => {
@@ -1521,7 +1384,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
 
     const handleInputSubmit = () => {
-      actions.clearLastCopied();
       const frozenElements = [...store.frozenElements];
       const element = store.frozenElement || targetElement();
       const prompt = isPromptMode() ? store.inputText.trim() : "";
@@ -1554,7 +1416,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
 
     const handleInputCancel = () => {
-      actions.clearLastCopied();
       if (!isPromptMode()) return;
 
       if (isPendingDismiss()) {
@@ -3055,7 +2916,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       stopEditPanelTracking = null;
       grabbedBoxTimeouts.forEach((timeoutId) => window.clearTimeout(timeoutId));
       grabbedBoxTimeouts.clear();
-      cancelAllLabelFades();
+      labelController.cancelAllFades();
       autoScroller.stop();
       document.body.style.userSelect = "";
       document.body.style.touchAction = "";
@@ -3098,6 +2959,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     });
 
     const selectionLabelVisible = createMemo(() => {
+      if (!isThemeEnabled()) return false;
       if (isModalPopoverOpen()) return false;
       if (!isElementLabelThemeEnabled()) return false;
       if (isSelectionSuppressed()) return false;
@@ -3318,7 +3180,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
               ? labelBounds.x + labelBounds.width / 2
               : position.x;
 
-            const labelInstanceId = createLabelInstance(
+            const labelInstanceId = labelController.createInstance(
               labelBounds,
               tagName || "element",
               componentName,
@@ -3343,7 +3205,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
               errorMessage = normalizeErrorMessage(error, "Action failed");
             }
 
-            updateLabelAfterCopy(labelInstanceId, didSucceed, errorMessage);
+            labelController.updateAfterCopy(labelInstanceId, didSucceed, errorMessage);
           } else {
             try {
               await action();
@@ -3403,7 +3265,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       };
 
       const defaultEnterPromptMode = () => {
-        clearAllLabels();
+        labelController.clearAll();
         clearPendingToolbarSelection();
         onBeforePrompt?.();
         preparePromptMode(element, position.x, position.y);
@@ -3483,7 +3345,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           keyboardSelectedElement = null;
         },
         customEnterPromptMode: () => {
-          clearAllLabels();
+          labelController.clearAll();
           clearPendingToolbarSelection();
           actions.clearInputText();
           actions.enterPromptMode(position, element);
@@ -3509,7 +3371,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           x: edge === "left" ? toolbarRect.right : toolbarRect.left,
           y: toolbarRect.top + toolbarRect.height / 2,
           edge,
-          toolbarWidth: toolbarRect.width,
         };
       }
 
@@ -3517,7 +3378,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         x: toolbarRect.left + toolbarRect.width / 2,
         y: edge === "top" ? toolbarRect.bottom : toolbarRect.top,
         edge,
-        toolbarWidth: toolbarRect.width,
       };
     };
 
@@ -3530,7 +3390,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         x: state.position.x,
         y: state.position.y,
         edge: "bottom",
-        toolbarWidth: EDIT_PANEL_POINTER_ANCHOR_WIDTH_PX,
       };
     };
 
@@ -3670,7 +3529,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
                 inputValue={store.inputText}
                 isPromptMode={isPromptMode()}
                 onShowContextMenuInstance={handleShowContextMenuInstance}
-                onLabelInstanceHoverChange={handleLabelInstanceHoverChange}
+                onLabelInstanceHoverChange={labelController.handleHoverChange}
                 onInputChange={actions.setInputText}
                 onInputSubmit={() => void handleInputSubmit()}
                 onToggleExpand={handleToggleExpand}
@@ -3782,7 +3641,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           edge: state.edge ?? currentState?.edge ?? "bottom",
           ratio: state.ratio ?? currentState?.ratio ?? TOOLBAR_DEFAULT_POSITION_RATIO,
           collapsed: resolvedCollapsed,
-          enabled: !resolvedCollapsed,
+          enabled: state.enabled ?? !resolvedCollapsed,
           defaultAction: state.defaultAction ?? currentState?.defaultAction ?? DEFAULT_ACTION_ID,
         };
         saveToolbarState(newState);

--- a/packages/react-grab/src/core/label-controller.ts
+++ b/packages/react-grab/src/core/label-controller.ts
@@ -181,7 +181,12 @@ export const createLabelController = (
       return;
     }
     const instance = getLabelInstances().find((labelInstance) => labelInstance.id === instanceId);
-    if (instance && instance.status === "copied") {
+    if (!instance) return;
+    if (
+      instance.status === "copied" ||
+      instance.status === "error" ||
+      instance.status === "fading"
+    ) {
       scheduleFade(instanceId);
     }
   };

--- a/packages/react-grab/src/core/label-controller.ts
+++ b/packages/react-grab/src/core/label-controller.ts
@@ -1,0 +1,197 @@
+import { FADE_COMPLETE_BUFFER_MS, FEEDBACK_DURATION_MS } from "../constants.js";
+import { createElementBounds } from "../utils/create-element-bounds.js";
+import { generateId } from "../utils/generate-id.js";
+import type { OverlayBounds, SelectionLabelInstance } from "../types.js";
+
+interface LabelStoreBridge {
+  clearLabelInstances: () => void;
+  addLabelInstance: (instance: SelectionLabelInstance) => void;
+  updateLabelInstance: (
+    instanceId: string,
+    status: SelectionLabelInstance["status"],
+    errorMessage?: string,
+  ) => void;
+  removeLabelInstance: (instanceId: string) => void;
+}
+
+interface CreateLabelInstanceOptions {
+  element?: Element;
+  mouseX?: number;
+  elements?: Element[];
+  boundsMultiple?: OverlayBounds[];
+  hideArrow?: boolean;
+}
+
+interface PerElementLabelEntry {
+  element: Element;
+  tagName: string;
+  componentName?: string;
+  mouseX?: number;
+}
+
+interface BuildLabelInstanceOptions {
+  bounds: OverlayBounds;
+  tagName: string;
+  componentName: string | undefined;
+  status: SelectionLabelInstance["status"];
+  element?: Element;
+  mouseX?: number;
+  elements?: Element[];
+  boundsMultiple?: OverlayBounds[];
+  hideArrow?: boolean;
+}
+
+interface LabelController {
+  createInstance: (
+    bounds: OverlayBounds,
+    tagName: string,
+    componentName: string | undefined,
+    status: SelectionLabelInstance["status"],
+    options?: CreateLabelInstanceOptions,
+  ) => string;
+  createPerElementInstances: (
+    entries: PerElementLabelEntry[],
+    status: SelectionLabelInstance["status"],
+  ) => string[];
+  updateAfterCopy: (instanceId: string, didSucceed: boolean, errorMessage?: string) => void;
+  cancelAllFades: () => void;
+  clearAll: () => void;
+  handleHoverChange: (instanceId: string, isHovered: boolean) => void;
+}
+
+const buildLabelInstance = (options: BuildLabelInstanceOptions): SelectionLabelInstance => {
+  const boundsCenterX = options.bounds.x + options.bounds.width / 2;
+  const boundsHalfWidth = options.bounds.width / 2;
+  const mouseXOffset = options.mouseX !== undefined ? options.mouseX - boundsCenterX : undefined;
+  return {
+    id: generateId("label"),
+    bounds: options.bounds,
+    boundsMultiple: options.boundsMultiple,
+    tagName: options.tagName,
+    componentName: options.componentName,
+    status: options.status,
+    createdAt: Date.now(),
+    element: options.element,
+    elements: options.elements,
+    mouseX: options.mouseX,
+    mouseXOffsetFromCenter: mouseXOffset,
+    mouseXOffsetRatio:
+      mouseXOffset !== undefined && boundsHalfWidth > 0
+        ? mouseXOffset / boundsHalfWidth
+        : undefined,
+    hideArrow: options.hideArrow,
+  };
+};
+
+export const createLabelController = (
+  store: LabelStoreBridge,
+  getLabelInstances: () => readonly SelectionLabelInstance[],
+): LabelController => {
+  const fadeTimeouts = new Map<string, number>();
+
+  const cancelFade = (instanceId: string) => {
+    const existingTimeout = fadeTimeouts.get(instanceId);
+    if (existingTimeout !== undefined) {
+      window.clearTimeout(existingTimeout);
+      fadeTimeouts.delete(instanceId);
+    }
+  };
+
+  const cancelAllFades = () => {
+    for (const timeoutId of fadeTimeouts.values()) {
+      window.clearTimeout(timeoutId);
+    }
+    fadeTimeouts.clear();
+  };
+
+  const clearAll = () => {
+    cancelAllFades();
+    store.clearLabelInstances();
+  };
+
+  const scheduleFade = (instanceId: string) => {
+    cancelFade(instanceId);
+    const fadeStartTimeoutId = window.setTimeout(() => {
+      store.updateLabelInstance(instanceId, "fading");
+      const removalTimeoutId = window.setTimeout(() => {
+        fadeTimeouts.delete(instanceId);
+        store.removeLabelInstance(instanceId);
+      }, FADE_COMPLETE_BUFFER_MS);
+      fadeTimeouts.set(instanceId, removalTimeoutId);
+    }, FEEDBACK_DURATION_MS);
+    fadeTimeouts.set(instanceId, fadeStartTimeoutId);
+  };
+
+  const createInstance = (
+    bounds: OverlayBounds,
+    tagName: string,
+    componentName: string | undefined,
+    status: SelectionLabelInstance["status"],
+    options?: CreateLabelInstanceOptions,
+  ): string => {
+    clearAll();
+    const instance = buildLabelInstance({
+      bounds,
+      tagName,
+      componentName,
+      status,
+      element: options?.element,
+      mouseX: options?.mouseX,
+      elements: options?.elements,
+      boundsMultiple: options?.boundsMultiple,
+      hideArrow: options?.hideArrow,
+    });
+    store.addLabelInstance(instance);
+    return instance.id;
+  };
+
+  const createPerElementInstances = (
+    entries: PerElementLabelEntry[],
+    status: SelectionLabelInstance["status"],
+  ): string[] => {
+    clearAll();
+    const instanceIds: string[] = [];
+    for (const entry of entries) {
+      const instance = buildLabelInstance({
+        bounds: createElementBounds(entry.element),
+        tagName: entry.tagName,
+        componentName: entry.componentName,
+        status,
+        element: entry.element,
+        mouseX: entry.mouseX,
+      });
+      store.addLabelInstance(instance);
+      instanceIds.push(instance.id);
+    }
+    return instanceIds;
+  };
+
+  const updateAfterCopy = (instanceId: string, didSucceed: boolean, errorMessage?: string) => {
+    if (didSucceed) {
+      store.updateLabelInstance(instanceId, "copied");
+    } else {
+      store.updateLabelInstance(instanceId, "error", errorMessage || "Unknown error");
+    }
+    scheduleFade(instanceId);
+  };
+
+  const handleHoverChange = (instanceId: string, isHovered: boolean) => {
+    if (isHovered) {
+      cancelFade(instanceId);
+      return;
+    }
+    const instance = getLabelInstances().find((labelInstance) => labelInstance.id === instanceId);
+    if (instance && instance.status === "copied") {
+      scheduleFade(instanceId);
+    }
+  };
+
+  return {
+    createInstance,
+    createPerElementInstances,
+    updateAfterCopy,
+    cancelAllFades,
+    clearAll,
+    handleHoverChange,
+  };
+};

--- a/packages/react-grab/src/core/store.ts
+++ b/packages/react-grab/src/core/store.ts
@@ -1,6 +1,6 @@
 import { createStore, produce } from "solid-js/store";
 import { batch, createSignal } from "solid-js";
-import type { Position, Theme, GrabbedBox, SelectionLabelInstance } from "../types.js";
+import type { Position, GrabbedBox, SelectionLabelInstance } from "../types.js";
 import { OFFSCREEN_POSITION } from "../constants.js";
 import { createElementBounds } from "../utils/create-element-bounds.js";
 import { getBoundsCenter } from "../utils/get-bounds-center.js";
@@ -43,7 +43,6 @@ interface GrabStore {
   frozenElements: Element[];
   frozenDragRect: FrozenDragRect | null;
   lastGrabbedElement: Element | null;
-  lastCopiedElement: Element | null;
 
   selectionFilePath: string | null;
   selectionLineNumber: number | null;
@@ -55,8 +54,6 @@ interface GrabStore {
 
   isTouchMode: boolean;
 
-  theme: Required<Theme>;
-
   activationTimestamp: number | null;
   previouslyFocusedElement: Element | null;
 
@@ -66,7 +63,6 @@ interface GrabStore {
 }
 
 interface GrabStoreInput {
-  theme: Required<Theme>;
   keyHoldDuration: number;
 }
 
@@ -86,7 +82,6 @@ const createInitialStore = (input: GrabStoreInput): GrabStore => ({
   frozenElements: [],
   frozenDragRect: null,
   lastGrabbedElement: null,
-  lastCopiedElement: null,
 
   selectionFilePath: null,
   selectionLineNumber: null,
@@ -97,8 +92,6 @@ const createInitialStore = (input: GrabStoreInput): GrabStore => ({
   labelInstances: [],
 
   isTouchMode: false,
-
-  theme: input.theme,
 
   activationTimestamp: null,
   previouslyFocusedElement: null,
@@ -124,7 +117,7 @@ interface GrabActions {
   cancelDrag: () => void;
   finishJustDragged: () => void;
   startCopy: () => void;
-  completeCopy: (element?: Element) => void;
+  completeCopy: () => void;
   finishJustCopied: () => void;
   enterPromptMode: (position: Position, element: Element) => void;
   exitPromptMode: () => void;
@@ -140,7 +133,6 @@ interface GrabActions {
   setFrozenDragRect: (rect: FrozenDragRect | null) => void;
   setCopyStart: (position: Position, element: Element) => void;
   setLastGrabbed: (element: Element | null) => void;
-  clearLastCopied: () => void;
   setWasActivatedByToggle: (value: boolean) => void;
   setPendingCommentMode: (value: boolean) => void;
   setTouchMode: (value: boolean) => void;
@@ -237,7 +229,6 @@ const createGrabStore = (input: GrabStoreInput) => {
             draft.contextMenuPosition = null;
             draft.contextMenuElement = null;
             draft.contextMenuClickOffset = null;
-            draft.lastCopiedElement = null;
             // In touch mode there is no pointer movement between taps, so a
             // stale detectedElement from the previous interaction would
             // render its selection box the moment the user re-activates.
@@ -366,18 +357,13 @@ const createGrabStore = (input: GrabStoreInput) => {
       });
     },
 
-    completeCopy: (element?: Element) => {
+    completeCopy: () => {
       const currentState = current();
       const wasActive = currentState.state === "copying" ? currentState.wasActive : false;
-      batch(() => {
-        if (element) {
-          setStore("lastCopiedElement", element);
-        }
-        setCurrent({
-          state: "justCopied",
-          copiedAt: Date.now(),
-          wasActive,
-        });
+      setCurrent({
+        state: "justCopied",
+        copiedAt: Date.now(),
+        wasActive,
       });
     },
 
@@ -505,10 +491,6 @@ const createGrabStore = (input: GrabStoreInput) => {
 
     setLastGrabbed: (element: Element | null) => {
       setStore("lastGrabbedElement", element);
-    },
-
-    clearLastCopied: () => {
-      setStore("lastCopiedElement", null);
     },
 
     setWasActivatedByToggle: (value: boolean) => {

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -386,7 +386,6 @@ export interface DropdownAnchor {
   x: number;
   y: number;
   edge: ToolbarState["edge"];
-  toolbarWidth: number;
 }
 
 export interface ReactGrabAPI {
@@ -558,7 +557,6 @@ export interface TagBadgeProps {
   onClick: (event: MouseEvent) => void;
   onHoverChange?: (hovered: boolean) => void;
   shrink?: boolean;
-  forceShowIcon?: boolean;
 }
 
 export interface BottomSectionProps {

--- a/packages/react-grab/src/utils/copy-content.ts
+++ b/packages/react-grab/src/utils/copy-content.ts
@@ -2,7 +2,7 @@ import { VERSION } from "../constants.js";
 
 const REACT_GRAB_MIME_TYPE = "application/x-react-grab";
 
-export interface ReactGrabEntry {
+interface ReactGrabEntry {
   tagName?: string;
   componentName?: string;
   content: string;

--- a/packages/react-grab/src/utils/create-element-selector.ts
+++ b/packages/react-grab/src/utils/create-element-selector.ts
@@ -97,26 +97,24 @@ const createNthChildSelector = (element: Element): string => {
   return segments.join(" > ");
 };
 
-export const createElementSelector = (element: Element, shouldUseFinder = true): string => {
+export const createElementSelector = (element: Element): string => {
   const fastSelector = createFastElementSelector(element);
   if (fastSelector) return fastSelector;
 
-  if (shouldUseFinder) {
-    try {
-      const selector = findUniqueSelector(
-        element,
-        getFinderRoot(element),
-        FINDER_TIMEOUT_MS,
-        (attributeName, attributeValue) =>
-          isAcceptedAttr(attributeName, attributeValue) ||
-          (PREFERRED_SELECTOR_ATTRIBUTE_NAMES.has(attributeName) &&
-            isPreferredAttributeValueSafe(attributeValue)),
-      );
-      if (selector) return selector;
-      // @medv/finder can throw on unusual DOM structures (SVG, web components,
-      // detached nodes), so we fall back to an nth-child selector instead.
-    } catch {}
-  }
+  try {
+    const selector = findUniqueSelector(
+      element,
+      getFinderRoot(element),
+      FINDER_TIMEOUT_MS,
+      (attributeName, attributeValue) =>
+        isAcceptedAttr(attributeName, attributeValue) ||
+        (PREFERRED_SELECTOR_ATTRIBUTE_NAMES.has(attributeName) &&
+          isPreferredAttributeValueSafe(attributeValue)),
+    );
+    if (selector) return selector;
+    // @medv/finder can throw on unusual DOM structures (SVG, web components,
+    // detached nodes), so we fall back to an nth-child selector instead.
+  } catch {}
 
   return createNthChildSelector(element);
 };

--- a/packages/react-grab/src/utils/create-menu-highlight.ts
+++ b/packages/react-grab/src/utils/create-menu-highlight.ts
@@ -112,7 +112,8 @@ const createAnimatedBoundsFollower = ({
 const isActionableSibling = (
   siblingElement: Element,
   followerElement: HTMLElement | undefined,
-): boolean => siblingElement !== followerElement && siblingElement instanceof HTMLElement;
+): siblingElement is HTMLElement =>
+  siblingElement !== followerElement && siblingElement instanceof HTMLElement;
 
 const getActionableSiblings = (
   parent: HTMLElement,
@@ -121,7 +122,7 @@ const getActionableSiblings = (
   const siblings: HTMLElement[] = [];
   for (const childElement of Array.from(parent.children)) {
     if (isActionableSibling(childElement, followerElement)) {
-      siblings.push(childElement as HTMLElement);
+      siblings.push(childElement);
     }
   }
   return siblings;

--- a/packages/react-grab/src/utils/css-property-builders.ts
+++ b/packages/react-grab/src/utils/css-property-builders.ts
@@ -45,7 +45,7 @@ export const buildColorProperty = (
 ): ColorEditableProperty | null => {
   const hexValue = parseAnyColor(rawCssValue);
   const channels = hexValue ? parseHexChannels(hexValue) : null;
-  const isUsableColor = channels !== null && channels.a !== 0;
+  const isUsableColor = channels !== null && channels.alpha !== 0;
   if (!isUsableColor && !alwaysShow) return null;
   const value = isUsableColor && hexValue ? hexValue : EDIT_TRANSPARENT_COLOR_HEX;
   return {

--- a/packages/react-grab/src/utils/detect-app-theme.ts
+++ b/packages/react-grab/src/utils/detect-app-theme.ts
@@ -2,6 +2,8 @@ import { nativeCancelAnimationFrame, nativeRequestAnimationFrame } from "./nativ
 
 type AppTheme = "dark" | "light";
 
+const isAppTheme = (token: string): token is AppTheme => token === "dark" || token === "light";
+
 interface ThemeWatcherResult {
   theme: AppTheme;
   cleanup: () => void;
@@ -78,8 +80,7 @@ const themeFromColorScheme = (colorSchemeValue: string): AppTheme | null => {
   if (!normalized || normalized === "normal" || normalized === "auto") return null;
 
   const tokens = normalized.split(/\s+/);
-  const firstRelevantToken = tokens.find((token) => token === "dark" || token === "light");
-  return (firstRelevantToken as AppTheme) ?? null;
+  return tokens.find(isAppTheme) ?? null;
 };
 
 const detectTheme = (): AppTheme => {

--- a/packages/react-grab/src/utils/find-unique-selector.ts
+++ b/packages/react-grab/src/utils/find-unique-selector.ts
@@ -67,8 +67,8 @@ const getChildIndex = (element: Element, filterTagName?: string): number | undef
   let position = 0;
   while (sibling) {
     if (
-      sibling.nodeType === Node.ELEMENT_NODE &&
-      (filterTagName === undefined || (sibling as Element).tagName.toLowerCase() === filterTagName)
+      sibling instanceof Element &&
+      (filterTagName === undefined || sibling.tagName.toLowerCase() === filterTagName)
     ) {
       position++;
     }
@@ -165,8 +165,8 @@ const resolveRootDocument = (
   if (attachedRoot instanceof ShadowRoot) {
     return attachedRoot as unknown as Document;
   }
-  if (rootNode.nodeType === Node.DOCUMENT_NODE) return rootNode;
-  return (rootNode as Element).ownerDocument;
+  if (rootNode instanceof Document) return rootNode;
+  return rootNode.ownerDocument;
 };
 
 const isSelectorUnique = (

--- a/packages/react-grab/src/utils/native-raf.ts
+++ b/packages/react-grab/src/utils/native-raf.ts
@@ -1,7 +1,7 @@
 const isClientSide = typeof window !== "undefined";
 
 const noopAnimationFrame = (_callback: FrameRequestCallback): number => 0;
-const noopCancelFrame = (_id: number): void => {};
+const noopCancelFrame = (_animationFrameId: number): void => {};
 
 // We read requestAnimationFrame from Window.prototype rather than the window
 // instance to bypass the GSAP freeze wrapper installed by freeze-gsap.ts.

--- a/packages/react-grab/src/utils/parse-any-color.ts
+++ b/packages/react-grab/src/utils/parse-any-color.ts
@@ -1,3 +1,4 @@
+import { EDIT_TRANSPARENT_COLOR_HEX } from "../constants.js";
 import { rgbaChannelsToHex, rgbStringToHex } from "./parse-color.js";
 
 const HEX_PATTERN = /^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
@@ -19,7 +20,6 @@ const normalizeHex = (raw: string): string | null => {
 // user input is either fully-transparent black OR was rejected — the
 // caller disambiguates from the input form.
 const REJECTED_FILL_STYLE_SENTINEL = "rgba(0, 0, 0, 0)";
-const TRANSPARENT_BLACK_HEX = "#00000000";
 const OPAQUE_HEX_LENGTH = 7;
 const OKLCH_PATTERN =
   /^oklch\(\s*([+-]?\d*\.?\d+%?)\s+([+-]?\d*\.?\d+%?)\s+([+-]?\d*\.?\d+)(deg|grad|rad|turn)?(?:\s*\/\s*([+-]?\d*\.?\d+%?))?\s*\)$/i;
@@ -109,7 +109,7 @@ export const parseAnyColor = (input: string): string | null => {
   // `rgba(0,0,0,0)` — same string as the rejection sentinel — so
   // without this allow-list it'd fall through to null and silently
   // refuse a perfectly valid color.
-  if (trimmedColorInput.toLowerCase() === "transparent") return TRANSPARENT_BLACK_HEX;
+  if (trimmedColorInput.toLowerCase() === "transparent") return EDIT_TRANSPARENT_COLOR_HEX;
 
   const directHex = normalizeHex(trimmedColorInput);
   if (directHex) return directHex;
@@ -127,7 +127,7 @@ export const parseAnyColor = (input: string): string | null => {
     // Sentinel came back unchanged — input was either rejected OR is
     // itself fully-transparent black. The input form disambiguates.
     return trimmedColorInput.toLowerCase().replace(/\s+/g, "") === "rgba(0,0,0,0)"
-      ? TRANSPARENT_BLACK_HEX
+      ? EDIT_TRANSPARENT_COLOR_HEX
       : null;
   }
   if (resolved.startsWith("#") && resolved.length === OPAQUE_HEX_LENGTH) return resolved;

--- a/packages/react-grab/src/utils/parse-color.ts
+++ b/packages/react-grab/src/utils/parse-color.ts
@@ -21,16 +21,16 @@ export const rgbaChannelsToHex = (
 
 export const parseHexChannels = (
   hex: string,
-): { r: number; g: number; b: number; a: number } | null => {
+): { red: number; green: number; blue: number; alpha: number } | null => {
   if (!hex.startsWith("#")) return null;
   const digits = hex.slice(1);
   if (digits.length !== 6 && digits.length !== 8) return null;
-  const r = parseInt(digits.slice(0, 2), 16);
-  const g = parseInt(digits.slice(2, 4), 16);
-  const b = parseInt(digits.slice(4, 6), 16);
-  const a = digits.length === 8 ? parseInt(digits.slice(6, 8), 16) / 255 : 1;
-  if (!Number.isFinite(r) || !Number.isFinite(g) || !Number.isFinite(b)) return null;
-  return { r, g, b, a };
+  const red = parseInt(digits.slice(0, 2), 16);
+  const green = parseInt(digits.slice(2, 4), 16);
+  const blue = parseInt(digits.slice(4, 6), 16);
+  const alpha = digits.length === 8 ? parseInt(digits.slice(6, 8), 16) / 255 : 1;
+  if (!Number.isFinite(red) || !Number.isFinite(green) || !Number.isFinite(blue)) return null;
+  return { red, green, blue, alpha };
 };
 
 export const rgbStringToHex = (cssValue: string): string | null => {

--- a/packages/react-grab/src/utils/register-overlay-dismiss.ts
+++ b/packages/react-grab/src/utils/register-overlay-dismiss.ts
@@ -6,7 +6,6 @@ import { nativeCancelAnimationFrame, nativeRequestAnimationFrame } from "./nativ
 interface RegisterOverlayDismissOptions {
   isOpen: () => boolean;
   onDismiss: (source: OverlayDismissSource) => void;
-  onConfirm?: () => void;
   shouldIgnoreKeyboardEvent?: (event: KeyboardEvent) => boolean;
   shouldIgnoreInputEvents?: boolean;
   shouldIgnoreRightClick?: boolean;
@@ -20,19 +19,10 @@ export const registerOverlayDismiss = (options: RegisterOverlayDismissOptions): 
       return;
     }
 
-    const isEscape = event.code === "Escape";
-
-    if (isEscape) {
+    if (event.code === "Escape") {
       event.preventDefault();
       event.stopImmediatePropagation();
       options.onDismiss("keyboard");
-      return;
-    }
-
-    if (event.code === "Enter" && options.onConfirm) {
-      event.preventDefault();
-      event.stopImmediatePropagation();
-      options.onConfirm();
     }
   };
 


### PR DESCRIPTION
## Summary
A cleanup pass over `packages/react-grab` (plus one CLI nit) that is strictly **net-subtractive** — no new abstraction layers. Deletes verified dead code, removes duplication, and fixes four real bugs surgically.

**Structure (no new concepts):**
- Extracted the selection-label lifecycle (timer map + create/cancel/fade/update) into `core/label-controller.ts`, draining ~115 lines from the `core/index.tsx` god-file, and deduped the copy flow (`buildLabelInstance`, `runLabeledCopy`).
- Descriptive renames (`deltaX`/`deltaY`, `parseHexChannels` channels), a few `as` casts → `instanceof`/type-guards, and DRY constant reuse (`EDIT_LABEL_CLASS`, `EDIT_TRANSPARENT_COLOR_HEX`).

**Dead code removed (all confirmed unused via grep):**
- `store.theme` and `lastCopiedElement` (write-only state) + `clearLastCopied`.
- Dead props/params: `TagBadge.forceShowIcon`, `DropdownAnchor.toolbarWidth` (+ `EDIT_PANEL_POINTER_ANCHOR_WIDTH_PX`), `StepArrow.disabled`/`onPointerUp`/`onPointerLeave`, `ToolbarContent.collapseButton`, `registerOverlayDismiss.onConfirm`, `createElementSelector.shouldUseFinder`.
- Unexported internal-only interfaces; deduped `EDIT_LABEL_CLASS`.

**Bug fixes (surgical, in-place):**
- **Copy success-on-failure** — `copyElementsToClipboard` now returns the real result and `executeCopyOperation` honors it, so a failed clipboard write shows the error label + unfreezes instead of falsely showing "Copied".
- **Label fade-removal timer leak** — the nested removal timeout is now tracked, so it's cancellable on hover/dispose.
- **`setToolbarState`** now honors an explicit `state.enabled` instead of always deriving it from `collapsed`.
- **`selectionLabelVisible`** now respects the `theme.enabled` kill-switch like its sibling memos.

Net: 358 insertions / 353 deletions across 29 files.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint` (0 warnings, 0 errors)
- [x] `pnpm format`
- [x] `pnpm build`
- [x] `pnpm test` — 650 passing; the lone failure (`edge-cases › recover after target element is removed`) is a pre-existing timing flake (3/3 green in isolation) and touches none of the changed paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch core activation/copy/state paths and toolbar enablement, but behavior fixes are localized and most edits are removals or extractions without new features.
> 
> **Overview**
> This PR is a **net-subtractive cleanup** of `packages/react-grab` (plus a small CLI tweak) that removes dead code, pulls selection-label logic out of the core entrypoint, and fixes a few interaction bugs.
> 
> **Core / copy flow:** Label create/fade/update logic moves into `core/label-controller.ts`, with shared helpers (`buildLabelInstance`, `runLabeledCopy`) replacing duplicated paths in `core/index.tsx`. Clipboard copy now **returns and respects a boolean** so failed writes show error state and unfreeze instead of treating success as copied. Unused grab-store fields (`theme`, `lastCopiedElement`, `clearLastCopied`) and `completeCopy(element)` are dropped.
> 
> **UI / API trimming:** Removes unused props and anchors (`TagBadge.forceShowIcon`, `DropdownAnchor.toolbarWidth`, toolbar `collapseButton` override, `StepArrow` disabled/pointer-up handlers, overlay dismiss `onConfirm`). Edit panel labels share `EDIT_LABEL_CLASS`. `createElementSelector` always runs the finder path (no `shouldUseFinder` flag).
> 
> **Bug fixes:** Label fade schedules a removal timeout that is **tracked and cancellable** on hover/dispose; hover resume also applies to error/fading labels. `setToolbarState` honors explicit `enabled`; `selectionLabelVisible` gates on global theme enabled like other overlay memos.
> 
> **Misc:** CLI `CHROMIUM_CUSTOM_FORMAT` is module-private; small renames and `instanceof`/channel naming cleanups across utils.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da0ffff6ca12be8bbb0894462648fce57726ad80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleanup of `packages/react-grab` that deletes dead code, extracts the selection-label lifecycle into `core/label-controller.ts`, and fixes copy/toolbar/label visibility bugs. Copy feedback is now accurate, label timers don’t leak or stick, and toolbar enablement is predictable.

- **Bug Fixes**
  - Copy result is honored and plugin intercept results are awaited even with mixed selections; failed copies show an error and unfreeze instead of “Copied”.
  - Fixed label fade/removal leak by tracking and cancelling nested timers; unhover now reschedules fade for error/fading labels so they don’t stick.
  - `setToolbarState` respects an explicit `enabled` value.
  - Selection label visibility now honors the theme kill-switch.

- **Refactors**
  - Moved label lifecycle into `core/label-controller.ts`; deduped `buildLabelInstance` and labeled copy flow.
  - Removed unused state/props: `store.theme`, `lastCopiedElement`, and stale component props; dropped `EDIT_PANEL_POINTER_ANCHOR_WIDTH_PX`.
  - Safer typing and clearer names: `instanceof` guards, `deltaX/deltaY`, `parseHexChannels` uses `red/green/blue/alpha`, and shared `EDIT_LABEL_CLASS`.
  - Simplified APIs: removed `createElementSelector.shouldUseFinder`, `registerOverlayDismiss.onConfirm`, and the toolbar collapse button override.

<sup>Written for commit da0ffff6ca12be8bbb0894462648fce57726ad80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

