### PR TITLE
Add shadcn registry component

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,22 @@ Run this at your project root:
 npx grab@latest init
 ```
 
+## How It Works
+
+React Grab turns a browser selection into source context your agent can use:
+
+1. Hover any UI element in your app.
+2. Press **⌘C** or **Ctrl+C**.
+3. Paste the copied context into your agent.
+
+The copied context includes the selected element and its component stack with source locations:
+
+```txt
+[<a class="ml-auto inline-block text-sm" href="#">Forgot your password?</a> in LoginForm (at components/login-form.tsx:46:19)]
+```
+
+## Manual Installation
+
 ### shadcn Registry
 
 Install the React Grab component from this GitHub registry:
@@ -39,22 +55,6 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   );
 }
 ```
-
-## How It Works
-
-React Grab turns a browser selection into source context your agent can use:
-
-1. Hover any UI element in your app.
-2. Press **⌘C** or **Ctrl+C**.
-3. Paste the copied context into your agent.
-
-The copied context includes the selected element and its component stack with source locations:
-
-```txt
-[<a class="ml-auto inline-block text-sm" href="#">Forgot your password?</a> in LoginForm (at components/login-form.tsx:46:19)]
-```
-
-## Manual Installation
 
 If you cannot use the CLI, install React Grab manually for your framework:
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,29 @@ Run this at your project root:
 npx grab@latest init
 ```
 
+### shadcn Registry
+
+Install the React Grab component from this GitHub registry:
+
+```bash
+npx shadcn@latest add aidenybai/react-grab/react-grab
+```
+
+Render it once near the root of your app:
+
+```tsx
+import { ReactGrab } from "@/components/react-grab";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      {children}
+      {process.env.NODE_ENV === "development" && <ReactGrab />}
+    </>
+  );
+}
+```
+
 ## How It Works
 
 React Grab turns a browser selection into source context your agent can use:

--- a/packages/grab/README.md
+++ b/packages/grab/README.md
@@ -33,6 +33,29 @@ The copied context includes the selected element and its component stack with so
 
 ## Manual Installation
 
+### shadcn Registry
+
+Install the React Grab component from this GitHub registry:
+
+```bash
+npx shadcn@latest add aidenybai/react-grab/react-grab
+```
+
+Render it once near the root of your app:
+
+```tsx
+import { ReactGrab } from "@/components/react-grab";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      {children}
+      {process.env.NODE_ENV === "development" && <ReactGrab />}
+    </>
+  );
+}
+```
+
 If you cannot use the CLI, install React Grab manually for your framework:
 
 #### Next.js (App router)

--- a/packages/react-grab/README.md
+++ b/packages/react-grab/README.md
@@ -33,6 +33,29 @@ The copied context includes the selected element and its component stack with so
 
 ## Manual Installation
 
+### shadcn Registry
+
+Install the React Grab component from this GitHub registry:
+
+```bash
+npx shadcn@latest add aidenybai/react-grab/react-grab
+```
+
+Render it once near the root of your app:
+
+```tsx
+import { ReactGrab } from "@/components/react-grab";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      {children}
+      {process.env.NODE_ENV === "development" && <ReactGrab />}
+    </>
+  );
+}
+```
+
 If you cannot use the CLI, install React Grab manually for your framework:
 
 #### Next.js (App router)

--- a/registry.json
+++ b/registry.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry.json",
+  "name": "react-grab",
+  "homepage": "https://react-grab.com",
+  "items": [
+    {
+      "name": "react-grab",
+      "type": "registry:component",
+      "title": "React Grab",
+      "description": "Installs and loads React Grab from a React component.",
+      "dependencies": ["react-grab"],
+      "files": [
+        {
+          "path": "registry/react-grab.tsx",
+          "type": "registry:component",
+          "target": "@components/react-grab.tsx"
+        }
+      ]
+    }
+  ]
+}

--- a/registry/react-grab.tsx
+++ b/registry/react-grab.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect } from "react";
+import type { Options } from "react-grab";
+
+declare global {
+  interface Window {
+    __REACT_GRAB_DISABLED__?: boolean;
+  }
+}
+
+interface ReactGrabProps {
+  enabled?: boolean;
+  options?: Options;
+}
+
+const reactGrabOptions: Options = {
+  // activationMode: "toggle",
+  // activationKey: "Alt+KeyG",
+  // keyHoldDuration: 500,
+  // allowActivationInsideInput: true,
+  // freezeReactUpdates: true,
+  // telemetry: true,
+  // getContent: async (elements) => elements.map((element) => element.outerHTML).join("\n"),
+};
+
+export const ReactGrab = (props: ReactGrabProps) => {
+  useEffect(() => {
+    if (props.enabled === false) return;
+
+    let isActive = true;
+
+    const loadReactGrab = async () => {
+      window.__REACT_GRAB_DISABLED__ = true;
+      try {
+        const reactGrab = await import("react-grab");
+
+        if (!isActive) return;
+
+        const existingApi = reactGrab.getGlobalApi();
+        if (existingApi) return;
+
+        const api = reactGrab.init({
+          ...reactGrabOptions,
+          ...props.options,
+        });
+
+        reactGrab.setGlobalApi(api);
+        window.dispatchEvent(new CustomEvent("react-grab:init", { detail: api }));
+      } finally {
+        delete window.__REACT_GRAB_DISABLED__;
+      }
+    };
+
+    void loadReactGrab();
+
+    return () => {
+      isActive = false;
+    };
+  }, [props.enabled, props.options]);
+
+  return null;
+};

--- a/registry/react-grab.tsx
+++ b/registry/react-grab.tsx
@@ -19,9 +19,6 @@ const reactGrabOptions: Options = {
   // activationKey: "Alt+KeyG",
   // keyHoldDuration: 500,
   // allowActivationInsideInput: true,
-  // freezeReactUpdates: true,
-  // telemetry: true,
-  // getContent: async (elements) => elements.map((element) => element.outerHTML).join("\n"),
 };
 
 export const ReactGrab = (props: ReactGrabProps) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a root shadcn GitHub `registry.json` with a `react-grab` registry item.
- Add a client `ReactGrab` installer component with commented optional config.
- Document the GitHub registry install command and usage under Manual Installation, including synced package READMEs.

## Verification
- `pnpm dlx shadcn@latest registry validate registry.json`
- `pnpm build`
- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b43e48e1-f463-4f37-8cdc-0fc57a59b16d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b43e48e1-f463-4f37-8cdc-0fc57a59b16d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `shadcn` GitHub registry entry and a `ReactGrab` installer component so apps can install and initialize `react-grab` with one command and a single render. Also expands install docs and examples across all READMEs.

- New Features
  - Added root `registry.json` for `shadcn` with a `react-grab` item targeting `@components/react-grab.tsx`.
  - Added client `ReactGrab` component that lazy-loads `react-grab`, sets a global API, and supports optional `Options`.
  - Updated root and package READMEs with `npx shadcn@latest add aidenybai/react-grab/react-grab` and a dev-only root render example.

<sup>Written for commit 3634587cdbe755d0dbab7b1b29d5cf8265f57704. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

