### PR TITLE
Add mouse-move discard prompt for keyboard tweaks

### DIFF
--- a/apps/openstory/stories/renderer.stories.tsx
+++ b/apps/openstory/stories/renderer.stories.tsx
@@ -321,7 +321,11 @@ const Scene = (props: SceneProps) => {
         mouseX={mouseX()}
         isPromptMode={props.isPromptMode}
         inputValue={props.inputValue}
-        isPendingDismiss={props.isPendingDismiss}
+        discardPrompt={
+          props.isPendingDismiss
+            ? { kind: "standard", onConfirm: noop, onCancel: noop }
+            : undefined
+        }
         isFrozen={false}
         toolbarVisible={props.showToolbar}
         isActive={props.isActive}
@@ -336,7 +340,6 @@ const Scene = (props: SceneProps) => {
         onInputSubmit={noop}
         onToggleExpand={noop}
         onConfirmDismiss={noop}
-        onCancelDismiss={noop}
         onToggleActive={noop}
         onToolbarStateChange={noop}
         onContextMenuDismiss={noop}

--- a/apps/openstory/stories/renderer.stories.tsx
+++ b/apps/openstory/stories/renderer.stories.tsx
@@ -322,9 +322,7 @@ const Scene = (props: SceneProps) => {
         isPromptMode={props.isPromptMode}
         inputValue={props.inputValue}
         discardPrompt={
-          props.isPendingDismiss
-            ? { kind: "standard", onConfirm: noop, onCancel: noop }
-            : undefined
+          props.isPendingDismiss ? { onConfirm: noop, onCancel: noop } : undefined
         }
         isFrozen={false}
         toolbarVisible={props.showToolbar}

--- a/apps/openstory/stories/selection-label.stories.tsx
+++ b/apps/openstory/stories/selection-label.stories.tsx
@@ -17,7 +17,6 @@ const baseProps: SelectionLabelProps = {
   onSubmit: noop,
   onDismiss: noop,
   onConfirmDismiss: noop,
-  onCancelDismiss: noop,
   onAcknowledgeError: noop,
   onRetry: noop,
   onShowContextMenu: noop,
@@ -122,7 +121,7 @@ export const PendingDismiss: Story = {
     tagName: "header",
     componentName: "Header",
     isPromptMode: true,
-    isPendingDismiss: true,
+    discardPrompt: { kind: "standard", onConfirm: noop, onCancel: noop },
     inputValue: "tweak the spacing",
   },
 };

--- a/apps/openstory/stories/selection-label.stories.tsx
+++ b/apps/openstory/stories/selection-label.stories.tsx
@@ -121,7 +121,7 @@ export const PendingDismiss: Story = {
     tagName: "header",
     componentName: "Header",
     isPromptMode: true,
-    discardPrompt: { kind: "standard", onConfirm: noop, onCancel: noop },
+    discardPrompt: { onConfirm: noop, onCancel: noop },
     inputValue: "tweak the spacing",
   },
 };

--- a/packages/react-grab/e2e/edit-panel-helpers.ts
+++ b/packages/react-grab/e2e/edit-panel-helpers.ts
@@ -452,6 +452,24 @@ export const clickHeaderCopyButton = async (page: Page): Promise<void> => {
   );
 };
 
+export const clickDiscardButton = async (
+  page: Page,
+  action: "cancel" | "confirm" | "copy",
+): Promise<void> => {
+  await page.evaluate(
+    ({ attrName, actionName }) => {
+      const host = document.querySelector(`[${attrName}]`);
+      const shadowRoot = host?.shadowRoot;
+      const button = shadowRoot?.querySelector<HTMLButtonElement>(
+        `[data-react-grab-discard-button='${actionName}']`,
+      );
+      if (!button) throw new Error("Discard button not found");
+      button.click();
+    },
+    { attrName: ATTRIBUTE_NAME, actionName: action },
+  );
+};
+
 export const dragActiveSlider = async (page: Page): Promise<void> => {
   const sliderBounds = await page.evaluate(
     ({ attrName, propertyAttr }) => {

--- a/packages/react-grab/e2e/edit-panel.spec.ts
+++ b/packages/react-grab/e2e/edit-panel.spec.ts
@@ -447,6 +447,91 @@ test.describe("Style Panel", () => {
       await reactGrab.page.keyboard.press("Escape");
       await expect.poll(() => isEditPanelVisible(reactGrab.page)).toBe(false);
     });
+
+    test("mouse movement without pending tweaks does not open the discard prompt", async ({
+      reactGrab,
+    }) => {
+      await openEditPanel(reactGrab, BUTTON_SELECTOR);
+
+      await reactGrab.page.mouse.move(10, 10);
+      await reactGrab.page.waitForTimeout(80);
+
+      // Nothing was tweaked, so the handoff was never armed.
+      expect(await isEditPanelVisible(reactGrab.page)).toBe(true);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(false);
+    });
+
+    test("mouse-move discard prompt Yes reverts the keyboard tweak", async ({ reactGrab }) => {
+      await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      const beforeTweak = await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR);
+      await reactGrab.page.keyboard.press("ArrowRight");
+      await reactGrab.page.waitForTimeout(80);
+      expect(await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR)).not.toBe(beforeTweak);
+
+      await reactGrab.page.mouse.move(10, 10);
+      await reactGrab.page.waitForTimeout(80);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(true);
+
+      await clickDiscardButton(reactGrab.page, "confirm");
+      await expect.poll(() => isEditPanelVisible(reactGrab.page)).toBe(false);
+      expect(await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR)).toBe(beforeTweak);
+    });
+
+    test("a fresh keyboard tweak re-arms the consumed pointer handoff", async ({ reactGrab }) => {
+      await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      await reactGrab.page.keyboard.press("ArrowRight");
+      await reactGrab.page.waitForTimeout(80);
+
+      await reactGrab.page.mouse.move(10, 10);
+      await reactGrab.page.waitForTimeout(80);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(true);
+
+      await clickDiscardButton(reactGrab.page, "cancel");
+      await reactGrab.page.waitForTimeout(80);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(false);
+
+      // The handoff is one-shot, but a new keyboard commit re-arms it.
+      await reactGrab.page.keyboard.press("ArrowRight");
+      await reactGrab.page.waitForTimeout(80);
+      await reactGrab.page.mouse.move(40, 40);
+      await reactGrab.page.waitForTimeout(80);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(true);
+    });
+
+    test("typing a tailwind class arms the mouse-move discard handoff", async ({ reactGrab }) => {
+      await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      const beforeTweak = await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR);
+      // px-4 (16px) differs from the button's px-2 (8px), so it's a real,
+      // submittable edit rather than a net-zero one.
+      await reactGrab.page.keyboard.type("px-4");
+      await reactGrab.page.waitForTimeout(IDLE_BUFFER_MS);
+      expect(await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR)).not.toBe(beforeTweak);
+
+      await reactGrab.page.mouse.move(10, 10);
+      await reactGrab.page.waitForTimeout(80);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(true);
+    });
+
+    test("touch pointer movement does not consume the keyboard handoff", async ({ reactGrab }) => {
+      await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      await reactGrab.page.keyboard.press("ArrowRight");
+      await reactGrab.page.waitForTimeout(80);
+
+      // A touch pointermove is ignored by the mouse-only handoff, so it must
+      // neither open the prompt nor consume the arm.
+      await reactGrab.page.evaluate(() => {
+        window.dispatchEvent(
+          new PointerEvent("pointermove", { pointerType: "touch", bubbles: true }),
+        );
+      });
+      await reactGrab.page.waitForTimeout(80);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(false);
+
+      // The still-armed handoff fires on the next real mouse move.
+      await reactGrab.page.mouse.move(10, 10);
+      await reactGrab.page.waitForTimeout(80);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(true);
+    });
   });
 
   test.describe("Property listing", () => {

--- a/packages/react-grab/e2e/edit-panel.spec.ts
+++ b/packages/react-grab/e2e/edit-panel.spec.ts
@@ -9,6 +9,7 @@ import {
   IDLE_BUFFER_MS,
   SEARCH_INPUT_ATTR,
   clearEditStorage,
+  clickDiscardButton,
   clickHeaderCopyButton,
   dispatchOutsideDismiss,
   dragActiveSlider,
@@ -25,7 +26,6 @@ import {
   getOverlayFocusVisualStates,
   getPropertyRowBounds,
   getSearchInputFocusVisualState,
-  getVisibleSliderVisualState,
   getVisiblePropertyKeys,
   hoverVisibleSlider,
   isDiscardPromptVisible,
@@ -283,6 +283,110 @@ test.describe("Style Panel", () => {
       expect(await isEditPanelVisible(reactGrab.page)).toBe(true);
       expect(await isEditPanelCompact(reactGrab.page)).toBe(false);
       expect(await isDiscardPromptVisible(reactGrab.page)).toBe(true);
+    });
+
+    test("mouse movement after keyboard tweak opens discard prompt with Copy", async ({
+      reactGrab,
+    }) => {
+      await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      await reactGrab.page.keyboard.press("ArrowRight");
+      await reactGrab.page.waitForTimeout(80);
+      const inlineStyleAfterTweak = await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR);
+      expect(inlineStyleAfterTweak.length).toBeGreaterThan(0);
+
+      await reactGrab.page.mouse.move(10, 10);
+      await reactGrab.page.waitForTimeout(80);
+      expect(await isEditPanelVisible(reactGrab.page)).toBe(true);
+      expect(await isEditPanelCompact(reactGrab.page)).toBe(false);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(true);
+
+      await clickDiscardButton(reactGrab.page, "copy");
+      await expect.poll(() => isEditPanelVisible(reactGrab.page)).toBe(false);
+      expect(await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR)).toBe(
+        inlineStyleAfterTweak,
+      );
+    });
+
+    test("canceling mouse-move discard prompt consumes the pointer handoff", async ({
+      reactGrab,
+    }) => {
+      await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      await reactGrab.page.keyboard.press("ArrowRight");
+      await reactGrab.page.waitForTimeout(80);
+
+      await reactGrab.page.mouse.move(10, 10);
+      await reactGrab.page.waitForTimeout(80);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(true);
+
+      await clickDiscardButton(reactGrab.page, "cancel");
+      await reactGrab.page.waitForTimeout(80);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(false);
+
+      await reactGrab.page.mouse.move(20, 20);
+      await reactGrab.page.waitForTimeout(80);
+      expect(await isEditPanelVisible(reactGrab.page)).toBe(true);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(false);
+    });
+
+    test("canceling outside-click discard prompt consumes the pointer handoff", async ({
+      reactGrab,
+    }) => {
+      await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      await reactGrab.page.keyboard.press("ArrowRight");
+      await reactGrab.page.waitForTimeout(80);
+
+      await dispatchOutsideDismiss(reactGrab.page);
+      await reactGrab.page.waitForTimeout(80);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(true);
+
+      await clickDiscardButton(reactGrab.page, "cancel");
+      await reactGrab.page.waitForTimeout(80);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(false);
+
+      await reactGrab.page.mouse.move(20, 20);
+      await reactGrab.page.waitForTimeout(80);
+      expect(await isEditPanelVisible(reactGrab.page)).toBe(true);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(false);
+    });
+
+    test("mouse movement while discard prompt is visible does not consume the handoff", async ({
+      reactGrab,
+    }) => {
+      await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      await reactGrab.page.keyboard.press("ArrowRight");
+      await reactGrab.page.waitForTimeout(80);
+
+      await openDiscardPromptViaEscape(reactGrab.page);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(true);
+      await reactGrab.page.mouse.move(10, 10);
+      await reactGrab.page.waitForTimeout(80);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(true);
+
+      await clickDiscardButton(reactGrab.page, "cancel");
+      await reactGrab.page.waitForTimeout(80);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(false);
+
+      await reactGrab.page.mouse.move(20, 20);
+      await reactGrab.page.waitForTimeout(80);
+      expect(await isEditPanelVisible(reactGrab.page)).toBe(true);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(false);
+    });
+
+    test("keyboard navigation after pointer tweak does not arm mouse-move discard prompt", async ({
+      reactGrab,
+    }) => {
+      await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      await dragActiveSlider(reactGrab.page);
+      await reactGrab.page.waitForTimeout(80);
+      expect(await isHeaderCopyButtonVisible(reactGrab.page)).toBe(true);
+
+      await reactGrab.page.keyboard.press("ArrowDown");
+      await reactGrab.page.waitForTimeout(80);
+      await reactGrab.page.mouse.move(10, 10);
+      await reactGrab.page.waitForTimeout(80);
+
+      expect(await isEditPanelVisible(reactGrab.page)).toBe(true);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(false);
     });
 
     test("net-zero tweak dismiss restores preview inline styles", async ({ reactGrab }) => {
@@ -777,17 +881,16 @@ test.describe("Style Panel", () => {
       expect(await isEditPanelCompact(reactGrab.page)).toBe(true);
     });
 
-    test("compact slider shows unit marks on hover", async ({ reactGrab }) => {
+    test("compact keyboard tweak opens discard prompt on hover", async ({ reactGrab }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
       await reactGrab.page.keyboard.press("ArrowRight");
       await reactGrab.page.waitForTimeout(IDLE_BUFFER_MS);
       expect(await isEditPanelCompact(reactGrab.page)).toBe(true);
-      const beforeHover = await getVisibleSliderVisualState(reactGrab.page);
-      expect(beforeHover.maxHashMarkOpacity).toBe(0);
+
       await hoverVisibleSlider(reactGrab.page);
       await reactGrab.page.waitForTimeout(IDLE_BUFFER_MS);
-      const afterHover = await getVisibleSliderVisualState(reactGrab.page);
-      expect(afterHover.maxHashMarkOpacity).toBeGreaterThan(0);
+      expect(await isEditPanelCompact(reactGrab.page)).toBe(false);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(true);
     });
 
     test("typing in search re-expands the compact panel", async ({ reactGrab }) => {

--- a/packages/react-grab/e2e/keyboard-navigation.spec.ts
+++ b/packages/react-grab/e2e/keyboard-navigation.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type ReactGrabPageObject } from "./fixtures.js";
+import { isEditPanelVisible } from "./edit-panel-helpers.js";
 
 const ATTRIBUTE_NAME = "data-react-grab";
 
@@ -253,6 +254,65 @@ test.describe("Keyboard Navigation", () => {
     await reactGrab.page.keyboard.press("Enter");
 
     await expect.poll(() => reactGrab.isPendingDismissVisible()).toBe(false);
+  });
+
+  test("Enter on the focused Copy button copies without opening the Style panel", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.page.evaluate(() => navigator.clipboard.writeText(""));
+    await reactGrab.activate();
+    await reactGrab.hoverElement("[data-testid='todo-list'] li:first-child");
+    await reactGrab.waitForSelectionBox();
+
+    await reactGrab.page.keyboard.press("ArrowUp");
+    await reactGrab.waitForSelectionBox();
+    await reactGrab.page.mouse.move(10, 10);
+    await expect.poll(() => reactGrab.isPendingDismissVisible()).toBe(true);
+
+    await reactGrab.page.locator("[data-react-grab-discard-copy]").focus();
+    await reactGrab.page.keyboard.press("Enter");
+
+    // Enter on Copy must copy, not fall through to the Enter-to-expand
+    // shortcut that would open the Style panel.
+    await expect.poll(() => reactGrab.getClipboardContent(), { timeout: 5000 }).not.toBe("");
+    expect(await isEditPanelVisible(reactGrab.page)).toBe(false);
+  });
+
+  test("Enter on the focused Yes button discards without copying", async ({ reactGrab }) => {
+    await reactGrab.page.evaluate(() => navigator.clipboard.writeText(""));
+    await reactGrab.activate();
+    await reactGrab.hoverElement("[data-testid='todo-list'] li:first-child");
+    await reactGrab.waitForSelectionBox();
+
+    await reactGrab.page.keyboard.press("ArrowUp");
+    await reactGrab.waitForSelectionBox();
+    await reactGrab.page.mouse.move(10, 10);
+    await expect.poll(() => reactGrab.isPendingDismissVisible()).toBe(true);
+
+    await reactGrab.page.locator("[data-react-grab-discard-yes]").focus();
+    await reactGrab.page.keyboard.press("Enter");
+
+    await expect.poll(() => reactGrab.isPendingDismissVisible()).toBe(false);
+    expect(await reactGrab.getClipboardContent()).toBe("");
+  });
+
+  test("arrow keys are ignored while the discard-selection prompt is open", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.activate();
+    await reactGrab.hoverElement("[data-testid='todo-list'] li:first-child");
+    await reactGrab.waitForSelectionBox();
+
+    await reactGrab.page.keyboard.press("ArrowDown");
+    await reactGrab.waitForSelectionBox();
+    await reactGrab.page.mouse.move(0, 0);
+    await expect.poll(() => reactGrab.isPendingDismissVisible()).toBe(true);
+
+    // Navigation is suppressed while the prompt is up: a navigating key would
+    // re-select and clear the prompt, so it must stay open.
+    await reactGrab.page.keyboard.press("ArrowDown");
+    await reactGrab.page.waitForTimeout(100);
+    expect(await reactGrab.isPendingDismissVisible()).toBe(true);
   });
 });
 

--- a/packages/react-grab/e2e/keyboard-navigation.spec.ts
+++ b/packages/react-grab/e2e/keyboard-navigation.spec.ts
@@ -1,5 +1,54 @@
 import { expect, test, type ReactGrabPageObject } from "./fixtures.js";
 
+const ATTRIBUTE_NAME = "data-react-grab";
+
+const clickSelectionDiscardButton = async (
+  reactGrab: ReactGrabPageObject,
+  action: "copy" | "yes",
+  options: { programmatic?: boolean } = {},
+): Promise<void> => {
+  if (!options.programmatic) {
+    await reactGrab.page.locator(`[data-react-grab-discard-${action}]`).click();
+    return;
+  }
+  await reactGrab.page.evaluate(
+    ({ attrName, actionName }) => {
+      const host = document.querySelector(`[${attrName}]`);
+      const shadowRoot = host?.shadowRoot;
+      const button = shadowRoot?.querySelector<HTMLButtonElement>(
+        `[data-react-grab-discard-${actionName}]`,
+      );
+      if (!button) throw new Error(`Discard ${actionName} button not found`);
+      button.click();
+    },
+    { attrName: ATTRIBUTE_NAME, actionName: action },
+  );
+};
+
+const getSelectionDiscardPromptState = async (
+  reactGrab: ReactGrabPageObject,
+): Promise<{
+  promptText: string;
+  labelText: string;
+  hasCopy: boolean;
+  hasNo: boolean;
+  hasYes: boolean;
+}> => {
+  return reactGrab.page.evaluate((attrName) => {
+    const host = document.querySelector(`[${attrName}]`);
+    const shadowRoot = host?.shadowRoot;
+    const label = shadowRoot?.querySelector<HTMLElement>("[data-react-grab-selection-label]");
+    const prompt = shadowRoot?.querySelector<HTMLElement>("[data-react-grab-discard-prompt]");
+    return {
+      promptText: prompt?.textContent?.replace(/\s+/g, " ").trim() ?? "",
+      labelText: label?.textContent?.replace(/\s+/g, " ").trim() ?? "",
+      hasCopy: Boolean(prompt?.querySelector("[data-react-grab-discard-copy]")),
+      hasNo: Boolean(prompt?.querySelector("[data-react-grab-discard-no]")),
+      hasYes: Boolean(prompt?.querySelector("[data-react-grab-discard-yes]")),
+    };
+  }, ATTRIBUTE_NAME);
+};
+
 test.describe("Keyboard Navigation", () => {
   test("should navigate to next element with ArrowDown", async ({ reactGrab }) => {
     await reactGrab.activate();
@@ -62,7 +111,9 @@ test.describe("Keyboard Navigation", () => {
     expect(isVisible).toBe(true);
   });
 
-  test("should copy element after keyboard navigation with click", async ({ reactGrab }) => {
+  test("should copy element after keyboard navigation with mouse-move prompt", async ({
+    reactGrab,
+  }) => {
     await reactGrab.activate();
     await reactGrab.hoverElement("[data-testid='todo-list'] li:first-child");
     await reactGrab.waitForSelectionBox();
@@ -73,15 +124,33 @@ test.describe("Keyboard Navigation", () => {
     const secondItem = reactGrab.page.locator("[data-testid='todo-list'] li:nth-child(2)");
     const box = await secondItem.boundingBox();
     if (box) {
-      await reactGrab.page.mouse.click(box.x + 10, box.y + 10);
+      await reactGrab.page.mouse.move(box.x + 10, box.y + 10);
     }
-    await reactGrab.page.waitForTimeout(500);
+    await expect.poll(() => reactGrab.isPendingDismissVisible()).toBe(true);
+    await clickSelectionDiscardButton(reactGrab, "copy");
 
-    const clipboardContent = await reactGrab.getClipboardContent();
-    expect(clipboardContent).toBeTruthy();
+    await expect.poll(() => reactGrab.getClipboardContent(), { timeout: 5000 }).not.toBe("");
   });
 
-  test("should copy keyboard-selected element when clicking after mouse movement", async ({
+  test("should copy keyboard-selected element when clicking over previous mouse target", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.page.evaluate(() => navigator.clipboard.writeText(""));
+    await reactGrab.activate();
+    await reactGrab.hoverElement("[data-testid='todo-list'] h1");
+    await reactGrab.waitForSelectionBox();
+
+    await reactGrab.page.keyboard.press("ArrowLeft");
+    await reactGrab.waitForSelectionBox();
+
+    await reactGrab.page.mouse.down();
+    await reactGrab.page.mouse.up();
+
+    await expect.poll(() => reactGrab.getClipboardContent(), { timeout: 5000 }).toContain("[<div");
+    expect(await reactGrab.getClipboardContent()).not.toContain("[<h1");
+  });
+
+  test("should offer Copy for keyboard-selected element after mouse movement", async ({
     reactGrab,
   }) => {
     await reactGrab.activate();
@@ -99,18 +168,34 @@ test.describe("Keyboard Navigation", () => {
 
     await reactGrab.page.mouse.move(10, 10);
     await reactGrab.page.waitForTimeout(50);
+    await expect.poll(() => reactGrab.isPendingDismissVisible()).toBe(true);
 
-    await reactGrab.page.mouse.click(
-      selectionBoundsAfterArrow!.x + selectionBoundsAfterArrow!.width / 2,
-      selectionBoundsAfterArrow!.y + selectionBoundsAfterArrow!.height / 2,
-    );
-    await reactGrab.page.waitForTimeout(500);
+    await clickSelectionDiscardButton(reactGrab, "copy");
 
-    const clipboardContent = await reactGrab.getClipboardContent();
-    expect(clipboardContent).toBeTruthy();
+    await expect.poll(() => reactGrab.getClipboardContent(), { timeout: 5000 }).not.toBe("");
   });
 
-  test("should freeze selection when navigating with arrow keys", async ({ reactGrab }) => {
+  test("should copy keyboard-selected element with Enter on focused Copy prompt button", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.activate();
+    await reactGrab.hoverElement("[data-testid='todo-list'] li:first-child");
+    await reactGrab.waitForSelectionBox();
+
+    await reactGrab.page.keyboard.press("ArrowUp");
+    await reactGrab.waitForSelectionBox();
+    await reactGrab.page.mouse.move(10, 10);
+    await expect.poll(() => reactGrab.isPendingDismissVisible()).toBe(true);
+
+    await reactGrab.page.locator("[data-react-grab-discard-copy]").focus();
+    await reactGrab.page.keyboard.press("Enter");
+
+    await expect.poll(() => reactGrab.getClipboardContent(), { timeout: 5000 }).not.toBe("");
+  });
+
+  test("should prompt before mouse movement discards arrow-key selection", async ({
+    reactGrab,
+  }) => {
     await reactGrab.activate();
     await reactGrab.hoverElement("li:first-child");
     await reactGrab.waitForSelectionBox();
@@ -123,6 +208,51 @@ test.describe("Keyboard Navigation", () => {
 
     const isVisible = await reactGrab.isOverlayVisible();
     expect(isVisible).toBe(true);
+    expect(await reactGrab.isPendingDismissVisible()).toBe(true);
+    const prompt = await getSelectionDiscardPromptState(reactGrab);
+    expect(prompt.promptText).toBe("Discard selection?CopyYes");
+    expect(prompt.labelText).toBe("Discard selection?CopyYes");
+    expect(prompt.hasCopy).toBe(true);
+    expect(prompt.hasNo).toBe(false);
+    expect(prompt.hasYes).toBe(true);
+  });
+
+  test("should discard arrow-key selection when confirming mouse handoff", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.activate();
+    await reactGrab.hoverElement("li:first-child");
+    await reactGrab.waitForSelectionBox();
+
+    await reactGrab.page.keyboard.press("ArrowDown");
+    await reactGrab.waitForSelectionBox();
+    const selectionBoundsAfterArrow = await reactGrab.getSelectionBoxBounds();
+    expect(selectionBoundsAfterArrow).not.toBeNull();
+
+    await reactGrab.page.mouse.move(0, 0);
+    await expect.poll(() => reactGrab.isPendingDismissVisible()).toBe(true);
+    await reactGrab.page.mouse.move(400, 400);
+    await reactGrab.page.waitForTimeout(100);
+    expect(await reactGrab.isPendingDismissVisible()).toBe(true);
+    expect((await reactGrab.getState()).targetElement).toBeFalsy();
+
+    await clickSelectionDiscardButton(reactGrab, "yes");
+    await expect.poll(() => reactGrab.isPendingDismissVisible()).toBe(false);
+  });
+
+  test("should confirm discard selection with Enter", async ({ reactGrab }) => {
+    await reactGrab.activate();
+    await reactGrab.hoverElement("li:first-child");
+    await reactGrab.waitForSelectionBox();
+
+    await reactGrab.page.keyboard.press("ArrowDown");
+    await reactGrab.waitForSelectionBox();
+    await reactGrab.page.mouse.move(0, 0);
+    await expect.poll(() => reactGrab.isPendingDismissVisible()).toBe(true);
+
+    await reactGrab.page.keyboard.press("Enter");
+
+    await expect.poll(() => reactGrab.isPendingDismissVisible()).toBe(false);
   });
 });
 
@@ -148,6 +278,9 @@ test.describe("Navigation History and Wrapping", () => {
       await reactGrab.waitForSelectionBox();
     }
 
+    await reactGrab.page.locator(scenario.targetSelector).hover({ force: true });
+    await expect.poll(() => reactGrab.isPendingDismissVisible()).toBe(true);
+    await clickSelectionDiscardButton(reactGrab, "yes", { programmatic: true });
     await reactGrab.page.locator(scenario.targetSelector).click({ force: true });
 
     await expect

--- a/packages/react-grab/src/components/edit-panel/active-property-control.tsx
+++ b/packages/react-grab/src/components/edit-panel/active-property-control.tsx
@@ -9,7 +9,7 @@ interface ActivePropertyControlProps {
   property: EditableProperty;
   activeKey: "left" | "right" | null;
   onStep: (direction: 1 | -1) => void;
-  onCommit: (value: number | string) => void;
+  onCommit: (value: number | string, source: "keyboard" | "pointer") => void;
   onEditComplete: () => void;
   onInvalidCommit: () => void;
   onInteract: () => void;

--- a/packages/react-grab/src/components/edit-panel/color-picker.tsx
+++ b/packages/react-grab/src/components/edit-panel/color-picker.tsx
@@ -12,7 +12,7 @@ const stripHexAlpha = (hex: string): string => (hex.length === 9 ? hex.slice(0, 
 interface ColorPickerProps {
   label?: string;
   value: string;
-  onCommit: (value: string) => void;
+  onCommit: (value: string, source: "keyboard" | "pointer") => void;
   onEditComplete?: () => void;
   onInvalidCommit?: () => void;
   onRegisterTrigger?: (trigger: (() => void) | null, owner?: () => void) => void;
@@ -52,7 +52,7 @@ export const ColorPicker: Component<ColorPickerProps> = (props) => {
     if (!normalizedHexColor) {
       props.onInvalidCommit?.();
     } else if (normalizedHexColor.toLowerCase() !== props.value.toLowerCase()) {
-      props.onCommit(normalizedHexColor);
+      props.onCommit(normalizedHexColor, "keyboard");
     }
     props.onEditComplete?.();
   };
@@ -170,7 +170,7 @@ export const ColorPicker: Component<ColorPickerProps> = (props) => {
             const nextColorValue = pickedRgb + preservedAlpha;
             props.onInteract?.();
             if (nextColorValue && nextColorValue.toLowerCase() !== props.value.toLowerCase()) {
-              props.onCommit(nextColorValue);
+              props.onCommit(nextColorValue, "pointer");
             }
           }}
         />

--- a/packages/react-grab/src/components/edit-panel/copy-button.tsx
+++ b/packages/react-grab/src/components/edit-panel/copy-button.tsx
@@ -1,0 +1,25 @@
+import type { Component } from "solid-js";
+
+interface EditPanelCopyButtonProps {
+  discardAction?: "copy";
+  onCopy: () => void;
+}
+
+export const EditPanelCopyButton: Component<EditPanelCopyButtonProps> = (props) => (
+  <button
+    data-react-grab-ignore-events
+    data-react-grab-copy-button
+    data-react-grab-discard-button={props.discardAction}
+    type="button"
+    class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[var(--rg-surface-hover)] [border-width:0.5px] border-solid border-[var(--rg-border-button)] cursor-pointer transition-all hover:bg-[var(--rg-surface-active)] press-scale h-[17px]"
+    onClick={(event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      props.onCopy();
+    }}
+  >
+    <span class="text-[var(--rg-text-primary)] text-[13px] leading-3.5 font-sans font-medium">
+      Copy
+    </span>
+  </button>
+);

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -300,7 +300,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
 
   const stepController = createStepController({ step: stepFromKeyboard, isShiftHeld });
 
-  const commitActive = (rawValue: number | string, source: "keyboard" | "pointer" = "keyboard") => {
+  const commitActive = (rawValue: number | string, source: "keyboard" | "pointer") => {
     const property = activeProperty();
     if (!property) return;
     if (property.kind === "numeric" && typeof rawValue === "number") {

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -35,12 +35,14 @@ import { findTailwindClass } from "../../utils/find-tailwind-class.js";
 import { formatEditableValue, roundEditableNumericValue } from "../../utils/format-css-value.js";
 import { getShadowActiveElement } from "../../utils/get-shadow-active-element.js";
 import { getTagDisplay } from "../../utils/get-tag-display.js";
+import { createPointerMovePromptHandoff } from "../../utils/create-pointer-move-prompt-handoff.js";
 import { isEventFromOverlay } from "../../utils/is-event-from-overlay.js";
 import { registerOverlayDismiss } from "../../utils/register-overlay-dismiss.js";
 import { suppressMenuEvent } from "../../utils/suppress-menu-event.js";
 import { TagBadge } from "../selection-label/tag-badge.js";
 import { ActivePropertyControl } from "./active-property-control.js";
 import { HIDDEN_FOCUS_PRESERVING_STYLE } from "./constants.js";
+import { EditPanelCopyButton } from "./copy-button.js";
 import { createDiscardConfirmation } from "./discard-confirmation.js";
 import { PropertyList } from "./property-list.js";
 import { arePropertyValuesEqual } from "./property-values-equal.js";
@@ -122,6 +124,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
   const [isTransientInteraction, setIsTransientInteraction] = createSignal(false);
   const isInteracting = createMemo(() => isTransientInteraction() || hasPendingStyles());
   const [isHeaderHovered, setIsHeaderHovered] = createSignal(false);
+  const pointerMovePromptHandoff = createPointerMovePromptHandoff();
 
   const tagDisplay = createMemo(() =>
     getTagDisplay({
@@ -243,6 +246,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     shouldFocus?: boolean;
     shouldCompact?: boolean;
     isFromKeyRepeat?: boolean;
+    source?: "keyboard" | "pointer";
   }
 
   const commit = (
@@ -258,6 +262,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     if (options.flashDirection) flashActiveKey(options.flashDirection === 1 ? "right" : "left");
     if (options.shouldFocus) ensureSearchFocused();
     if (options.shouldCompact) setIsCompact(true);
+    if (options.source === "keyboard") pointerMovePromptHandoff.arm();
   };
 
   const isShiftHeld = createShiftTracker();
@@ -266,6 +271,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     direction: 1 | -1,
     shift: boolean,
     fromRepeat: boolean,
+    source: "keyboard" | "pointer",
   ): EditableProperty | null => {
     const property = activeProperty();
     if (!property) return null;
@@ -278,26 +284,34 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
       flashDirection: direction,
       shouldFocus: true,
       isFromKeyRepeat: fromRepeat,
+      source,
     });
     return property;
   };
 
   const stepFromKeyboard = (direction: 1 | -1, shift: boolean, fromRepeat: boolean) => {
-    if (stepActiveProperty(direction, shift, fromRepeat)) setIsCompact(true);
+    if (!stepActiveProperty(direction, shift, fromRepeat, "keyboard")) return;
+    setIsCompact(true);
+  };
+
+  const stepFromPointer = (direction: 1 | -1) => {
+    stepActiveProperty(direction, false, false, "pointer");
   };
 
   const stepController = createStepController({ step: stepFromKeyboard, isShiftHeld });
 
-  const commitActive = (rawValue: number | string) => {
+  const commitActive = (rawValue: number | string, source: "keyboard" | "pointer" = "keyboard") => {
     const property = activeProperty();
     if (!property) return;
     if (property.kind === "numeric" && typeof rawValue === "number") {
       const clamped = roundEditableNumericValue(clampToRange(rawValue, property.min, property.max));
-      if (clamped !== property.value) commit(property, clamped);
+      if (clamped !== property.value) commit(property, clamped, { source });
       return;
     }
     if (typeof rawValue !== "string") return;
-    if (!arePropertyValuesEqual(property, rawValue, property.value)) commit(property, rawValue);
+    if (!arePropertyValuesEqual(property, rawValue, property.value)) {
+      commit(property, rawValue, { source });
+    }
   };
 
   const activeTailwindLabel = createMemo<string | null>(() => {
@@ -312,7 +326,9 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     searchQuery,
     isCompact,
     activeProperty,
-    commit,
+    commit: (property, value, options) => {
+      commit(property, value, { ...options, source: "keyboard" });
+    },
     setIsCompact,
   });
 
@@ -321,6 +337,8 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
   );
 
   const handleSubmit = () => {
+    discardConfirmation.hide();
+    pointerMovePromptHandoff.clear();
     props.onSubmit(styleStore.buildPendingEdits());
   };
 
@@ -343,6 +361,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
 
   const attemptDismiss = (source: OverlayDismissSource) => {
     stepController.cancelRepeat();
+    if (source === "pointer") pointerMovePromptHandoff.clear();
     if (discardConfirmation.isPending()) {
       closePanel("discard");
       return;
@@ -366,6 +385,11 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     if (properties.length === 0) return;
     setActiveIndex((current) => (current + direction + properties.length) % properties.length);
     expandPanel();
+  };
+
+  const cancelDiscardPrompt = () => {
+    pointerMovePromptHandoff.clear();
+    discardConfirmation.hide();
   };
 
   let colorPickerTriggers: Array<() => void> = [];
@@ -486,13 +510,22 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     const handleWindowKeyUp = (event: KeyboardEvent) => {
       stepController.releaseKey(event.key);
     };
+    const handleWindowPointerMove = (event: PointerEvent) => {
+      if (event.pointerType !== "mouse") return;
+      if (discardConfirmation.isPending()) return;
+      if (!pointerMovePromptHandoff.consume()) return;
+      if (!hasSubmittableEdits()) return;
+      attemptDismiss("pointer");
+    };
     window.addEventListener("keydown", handleWindowKeyDown, { capture: true });
     window.addEventListener("keyup", handleWindowKeyUp, { capture: true });
+    window.addEventListener("pointermove", handleWindowPointerMove, { capture: true });
 
     onCleanup(() => {
       unregisterDismiss();
       window.removeEventListener("keydown", handleWindowKeyDown, { capture: true });
       window.removeEventListener("keyup", handleWindowKeyUp, { capture: true });
+      window.removeEventListener("pointermove", handleWindowPointerMove, { capture: true });
       clearTimeout(activeKeyTimerId);
       clearTimeout(interactingIdleTimerId);
       clearTimeout(inlineNumericReplaceTimerId);
@@ -568,21 +601,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
                     shrink
                   />
                   <Show when={hasSubmittableEdits()}>
-                    <button
-                      data-react-grab-ignore-events
-                      data-react-grab-copy-button
-                      type="button"
-                      class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[var(--rg-surface-hover)] [border-width:0.5px] border-solid border-[var(--rg-border-button)] cursor-pointer transition-all hover:bg-[var(--rg-surface-active)] press-scale h-[17px]"
-                      onClick={(event) => {
-                        event.preventDefault();
-                        event.stopPropagation();
-                        handleSubmit();
-                      }}
-                    >
-                      <span class="text-[var(--rg-text-primary)] text-[13px] leading-3.5 font-sans font-medium">
-                        Copy
-                      </span>
-                    </button>
+                    <EditPanelCopyButton onCopy={handleSubmit} />
                   </Show>
                 </div>
               </Show>
@@ -609,13 +628,14 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
                   onClick={(event) => {
                     event.preventDefault();
                     event.stopPropagation();
-                    discardConfirmation.hide();
+                    cancelDiscardPrompt();
                   }}
                 >
                   <span class="text-[var(--rg-text-primary)] text-[13px] leading-3.5 font-sans font-medium">
                     No
                   </span>
                 </button>
+                <EditPanelCopyButton discardAction="copy" onCopy={handleSubmit} />
                 <button
                   data-react-grab-ignore-events
                   data-react-grab-discard-button="confirm"
@@ -713,7 +733,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
                 activeKey={activeKey()}
                 onHoverIndex={setActiveIndex}
                 onSelect={handleSelectProperty}
-                onStep={(direction) => stepActiveProperty(direction, false, false)}
+                onStep={stepFromPointer}
                 onCommit={commitActive}
                 onColorPickerRegister={registerColorPickerTrigger}
                 onEditComplete={ensureSearchFocused}
@@ -734,7 +754,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
                 <ActivePropertyControl
                   property={compactProperty()}
                   activeKey={activeKey()}
-                  onStep={(direction) => stepActiveProperty(direction, false, false)}
+                  onStep={stepFromPointer}
                   onCommit={commitActive}
                   onEditComplete={ensureSearchFocused}
                   onInvalidCommit={playShake}

--- a/packages/react-grab/src/components/edit-panel/property-list.tsx
+++ b/packages/react-grab/src/components/edit-panel/property-list.tsx
@@ -21,7 +21,7 @@ interface PropertyListProps {
   onHoverIndex: (index: number) => void;
   onSelect: (index: number) => void;
   onStep: (direction: 1 | -1) => void;
-  onCommit: (value: number | string) => void;
+  onCommit: (value: number | string, source: "keyboard" | "pointer") => void;
   onColorPickerRegister: (trigger: (() => void) | null, owner?: () => void) => void;
   onEditComplete: () => void;
   onInvalidCommit: () => void;

--- a/packages/react-grab/src/components/edit-panel/value-stepper.tsx
+++ b/packages/react-grab/src/components/edit-panel/value-stepper.tsx
@@ -23,7 +23,7 @@ interface ValueStepperProps {
   activeKey: "left" | "right" | null;
   onStep: (direction: 1 | -1) => void;
   label?: string;
-  onCommitValue?: (value: number) => void;
+  onCommitValue?: (value: number, source: "keyboard" | "pointer") => void;
   onEditComplete?: () => void;
   onInvalidCommit?: () => void;
   onInteract?: () => void;
@@ -74,7 +74,7 @@ export const ValueStepper: Component<ValueStepperProps> = (props) => {
   };
 
   const commitDrag = (clientX: number, rect: DOMRect) => {
-    props.onCommitValue?.(positionToValue(clientX, rect));
+    props.onCommitValue?.(positionToValue(clientX, rect), "pointer");
   };
 
   const computeRubberStretch = (clientX: number, trackRect: DOMRect): number => {
@@ -177,7 +177,7 @@ export const ValueStepper: Component<ValueStepperProps> = (props) => {
     }
     const parsed = Number.parseFloat(valueMatch[1]);
     if (Number.isFinite(parsed)) {
-      props.onCommitValue?.(parsed);
+      props.onCommitValue?.(parsed, "keyboard");
     } else {
       props.onInvalidCommit?.();
     }

--- a/packages/react-grab/src/components/renderer.tsx
+++ b/packages/react-grab/src/components/renderer.tsx
@@ -17,16 +17,6 @@ import { EditPanel } from "./edit-panel/index.js";
 import { ToolbarMenu } from "./toolbar/toolbar-menu.js";
 
 export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
-  const selectionDiscardPrompt = () =>
-    props.discardPrompt ??
-    (props.isPendingDismiss
-      ? {
-          kind: "standard",
-          onConfirm: props.onConfirmDismiss,
-          onCancel: props.onCancelDismiss,
-        }
-      : undefined);
-
   return (
     <>
       <OverlayCanvas
@@ -110,7 +100,7 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
           onToggleExpand={props.onToggleExpand}
           selectionLabelShakeCount={props.selectionLabelShakeCount}
           onConfirmDismiss={props.onConfirmDismiss}
-          discardPrompt={selectionDiscardPrompt()}
+          discardPrompt={props.discardPrompt}
           onOpen={() => {
             if (props.selectionFilePath) {
               requestOpenFile(props.selectionFilePath, props.selectionLineNumber);

--- a/packages/react-grab/src/components/renderer.tsx
+++ b/packages/react-grab/src/components/renderer.tsx
@@ -17,6 +17,16 @@ import { EditPanel } from "./edit-panel/index.js";
 import { ToolbarMenu } from "./toolbar/toolbar-menu.js";
 
 export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
+  const selectionDiscardPrompt = () =>
+    props.discardPrompt ??
+    (props.isPendingDismiss
+      ? {
+          kind: "standard",
+          onConfirm: props.onConfirmDismiss,
+          onCancel: props.onCancelDismiss,
+        }
+      : undefined);
+
   return (
     <>
       <OverlayCanvas
@@ -98,10 +108,9 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
           onInputChange={props.onInputChange}
           onSubmit={props.onInputSubmit}
           onToggleExpand={props.onToggleExpand}
-          isPendingDismiss={props.isPendingDismiss}
           selectionLabelShakeCount={props.selectionLabelShakeCount}
           onConfirmDismiss={props.onConfirmDismiss}
-          onCancelDismiss={props.onCancelDismiss}
+          discardPrompt={selectionDiscardPrompt()}
           onOpen={() => {
             if (props.selectionFilePath) {
               requestOpenFile(props.selectionFilePath, props.selectionLineNumber);

--- a/packages/react-grab/src/components/selection-label/discard-prompt.tsx
+++ b/packages/react-grab/src/components/selection-label/discard-prompt.tsx
@@ -1,4 +1,4 @@
-import { onCleanup, onMount, type Component } from "solid-js";
+import { onCleanup, onMount, Show, type Component } from "solid-js";
 import type { DiscardPromptProps } from "../../types.js";
 import { confirmationFocusManager } from "../../utils/confirmation-focus-manager.js";
 import { isKeyboardEventTriggeredByInput } from "../../utils/is-keyboard-event-triggered-by-input.js";
@@ -7,6 +7,7 @@ import { BottomSection } from "./bottom-section.js";
 
 export const DiscardPrompt: Component<DiscardPromptProps> = (props) => {
   const instanceId = Symbol();
+  const shouldShowCancel = () => props.showCancel ?? true;
 
   const handleKeyDown = (event: KeyboardEvent) => {
     if (!confirmationFocusManager.isActive(instanceId)) return;
@@ -21,6 +22,20 @@ export const DiscardPrompt: Component<DiscardPromptProps> = (props) => {
     if (isEnter || isEscape) {
       event.preventDefault();
       event.stopPropagation();
+      const target = event.composedPath()[0];
+      const targetElement = target instanceof HTMLElement ? target : null;
+      if (isEnter && targetElement?.closest("[data-react-grab-discard-copy]")) {
+        props.onCopy?.();
+        return;
+      }
+      if (isEnter && targetElement?.closest("[data-react-grab-discard-no]")) {
+        props.onCancel?.();
+        return;
+      }
+      if (isEnter && targetElement?.closest("[data-react-grab-discard-yes]")) {
+        props.onConfirm?.();
+        return;
+      }
       if (isEscape && props.cancelOnEscape) {
         props.onCancel?.();
       } else {
@@ -57,15 +72,28 @@ export const DiscardPrompt: Component<DiscardPromptProps> = (props) => {
       </div>
       <BottomSection>
         <div class="contain-layout shrink-0 flex items-center justify-end gap-[5px] w-full h-fit">
-          <button
-            data-react-grab-discard-no
-            class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[var(--rg-surface-hover)] [border-width:0.5px] border-solid border-[var(--rg-border-button)] cursor-pointer transition-all hover:bg-[var(--rg-surface-active)] press-scale h-[17px]"
-            onClick={props.onCancel}
-          >
-            <span class="text-[var(--rg-text-primary)] text-[13px] leading-3.5 font-sans font-medium">
-              No
-            </span>
-          </button>
+          <Show when={shouldShowCancel()}>
+            <button
+              data-react-grab-discard-no
+              class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[var(--rg-surface-hover)] [border-width:0.5px] border-solid border-[var(--rg-border-button)] cursor-pointer transition-all hover:bg-[var(--rg-surface-active)] press-scale h-[17px]"
+              onClick={props.onCancel}
+            >
+              <span class="text-[var(--rg-text-primary)] text-[13px] leading-3.5 font-sans font-medium">
+                No
+              </span>
+            </button>
+          </Show>
+          <Show when={props.onCopy}>
+            <button
+              data-react-grab-discard-copy
+              class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[var(--rg-surface-hover)] [border-width:0.5px] border-solid border-[var(--rg-border-button)] cursor-pointer transition-all hover:bg-[var(--rg-surface-active)] press-scale h-[17px]"
+              onClick={props.onCopy}
+            >
+              <span class="text-[var(--rg-text-primary)] text-[13px] leading-3.5 font-sans font-medium">
+                Copy
+              </span>
+            </button>
+          </Show>
           <button
             data-react-grab-discard-yes
             class="contain-layout shrink-0 flex items-center justify-center gap-0.5 px-[3px] py-px rounded-sm bg-[var(--rg-error-bg)] cursor-pointer transition-all hover:bg-[var(--rg-error-bg-hover)] press-scale h-[17px]"

--- a/packages/react-grab/src/components/selection-label/index.tsx
+++ b/packages/react-grab/src/components/selection-label/index.tsx
@@ -543,24 +543,16 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
               return (
                 <DiscardPrompt
                   label={
-                    currentDiscardPrompt.kind === "keyboard-selection"
+                    currentDiscardPrompt.isKeyboardSelection
                       ? "Discard selection?"
                       : currentDiscardPrompt.label
                   }
-                  showCancel={currentDiscardPrompt.kind === "standard"}
-                  cancelOnEscape={
-                    currentDiscardPrompt.kind === "standard"
-                      ? currentDiscardPrompt.cancelOnEscape
-                      : undefined
-                  }
+                  showCancel={!currentDiscardPrompt.isKeyboardSelection}
+                  cancelOnEscape={currentDiscardPrompt.cancelOnEscape}
                   onConfirm={currentDiscardPrompt.onConfirm}
-                  onCopy={
-                    currentDiscardPrompt.kind === "keyboard-selection"
-                      ? currentDiscardPrompt.onCopy
-                      : undefined
-                  }
+                  onCopy={currentDiscardPrompt.onCopy}
                   onCancel={() => {
-                    if (currentDiscardPrompt.kind === "standard") {
+                    if (!currentDiscardPrompt.isKeyboardSelection) {
                       currentDiscardPrompt.onCancel?.();
                     }
                     inputRef?.focus({ preventScroll: true });

--- a/packages/react-grab/src/components/selection-label/index.tsx
+++ b/packages/react-grab/src/components/selection-label/index.tsx
@@ -84,10 +84,12 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
     Boolean(props.shouldToggleExpandOnClick) &&
     Boolean(props.onToggleExpand) &&
     canInteract() &&
+    !props.discardPrompt &&
     !props.isPromptMode;
 
   const shouldEnablePointerEvents = (): boolean => {
     if (props.isPromptMode) return true;
+    if (props.discardPrompt) return true;
     if (canToggleExpand()) return true;
     if (isCompletedStatus() && (props.onDismiss || props.onShowContextMenu)) {
       return true;
@@ -345,7 +347,7 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
   const isArrowNavigationVisible = () => Boolean(props.arrowNavigationState?.isVisible);
 
   const isSinglePanelLine = createMemo(() => {
-    if (props.error || props.isPendingDismiss) return false;
+    if (props.error || props.discardPrompt) return false;
     if (canInteract() && (props.isPromptMode || isArrowNavigationVisible())) return false;
     return true;
   });
@@ -364,7 +366,7 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
   const handleContainerPointerDown = (event: PointerEvent) => {
     event.stopImmediatePropagation();
     const isEditableInputVisible =
-      canInteract() && props.isPromptMode && !props.isPendingDismiss && props.onSubmit;
+      canInteract() && props.isPromptMode && !props.discardPrompt && props.onSubmit;
     if (isEditableInputVisible && inputRef) {
       inputRef.focus({ preventScroll: true });
     }
@@ -441,7 +443,7 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
             </div>
           </Show>
 
-          <Show when={canInteract() && !props.isPromptMode}>
+          <Show when={canInteract() && !props.isPromptMode && !props.discardPrompt}>
             <div
               class="contain-layout shrink-0 flex flex-col items-start w-fit h-fit"
               classList={{
@@ -474,7 +476,7 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
             </div>
           </Show>
 
-          <Show when={canInteract() && props.isPromptMode && !props.isPendingDismiss}>
+          <Show when={canInteract() && props.isPromptMode && !props.discardPrompt}>
             <div class="contain-layout shrink-0 flex flex-col justify-center items-start w-fit h-fit min-w-[150px] max-w-[280px]">
               <div class="contain-layout shrink-0 flex items-center gap-1 pt-1.5 pb-1 w-fit h-fit px-2 max-w-full">
                 <TagBadge
@@ -534,14 +536,37 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
             </div>
           </Show>
 
-          <Show when={props.isPendingDismiss}>
-            <DiscardPrompt
-              onConfirm={props.onConfirmDismiss}
-              onCancel={() => {
-                props.onCancelDismiss?.();
-                inputRef?.focus({ preventScroll: true });
-              }}
-            />
+          <Show when={props.discardPrompt}>
+            {(discardPrompt) => {
+              const currentDiscardPrompt = discardPrompt();
+              return (
+                <DiscardPrompt
+                  label={
+                    currentDiscardPrompt.kind === "keyboard-selection"
+                      ? "Discard selection?"
+                      : currentDiscardPrompt.label
+                  }
+                  showCancel={currentDiscardPrompt.kind === "standard"}
+                  cancelOnEscape={
+                    currentDiscardPrompt.kind === "standard"
+                      ? currentDiscardPrompt.cancelOnEscape
+                      : undefined
+                  }
+                  onConfirm={currentDiscardPrompt.onConfirm}
+                  onCopy={
+                    currentDiscardPrompt.kind === "keyboard-selection"
+                      ? currentDiscardPrompt.onCopy
+                      : undefined
+                  }
+                  onCancel={() => {
+                    if (currentDiscardPrompt.kind === "standard") {
+                      currentDiscardPrompt.onCancel?.();
+                    }
+                    inputRef?.focus({ preventScroll: true });
+                  }}
+                />
+              );
+            }}
           </Show>
 
           <Show when={props.error}>

--- a/packages/react-grab/src/components/selection-label/index.tsx
+++ b/packages/react-grab/src/components/selection-label/index.tsx
@@ -114,7 +114,8 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
   const handleGlobalKeyDown = (event: KeyboardEvent) => {
     if (isKeyboardEventTriggeredByInput(event)) return;
 
-    const isEnterToExpand = event.code === "Enter" && !props.isPromptMode && canInteract();
+    const isEnterToExpand =
+      event.code === "Enter" && !props.isPromptMode && !props.discardPrompt && canInteract();
 
     if (isEnterToExpand) {
       event.preventDefault();

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -1447,10 +1447,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
 
     const handleCancelDismiss = () => {
-      if (keyboardSelection.isPendingDismiss()) {
-        cancelArrowNavigationDismiss();
-        return;
-      }
       actions.setPendingDismiss(false);
     };
 
@@ -2110,10 +2106,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       clearArrowNavigation();
     };
 
-    const cancelArrowNavigationDismiss = () => {
-      keyboardSelection.cancelDismiss();
-    };
-
     const copyArrowNavigationSelection = () => {
       const selectedElement = keyboardSelection.takeSelection(store.frozenElement);
       if (!selectedElement) {
@@ -2662,7 +2654,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
             showArrowNavigationDismissPrompt();
             return;
           }
-          if (keyboardSelection.isPendingDismiss()) return;
           actions.unfreeze();
           clearArrowNavigation();
         }

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -138,6 +138,7 @@ import { generateId } from "../utils/generate-id.js";
 import { logRecoverableError } from "../utils/log-recoverable-error.js";
 import { getNearestEdge } from "../utils/get-nearest-edge.js";
 import { findShortcutAction } from "../utils/action-shortcuts.js";
+import { createKeyboardSelectionController } from "./keyboard-selection.js";
 
 const builtInPlugins = [copyPlugin, editPlugin, commentPlugin, openPlugin];
 
@@ -328,6 +329,14 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     let didSwitchEditTargetOnPointerDown = false;
 
     let shiftSelectionLabelAnchorRatioByElement = new WeakMap<Element, number>();
+    const keyboardSelection = createKeyboardSelectionController();
+
+    const isElementDetectionBlocked = () =>
+      !isEnabled() ||
+      isPromptMode() ||
+      isSelectionInteractionLocked() ||
+      isModalPopoverOpen() ||
+      keyboardSelection.isPendingDismiss();
 
     const clearShiftSelectionLabelAnchors = () => {
       shiftSelectionLabelAnchorRatioByElement = new WeakMap<Element, number>();
@@ -487,7 +496,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
     let selectionSourceRequestVersion = 0;
     let componentNameDebounceTimerId: number | null = null;
-    let keyboardSelectedElement: Element | null = null;
     let pendingDefaultActionId: string | null = null;
     const [isPendingContextMenuSelect, setIsPendingContextMenuSelect] = createSignal(false);
     const [pendingToolbarActionId, setPendingToolbarActionId] = createSignal<string | null>(null);
@@ -790,7 +798,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
     const targetElement = createMemo(() => {
       void viewportVersion();
-      if (!isRendererActive() || isActivelyDragging() || isSelectionInteractionLocked())
+      if (
+        !isRendererActive() ||
+        isActivelyDragging() ||
+        isSelectionInteractionLocked() ||
+        keyboardSelection.isPendingDismiss()
+      )
         return null;
       const element = store.detectedElement;
       if (!isElementConnected(element)) return null;
@@ -1341,7 +1354,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       dismissToolbarMenu();
       stopShiftMultiSelecting();
       clearArrowNavigation();
-      keyboardSelectedElement = null;
+      keyboardSelection.clear();
       setIsPendingContextMenuSelect(false);
       setPendingToolbarActionId(null);
       if (wasDragging) {
@@ -1425,11 +1438,19 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
 
     const handleConfirmDismiss = () => {
+      if (keyboardSelection.isPendingDismiss()) {
+        discardArrowNavigationSelection();
+        return;
+      }
       actions.clearInputText();
       deactivateRenderer();
     };
 
     const handleCancelDismiss = () => {
+      if (keyboardSelection.isPendingDismiss()) {
+        cancelArrowNavigationDismiss();
+        return;
+      }
       actions.setPendingDismiss(false);
     };
 
@@ -1599,13 +1620,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         !store.pendingCommentMode &&
         !isPendingContextMenuSelect();
 
-      if (
-        !isEnabled() ||
-        isPromptMode() ||
-        (isFrozenPhase() && !shouldTrackPendingShiftSelection) ||
-        isSelectionInteractionLocked() ||
-        isModalPopoverOpen()
-      ) {
+      if (isElementDetectionBlocked() || (isFrozenPhase() && !shouldTrackPendingShiftSelection)) {
         return;
       }
 
@@ -1633,6 +1648,10 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         elementDetectionState.lastDetectionTimestamp = now;
         elementDetectionState.pendingDetectionScheduledAt = now;
         setTimeout(() => {
+          if (isElementDetectionBlocked()) {
+            elementDetectionState.pendingDetectionScheduledAt = 0;
+            return;
+          }
           const candidate = getElementAtPosition(
             elementDetectionState.latestPointerX,
             elementDetectionState.latestPointerY,
@@ -1676,7 +1695,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         stopShiftMultiSelecting();
       }
 
-      actions.startDrag({ x: clientX, y: clientY }, isShiftHeld);
+      const shouldPreserveKeyboardSelection = keyboardSelection.selectedElement() !== null;
+      actions.startDrag({ x: clientX, y: clientY }, isShiftHeld || shouldPreserveKeyboardSelection);
       actions.setPointer({ x: clientX, y: clientY });
       document.body.style.userSelect = "none";
 
@@ -1868,9 +1888,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         ? store.frozenElement
         : null;
 
-      const validKeyboardSelectedElement = isElementConnected(keyboardSelectedElement)
-        ? keyboardSelectedElement
-        : null;
+      const validKeyboardSelectedElement = keyboardSelection.selectedElement();
 
       const elementAtPointer =
         getElementsAtPoint(clientX, clientY).find(isValidGrabbableElement) ?? null;
@@ -1878,7 +1896,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         elementAtPointer ??
         (isElementConnected(store.detectedElement) ? store.detectedElement : null);
       const selectedElement =
-        selectedElementUnderPointer ?? validFrozenElement ?? validKeyboardSelectedElement;
+        validKeyboardSelectedElement ?? selectedElementUnderPointer ?? validFrozenElement;
       if (!selectedElement) return;
 
       // While Shift is held we only operate on the live elementAtPointer.
@@ -1900,10 +1918,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
       const didResolveFromFrozenElement =
         selectedElementUnderPointer === null && validFrozenElement === selectedElement;
-      const didResolveFromKeyboardElement =
-        selectedElementUnderPointer === null &&
-        validFrozenElement === null &&
-        validKeyboardSelectedElement === selectedElement;
+      const didResolveFromKeyboardElement = validKeyboardSelectedElement === selectedElement;
 
       if (didResolveFromFrozenElement) {
         positionX = pointer().x;
@@ -1917,10 +1932,9 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         positionY = clientY;
       }
 
-      keyboardSelectedElement = null;
-
       if (store.pendingCommentMode) {
         enterCommentModeForElement(selectedElement, positionX, positionY);
+        keyboardSelection.clear();
         return;
       }
 
@@ -1928,6 +1942,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         setIsPendingContextMenuSelect(false);
         const { wasIntercepted } = pluginRegistry.hooks.onElementSelect(selectedElement);
         if (wasIntercepted) return;
+        keyboardSelection.clear();
 
         freezeAllAnimations([selectedElement]);
         actions.setFrozenElement(selectedElement);
@@ -1951,6 +1966,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         cursorX: positionX,
         shouldDeactivateAfter,
       });
+      keyboardSelection.clear();
     };
 
     const cancelActiveDrag = () => {
@@ -2015,7 +2031,11 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       const isEnterKey = originalKey === "Enter" || isEnterCode(event.code);
       const isOverlayActive = isActivated() || isHoldingKeys();
       const shouldBlockEnter =
-        isEnterKey && isOverlayActive && !isPromptMode() && !store.wasActivatedByToggle;
+        isEnterKey &&
+        isOverlayActive &&
+        !isPromptMode() &&
+        !keyboardSelection.isPendingDismiss() &&
+        !store.wasActivatedByToggle;
 
       if (shouldBlockEnter) {
         // React Grab inputs keep Enter so inline editors can commit.
@@ -2042,12 +2062,13 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       setArrowNavigationElements([]);
       setArrowNavigationActiveIndex(0);
       arrowNavigator.clearHistory();
+      keyboardSelection.clear();
     };
 
-    const selectAndFocusElement = (element: Element) => {
+    const selectAndFocusElement = (element: Element, shouldPromptBeforeMouseHandoff = false) => {
       actions.setFrozenElement(element);
       actions.freeze();
-      keyboardSelectedElement = element;
+      keyboardSelection.select(element, { shouldPromptBeforeMouseHandoff });
 
       const center = getBoundsCenter(createElementBounds(element));
       actions.setPointer(center);
@@ -2074,13 +2095,46 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
       setArrowNavigationActiveIndex(index);
       arrowNavigator.clearHistory();
-      selectAndFocusElement(targetElement);
+      selectAndFocusElement(targetElement, true);
+    };
+
+    const showArrowNavigationDismissPrompt = () => {
+      if (keyboardSelection.showDismissPrompt()) {
+        setSelectionLabelShakeCount((count) => count + 1);
+      }
+    };
+
+    const discardArrowNavigationSelection = () => {
+      keyboardSelection.clear();
+      actions.unfreeze();
+      clearArrowNavigation();
+    };
+
+    const cancelArrowNavigationDismiss = () => {
+      keyboardSelection.cancelDismiss();
+    };
+
+    const copyArrowNavigationSelection = () => {
+      const selectedElement = keyboardSelection.takeSelection(store.frozenElement);
+      if (!selectedElement) {
+        discardArrowNavigationSelection();
+        return;
+      }
+      const center = getBoundsCenter(createElementBounds(selectedElement));
+      clearArrowNavigation();
+      actions.setLastGrabbed(selectedElement);
+      performCopyWithLabel({
+        element: selectedElement,
+        cursorX: center.x,
+        shouldDeactivateAfter: store.wasActivatedByToggle,
+      });
     };
 
     const tryHandleArrowNavigation = (event: KeyboardEvent): boolean => {
       if (!isActivated()) return false;
       if (isPromptMode()) return false;
       if (isShiftMultiSelecting()) return false;
+      if (keyboardSelection.isPendingDismiss()) return false;
       if (!ARROW_KEYS.has(event.key)) return false;
       if (isAnyPopoverOpen()) return false;
 
@@ -2101,7 +2155,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         if (!nextElement && !isInitialSelection) return false;
         event.preventDefault();
         event.stopPropagation();
-        selectAndFocusElement(nextElement ?? currentElement);
+        selectAndFocusElement(nextElement ?? currentElement, true);
         return true;
       }
 
@@ -2114,7 +2168,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
       event.preventDefault();
       event.stopPropagation();
-      selectAndFocusElement(elementToSelect);
+      selectAndFocusElement(elementToSelect, true);
 
       const newIndex = arrowNavigationElements().indexOf(elementToSelect);
       if (newIndex !== -1) {
@@ -2353,6 +2407,17 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     eventListenerManager.addWindowListener(
       "keydown",
       (event: KeyboardEvent) => {
+        if (keyboardSelection.isPendingDismiss() && isEnterCode(event.code)) {
+          const target = event.composedPath()[0];
+          const targetElement = target instanceof HTMLElement ? target : null;
+          if (targetElement?.closest("[data-react-grab-discard-copy]")) return;
+          if (targetElement?.closest("[data-react-grab-discard-yes]")) return;
+          event.preventDefault();
+          event.stopImmediatePropagation();
+          handleConfirmDismiss();
+          return;
+        }
+
         blockEnterIfNeeded(event);
 
         if (!isEnabled()) {
@@ -2579,8 +2644,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         const isTouchPointer = event.pointerType === "touch";
         actions.setTouchMode(isTouchPointer);
         if (isEventFromOverlay(event, "data-react-grab-ignore-events")) return;
-        if (isModalPopoverOpen()) return;
-        if (isSelectionInteractionLocked()) return;
+        if (isElementDetectionBlocked()) return;
         if (isTouchPointer && !isHoldingKeys() && !isActivated()) return;
         const isActiveState = isTouchPointer ? isHoldingKeys() : isActivated();
         // The flag check covers the small window after physical Shift
@@ -2594,6 +2658,11 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           !event.shiftKey &&
           !isShiftMultiSelecting()
         ) {
+          if (keyboardSelection.consumeMouseHandoff()) {
+            showArrowNavigationDismissPrompt();
+            return;
+          }
+          if (keyboardSelection.isPendingDismiss()) return;
           actions.unfreeze();
           clearArrowNavigation();
         }
@@ -2633,6 +2702,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           } else {
             handleInputCancel();
           }
+          return;
+        }
+
+        if (keyboardSelection.isPendingDismiss()) {
+          event.preventDefault();
+          event.stopImmediatePropagation();
           return;
         }
 
@@ -2677,6 +2752,11 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       (event: MouseEvent) => {
         if (!isRendererActive() || isCopying() || isPromptMode()) return;
         if (editMode.isOpen()) return;
+        if (keyboardSelection.isPendingDismiss()) {
+          event.preventDefault();
+          event.stopPropagation();
+          return;
+        }
 
         const isFromOverlay = isEventFromOverlay(event, "data-react-grab-ignore-events");
         const position = { x: event.clientX, y: event.clientY };
@@ -2802,12 +2882,9 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     const redetectElementUnderPointer = () => {
       if (store.isTouchMode && !isHoldingKeys() && !isActivated()) return;
       if (
-        isEnabled() &&
-        !isPromptMode() &&
-        !isSelectionInteractionLocked() &&
+        !isElementDetectionBlocked() &&
         !isFrozenPhase() &&
         !isDragging() &&
-        store.contextMenuPosition === null &&
         store.frozenElements.length === 0
       ) {
         const candidate = getElementAtPosition(pointer().x, pointer().y);
@@ -3365,7 +3442,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         position,
         shouldDeferHideContextMenu: true,
         onBeforeCopy: () => {
-          keyboardSelectedElement = null;
+          keyboardSelection.clear();
         },
         customEnterPromptMode: () => {
           labelController.clearAll();
@@ -3556,10 +3633,23 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
                 onInputChange={actions.setInputText}
                 onInputSubmit={() => void handleInputSubmit()}
                 onToggleExpand={handleToggleExpand}
-                isPendingDismiss={isPendingDismiss()}
                 selectionLabelShakeCount={selectionLabelShakeCount()}
                 onConfirmDismiss={handleConfirmDismiss}
-                onCancelDismiss={handleCancelDismiss}
+                discardPrompt={
+                  keyboardSelection.isPendingDismiss()
+                    ? {
+                        kind: "keyboard-selection",
+                        onConfirm: handleConfirmDismiss,
+                        onCopy: copyArrowNavigationSelection,
+                      }
+                    : isPendingDismiss()
+                      ? {
+                          kind: "standard",
+                          onConfirm: handleConfirmDismiss,
+                          onCancel: handleCancelDismiss,
+                        }
+                      : undefined
+                }
                 toolbarVisible={pluginRegistry.store.theme.toolbar.enabled}
                 isActive={isActivated()}
                 onToggleActive={handleToggleActive}

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -3629,13 +3629,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
                 discardPrompt={
                   keyboardSelection.isPendingDismiss()
                     ? {
-                        kind: "keyboard-selection",
+                        isKeyboardSelection: true,
                         onConfirm: handleConfirmDismiss,
                         onCopy: copyArrowNavigationSelection,
                       }
                     : isPendingDismiss()
                       ? {
-                          kind: "standard",
                           onConfirm: handleConfirmDismiss,
                           onCancel: handleCancelDismiss,
                         }

--- a/packages/react-grab/src/core/keyboard-selection.ts
+++ b/packages/react-grab/src/core/keyboard-selection.ts
@@ -1,0 +1,69 @@
+import { createSignal, type Accessor } from "solid-js";
+import { isElementConnected } from "../utils/is-element-connected.js";
+
+interface KeyboardSelectionController {
+  selectedElement: () => Element | null;
+  isPendingDismiss: Accessor<boolean>;
+  select: (element: Element, options?: { shouldPromptBeforeMouseHandoff?: boolean }) => void;
+  clear: () => void;
+  consumeMouseHandoff: () => boolean;
+  showDismissPrompt: () => boolean;
+  cancelDismiss: () => void;
+  takeSelection: (fallbackElement?: Element | null) => Element | null;
+}
+
+export const createKeyboardSelectionController = (): KeyboardSelectionController => {
+  const [isPendingDismiss, setIsPendingDismiss] = createSignal(false);
+  let selectedElement: Element | null = null;
+  let isMouseHandoffArmed = false;
+
+  const connectedSelection = (): Element | null =>
+    isElementConnected(selectedElement) ? selectedElement : null;
+
+  const clear = () => {
+    selectedElement = null;
+    isMouseHandoffArmed = false;
+    setIsPendingDismiss(false);
+  };
+
+  const armMouseHandoff = () => {
+    if (connectedSelection()) isMouseHandoffArmed = true;
+  };
+
+  const takeSelection = (fallbackElement?: Element | null): Element | null => {
+    const element =
+      connectedSelection() ?? (isElementConnected(fallbackElement) ? fallbackElement : null);
+    clear();
+    return element;
+  };
+
+  return {
+    selectedElement: connectedSelection,
+    isPendingDismiss,
+    select: (element, options) => {
+      selectedElement = element;
+      setIsPendingDismiss(false);
+      isMouseHandoffArmed = Boolean(options?.shouldPromptBeforeMouseHandoff);
+    },
+    clear,
+    consumeMouseHandoff: () => {
+      if (!isMouseHandoffArmed) return false;
+      isMouseHandoffArmed = false;
+      return connectedSelection() !== null;
+    },
+    showDismissPrompt: () => {
+      if (!connectedSelection()) {
+        clear();
+        return false;
+      }
+      if (isPendingDismiss()) return false;
+      setIsPendingDismiss(true);
+      return true;
+    },
+    cancelDismiss: () => {
+      setIsPendingDismiss(false);
+      armMouseHandoff();
+    },
+    takeSelection,
+  };
+};

--- a/packages/react-grab/src/core/keyboard-selection.ts
+++ b/packages/react-grab/src/core/keyboard-selection.ts
@@ -8,7 +8,6 @@ interface KeyboardSelectionController {
   clear: () => void;
   consumeMouseHandoff: () => boolean;
   showDismissPrompt: () => boolean;
-  cancelDismiss: () => void;
   takeSelection: (fallbackElement?: Element | null) => Element | null;
 }
 
@@ -24,10 +23,6 @@ export const createKeyboardSelectionController = (): KeyboardSelectionController
     selectedElement = null;
     isMouseHandoffArmed = false;
     setIsPendingDismiss(false);
-  };
-
-  const armMouseHandoff = () => {
-    if (connectedSelection()) isMouseHandoffArmed = true;
   };
 
   const takeSelection = (fallbackElement?: Element | null): Element | null => {
@@ -59,10 +54,6 @@ export const createKeyboardSelectionController = (): KeyboardSelectionController
       if (isPendingDismiss()) return false;
       setIsPendingDismiss(true);
       return true;
-    },
-    cancelDismiss: () => {
-      setIsPendingDismiss(false);
-      armMouseHandoff();
     },
     takeSelection,
   };

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -482,10 +482,8 @@ export interface ReactGrabRendererProps {
   onInputChange?: (value: string) => void;
   onInputSubmit?: () => void;
   onToggleExpand?: () => void;
-  isPendingDismiss?: boolean;
   selectionLabelShakeCount?: number;
   onConfirmDismiss?: () => void;
-  onCancelDismiss?: () => void;
   discardPrompt?: SelectionDiscardPrompt;
   toolbarVisible?: boolean;
   isActive?: boolean;
@@ -625,10 +623,8 @@ export interface SelectionLabelProps {
   onToggleExpand?: () => void;
   onOpen?: () => void;
   onDismiss?: () => void;
-  isPendingDismiss?: boolean;
   selectionLabelShakeCount?: number;
   onConfirmDismiss?: () => void;
-  onCancelDismiss?: () => void;
   discardPrompt?: SelectionDiscardPrompt;
   error?: string;
   onAcknowledgeError?: () => void;

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -572,23 +572,14 @@ export interface DiscardPromptProps {
   onCopy?: () => void;
 }
 
-export interface StandardSelectionDiscardPrompt {
-  kind: "standard";
+export interface SelectionDiscardPrompt {
+  isKeyboardSelection?: boolean;
   label?: string;
   cancelOnEscape?: boolean;
   onConfirm?: () => void;
   onCancel?: () => void;
+  onCopy?: () => void;
 }
-
-export interface KeyboardSelectionDiscardPrompt {
-  kind: "keyboard-selection";
-  onConfirm: () => void;
-  onCopy: () => void;
-}
-
-export type SelectionDiscardPrompt =
-  | StandardSelectionDiscardPrompt
-  | KeyboardSelectionDiscardPrompt;
 
 export interface ErrorViewProps {
   error: string;

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -486,6 +486,7 @@ export interface ReactGrabRendererProps {
   selectionLabelShakeCount?: number;
   onConfirmDismiss?: () => void;
   onCancelDismiss?: () => void;
+  discardPrompt?: SelectionDiscardPrompt;
   toolbarVisible?: boolean;
   isActive?: boolean;
   onToggleActive?: () => void;
@@ -566,10 +567,30 @@ export interface BottomSectionProps {
 
 export interface DiscardPromptProps {
   label?: string;
+  showCancel?: boolean;
+  cancelOnEscape?: boolean;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+  onCopy?: () => void;
+}
+
+export interface StandardSelectionDiscardPrompt {
+  kind: "standard";
+  label?: string;
   cancelOnEscape?: boolean;
   onConfirm?: () => void;
   onCancel?: () => void;
 }
+
+export interface KeyboardSelectionDiscardPrompt {
+  kind: "keyboard-selection";
+  onConfirm: () => void;
+  onCopy: () => void;
+}
+
+export type SelectionDiscardPrompt =
+  | StandardSelectionDiscardPrompt
+  | KeyboardSelectionDiscardPrompt;
 
 export interface ErrorViewProps {
   error: string;
@@ -608,6 +629,7 @@ export interface SelectionLabelProps {
   selectionLabelShakeCount?: number;
   onConfirmDismiss?: () => void;
   onCancelDismiss?: () => void;
+  discardPrompt?: SelectionDiscardPrompt;
   error?: string;
   onAcknowledgeError?: () => void;
   onRetry?: () => void;

--- a/packages/react-grab/src/utils/create-pointer-move-prompt-handoff.ts
+++ b/packages/react-grab/src/utils/create-pointer-move-prompt-handoff.ts
@@ -1,5 +1,3 @@
-import { createSignal } from "solid-js";
-
 interface PointerMovePromptHandoff {
   arm: () => void;
   clear: () => void;
@@ -7,17 +5,21 @@ interface PointerMovePromptHandoff {
 }
 
 export const createPointerMovePromptHandoff = (): PointerMovePromptHandoff => {
-  const [isArmed, setIsArmed] = createSignal(false);
+  let isArmed = false;
 
   const consume = (): boolean => {
-    if (!isArmed()) return false;
-    setIsArmed(false);
+    if (!isArmed) return false;
+    isArmed = false;
     return true;
   };
 
   return {
-    arm: () => setIsArmed(true),
-    clear: () => setIsArmed(false),
+    arm: () => {
+      isArmed = true;
+    },
+    clear: () => {
+      isArmed = false;
+    },
     consume,
   };
 };

--- a/packages/react-grab/src/utils/create-pointer-move-prompt-handoff.ts
+++ b/packages/react-grab/src/utils/create-pointer-move-prompt-handoff.ts
@@ -1,0 +1,23 @@
+import { createSignal } from "solid-js";
+
+interface PointerMovePromptHandoff {
+  arm: () => void;
+  clear: () => void;
+  consume: () => boolean;
+}
+
+export const createPointerMovePromptHandoff = (): PointerMovePromptHandoff => {
+  const [isArmed, setIsArmed] = createSignal(false);
+
+  const consume = (): boolean => {
+    if (!isArmed()) return false;
+    setIsArmed(false);
+    return true;
+  };
+
+  return {
+    arm: () => setIsArmed(true),
+    clear: () => setIsArmed(false),
+    consume,
+  };
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- show the edit panel discard prompt when mouse movement follows keyboard-driven pending tweaks
- add a Copy action to the discard prompt that submits the same changes as Enter/header Copy
- update e2e coverage for the new keyboard-to-mouse prompt flow

## Verification
- `pnpm dlx --package @antfu/ni nr build`
- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8c8ecf9-0c7b-46b9-bea8-fbd15f16ea1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8c8ecf9-0c7b-46b9-bea8-fbd15f16ea1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-time discard prompt when the mouse moves after keyboard tweaks or arrow-key selection, with Copy to keep the edit or copy the keyboard-selected element. While shown, detection pauses, Expand is disabled, Enter confirms Copy/Yes, arrow keys are ignored, and clicks prefer the keyboard-selected element.

- **New Features**
  - Edit panel: Keyboard commits arm a mouse-only handoff; pointer move or hover opens a discard prompt only if submittable tweaks are pending. Touch pointer moves are ignored. Movement while open is ignored. The handoff is consumed on open/cancel and cleared on Copy and outside-click. Adds `EditPanelCopyButton`, `data-react-grab-discard-button="copy"`, and `data-react-grab-copy-button`.
  - Selection label: Arrow-key navigation arms a mouse-move handoff; moving the mouse shows “Discard selection?” with Yes/Copy (Cancel hidden). Enter activates Copy/Yes. Arrow keys are suppressed while the prompt is open. Copy preserves the arrow-selected element even if the mouse is over a different element. Expand is disabled while the prompt is shown. Adds `data-react-grab-discard-copy`, `data-react-grab-discard-yes` (and `-no` for the standard prompt).

- **Refactors**
  - Introduced `createPointerMovePromptHandoff` and `createKeyboardSelectionController`. Replaced `isPendingDismiss`/`onCancelDismiss` with a single `discardPrompt?: SelectionDiscardPrompt` that uses an `isKeyboardSelection` flag across renderer/label and updated stories.
  - Gated Enter-to-expand on `discardPrompt` so Enter triggers Copy/Yes, and threaded commit sources (`"keyboard"` | `"pointer"`) through steppers/color picker to arm the handoff only for keyboard commits. Removed unreachable guards and dead props. Expanded e2e coverage for discard flows, including touch pointer moves and Enter on Copy/Yes.

<sup>Written for commit ec80831ca98d3168d1693c8184bd285476b24031. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

