### PR TITLE
Fix init setup detection

### DIFF
--- a/packages/cli/src/commands/configure.ts
+++ b/packages/cli/src/commands/configure.ts
@@ -287,6 +287,16 @@ export const configure = new Command()
         process.exit(1);
       }
 
+      if (!projectInfo.isReactGrabConfigured) {
+        preflightSpinner.fail("React Grab is installed, but setup is missing.");
+        logger.break();
+        logger.error(
+          `Run ${highlighter.info("react-grab init")} to add the setup script/import before configuring options.`,
+        );
+        logger.break();
+        process.exit(1);
+      }
+
       preflightSpinner.succeed();
 
       if (opts.cdn) {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -486,7 +486,7 @@ export const init = new Command()
         projectInfo.projectRoot,
         finalFramework,
         finalNextRouterType,
-        false,
+        projectInfo.isReactGrabConfigured,
         opts.force,
       );
 
@@ -542,7 +542,11 @@ export const init = new Command()
       }
 
       logger.break();
-      logger.log(`${highlighter.success("Success!")} React Grab has been installed.`);
+      if (hasLayoutChanges) {
+        logger.log(`${highlighter.success("Success!")} React Grab has been installed.`);
+      } else {
+        logger.log(`${highlighter.success("Success!")} ${result.message}.`);
+      }
       logger.log("You may now start your development server.");
       logger.break();
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -154,7 +154,7 @@ export const init = new Command()
 
       const projectInfo = await detectProject(cwd);
 
-      if (projectInfo.hasReactGrab && !opts.force) {
+      if (projectInfo.isReactGrabConfigured && !opts.force) {
         preflightSpinner.succeed();
 
         if (isNonInteractive) {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -129,7 +129,7 @@ export const init = new Command()
   .alias("setup")
   .description("initialize React Grab in your project")
   .option("-y, --yes", "skip confirmation prompts", false)
-  .option("-f, --force", "force overwrite existing config", false)
+  .option("-f, --force", "re-run setup checks even when React Grab is already configured", false)
   .option("-k, --key <key>", "shortcut (e.g., Meta+K, Ctrl+Shift+G, Space)")
   .option("--skip-install", "skip package installation", false)
   .option("--pkg <pkg>", "custom package URL for CLI (e.g., grab)")
@@ -161,7 +161,7 @@ export const init = new Command()
           logger.break();
           logger.warn("React Grab is already installed.");
           logger.log(
-            `Use ${highlighter.info("--force")} to reconfigure, or remove ${highlighter.info("--yes")} for interactive mode.`,
+            `Use ${highlighter.info("--force")} to re-run setup checks, or remove ${highlighter.info("--yes")} for interactive mode.`,
           );
           logger.break();
           process.exit(0);
@@ -487,7 +487,6 @@ export const init = new Command()
         finalFramework,
         finalNextRouterType,
         projectInfo.isReactGrabConfigured,
-        opts.force,
       );
 
       if (!result.success) {

--- a/packages/cli/src/utils/detect.ts
+++ b/packages/cli/src/utils/detect.ts
@@ -15,6 +15,7 @@ interface ProjectInfo {
   isMonorepo: boolean;
   projectRoot: string;
   hasReactGrab: boolean;
+  isReactGrabConfigured: boolean;
   reactGrabVersion: string | null;
   unsupportedFramework: UnsupportedFramework;
 }
@@ -361,10 +362,12 @@ const hasReactGrabInFile = (filePath: string): boolean => {
   }
 };
 
-export const detectReactGrab = (projectRoot: string): boolean => {
+const detectReactGrabDependency = (projectRoot: string): boolean => {
   const dependencies = readMergedDependencies(projectRoot);
-  if (dependencies?.["react-grab"]) return true;
+  return Boolean(dependencies?.["react-grab"]);
+};
 
+export const detectReactGrabConfigured = (projectRoot: string): boolean => {
   const filesToCheck = [
     join(projectRoot, "app", "layout.tsx"),
     join(projectRoot, "app", "layout.jsx"),
@@ -372,6 +375,8 @@ export const detectReactGrab = (projectRoot: string): boolean => {
     join(projectRoot, "src", "app", "layout.jsx"),
     join(projectRoot, "pages", "_document.tsx"),
     join(projectRoot, "pages", "_document.jsx"),
+    join(projectRoot, "src", "pages", "_document.tsx"),
+    join(projectRoot, "src", "pages", "_document.jsx"),
     join(projectRoot, "instrumentation-client.ts"),
     join(projectRoot, "instrumentation-client.js"),
     join(projectRoot, "src", "instrumentation-client.ts"),
@@ -379,9 +384,13 @@ export const detectReactGrab = (projectRoot: string): boolean => {
     join(projectRoot, "index.html"),
     join(projectRoot, "public", "index.html"),
     join(projectRoot, "src", "index.tsx"),
+    join(projectRoot, "src", "index.jsx"),
     join(projectRoot, "src", "index.ts"),
+    join(projectRoot, "src", "index.js"),
     join(projectRoot, "src", "main.tsx"),
+    join(projectRoot, "src", "main.jsx"),
     join(projectRoot, "src", "main.ts"),
+    join(projectRoot, "src", "main.js"),
     join(projectRoot, "src", "routes", "__root.tsx"),
     join(projectRoot, "src", "routes", "__root.jsx"),
     join(projectRoot, "app", "routes", "__root.tsx"),
@@ -390,6 +399,9 @@ export const detectReactGrab = (projectRoot: string): boolean => {
 
   return filesToCheck.some(hasReactGrabInFile);
 };
+
+export const detectReactGrab = (projectRoot: string): boolean =>
+  detectReactGrabDependency(projectRoot) || detectReactGrabConfigured(projectRoot);
 
 export const detectUnsupportedFramework = (projectRoot: string): UnsupportedFramework => {
   const dependencies = readMergedDependencies(projectRoot);
@@ -417,6 +429,7 @@ export const detectProject = async (projectRoot: string = process.cwd()): Promis
   const framework =
     localFramework === "unknown" ? detectFrameworkFromMonorepoRoot(projectRoot) : localFramework;
   const packageManager = await detectPackageManager(projectRoot);
+  const isReactGrabConfigured = detectReactGrabConfigured(projectRoot);
 
   return {
     packageManager,
@@ -424,7 +437,8 @@ export const detectProject = async (projectRoot: string = process.cwd()): Promis
     nextRouterType: framework === "next" ? detectNextRouterType(projectRoot) : "unknown",
     isMonorepo: detectMonorepo(projectRoot),
     projectRoot,
-    hasReactGrab: detectReactGrab(projectRoot),
+    hasReactGrab: detectReactGrabDependency(projectRoot) || isReactGrabConfigured,
+    isReactGrabConfigured,
     reactGrabVersion: detectReactGrabVersion(projectRoot),
     unsupportedFramework: detectUnsupportedFramework(projectRoot),
   };

--- a/packages/cli/src/utils/detect.ts
+++ b/packages/cli/src/utils/detect.ts
@@ -325,8 +325,12 @@ export const findReactProjects = (projectRoot: string): WorkspaceProject[] => {
     : findEnclosingMonorepoRoot(projectRoot);
   if (monorepoRoot) {
     const workspaceProjects = findWorkspaceProjects(monorepoRoot);
-    if (workspaceProjects.length > 0) {
-      return workspaceProjects;
+    const localProject = projectRoot === monorepoRoot ? null : buildReactProject(projectRoot);
+    const projects = localProject
+      ? [localProject, ...workspaceProjects.filter((project) => project.path !== localProject.path)]
+      : workspaceProjects;
+    if (projects.length > 0) {
+      return projects;
     }
   }
 

--- a/packages/cli/src/utils/detect.ts
+++ b/packages/cli/src/utils/detect.ts
@@ -3,6 +3,7 @@ import { basename, dirname, join } from "node:path";
 import { detect } from "package-manager-detector/detect";
 import ignore from "ignore";
 import { hasReactGrabSetupCode } from "./react-grab-code.js";
+import { getReactGrabSetupFileCandidates } from "./react-grab-setup-files.js";
 
 export type PackageManager = "npm" | "yarn" | "pnpm" | "bun";
 export type Framework = "next" | "vite" | "tanstack" | "webpack" | "unknown";
@@ -360,48 +361,7 @@ const detectReactGrabDependency = (projectRoot: string): boolean => {
 };
 
 export const detectReactGrabConfigured = (projectRoot: string): boolean => {
-  const filesToCheck = [
-    join(projectRoot, "app", "layout.tsx"),
-    join(projectRoot, "app", "layout.jsx"),
-    join(projectRoot, "app", "layout.ts"),
-    join(projectRoot, "app", "layout.js"),
-    join(projectRoot, "src", "app", "layout.tsx"),
-    join(projectRoot, "src", "app", "layout.jsx"),
-    join(projectRoot, "src", "app", "layout.ts"),
-    join(projectRoot, "src", "app", "layout.js"),
-    join(projectRoot, "pages", "_document.tsx"),
-    join(projectRoot, "pages", "_document.jsx"),
-    join(projectRoot, "pages", "_document.ts"),
-    join(projectRoot, "pages", "_document.js"),
-    join(projectRoot, "src", "pages", "_document.tsx"),
-    join(projectRoot, "src", "pages", "_document.jsx"),
-    join(projectRoot, "src", "pages", "_document.ts"),
-    join(projectRoot, "src", "pages", "_document.js"),
-    join(projectRoot, "instrumentation-client.ts"),
-    join(projectRoot, "instrumentation-client.tsx"),
-    join(projectRoot, "instrumentation-client.js"),
-    join(projectRoot, "instrumentation-client.jsx"),
-    join(projectRoot, "src", "instrumentation-client.ts"),
-    join(projectRoot, "src", "instrumentation-client.tsx"),
-    join(projectRoot, "src", "instrumentation-client.js"),
-    join(projectRoot, "src", "instrumentation-client.jsx"),
-    join(projectRoot, "index.html"),
-    join(projectRoot, "public", "index.html"),
-    join(projectRoot, "src", "index.tsx"),
-    join(projectRoot, "src", "index.jsx"),
-    join(projectRoot, "src", "index.ts"),
-    join(projectRoot, "src", "index.js"),
-    join(projectRoot, "src", "main.tsx"),
-    join(projectRoot, "src", "main.jsx"),
-    join(projectRoot, "src", "main.ts"),
-    join(projectRoot, "src", "main.js"),
-    join(projectRoot, "src", "routes", "__root.tsx"),
-    join(projectRoot, "src", "routes", "__root.jsx"),
-    join(projectRoot, "app", "routes", "__root.tsx"),
-    join(projectRoot, "app", "routes", "__root.jsx"),
-  ];
-
-  return filesToCheck.some(hasReactGrabSetupInFile);
+  return getReactGrabSetupFileCandidates(projectRoot).some(hasReactGrabSetupInFile);
 };
 
 export const detectReactGrab = (projectRoot: string): boolean =>

--- a/packages/cli/src/utils/detect.ts
+++ b/packages/cli/src/utils/detect.ts
@@ -320,8 +320,11 @@ const scanDirectoryForProjects = (
 const MAX_SCAN_DEPTH = 2;
 
 export const findReactProjects = (projectRoot: string): WorkspaceProject[] => {
-  if (detectMonorepo(projectRoot)) {
-    const workspaceProjects = findWorkspaceProjects(projectRoot);
+  const monorepoRoot = detectMonorepo(projectRoot)
+    ? projectRoot
+    : findEnclosingMonorepoRoot(projectRoot);
+  if (monorepoRoot) {
+    const workspaceProjects = findWorkspaceProjects(monorepoRoot);
     if (workspaceProjects.length > 0) {
       return workspaceProjects;
     }

--- a/packages/cli/src/utils/detect.ts
+++ b/packages/cli/src/utils/detect.ts
@@ -2,6 +2,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { detect } from "package-manager-detector/detect";
 import ignore from "ignore";
+import { hasReactGrabSetupCode } from "./react-grab-code.js";
 
 export type PackageManager = "npm" | "yarn" | "pnpm" | "bun";
 export type Framework = "next" | "vite" | "tanstack" | "webpack" | "unknown";
@@ -343,20 +344,11 @@ export const findReactProjects = (projectRoot: string): WorkspaceProject[] => {
   return [];
 };
 
-const hasReactGrabInFile = (filePath: string): boolean => {
+const hasReactGrabSetupInFile = (filePath: string): boolean => {
   if (!existsSync(filePath)) return false;
   try {
     const content = readFileSync(filePath, "utf-8");
-    const fuzzyPatterns = [
-      /["'`][^"'`]*react-grab/,
-      /react-grab[^"'`]*["'`]/,
-      /<[^>]*react-grab/i,
-      /import[^;]*react-grab/i,
-      /require[^)]*react-grab/i,
-      /from\s+[^;]*react-grab/i,
-      /src[^>]*react-grab/i,
-    ];
-    return fuzzyPatterns.some((pattern) => pattern.test(content));
+    return hasReactGrabSetupCode(content);
   } catch {
     return false;
   }
@@ -371,16 +363,28 @@ export const detectReactGrabConfigured = (projectRoot: string): boolean => {
   const filesToCheck = [
     join(projectRoot, "app", "layout.tsx"),
     join(projectRoot, "app", "layout.jsx"),
+    join(projectRoot, "app", "layout.ts"),
+    join(projectRoot, "app", "layout.js"),
     join(projectRoot, "src", "app", "layout.tsx"),
     join(projectRoot, "src", "app", "layout.jsx"),
+    join(projectRoot, "src", "app", "layout.ts"),
+    join(projectRoot, "src", "app", "layout.js"),
     join(projectRoot, "pages", "_document.tsx"),
     join(projectRoot, "pages", "_document.jsx"),
+    join(projectRoot, "pages", "_document.ts"),
+    join(projectRoot, "pages", "_document.js"),
     join(projectRoot, "src", "pages", "_document.tsx"),
     join(projectRoot, "src", "pages", "_document.jsx"),
+    join(projectRoot, "src", "pages", "_document.ts"),
+    join(projectRoot, "src", "pages", "_document.js"),
     join(projectRoot, "instrumentation-client.ts"),
+    join(projectRoot, "instrumentation-client.tsx"),
     join(projectRoot, "instrumentation-client.js"),
+    join(projectRoot, "instrumentation-client.jsx"),
     join(projectRoot, "src", "instrumentation-client.ts"),
+    join(projectRoot, "src", "instrumentation-client.tsx"),
     join(projectRoot, "src", "instrumentation-client.js"),
+    join(projectRoot, "src", "instrumentation-client.jsx"),
     join(projectRoot, "index.html"),
     join(projectRoot, "public", "index.html"),
     join(projectRoot, "src", "index.tsx"),
@@ -397,7 +401,7 @@ export const detectReactGrabConfigured = (projectRoot: string): boolean => {
     join(projectRoot, "app", "routes", "__root.jsx"),
   ];
 
-  return filesToCheck.some(hasReactGrabInFile);
+  return filesToCheck.some(hasReactGrabSetupInFile);
 };
 
 export const detectReactGrab = (projectRoot: string): boolean =>
@@ -429,13 +433,14 @@ export const detectProject = async (projectRoot: string = process.cwd()): Promis
   const framework =
     localFramework === "unknown" ? detectFrameworkFromMonorepoRoot(projectRoot) : localFramework;
   const packageManager = await detectPackageManager(projectRoot);
+  const isMonorepo = detectMonorepo(projectRoot) || findEnclosingMonorepoRoot(projectRoot) !== null;
   const isReactGrabConfigured = detectReactGrabConfigured(projectRoot);
 
   return {
     packageManager,
     framework,
     nextRouterType: framework === "next" ? detectNextRouterType(projectRoot) : "unknown",
-    isMonorepo: detectMonorepo(projectRoot),
+    isMonorepo,
     projectRoot,
     hasReactGrab: detectReactGrabDependency(projectRoot) || isReactGrabConfigured,
     isReactGrabConfigured,

--- a/packages/cli/src/utils/detect.ts
+++ b/packages/cli/src/utils/detect.ts
@@ -319,6 +319,8 @@ const scanDirectoryForProjects = (
 
 const MAX_SCAN_DEPTH = 2;
 
+const normalizePathForComparison = (filePath: string): string => filePath.replace(/\\/g, "/");
+
 export const findReactProjects = (projectRoot: string): WorkspaceProject[] => {
   const monorepoRoot = detectMonorepo(projectRoot)
     ? projectRoot
@@ -327,7 +329,14 @@ export const findReactProjects = (projectRoot: string): WorkspaceProject[] => {
     const workspaceProjects = findWorkspaceProjects(monorepoRoot);
     const localProject = projectRoot === monorepoRoot ? null : buildReactProject(projectRoot);
     const projects = localProject
-      ? [localProject, ...workspaceProjects.filter((project) => project.path !== localProject.path)]
+      ? [
+          localProject,
+          ...workspaceProjects.filter(
+            (project) =>
+              normalizePathForComparison(project.path) !==
+              normalizePathForComparison(localProject.path),
+          ),
+        ]
       : workspaceProjects;
     if (projects.length > 0) {
       return projects;

--- a/packages/cli/src/utils/react-grab-code.ts
+++ b/packages/cli/src/utils/react-grab-code.ts
@@ -7,10 +7,13 @@ const stripComments = (content: string): string =>
 
 export const hasReactGrabSetupCode = (content: string): boolean => {
   const uncommentedContent = stripComments(content);
+  const reactGrabSpecifierPattern = String.raw`react-grab(?:\/[^"']+)?`;
   const setupPatterns = [
-    /import\s*\(\s*["']react-grab(?:\/core)?["']\s*\)/,
-    /import\s+(?!type\b)(?:[^"';]+from\s+)?["']react-grab(?:\/core)?["']/,
-    /require\s*\(\s*["']react-grab(?:\/core)?["']\s*\)/,
+    new RegExp(String.raw`import\s*\(\s*["']${reactGrabSpecifierPattern}["']\s*\)`),
+    new RegExp(
+      String.raw`import\s+(?!type\b)(?:[^"';]+from\s+)?["']${reactGrabSpecifierPattern}["']`,
+    ),
+    new RegExp(String.raw`require\s*\(\s*["']${reactGrabSpecifierPattern}["']\s*\)`),
     /<Script[\s\S]*?src\s*=\s*(?:["'][^"']*react-grab[^"']*["']|\{["'][^"']*react-grab[^"']*["']\})/i,
     /<script[\s\S]*?src\s*=\s*["'][^"']*react-grab[^"']*["']/i,
   ];

--- a/packages/cli/src/utils/react-grab-code.ts
+++ b/packages/cli/src/utils/react-grab-code.ts
@@ -1,0 +1,19 @@
+const stripComments = (content: string): string =>
+  content
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .replace(/\{\/\*[\s\S]*?\*\/\}/g, "")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+
+export const hasReactGrabSetupCode = (content: string): boolean => {
+  const uncommentedContent = stripComments(content);
+  const setupPatterns = [
+    /import\s*\(\s*["']react-grab(?:\/core)?["']\s*\)/,
+    /import\s+(?:[^"';]+from\s+)?["']react-grab(?:\/core)?["']/,
+    /require\s*\(\s*["']react-grab(?:\/core)?["']\s*\)/,
+    /<Script[\s\S]*?src\s*=\s*(?:["'][^"']*react-grab[^"']*["']|\{["'][^"']*react-grab[^"']*["']\})/i,
+    /<script[\s\S]*?src\s*=\s*["'][^"']*react-grab[^"']*["']/i,
+  ];
+
+  return setupPatterns.some((pattern) => pattern.test(uncommentedContent));
+};

--- a/packages/cli/src/utils/react-grab-code.ts
+++ b/packages/cli/src/utils/react-grab-code.ts
@@ -1,3 +1,5 @@
+const REACT_GRAB_SPECIFIER_PATTERN = String.raw`react-grab(?:\/[^"']+)?`;
+
 const stripComments = (content: string): string =>
   content
     .replace(/<!--[\s\S]*?-->/g, "")
@@ -6,18 +8,17 @@ const stripComments = (content: string): string =>
     .replace(/(^|\s)\/\/.*$/gm, "$1");
 
 const stripTypeOnlyReactGrabImports = (content: string): string => {
-  const reactGrabSpecifierPattern = String.raw`react-grab(?:\/[^"']+)?`;
   return content
     .replace(
       new RegExp(
-        String.raw`import\s+type\s+[^;]+from\s+["']${reactGrabSpecifierPattern}["'];?`,
+        String.raw`import\s+type\s+[^;]+from\s+["']${REACT_GRAB_SPECIFIER_PATTERN}["'];?`,
         "g",
       ),
       "",
     )
     .replace(
       new RegExp(
-        String.raw`import\s*\{\s*type\s+[^,}]+(?:,\s*type\s+[^,}]+)*\s*\}\s*from\s+["']${reactGrabSpecifierPattern}["'];?`,
+        String.raw`import\s*\{\s*type\s+[^,}]+(?:\s*,\s*type\s+[^,}]+)*\s*,?\s*\}\s*from\s+["']${REACT_GRAB_SPECIFIER_PATTERN}["'];?`,
         "g",
       ),
       "",
@@ -25,17 +26,16 @@ const stripTypeOnlyReactGrabImports = (content: string): string => {
 };
 
 export const hasReactGrabSetupCode = (content: string): boolean => {
-  const uncommentedContent = stripTypeOnlyReactGrabImports(stripComments(content));
-  const reactGrabSpecifierPattern = String.raw`react-grab(?:\/[^"']+)?`;
+  const setupCandidateContent = stripTypeOnlyReactGrabImports(stripComments(content));
   const setupPatterns = [
-    new RegExp(String.raw`import\s*\(\s*["']${reactGrabSpecifierPattern}["']\s*\)`),
+    new RegExp(String.raw`import\s*\(\s*["']${REACT_GRAB_SPECIFIER_PATTERN}["']\s*\)`),
     new RegExp(
-      String.raw`import\s+(?!type\b)(?:[^"';]+from\s+)?["']${reactGrabSpecifierPattern}["']`,
+      String.raw`import\s+(?!type\b)(?:[^"';]+from\s+)?["']${REACT_GRAB_SPECIFIER_PATTERN}["']`,
     ),
-    new RegExp(String.raw`require\s*\(\s*["']${reactGrabSpecifierPattern}["']\s*\)`),
+    new RegExp(String.raw`require\s*\(\s*["']${REACT_GRAB_SPECIFIER_PATTERN}["']\s*\)`),
     /<Script[\s\S]*?src\s*=\s*(?:["'][^"']*react-grab[^"']*["']|\{(?:["'][^"']*react-grab[^"']*["']|`[^`]*react-grab[^`]*`)\})/i,
     /<script[\s\S]*?src\s*=\s*["'][^"']*react-grab[^"']*["']/i,
   ];
 
-  return setupPatterns.some((pattern) => pattern.test(uncommentedContent));
+  return setupPatterns.some((pattern) => pattern.test(setupCandidateContent));
 };

--- a/packages/cli/src/utils/react-grab-code.ts
+++ b/packages/cli/src/utils/react-grab-code.ts
@@ -9,7 +9,7 @@ export const hasReactGrabSetupCode = (content: string): boolean => {
   const uncommentedContent = stripComments(content);
   const setupPatterns = [
     /import\s*\(\s*["']react-grab(?:\/core)?["']\s*\)/,
-    /import\s+(?:[^"';]+from\s+)?["']react-grab(?:\/core)?["']/,
+    /import\s+(?!type\b)(?:[^"';]+from\s+)?["']react-grab(?:\/core)?["']/,
     /require\s*\(\s*["']react-grab(?:\/core)?["']\s*\)/,
     /<Script[\s\S]*?src\s*=\s*(?:["'][^"']*react-grab[^"']*["']|\{["'][^"']*react-grab[^"']*["']\})/i,
     /<script[\s\S]*?src\s*=\s*["'][^"']*react-grab[^"']*["']/i,

--- a/packages/cli/src/utils/react-grab-code.ts
+++ b/packages/cli/src/utils/react-grab-code.ts
@@ -3,7 +3,7 @@ const stripComments = (content: string): string =>
     .replace(/<!--[\s\S]*?-->/g, "")
     .replace(/\{\/\*[\s\S]*?\*\/\}/g, "")
     .replace(/\/\*[\s\S]*?\*\//g, "")
-    .replace(/^\s*\/\/.*$/gm, "");
+    .replace(/(^|\s)\/\/.*$/gm, "$1");
 
 export const hasReactGrabSetupCode = (content: string): boolean => {
   const uncommentedContent = stripComments(content);

--- a/packages/cli/src/utils/react-grab-code.ts
+++ b/packages/cli/src/utils/react-grab-code.ts
@@ -5,8 +5,27 @@ const stripComments = (content: string): string =>
     .replace(/\/\*[\s\S]*?\*\//g, "")
     .replace(/(^|\s)\/\/.*$/gm, "$1");
 
+const stripTypeOnlyReactGrabImports = (content: string): string => {
+  const reactGrabSpecifierPattern = String.raw`react-grab(?:\/[^"']+)?`;
+  return content
+    .replace(
+      new RegExp(
+        String.raw`import\s+type\s+[^;]+from\s+["']${reactGrabSpecifierPattern}["'];?`,
+        "g",
+      ),
+      "",
+    )
+    .replace(
+      new RegExp(
+        String.raw`import\s*\{\s*type\s+[^,}]+(?:,\s*type\s+[^,}]+)*\s*\}\s*from\s+["']${reactGrabSpecifierPattern}["'];?`,
+        "g",
+      ),
+      "",
+    );
+};
+
 export const hasReactGrabSetupCode = (content: string): boolean => {
-  const uncommentedContent = stripComments(content);
+  const uncommentedContent = stripTypeOnlyReactGrabImports(stripComments(content));
   const reactGrabSpecifierPattern = String.raw`react-grab(?:\/[^"']+)?`;
   const setupPatterns = [
     new RegExp(String.raw`import\s*\(\s*["']${reactGrabSpecifierPattern}["']\s*\)`),
@@ -14,7 +33,7 @@ export const hasReactGrabSetupCode = (content: string): boolean => {
       String.raw`import\s+(?!type\b)(?:[^"';]+from\s+)?["']${reactGrabSpecifierPattern}["']`,
     ),
     new RegExp(String.raw`require\s*\(\s*["']${reactGrabSpecifierPattern}["']\s*\)`),
-    /<Script[\s\S]*?src\s*=\s*(?:["'][^"']*react-grab[^"']*["']|\{["'][^"']*react-grab[^"']*["']\})/i,
+    /<Script[\s\S]*?src\s*=\s*(?:["'][^"']*react-grab[^"']*["']|\{(?:["'][^"']*react-grab[^"']*["']|`[^`]*react-grab[^`]*`)\})/i,
     /<script[\s\S]*?src\s*=\s*["'][^"']*react-grab[^"']*["']/i,
   ];
 

--- a/packages/cli/src/utils/react-grab-setup-files.ts
+++ b/packages/cli/src/utils/react-grab-setup-files.ts
@@ -1,0 +1,79 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const COMPONENT_EXTENSIONS = ["tsx", "jsx", "ts", "js"];
+const ROUTE_EXTENSIONS = ["tsx", "jsx"];
+
+const createFileCandidates = (
+  projectRoot: string,
+  directories: string[],
+  baseName: string,
+  extensions: string[],
+): string[] => {
+  const fileCandidates: string[] = [];
+  for (const directory of directories) {
+    for (const extension of extensions) {
+      fileCandidates.push(join(projectRoot, directory, `${baseName}.${extension}`));
+    }
+  }
+  return fileCandidates;
+};
+
+const findExistingFile = (fileCandidates: string[]): string | null => {
+  for (const filePath of fileCandidates) {
+    if (existsSync(filePath)) return filePath;
+  }
+  return null;
+};
+
+export const getLayoutFileCandidates = (projectRoot: string): string[] =>
+  createFileCandidates(projectRoot, ["app", "src/app"], "layout", COMPONENT_EXTENSIONS);
+
+export const getDocumentFileCandidates = (projectRoot: string): string[] =>
+  createFileCandidates(projectRoot, ["pages", "src/pages"], "_document", COMPONENT_EXTENSIONS);
+
+export const getInstrumentationFileCandidates = (projectRoot: string): string[] =>
+  createFileCandidates(projectRoot, ["", "src"], "instrumentation-client", COMPONENT_EXTENSIONS);
+
+export const getIndexHtmlCandidates = (projectRoot: string): string[] => [
+  join(projectRoot, "index.html"),
+  join(projectRoot, "public", "index.html"),
+];
+
+export const getEntryFileCandidates = (projectRoot: string): string[] => [
+  ...createFileCandidates(projectRoot, ["src"], "index", COMPONENT_EXTENSIONS),
+  ...createFileCandidates(projectRoot, ["src"], "main", COMPONENT_EXTENSIONS),
+];
+
+export const getTanStackRootFileCandidates = (projectRoot: string): string[] =>
+  createFileCandidates(projectRoot, ["src/routes", "app/routes"], "__root", ROUTE_EXTENSIONS);
+
+export const getReactGrabSetupFileCandidates = (projectRoot: string): string[] => [
+  ...getLayoutFileCandidates(projectRoot),
+  ...getDocumentFileCandidates(projectRoot),
+  ...getInstrumentationFileCandidates(projectRoot),
+  ...getIndexHtmlCandidates(projectRoot),
+  ...getEntryFileCandidates(projectRoot),
+  ...getTanStackRootFileCandidates(projectRoot),
+];
+
+export const findLayoutFile = (projectRoot: string): string | null =>
+  findExistingFile(getLayoutFileCandidates(projectRoot));
+
+export const findDocumentFile = (projectRoot: string): string | null =>
+  findExistingFile(getDocumentFileCandidates(projectRoot));
+
+export const findInstrumentationFile = (projectRoot: string): string | null =>
+  findExistingFile(getInstrumentationFileCandidates(projectRoot));
+
+export const findIndexHtml = (projectRoot: string): string | null =>
+  findExistingFile(getIndexHtmlCandidates(projectRoot));
+
+export const findEntryFile = (projectRoot: string): string | null =>
+  findExistingFile(getEntryFileCandidates(projectRoot));
+
+export const findTanStackRootFile = (projectRoot: string): string | null =>
+  findExistingFile(getTanStackRootFileCandidates(projectRoot));
+
+export const isInstrumentationFile = (filePath: string): boolean =>
+  /(?:^|[/\\])instrumentation-client\.[cm]?[jt]sx?$/.test(filePath);

--- a/packages/cli/src/utils/react-grab-setup-files.ts
+++ b/packages/cli/src/utils/react-grab-setup-files.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 
 const COMPONENT_EXTENSIONS = ["tsx", "jsx", "ts", "js"];
+const INSTRUMENTATION_EXTENSIONS = ["ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs"];
 const ROUTE_EXTENSIONS = ["tsx", "jsx"];
 
 const createFileCandidates = (
@@ -33,7 +34,12 @@ export const getDocumentFileCandidates = (projectRoot: string): string[] =>
   createFileCandidates(projectRoot, ["pages", "src/pages"], "_document", COMPONENT_EXTENSIONS);
 
 export const getInstrumentationFileCandidates = (projectRoot: string): string[] =>
-  createFileCandidates(projectRoot, ["", "src"], "instrumentation-client", COMPONENT_EXTENSIONS);
+  createFileCandidates(
+    projectRoot,
+    ["", "src"],
+    "instrumentation-client",
+    INSTRUMENTATION_EXTENSIONS,
+  );
 
 export const getIndexHtmlCandidates = (projectRoot: string): string[] => [
   join(projectRoot, "index.html"),

--- a/packages/cli/src/utils/transform.ts
+++ b/packages/cli/src/utils/transform.ts
@@ -12,7 +12,6 @@ import {
   findDocumentFile,
   findEntryFile,
   findIndexHtml,
-  findInstrumentationFile,
   findLayoutFile,
   findTanStackRootFile,
   getDocumentFileCandidates,
@@ -42,11 +41,15 @@ export interface ReactGrabOptions {
 }
 
 const hasReactGrabInInstrumentation = (projectRoot: string): boolean => {
-  const instrumentationPath = findInstrumentationFile(projectRoot);
-  if (!instrumentationPath) return false;
+  return findFileWithReactGrabSetup(getInstrumentationFileCandidates(projectRoot)) !== null;
+};
 
-  const content = readFileSync(instrumentationPath, "utf-8");
-  return hasReactGrabSetupCode(content);
+const findFileWithReactGrabSetup = (fileCandidates: string[]): string | null => {
+  for (const filePath of fileCandidates) {
+    if (!existsSync(filePath)) continue;
+    if (hasReactGrabSetupCode(readFileSync(filePath, "utf-8"))) return filePath;
+  }
+  return null;
 };
 
 const alreadyConfiguredResult = (filePath: string): TransformResult => ({
@@ -502,14 +505,6 @@ const formatOptionsAsJson = (options: ReactGrabOptions): string => {
   }
 
   return JSON.stringify(cleanOptions);
-};
-
-const findFileWithReactGrabSetup = (fileCandidates: string[]): string | null => {
-  for (const filePath of fileCandidates) {
-    if (!existsSync(filePath)) continue;
-    if (hasReactGrabSetupCode(readFileSync(filePath, "utf-8"))) return filePath;
-  }
-  return null;
 };
 
 const findReactGrabFile = (

--- a/packages/cli/src/utils/transform.ts
+++ b/packages/cli/src/utils/transform.ts
@@ -1,5 +1,4 @@
-import { accessSync, constants, existsSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { accessSync, constants, readFileSync, writeFileSync } from "node:fs";
 import type { Framework, NextRouterType } from "./detect.js";
 import {
   NEXT_APP_ROUTER_SCRIPT,
@@ -9,6 +8,15 @@ import {
   WEBPACK_IMPORT,
 } from "./templates.js";
 import { hasReactGrabSetupCode } from "./react-grab-code.js";
+import {
+  findDocumentFile,
+  findEntryFile,
+  findIndexHtml,
+  findInstrumentationFile,
+  findLayoutFile,
+  findTanStackRootFile,
+  isInstrumentationFile,
+} from "./react-grab-setup-files.js";
 
 export interface TransformResult {
   success: boolean;
@@ -27,133 +35,12 @@ export interface ReactGrabOptions {
   maxContextLines?: number;
 }
 
-const hasReactGrabCode = hasReactGrabSetupCode;
-
-const findLayoutFile = (projectRoot: string): string | null => {
-  const possiblePaths = [
-    join(projectRoot, "app", "layout.tsx"),
-    join(projectRoot, "app", "layout.jsx"),
-    join(projectRoot, "app", "layout.ts"),
-    join(projectRoot, "app", "layout.js"),
-    join(projectRoot, "src", "app", "layout.tsx"),
-    join(projectRoot, "src", "app", "layout.jsx"),
-    join(projectRoot, "src", "app", "layout.ts"),
-    join(projectRoot, "src", "app", "layout.js"),
-  ];
-
-  for (const filePath of possiblePaths) {
-    if (existsSync(filePath)) {
-      return filePath;
-    }
-  }
-
-  return null;
-};
-
-const findInstrumentationFile = (projectRoot: string): string | null => {
-  const possiblePaths = [
-    join(projectRoot, "instrumentation-client.ts"),
-    join(projectRoot, "instrumentation-client.tsx"),
-    join(projectRoot, "instrumentation-client.js"),
-    join(projectRoot, "instrumentation-client.jsx"),
-    join(projectRoot, "src", "instrumentation-client.ts"),
-    join(projectRoot, "src", "instrumentation-client.tsx"),
-    join(projectRoot, "src", "instrumentation-client.js"),
-    join(projectRoot, "src", "instrumentation-client.jsx"),
-  ];
-
-  for (const filePath of possiblePaths) {
-    if (existsSync(filePath)) {
-      return filePath;
-    }
-  }
-
-  return null;
-};
-
-const isInstrumentationFile = (filePath: string): boolean =>
-  /(?:^|[/\\])instrumentation-client\.[cm]?[jt]sx?$/.test(filePath);
-
 const hasReactGrabInInstrumentation = (projectRoot: string): boolean => {
   const instrumentationPath = findInstrumentationFile(projectRoot);
   if (!instrumentationPath) return false;
 
   const content = readFileSync(instrumentationPath, "utf-8");
-  return hasReactGrabCode(content);
-};
-
-const findDocumentFile = (projectRoot: string): string | null => {
-  const possiblePaths = [
-    join(projectRoot, "pages", "_document.tsx"),
-    join(projectRoot, "pages", "_document.jsx"),
-    join(projectRoot, "pages", "_document.ts"),
-    join(projectRoot, "pages", "_document.js"),
-    join(projectRoot, "src", "pages", "_document.tsx"),
-    join(projectRoot, "src", "pages", "_document.jsx"),
-    join(projectRoot, "src", "pages", "_document.ts"),
-    join(projectRoot, "src", "pages", "_document.js"),
-  ];
-
-  for (const filePath of possiblePaths) {
-    if (existsSync(filePath)) {
-      return filePath;
-    }
-  }
-
-  return null;
-};
-
-const findIndexHtml = (projectRoot: string): string | null => {
-  const possiblePaths = [
-    join(projectRoot, "index.html"),
-    join(projectRoot, "public", "index.html"),
-  ];
-
-  for (const filePath of possiblePaths) {
-    if (existsSync(filePath)) {
-      return filePath;
-    }
-  }
-
-  return null;
-};
-
-const findEntryFile = (projectRoot: string): string | null => {
-  const possiblePaths = [
-    join(projectRoot, "src", "index.tsx"),
-    join(projectRoot, "src", "index.jsx"),
-    join(projectRoot, "src", "index.ts"),
-    join(projectRoot, "src", "index.js"),
-    join(projectRoot, "src", "main.tsx"),
-    join(projectRoot, "src", "main.jsx"),
-    join(projectRoot, "src", "main.ts"),
-    join(projectRoot, "src", "main.js"),
-  ];
-
-  for (const filePath of possiblePaths) {
-    if (existsSync(filePath)) {
-      return filePath;
-    }
-  }
-
-  return null;
-};
-
-const findTanStackRootFile = (projectRoot: string): string | null => {
-  const possiblePaths = [
-    join(projectRoot, "src", "routes", "__root.tsx"),
-    join(projectRoot, "src", "routes", "__root.jsx"),
-    join(projectRoot, "app", "routes", "__root.tsx"),
-    join(projectRoot, "app", "routes", "__root.jsx"),
-  ];
-
-  for (const filePath of possiblePaths) {
-    if (existsSync(filePath)) {
-      return filePath;
-    }
-  }
-
-  return null;
+  return hasReactGrabSetupCode(content);
 };
 
 const alreadyConfiguredResult = (filePath: string): TransformResult => ({
@@ -166,7 +53,6 @@ const alreadyConfiguredResult = (filePath: string): TransformResult => ({
 const transformNextAppRouter = (
   projectRoot: string,
   reactGrabAlreadyConfigured: boolean,
-  _force: boolean = false,
 ): TransformResult => {
   const layoutPath = findLayoutFile(projectRoot);
 
@@ -180,7 +66,7 @@ const transformNextAppRouter = (
 
   const originalContent = readFileSync(layoutPath, "utf-8");
   let newContent = originalContent;
-  const hasReactGrabInFile = hasReactGrabCode(originalContent);
+  const hasReactGrabInFile = hasReactGrabSetupCode(originalContent);
   const hasReactGrabInInstrumentationFile = hasReactGrabInInstrumentation(projectRoot);
 
   if (hasReactGrabInFile && reactGrabAlreadyConfigured) {
@@ -235,7 +121,6 @@ const transformNextAppRouter = (
 const transformNextPagesRouter = (
   projectRoot: string,
   reactGrabAlreadyConfigured: boolean,
-  _force: boolean = false,
 ): TransformResult => {
   const documentPath = findDocumentFile(projectRoot);
 
@@ -268,7 +153,7 @@ const transformNextPagesRouter = (
 
   const originalContent = readFileSync(documentPath, "utf-8");
   let newContent = originalContent;
-  const hasReactGrabInFile = hasReactGrabCode(originalContent);
+  const hasReactGrabInFile = hasReactGrabSetupCode(originalContent);
   const hasReactGrabInInstrumentationFile = hasReactGrabInInstrumentation(projectRoot);
 
   if (hasReactGrabInFile && reactGrabAlreadyConfigured) {
@@ -315,7 +200,7 @@ const checkExistingInstallation = (
   reactGrabAlreadyConfigured: boolean,
 ): TransformResult | null => {
   const content = readFileSync(filePath, "utf-8");
-  if (!hasReactGrabCode(content)) return null;
+  if (!hasReactGrabSetupCode(content)) return null;
 
   return {
     success: true,
@@ -330,7 +215,6 @@ const checkExistingInstallation = (
 const transformVite = (
   projectRoot: string,
   reactGrabAlreadyConfigured: boolean,
-  _force: boolean = false,
 ): TransformResult => {
   const entryPath = findEntryFile(projectRoot);
 
@@ -366,7 +250,6 @@ const transformVite = (
 const transformWebpack = (
   projectRoot: string,
   reactGrabAlreadyConfigured: boolean,
-  _force: boolean = false,
 ): TransformResult => {
   const entryPath = findEntryFile(projectRoot);
 
@@ -396,7 +279,6 @@ const transformWebpack = (
 const transformTanStack = (
   projectRoot: string,
   reactGrabAlreadyConfigured: boolean,
-  _force: boolean = false,
 ): TransformResult => {
   const rootPath = findTanStackRootFile(projectRoot);
 
@@ -418,7 +300,7 @@ const transformTanStack = (
 
   const originalContent = readFileSync(rootPath, "utf-8");
   let newContent = originalContent;
-  const hasReactGrabInFile = hasReactGrabCode(originalContent);
+  const hasReactGrabInFile = hasReactGrabSetupCode(originalContent);
 
   if (hasReactGrabInFile && reactGrabAlreadyConfigured) {
     return alreadyConfiguredResult(rootPath);
@@ -507,23 +389,22 @@ export const previewTransform = (
   framework: Framework,
   nextRouterType: NextRouterType,
   reactGrabAlreadyConfigured: boolean = false,
-  force: boolean = false,
 ): TransformResult => {
   switch (framework) {
     case "next":
       if (nextRouterType === "app") {
-        return transformNextAppRouter(projectRoot, reactGrabAlreadyConfigured, force);
+        return transformNextAppRouter(projectRoot, reactGrabAlreadyConfigured);
       }
-      return transformNextPagesRouter(projectRoot, reactGrabAlreadyConfigured, force);
+      return transformNextPagesRouter(projectRoot, reactGrabAlreadyConfigured);
 
     case "vite":
-      return transformVite(projectRoot, reactGrabAlreadyConfigured, force);
+      return transformVite(projectRoot, reactGrabAlreadyConfigured);
 
     case "tanstack":
-      return transformTanStack(projectRoot, reactGrabAlreadyConfigured, force);
+      return transformTanStack(projectRoot, reactGrabAlreadyConfigured);
 
     case "webpack":
-      return transformWebpack(projectRoot, reactGrabAlreadyConfigured, force);
+      return transformWebpack(projectRoot, reactGrabAlreadyConfigured);
 
     default:
       return {
@@ -626,12 +507,15 @@ const findReactGrabFile = (
     case "next": {
       const primaryFile =
         nextRouterType === "app" ? findLayoutFile(projectRoot) : findDocumentFile(projectRoot);
-      if (primaryFile && hasReactGrabCode(readFileSync(primaryFile, "utf-8"))) {
+      if (primaryFile && hasReactGrabSetupCode(readFileSync(primaryFile, "utf-8"))) {
         return primaryFile;
       }
 
       const instrumentationFile = findInstrumentationFile(projectRoot);
-      if (instrumentationFile && hasReactGrabCode(readFileSync(instrumentationFile, "utf-8"))) {
+      if (
+        instrumentationFile &&
+        hasReactGrabSetupCode(readFileSync(instrumentationFile, "utf-8"))
+      ) {
         return instrumentationFile;
       }
 
@@ -639,11 +523,11 @@ const findReactGrabFile = (
     }
     case "vite": {
       const entryFile = findEntryFile(projectRoot);
-      if (entryFile && hasReactGrabCode(readFileSync(entryFile, "utf-8"))) {
+      if (entryFile && hasReactGrabSetupCode(readFileSync(entryFile, "utf-8"))) {
         return entryFile;
       }
       const indexHtml = findIndexHtml(projectRoot);
-      if (indexHtml && hasReactGrabCode(readFileSync(indexHtml, "utf-8"))) {
+      if (indexHtml && hasReactGrabSetupCode(readFileSync(indexHtml, "utf-8"))) {
         return indexHtml;
       }
       return entryFile;
@@ -706,7 +590,7 @@ const addOptionsToDynamicImport = (
   filePath: string,
 ): TransformResult => {
   const reactGrabImportWithInitMatch = originalContent.match(
-    /(?:void\s+)?import\s*\(\s*["']react-grab["']\s*\)(?:\.then\s*\(\s*\(m\)\s*=>\s*m\.init\s*\([^)]*\)\s*\))?/,
+    /(void\s+)?import\s*\(\s*["']react-grab["']\s*\)(?:\.then\s*\(\s*\(m\)\s*=>\s*m\.init\s*\([^)]*\)\s*\))?/,
   );
 
   if (!reactGrabImportWithInitMatch) {
@@ -718,7 +602,8 @@ const addOptionsToDynamicImport = (
   }
 
   const optionsJson = formatOptionsAsJson(options);
-  const newImport = `import("react-grab").then((m) => m.init(${optionsJson}))`;
+  const voidPrefix = reactGrabImportWithInitMatch[1] ?? "";
+  const newImport = `${voidPrefix}import("react-grab").then((m) => m.init(${optionsJson}))`;
 
   const newContent = originalContent.replace(reactGrabImportWithInitMatch[0], newImport);
 
@@ -737,7 +622,7 @@ const addOptionsToTanStackImport = (
   filePath: string,
 ): TransformResult => {
   const reactGrabImportWithInitMatch = originalContent.match(
-    /(?:void\s+import\s*\(\s*["']react-grab["']\s*\)|import\s*\(\s*["']react-grab\/core["']\s*\)\.then\s*\(\s*\(\s*\{\s*init\s*\}\s*\)\s*=>\s*init\s*\([^)]*\)\s*\))/,
+    /(?:(void\s+)?import\s*\(\s*["']react-grab["']\s*\)|(void\s+)?import\s*\(\s*["']react-grab\/core["']\s*\)\.then\s*\(\s*\(\s*\{\s*init\s*\}\s*\)\s*=>\s*init\s*\([^)]*\)\s*\))/,
   );
 
   if (!reactGrabImportWithInitMatch) {
@@ -749,7 +634,8 @@ const addOptionsToTanStackImport = (
   }
 
   const optionsJson = formatOptionsAsJson(options);
-  const newImport = `import("react-grab/core").then(({ init }) => init(${optionsJson}))`;
+  const voidPrefix = reactGrabImportWithInitMatch[1] ?? reactGrabImportWithInitMatch[2] ?? "";
+  const newImport = `${voidPrefix}import("react-grab/core").then(({ init }) => init(${optionsJson}))`;
 
   const newContent = originalContent.replace(reactGrabImportWithInitMatch[0], newImport);
 
@@ -790,7 +676,7 @@ export const previewOptionsTransform = (
 
   const originalContent = readFileSync(filePath, "utf-8");
 
-  if (!hasReactGrabCode(originalContent)) {
+  if (!hasReactGrabSetupCode(originalContent)) {
     return {
       success: false,
       filePath,

--- a/packages/cli/src/utils/transform.ts
+++ b/packages/cli/src/utils/transform.ts
@@ -607,7 +607,7 @@ const addOptionsToDynamicImport = (
   filePath: string,
 ): TransformResult => {
   const reactGrabImportWithInitMatch = originalContent.match(
-    /(void\s+)?import\s*\(\s*["']react-grab(?:\/[^"']+)?["']\s*\)(?:\.then\s*\(\s*\(m\)\s*=>\s*m\.init\s*\([^)]*\)\s*\))?/,
+    /(void\s+)?import\s*\(\s*["']react-grab(?:\/[^"']+)?["']\s*\)(?:\.then\s*\(\s*(?:\(m\)\s*=>\s*m\.init\s*\([^)]*\)|\(\{\s*init\s*\}\)\s*=>\s*init\s*\([^)]*\))\s*\))?/,
   );
 
   if (!reactGrabImportWithInitMatch) {
@@ -639,7 +639,7 @@ const addOptionsToTanStackImport = (
   filePath: string,
 ): TransformResult => {
   const reactGrabImportWithInitMatch = originalContent.match(
-    /(?:(void\s+)?import\s*\(\s*["']react-grab\/core["']\s*\)\.then\s*\(\s*\(\s*\{\s*init\s*\}\s*\)\s*=>\s*init\s*\([^)]*\)\s*\)|(void\s+)?import\s*\(\s*["']react-grab(?:\/[^"']+)?["']\s*\))/,
+    /(?:(void\s+)?import\s*\(\s*["']react-grab\/core["']\s*\)\.then\s*\(\s*(?:\(\s*\{\s*init\s*\}\s*\)\s*=>\s*init\s*\([^)]*\)|\(m\)\s*=>\s*m\.init\s*\([^)]*\))\s*\)|(void\s+)?import\s*\(\s*["']react-grab(?!\/core)(?:\/[^"']+)?["']\s*\))/,
   );
 
   if (!reactGrabImportWithInitMatch) {

--- a/packages/cli/src/utils/transform.ts
+++ b/packages/cli/src/utils/transform.ts
@@ -8,6 +8,7 @@ import {
   VITE_IMPORT,
   WEBPACK_IMPORT,
 } from "./templates.js";
+import { hasReactGrabSetupCode } from "./react-grab-code.js";
 
 export interface TransformResult {
   success: boolean;
@@ -26,26 +27,18 @@ export interface ReactGrabOptions {
   maxContextLines?: number;
 }
 
-const hasReactGrabCode = (content: string): boolean => {
-  const fuzzyPatterns = [
-    /["'`][^"'`]*react-grab/,
-    /react-grab[^"'`]*["'`]/,
-    /<[^>]*react-grab/i,
-    /import[^;]*react-grab/i,
-    /require[^)]*react-grab/i,
-    /from\s+[^;]*react-grab/i,
-    /src[^>]*react-grab/i,
-    /href[^>]*react-grab/i,
-  ];
-  return fuzzyPatterns.some((pattern) => pattern.test(content));
-};
+const hasReactGrabCode = hasReactGrabSetupCode;
 
 const findLayoutFile = (projectRoot: string): string | null => {
   const possiblePaths = [
     join(projectRoot, "app", "layout.tsx"),
     join(projectRoot, "app", "layout.jsx"),
+    join(projectRoot, "app", "layout.ts"),
+    join(projectRoot, "app", "layout.js"),
     join(projectRoot, "src", "app", "layout.tsx"),
     join(projectRoot, "src", "app", "layout.jsx"),
+    join(projectRoot, "src", "app", "layout.ts"),
+    join(projectRoot, "src", "app", "layout.js"),
   ];
 
   for (const filePath of possiblePaths) {
@@ -60,9 +53,13 @@ const findLayoutFile = (projectRoot: string): string | null => {
 const findInstrumentationFile = (projectRoot: string): string | null => {
   const possiblePaths = [
     join(projectRoot, "instrumentation-client.ts"),
+    join(projectRoot, "instrumentation-client.tsx"),
     join(projectRoot, "instrumentation-client.js"),
+    join(projectRoot, "instrumentation-client.jsx"),
     join(projectRoot, "src", "instrumentation-client.ts"),
+    join(projectRoot, "src", "instrumentation-client.tsx"),
     join(projectRoot, "src", "instrumentation-client.js"),
+    join(projectRoot, "src", "instrumentation-client.jsx"),
   ];
 
   for (const filePath of possiblePaths) {
@@ -73,6 +70,9 @@ const findInstrumentationFile = (projectRoot: string): string | null => {
 
   return null;
 };
+
+const isInstrumentationFile = (filePath: string): boolean =>
+  /(?:^|[/\\])instrumentation-client\.[cm]?[jt]sx?$/.test(filePath);
 
 const hasReactGrabInInstrumentation = (projectRoot: string): boolean => {
   const instrumentationPath = findInstrumentationFile(projectRoot);
@@ -86,8 +86,12 @@ const findDocumentFile = (projectRoot: string): string | null => {
   const possiblePaths = [
     join(projectRoot, "pages", "_document.tsx"),
     join(projectRoot, "pages", "_document.jsx"),
+    join(projectRoot, "pages", "_document.ts"),
+    join(projectRoot, "pages", "_document.js"),
     join(projectRoot, "src", "pages", "_document.tsx"),
     join(projectRoot, "src", "pages", "_document.jsx"),
+    join(projectRoot, "src", "pages", "_document.ts"),
+    join(projectRoot, "src", "pages", "_document.js"),
   ];
 
   for (const filePath of possiblePaths) {
@@ -162,7 +166,7 @@ const alreadyConfiguredResult = (filePath: string): TransformResult => ({
 const transformNextAppRouter = (
   projectRoot: string,
   reactGrabAlreadyConfigured: boolean,
-  force: boolean = false,
+  _force: boolean = false,
 ): TransformResult => {
   const layoutPath = findLayoutFile(projectRoot);
 
@@ -170,7 +174,7 @@ const transformNextAppRouter = (
     return {
       success: false,
       filePath: "",
-      message: "Could not find app/layout.tsx or app/layout.jsx",
+      message: "Could not find app/layout.tsx, app/layout.jsx, app/layout.ts, or app/layout.js",
     };
   }
 
@@ -179,11 +183,11 @@ const transformNextAppRouter = (
   const hasReactGrabInFile = hasReactGrabCode(originalContent);
   const hasReactGrabInInstrumentationFile = hasReactGrabInInstrumentation(projectRoot);
 
-  if (!force && hasReactGrabInFile && reactGrabAlreadyConfigured) {
+  if (hasReactGrabInFile && reactGrabAlreadyConfigured) {
     return alreadyConfiguredResult(layoutPath);
   }
 
-  if (!force && (hasReactGrabInFile || hasReactGrabInInstrumentationFile)) {
+  if (hasReactGrabInFile || hasReactGrabInInstrumentationFile) {
     return {
       success: true,
       filePath: layoutPath,
@@ -231,7 +235,7 @@ const transformNextAppRouter = (
 const transformNextPagesRouter = (
   projectRoot: string,
   reactGrabAlreadyConfigured: boolean,
-  force: boolean = false,
+  _force: boolean = false,
 ): TransformResult => {
   const documentPath = findDocumentFile(projectRoot);
 
@@ -240,7 +244,7 @@ const transformNextPagesRouter = (
       success: false,
       filePath: "",
       message:
-        "Could not find pages/_document.tsx or pages/_document.jsx.\n\n" +
+        "Could not find pages/_document.tsx, pages/_document.jsx, pages/_document.ts, or pages/_document.js.\n\n" +
         "To set up React Grab with Pages Router, create pages/_document.tsx with:\n\n" +
         '  import { Html, Head, Main, NextScript } from "next/document";\n' +
         '  import Script from "next/script";\n\n' +
@@ -267,11 +271,11 @@ const transformNextPagesRouter = (
   const hasReactGrabInFile = hasReactGrabCode(originalContent);
   const hasReactGrabInInstrumentationFile = hasReactGrabInInstrumentation(projectRoot);
 
-  if (!force && hasReactGrabInFile && reactGrabAlreadyConfigured) {
+  if (hasReactGrabInFile && reactGrabAlreadyConfigured) {
     return alreadyConfiguredResult(documentPath);
   }
 
-  if (!force && (hasReactGrabInFile || hasReactGrabInInstrumentationFile)) {
+  if (hasReactGrabInFile || hasReactGrabInInstrumentationFile) {
     return {
       success: true,
       filePath: documentPath,
@@ -326,16 +330,14 @@ const checkExistingInstallation = (
 const transformVite = (
   projectRoot: string,
   reactGrabAlreadyConfigured: boolean,
-  force: boolean = false,
+  _force: boolean = false,
 ): TransformResult => {
   const entryPath = findEntryFile(projectRoot);
 
-  if (!force) {
-    const indexPath = findIndexHtml(projectRoot);
-    if (indexPath) {
-      const existingResult = checkExistingInstallation(indexPath, reactGrabAlreadyConfigured);
-      if (existingResult) return existingResult;
-    }
+  const indexPath = findIndexHtml(projectRoot);
+  if (indexPath) {
+    const existingResult = checkExistingInstallation(indexPath, reactGrabAlreadyConfigured);
+    if (existingResult) return existingResult;
   }
 
   if (!entryPath) {
@@ -346,10 +348,8 @@ const transformVite = (
     };
   }
 
-  if (!force) {
-    const existingResult = checkExistingInstallation(entryPath, reactGrabAlreadyConfigured);
-    if (existingResult) return existingResult;
-  }
+  const existingResult = checkExistingInstallation(entryPath, reactGrabAlreadyConfigured);
+  if (existingResult) return existingResult;
 
   const originalContent = readFileSync(entryPath, "utf-8");
   const newContent = `${VITE_IMPORT}\n\n${originalContent}`;
@@ -366,7 +366,7 @@ const transformVite = (
 const transformWebpack = (
   projectRoot: string,
   reactGrabAlreadyConfigured: boolean,
-  force: boolean = false,
+  _force: boolean = false,
 ): TransformResult => {
   const entryPath = findEntryFile(projectRoot);
 
@@ -378,10 +378,8 @@ const transformWebpack = (
     };
   }
 
-  if (!force) {
-    const existingResult = checkExistingInstallation(entryPath, reactGrabAlreadyConfigured);
-    if (existingResult) return existingResult;
-  }
+  const existingResult = checkExistingInstallation(entryPath, reactGrabAlreadyConfigured);
+  if (existingResult) return existingResult;
 
   const originalContent = readFileSync(entryPath, "utf-8");
   const newContent = `${WEBPACK_IMPORT}\n\n${originalContent}`;
@@ -398,7 +396,7 @@ const transformWebpack = (
 const transformTanStack = (
   projectRoot: string,
   reactGrabAlreadyConfigured: boolean,
-  force: boolean = false,
+  _force: boolean = false,
 ): TransformResult => {
   const rootPath = findTanStackRootFile(projectRoot);
 
@@ -422,11 +420,11 @@ const transformTanStack = (
   let newContent = originalContent;
   const hasReactGrabInFile = hasReactGrabCode(originalContent);
 
-  if (!force && hasReactGrabInFile && reactGrabAlreadyConfigured) {
+  if (hasReactGrabInFile && reactGrabAlreadyConfigured) {
     return alreadyConfiguredResult(rootPath);
   }
 
-  if (!force && hasReactGrabInFile) {
+  if (hasReactGrabInFile) {
     return {
       success: true,
       filePath: rootPath,
@@ -625,11 +623,20 @@ const findReactGrabFile = (
   nextRouterType: NextRouterType,
 ): string | null => {
   switch (framework) {
-    case "next":
-      if (nextRouterType === "app") {
-        return findLayoutFile(projectRoot);
+    case "next": {
+      const primaryFile =
+        nextRouterType === "app" ? findLayoutFile(projectRoot) : findDocumentFile(projectRoot);
+      if (primaryFile && hasReactGrabCode(readFileSync(primaryFile, "utf-8"))) {
+        return primaryFile;
       }
-      return findDocumentFile(projectRoot);
+
+      const instrumentationFile = findInstrumentationFile(projectRoot);
+      if (instrumentationFile && hasReactGrabCode(readFileSync(instrumentationFile, "utf-8"))) {
+        return instrumentationFile;
+      }
+
+      return primaryFile;
+    }
     case "vite": {
       const entryFile = findEntryFile(projectRoot);
       if (entryFile && hasReactGrabCode(readFileSync(entryFile, "utf-8"))) {
@@ -699,7 +706,7 @@ const addOptionsToDynamicImport = (
   filePath: string,
 ): TransformResult => {
   const reactGrabImportWithInitMatch = originalContent.match(
-    /import\s*\(\s*["']react-grab["']\s*\)(?:\.then\s*\(\s*\(m\)\s*=>\s*m\.init\s*\([^)]*\)\s*\))?/,
+    /(?:void\s+)?import\s*\(\s*["']react-grab["']\s*\)(?:\.then\s*\(\s*\(m\)\s*=>\s*m\.init\s*\([^)]*\)\s*\))?/,
   );
 
   if (!reactGrabImportWithInitMatch) {
@@ -755,6 +762,16 @@ const addOptionsToTanStackImport = (
   };
 };
 
+const addOptionsToAnyImport = (
+  originalContent: string,
+  options: ReactGrabOptions,
+  filePath: string,
+): TransformResult => {
+  const dynamicImportResult = addOptionsToDynamicImport(originalContent, options, filePath);
+  if (dynamicImportResult.success) return dynamicImportResult;
+  return addOptionsToTanStackImport(originalContent, options, filePath);
+};
+
 export const previewOptionsTransform = (
   projectRoot: string,
   framework: Framework,
@@ -783,6 +800,9 @@ export const previewOptionsTransform = (
 
   switch (framework) {
     case "next":
+      if (isInstrumentationFile(filePath)) {
+        return addOptionsToAnyImport(originalContent, options, filePath);
+      }
       return addOptionsToNextScript(originalContent, options, filePath);
     case "vite":
       return addOptionsToDynamicImport(originalContent, options, filePath);

--- a/packages/cli/src/utils/transform.ts
+++ b/packages/cli/src/utils/transform.ts
@@ -1,4 +1,4 @@
-import { accessSync, constants, readFileSync, writeFileSync } from "node:fs";
+import { accessSync, constants, existsSync, readFileSync, writeFileSync } from "node:fs";
 import type { Framework, NextRouterType } from "./detect.js";
 import {
   NEXT_APP_ROUTER_SCRIPT,
@@ -15,6 +15,12 @@ import {
   findInstrumentationFile,
   findLayoutFile,
   findTanStackRootFile,
+  getDocumentFileCandidates,
+  getEntryFileCandidates,
+  getIndexHtmlCandidates,
+  getInstrumentationFileCandidates,
+  getLayoutFileCandidates,
+  getTanStackRootFileCandidates,
   isInstrumentationFile,
 } from "./react-grab-setup-files.js";
 
@@ -498,6 +504,14 @@ const formatOptionsAsJson = (options: ReactGrabOptions): string => {
   return JSON.stringify(cleanOptions);
 };
 
+const findFileWithReactGrabSetup = (fileCandidates: string[]): string | null => {
+  for (const filePath of fileCandidates) {
+    if (!existsSync(filePath)) continue;
+    if (hasReactGrabSetupCode(readFileSync(filePath, "utf-8"))) return filePath;
+  }
+  return null;
+};
+
 const findReactGrabFile = (
   projectRoot: string,
   framework: Framework,
@@ -507,35 +521,38 @@ const findReactGrabFile = (
     case "next": {
       const primaryFile =
         nextRouterType === "app" ? findLayoutFile(projectRoot) : findDocumentFile(projectRoot);
-      if (primaryFile && hasReactGrabSetupCode(readFileSync(primaryFile, "utf-8"))) {
-        return primaryFile;
-      }
+      const primaryCandidates =
+        nextRouterType === "app"
+          ? getLayoutFileCandidates(projectRoot)
+          : getDocumentFileCandidates(projectRoot);
+      const primarySetupFile = findFileWithReactGrabSetup(primaryCandidates);
+      if (primarySetupFile) return primarySetupFile;
 
-      const instrumentationFile = findInstrumentationFile(projectRoot);
-      if (
-        instrumentationFile &&
-        hasReactGrabSetupCode(readFileSync(instrumentationFile, "utf-8"))
-      ) {
-        return instrumentationFile;
-      }
+      const instrumentationFile = findFileWithReactGrabSetup(
+        getInstrumentationFileCandidates(projectRoot),
+      );
+      if (instrumentationFile) return instrumentationFile;
 
       return primaryFile;
     }
     case "vite": {
       const entryFile = findEntryFile(projectRoot);
-      if (entryFile && hasReactGrabSetupCode(readFileSync(entryFile, "utf-8"))) {
-        return entryFile;
-      }
-      const indexHtml = findIndexHtml(projectRoot);
-      if (indexHtml && hasReactGrabSetupCode(readFileSync(indexHtml, "utf-8"))) {
-        return indexHtml;
-      }
+      const entrySetupFile = findFileWithReactGrabSetup(getEntryFileCandidates(projectRoot));
+      if (entrySetupFile) return entrySetupFile;
+
+      const indexHtml = findFileWithReactGrabSetup(getIndexHtmlCandidates(projectRoot));
+      if (indexHtml) return indexHtml;
+
       return entryFile;
     }
-    case "tanstack":
-      return findTanStackRootFile(projectRoot);
-    case "webpack":
-      return findEntryFile(projectRoot);
+    case "tanstack": {
+      const rootSetupFile = findFileWithReactGrabSetup(getTanStackRootFileCandidates(projectRoot));
+      return rootSetupFile ?? findTanStackRootFile(projectRoot);
+    }
+    case "webpack": {
+      const entrySetupFile = findFileWithReactGrabSetup(getEntryFileCandidates(projectRoot));
+      return entrySetupFile ?? findEntryFile(projectRoot);
+    }
     default:
       return null;
   }
@@ -590,7 +607,7 @@ const addOptionsToDynamicImport = (
   filePath: string,
 ): TransformResult => {
   const reactGrabImportWithInitMatch = originalContent.match(
-    /(void\s+)?import\s*\(\s*["']react-grab["']\s*\)(?:\.then\s*\(\s*\(m\)\s*=>\s*m\.init\s*\([^)]*\)\s*\))?/,
+    /(void\s+)?import\s*\(\s*["']react-grab(?:\/[^"']+)?["']\s*\)(?:\.then\s*\(\s*\(m\)\s*=>\s*m\.init\s*\([^)]*\)\s*\))?/,
   );
 
   if (!reactGrabImportWithInitMatch) {
@@ -622,7 +639,7 @@ const addOptionsToTanStackImport = (
   filePath: string,
 ): TransformResult => {
   const reactGrabImportWithInitMatch = originalContent.match(
-    /(?:(void\s+)?import\s*\(\s*["']react-grab["']\s*\)|(void\s+)?import\s*\(\s*["']react-grab\/core["']\s*\)\.then\s*\(\s*\(\s*\{\s*init\s*\}\s*\)\s*=>\s*init\s*\([^)]*\)\s*\))/,
+    /(?:(void\s+)?import\s*\(\s*["']react-grab\/core["']\s*\)\.then\s*\(\s*\(\s*\{\s*init\s*\}\s*\)\s*=>\s*init\s*\([^)]*\)\s*\)|(void\s+)?import\s*\(\s*["']react-grab(?:\/[^"']+)?["']\s*\))/,
   );
 
   if (!reactGrabImportWithInitMatch) {

--- a/packages/cli/test/configure.test.ts
+++ b/packages/cli/test/configure.test.ts
@@ -274,7 +274,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return <html><body>{children}</body></html>;
 }`;
     const instrumentationWithReactGrab = `if (process.env.NODE_ENV === "development") {
-  import("react-grab");
+  void import("react-grab");
 }`;
 
     mockExistsSync.mockImplementation((path) => {
@@ -294,7 +294,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
     expect(result.success).toBe(true);
     expect(result.filePath).toContain("instrumentation-client.ts");
-    expect(result.newContent).toContain(".then((m) => m.init(");
+    expect(result.newContent).toContain('void import("react-grab").then((m) => m.init(');
     expect(result.newContent).toContain('"activationKey":"Meta+K"');
   });
 });
@@ -496,6 +496,39 @@ import ReactDOM from "react-dom/client";`;
     expect(result.newContent).toContain('"keyHoldDuration":300');
     expect(result.newContent).toContain('"allowActivationInsideInput":true');
     expect(result.newContent).toContain('"maxContextLines":7');
+  });
+});
+
+describe("previewOptionsTransform - TanStack Start", () => {
+  it("should preserve void when adding options to React Grab import", () => {
+    const rootWithReactGrab = `import { useEffect } from "react";
+import { Outlet, createRootRoute } from "@tanstack/react-router";
+
+export const Route = createRootRoute({ component: RootComponent });
+
+function RootComponent() {
+  useEffect(() => {
+    if (import.meta.env.DEV) {
+      void import("react-grab");
+    }
+  }, []);
+
+  return <Outlet />;
+}`;
+
+    mockExistsSync.mockImplementation((path) => String(path).endsWith("__root.tsx"));
+    mockReadFileSync.mockReturnValue(rootWithReactGrab);
+
+    const options: ReactGrabOptions = {
+      activationKey: "Meta+K",
+    };
+
+    const result = previewOptionsTransform("/test", "tanstack", "unknown", options);
+
+    expect(result.success).toBe(true);
+    expect(result.newContent).toContain(
+      'void import("react-grab/core").then(({ init }) => init({"activationKey":"Meta+K"}))',
+    );
   });
 });
 

--- a/packages/cli/test/configure.test.ts
+++ b/packages/cli/test/configure.test.ts
@@ -425,6 +425,31 @@ import ReactDOM from "react-dom/client";`;
     expect(initCount).toBe(1);
   });
 
+  it("should replace subpath import with existing callback without double-chaining", () => {
+    const entryWithSubpathInit = `if (import.meta.env.DEV) {
+  import("react-grab/dist/index.global.js").then(({ init }) => init({"activationKey":"g"}));
+}
+
+import React from "react";
+import ReactDOM from "react-dom/client";`;
+
+    mockExistsSync.mockImplementation((path) => String(path).endsWith("main.tsx"));
+    mockReadFileSync.mockReturnValue(entryWithSubpathInit);
+
+    const options: ReactGrabOptions = {
+      activationKey: "Meta+K",
+    };
+
+    const result = previewOptionsTransform("/test", "vite", "unknown", options);
+
+    expect(result.success).toBe(true);
+    expect(result.newContent).toContain(
+      'import("react-grab").then((m) => m.init({"activationKey":"Meta+K"}))',
+    );
+    const initCount = (result.newContent!.match(/\.then\(/g) || []).length;
+    expect(initCount).toBe(1);
+  });
+
   it("should add multiple options to Vite import", () => {
     mockExistsSync.mockImplementation((path) => String(path).endsWith("main.tsx"));
     mockReadFileSync.mockReturnValue(entryWithReactGrab);
@@ -591,6 +616,39 @@ function RootComponent() {
     expect(result.newContent).toContain(
       'void import("react-grab/core").then(({ init }) => init({"activationKey":"Meta+K"}))',
     );
+  });
+
+  it("should replace existing core init callback without double-chaining", () => {
+    const rootWithReactGrab = `import { useEffect } from "react";
+import { Outlet, createRootRoute } from "@tanstack/react-router";
+
+export const Route = createRootRoute({ component: RootComponent });
+
+function RootComponent() {
+  useEffect(() => {
+    if (import.meta.env.DEV) {
+      import("react-grab/core").then((m) => m.init({"activationKey":"g"}));
+    }
+  }, []);
+
+  return <Outlet />;
+}`;
+
+    mockExistsSync.mockImplementation((path) => String(path).endsWith("__root.tsx"));
+    mockReadFileSync.mockReturnValue(rootWithReactGrab);
+
+    const options: ReactGrabOptions = {
+      activationKey: "Meta+K",
+    };
+
+    const result = previewOptionsTransform("/test", "tanstack", "unknown", options);
+
+    expect(result.success).toBe(true);
+    expect(result.newContent).toContain(
+      'import("react-grab/core").then(({ init }) => init({"activationKey":"Meta+K"}))',
+    );
+    const initCount = (result.newContent!.match(/\.then\(/g) || []).length;
+    expect(initCount).toBe(1);
   });
 });
 

--- a/packages/cli/test/configure.test.ts
+++ b/packages/cli/test/configure.test.ts
@@ -268,6 +268,35 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     expect(result.success).toBe(false);
     expect(result.message).toContain("Could not find file");
   });
+
+  it("should configure options in instrumentation-client when layout is not wired", () => {
+    const layoutWithoutReactGrab = `export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return <html><body>{children}</body></html>;
+}`;
+    const instrumentationWithReactGrab = `if (process.env.NODE_ENV === "development") {
+  import("react-grab");
+}`;
+
+    mockExistsSync.mockImplementation((path) => {
+      const pathString = String(path);
+      return pathString.endsWith("layout.tsx") || pathString.endsWith("instrumentation-client.ts");
+    });
+    mockReadFileSync.mockImplementation((path) => {
+      if (String(path).endsWith("instrumentation-client.ts")) return instrumentationWithReactGrab;
+      return layoutWithoutReactGrab;
+    });
+
+    const options: ReactGrabOptions = {
+      activationKey: "Meta+K",
+    };
+
+    const result = previewOptionsTransform("/test", "next", "app", options);
+
+    expect(result.success).toBe(true);
+    expect(result.filePath).toContain("instrumentation-client.ts");
+    expect(result.newContent).toContain(".then((m) => m.init(");
+    expect(result.newContent).toContain('"activationKey":"Meta+K"');
+  });
 });
 
 describe("previewOptionsTransform - Next.js Pages Router", () => {

--- a/packages/cli/test/configure.test.ts
+++ b/packages/cli/test/configure.test.ts
@@ -297,6 +297,44 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     expect(result.newContent).toContain('void import("react-grab").then((m) => m.init(');
     expect(result.newContent).toContain('"activationKey":"Meta+K"');
   });
+
+  it("should configure options in the layout file that actually contains React Grab", () => {
+    const layoutWithoutReactGrab = `export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return <html><body>{children}</body></html>;
+}`;
+    const layoutWithReactGrab = `import Script from "next/script";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <head>
+        <Script src="//unpkg.com/react-grab/dist/index.global.js" />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}`;
+
+    mockExistsSync.mockImplementation((path) => {
+      const pathString = String(path);
+      return pathString.endsWith("app/layout.tsx") || pathString.endsWith("src/app/layout.tsx");
+    });
+    mockReadFileSync.mockImplementation((path) => {
+      if (String(path).includes("src/app/layout.tsx")) return layoutWithReactGrab;
+      return layoutWithoutReactGrab;
+    });
+
+    const options: ReactGrabOptions = {
+      activationKey: "Meta+K",
+    };
+
+    const result = previewOptionsTransform("/test", "next", "app", options);
+
+    expect(result.success).toBe(true);
+    expect(result.filePath).toContain("src/app/layout.tsx");
+    expect(result.newContent).toContain("data-options");
+    expect(result.newContent).toContain("Meta+K");
+  });
 });
 
 describe("previewOptionsTransform - Next.js Pages Router", () => {
@@ -403,6 +441,29 @@ import ReactDOM from "react-dom/client";`;
     expect(result.newContent).toContain('"activationKey":"Alt+E"');
     expect(result.newContent).toContain('"activationMode":"toggle"');
     expect(result.newContent).toContain('"maxContextLines":10');
+  });
+
+  it("should add options to Vite subpath import", () => {
+    const entryWithSubpathReactGrab = `if (import.meta.env.DEV) {
+  import("react-grab/dist/index.global.js");
+}
+
+import React from "react";
+import ReactDOM from "react-dom/client";`;
+
+    mockExistsSync.mockImplementation((path) => String(path).endsWith("main.tsx"));
+    mockReadFileSync.mockReturnValue(entryWithSubpathReactGrab);
+
+    const options: ReactGrabOptions = {
+      activationKey: "Meta+K",
+    };
+
+    const result = previewOptionsTransform("/test", "vite", "unknown", options);
+
+    expect(result.success).toBe(true);
+    expect(result.newContent).toContain(
+      'import("react-grab").then((m) => m.init({"activationKey":"Meta+K"}))',
+    );
   });
 
   it("should fail when React Grab import not found", () => {

--- a/packages/cli/test/configure.test.ts
+++ b/packages/cli/test/configure.test.ts
@@ -19,6 +19,7 @@ const mockExistsSync = vi.mocked(existsSync);
 const mockReadFileSync = vi.mocked(readFileSync);
 const mockWriteFileSync = vi.mocked(writeFileSync);
 const mockAccessSync = vi.mocked(accessSync);
+const toPosixPath = (path: unknown): string => String(path).replace(/\\/g, "/");
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -320,7 +321,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       return pathString.endsWith("app/layout.tsx") || pathString.endsWith("src/app/layout.tsx");
     });
     mockReadFileSync.mockImplementation((path) => {
-      if (String(path).includes("src/app/layout.tsx")) return layoutWithReactGrab;
+      if (toPosixPath(path).includes("src/app/layout.tsx")) return layoutWithReactGrab;
       return layoutWithoutReactGrab;
     });
 
@@ -331,7 +332,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     const result = previewOptionsTransform("/test", "next", "app", options);
 
     expect(result.success).toBe(true);
-    expect(result.filePath).toContain("src/app/layout.tsx");
+    expect(toPosixPath(result.filePath)).toContain("src/app/layout.tsx");
     expect(result.newContent).toContain("data-options");
     expect(result.newContent).toContain("Meta+K");
   });

--- a/packages/cli/test/configure.test.ts
+++ b/packages/cli/test/configure.test.ts
@@ -317,7 +317,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 }`;
 
     mockExistsSync.mockImplementation((path) => {
-      const pathString = String(path);
+      const pathString = toPosixPath(path);
       return pathString.endsWith("app/layout.tsx") || pathString.endsWith("src/app/layout.tsx");
     });
     mockReadFileSync.mockImplementation((path) => {

--- a/packages/cli/test/detect.test.ts
+++ b/packages/cli/test/detect.test.ts
@@ -7,6 +7,7 @@ import {
   detectReactGrab,
   detectReactGrabConfigured,
   detectUnsupportedFramework,
+  findReactProjects,
 } from "../src/utils/detect.js";
 
 vi.mock("node:fs", () => ({
@@ -305,6 +306,15 @@ describe("detectReactGrabConfigured", () => {
     expect(detectReactGrabConfigured("/test")).toBe(true);
   });
 
+  it("should detect react-grab setup in a JSX template literal script src", () => {
+    mockExistsSync.mockImplementation((path) => toPosixPath(path).endsWith("app/layout.tsx"));
+    mockReadFileSync.mockReturnValue(
+      "<Script src={`//unpkg.com/react-grab/dist/index.global.js`} />",
+    );
+
+    expect(detectReactGrabConfigured("/test")).toBe(true);
+  });
+
   it("should detect react-grab setup in a JavaScript Next.js app layout", () => {
     mockExistsSync.mockImplementation((path) => toPosixPath(path).endsWith("app/layout.js"));
     mockReadFileSync.mockReturnValue(
@@ -362,6 +372,24 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
     expect(detectReactGrabConfigured("/test")).toBe(false);
   });
+
+  it("should ignore inline type-only imports from react-grab", () => {
+    mockExistsSync.mockImplementation((path) => toPosixPath(path).endsWith("app/layout.tsx"));
+    mockReadFileSync.mockReturnValue(`import { type ReactGrabAPI } from "react-grab";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return <html><body>{children}</body></html>;
+}`);
+
+    expect(detectReactGrabConfigured("/test")).toBe(false);
+  });
+
+  it("should detect mixed runtime and inline type imports from react-grab", () => {
+    mockExistsSync.mockImplementation((path) => toPosixPath(path).endsWith("app/layout.tsx"));
+    mockReadFileSync.mockReturnValue('import { init, type ReactGrabAPI } from "react-grab";');
+
+    expect(detectReactGrabConfigured("/test")).toBe(true);
+  });
 });
 
 describe("detectMonorepo", () => {
@@ -372,6 +400,31 @@ describe("detectMonorepo", () => {
     mockReadFileSync.mockReturnValue("invalid");
 
     expect(detectMonorepo("/test")).toBe(false);
+  });
+});
+
+describe("findReactProjects", () => {
+  it("should use the enclosing monorepo root when called from a workspace package", () => {
+    mockExistsSync.mockImplementation((path) => {
+      const pathString = toPosixPath(path);
+      if (pathString === "/repo/pnpm-workspace.yaml") return true;
+      if (pathString === "/repo/package.json") return true;
+      if (pathString === "/repo/apps/web") return true;
+      if (pathString === "/repo/apps/web/package.json") return true;
+      return false;
+    });
+    mockReadFileSync.mockImplementation((path) => {
+      const pathString = toPosixPath(path);
+      if (pathString === "/repo/pnpm-workspace.yaml") return "packages:\n  - apps/web\n";
+      if (pathString === "/repo/apps/web/package.json") {
+        return JSON.stringify({ name: "web", dependencies: { react: "18.0.0", vite: "6.0.0" } });
+      }
+      return JSON.stringify({ private: true });
+    });
+
+    expect(findReactProjects("/repo/apps/web")).toEqual([
+      { name: "web", path: "/repo/apps/web", framework: "vite" },
+    ]);
   });
 });
 

--- a/packages/cli/test/detect.test.ts
+++ b/packages/cli/test/detect.test.ts
@@ -321,6 +321,17 @@ describe("detectReactGrabConfigured", () => {
     expect(detectReactGrabConfigured("/test")).toBe(true);
   });
 
+  it("should detect react-grab setup in module instrumentation files", () => {
+    mockExistsSync.mockImplementation((path) =>
+      toPosixPath(path).endsWith("instrumentation-client.mts"),
+    );
+    mockReadFileSync.mockReturnValue(
+      'if (process.env.NODE_ENV === "development") import("react-grab");',
+    );
+
+    expect(detectReactGrabConfigured("/test")).toBe(true);
+  });
+
   it("should ignore comments that mention react-grab", () => {
     mockExistsSync.mockImplementation((path) => toPosixPath(path).endsWith("app/layout.tsx"));
     mockReadFileSync.mockReturnValue(`const setupLater = true; // import("react-grab") later

--- a/packages/cli/test/detect.test.ts
+++ b/packages/cli/test/detect.test.ts
@@ -384,6 +384,17 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     expect(detectReactGrabConfigured("/test")).toBe(false);
   });
 
+  it("should ignore trailing-comma inline type-only imports from react-grab", () => {
+    mockExistsSync.mockImplementation((path) => toPosixPath(path).endsWith("app/layout.tsx"));
+    mockReadFileSync.mockReturnValue(`import { type ReactGrabAPI, } from "react-grab";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return <html><body>{children}</body></html>;
+}`);
+
+    expect(detectReactGrabConfigured("/test")).toBe(false);
+  });
+
   it("should detect mixed runtime and inline type imports from react-grab", () => {
     mockExistsSync.mockImplementation((path) => toPosixPath(path).endsWith("app/layout.tsx"));
     mockReadFileSync.mockReturnValue('import { init, type ReactGrabAPI } from "react-grab";');
@@ -428,6 +439,42 @@ describe("findReactProjects", () => {
         path: toPosixPath(project.path),
       })),
     ).toEqual([{ name: "web", path: "/repo/apps/web", framework: "vite" }]);
+  });
+
+  it("should include a local React project that is not listed in the enclosing workspace", () => {
+    mockExistsSync.mockImplementation((path) => {
+      const pathString = toPosixPath(path);
+      if (pathString === "/repo/pnpm-workspace.yaml") return true;
+      if (pathString === "/repo/package.json") return true;
+      if (pathString === "/repo/apps/web") return true;
+      if (pathString === "/repo/apps/web/package.json") return true;
+      if (pathString === "/repo/examples/demo/package.json") return true;
+      return false;
+    });
+    mockReadFileSync.mockImplementation((path) => {
+      const pathString = toPosixPath(path);
+      if (pathString === "/repo/pnpm-workspace.yaml") return "packages:\n  - apps/web\n";
+      if (pathString === "/repo/apps/web/package.json") {
+        return JSON.stringify({ name: "web", dependencies: { react: "18.0.0", vite: "6.0.0" } });
+      }
+      if (pathString === "/repo/examples/demo/package.json") {
+        return JSON.stringify({
+          name: "demo",
+          dependencies: { react: "18.0.0", vite: "6.0.0" },
+        });
+      }
+      return JSON.stringify({ private: true });
+    });
+
+    expect(
+      findReactProjects("/repo/examples/demo").map((project) => ({
+        ...project,
+        path: toPosixPath(project.path),
+      })),
+    ).toEqual([
+      { name: "demo", path: "/repo/examples/demo", framework: "vite" },
+      { name: "web", path: "/repo/apps/web", framework: "vite" },
+    ]);
   });
 });
 

--- a/packages/cli/test/detect.test.ts
+++ b/packages/cli/test/detect.test.ts
@@ -305,11 +305,30 @@ describe("detectReactGrabConfigured", () => {
     expect(detectReactGrabConfigured("/test")).toBe(true);
   });
 
+  it("should detect react-grab setup in a JavaScript Next.js app layout", () => {
+    mockExistsSync.mockImplementation((path) => toPosixPath(path).endsWith("app/layout.js"));
+    mockReadFileSync.mockReturnValue(
+      '<Script src="//unpkg.com/react-grab/dist/index.global.js" />',
+    );
+
+    expect(detectReactGrabConfigured("/test")).toBe(true);
+  });
+
   it("should detect react-grab setup in a JavaScript entry import", () => {
     mockExistsSync.mockImplementation((path) => toPosixPath(path).endsWith("src/main.js"));
     mockReadFileSync.mockReturnValue('if (import.meta.env.DEV) import("react-grab");');
 
     expect(detectReactGrabConfigured("/test")).toBe(true);
+  });
+
+  it("should ignore comments that mention react-grab", () => {
+    mockExistsSync.mockImplementation((path) => toPosixPath(path).endsWith("app/layout.tsx"));
+    mockReadFileSync.mockReturnValue(`// import("react-grab") later
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return <html><body>{children}</body></html>;
+}`);
+
+    expect(detectReactGrabConfigured("/test")).toBe(false);
   });
 });
 
@@ -435,6 +454,7 @@ describe("detectProject", () => {
     const project = await detectProject("/repo/apps/web");
 
     expect(project.framework).toBe("vite");
+    expect(project.isMonorepo).toBe(true);
     expect(project.projectRoot).toBe("/repo/apps/web");
   });
 
@@ -508,7 +528,7 @@ describe("detectProject", () => {
     const project = await detectProject("/repo/apps/web");
 
     expect(project.framework).toBe("unknown");
-    expect(project.isMonorepo).toBe(false);
+    expect(project.isMonorepo).toBe(true);
   });
 
   it("should resolve framework from local config file before falling back to monorepo root", async () => {

--- a/packages/cli/test/detect.test.ts
+++ b/packages/cli/test/detect.test.ts
@@ -331,6 +331,17 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
     expect(detectReactGrabConfigured("/test")).toBe(false);
   });
+
+  it("should ignore type-only imports from react-grab", () => {
+    mockExistsSync.mockImplementation((path) => toPosixPath(path).endsWith("app/layout.tsx"));
+    mockReadFileSync.mockReturnValue(`import type { ReactGrabAPI } from "react-grab";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return <html><body>{children}</body></html>;
+}`);
+
+    expect(detectReactGrabConfigured("/test")).toBe(false);
+  });
 });
 
 describe("detectMonorepo", () => {

--- a/packages/cli/test/detect.test.ts
+++ b/packages/cli/test/detect.test.ts
@@ -5,6 +5,7 @@ import {
   detectNextRouterType,
   detectProject,
   detectReactGrab,
+  detectReactGrabConfigured,
   detectUnsupportedFramework,
 } from "../src/utils/detect.js";
 
@@ -287,6 +288,31 @@ describe("detectReactGrab", () => {
   });
 });
 
+describe("detectReactGrabConfigured", () => {
+  it("should return false when react-grab only exists in dependencies", () => {
+    mockExistsSync.mockImplementation((path) => toPosixPath(path).endsWith("package.json"));
+    mockReadFileSync.mockReturnValue(JSON.stringify({ dependencies: { "react-grab": "1.0.0" } }));
+
+    expect(detectReactGrabConfigured("/test")).toBe(false);
+  });
+
+  it("should detect react-grab setup in a Next.js app layout", () => {
+    mockExistsSync.mockImplementation((path) => toPosixPath(path).endsWith("app/layout.tsx"));
+    mockReadFileSync.mockReturnValue(
+      '<Script src="//unpkg.com/react-grab/dist/index.global.js" />',
+    );
+
+    expect(detectReactGrabConfigured("/test")).toBe(true);
+  });
+
+  it("should detect react-grab setup in a JavaScript entry import", () => {
+    mockExistsSync.mockImplementation((path) => toPosixPath(path).endsWith("src/main.js"));
+    mockReadFileSync.mockReturnValue('if (import.meta.env.DEV) import("react-grab");');
+
+    expect(detectReactGrabConfigured("/test")).toBe(true);
+  });
+});
+
 describe("detectMonorepo", () => {
   it("should return false for malformed package.json", () => {
     mockExistsSync.mockImplementation((path) => {
@@ -353,6 +379,40 @@ describe("detectUnsupportedFramework", () => {
 });
 
 describe("detectProject", () => {
+  it("should distinguish an installed dependency from completed setup", async () => {
+    mockExistsSync.mockImplementation((path) => {
+      const pathString = toPosixPath(path);
+      return pathString === "/app/package.json";
+    });
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ dependencies: { next: "14.0.0", react: "18.0.0", "react-grab": "1.0.0" } }),
+    );
+
+    const project = await detectProject("/app");
+
+    expect(project.hasReactGrab).toBe(true);
+    expect(project.isReactGrabConfigured).toBe(false);
+  });
+
+  it("should mark setup complete when react-grab exists in a framework entry file", async () => {
+    mockExistsSync.mockImplementation((path) => {
+      const pathString = toPosixPath(path);
+      return pathString === "/app/package.json" || pathString === "/app/src/main.tsx";
+    });
+    mockReadFileSync.mockImplementation((path) => {
+      const pathString = toPosixPath(path);
+      if (pathString === "/app/package.json") {
+        return JSON.stringify({ dependencies: { react: "18.0.0", vite: "6.0.0" } });
+      }
+      return 'if (import.meta.env.DEV) import("react-grab");';
+    });
+
+    const project = await detectProject("/app");
+
+    expect(project.hasReactGrab).toBe(true);
+    expect(project.isReactGrabConfigured).toBe(true);
+  });
+
   it("should fall back to monorepo root framework when subpackage has hoisted deps", async () => {
     mockExistsSync.mockImplementation((path) => {
       const pathString = toPosixPath(path);

--- a/packages/cli/test/detect.test.ts
+++ b/packages/cli/test/detect.test.ts
@@ -321,6 +321,15 @@ describe("detectReactGrabConfigured", () => {
     expect(detectReactGrabConfigured("/test")).toBe(true);
   });
 
+  it("should detect react-grab setup in subpath imports", () => {
+    mockExistsSync.mockImplementation((path) => toPosixPath(path).endsWith("src/main.ts"));
+    mockReadFileSync.mockReturnValue(
+      'if (import.meta.env.DEV) import("react-grab/dist/index.global.js");',
+    );
+
+    expect(detectReactGrabConfigured("/test")).toBe(true);
+  });
+
   it("should detect react-grab setup in module instrumentation files", () => {
     mockExistsSync.mockImplementation((path) =>
       toPosixPath(path).endsWith("instrumentation-client.mts"),

--- a/packages/cli/test/detect.test.ts
+++ b/packages/cli/test/detect.test.ts
@@ -422,9 +422,12 @@ describe("findReactProjects", () => {
       return JSON.stringify({ private: true });
     });
 
-    expect(findReactProjects("/repo/apps/web")).toEqual([
-      { name: "web", path: "/repo/apps/web", framework: "vite" },
-    ]);
+    expect(
+      findReactProjects("/repo/apps/web").map((project) => ({
+        ...project,
+        path: toPosixPath(project.path),
+      })),
+    ).toEqual([{ name: "web", path: "/repo/apps/web", framework: "vite" }]);
   });
 });
 

--- a/packages/cli/test/detect.test.ts
+++ b/packages/cli/test/detect.test.ts
@@ -323,7 +323,8 @@ describe("detectReactGrabConfigured", () => {
 
   it("should ignore comments that mention react-grab", () => {
     mockExistsSync.mockImplementation((path) => toPosixPath(path).endsWith("app/layout.tsx"));
-    mockReadFileSync.mockReturnValue(`// import("react-grab") later
+    mockReadFileSync.mockReturnValue(`const setupLater = true; // import("react-grab") later
+// import("react-grab") later
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return <html><body>{children}</body></html>;
 }`);

--- a/packages/cli/test/transform.test.ts
+++ b/packages/cli/test/transform.test.ts
@@ -135,7 +135,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     expect(result.noChanges).toBe(true);
   });
 
-  it("should not duplicate existing setup when force is enabled", () => {
+  it("should not duplicate existing setup when already configured", () => {
     const layoutWithReactGrab = `import Script from "next/script";
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -152,7 +152,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     mockExistsSync.mockImplementation((path) => String(path).endsWith("layout.tsx"));
     mockReadFileSync.mockReturnValue(layoutWithReactGrab);
 
-    const result = previewTransform("/test", "next", "app", true, true);
+    const result = previewTransform("/test", "next", "app", true);
 
     expect(result.success).toBe(true);
     expect(result.noChanges).toBe(true);

--- a/packages/cli/test/transform.test.ts
+++ b/packages/cli/test/transform.test.ts
@@ -159,6 +159,31 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     expect(result.newContent).toBeUndefined();
   });
 
+  it("should not duplicate when setup exists in a later instrumentation candidate", () => {
+    mockExistsSync.mockImplementation((path) => {
+      const pathString = String(path).replace(/\\/g, "/");
+      return (
+        pathString.endsWith("layout.tsx") ||
+        pathString.endsWith("instrumentation-client.ts") ||
+        pathString.endsWith("src/instrumentation-client.ts")
+      );
+    });
+    mockReadFileSync.mockImplementation((path) => {
+      const pathString = String(path).replace(/\\/g, "/");
+      if (pathString.endsWith("src/instrumentation-client.ts")) {
+        return 'if (process.env.NODE_ENV === "development") import("react-grab");';
+      }
+      if (pathString.endsWith("instrumentation-client.ts")) return "";
+      return layoutContent;
+    });
+
+    const result = previewTransform("/test", "next", "app", true);
+
+    expect(result.success).toBe(true);
+    expect(result.noChanges).toBe(true);
+    expect(result.newContent).toBeUndefined();
+  });
+
   it("should fail when layout file not found", () => {
     mockExistsSync.mockReturnValue(false);
 

--- a/packages/cli/test/transform.test.ts
+++ b/packages/cli/test/transform.test.ts
@@ -50,6 +50,11 @@ describe("hasFrameworkEntryPoint", () => {
     expect(hasFrameworkEntryPoint("/app", "next", "app")).toBe(true);
   });
 
+  it("returns true for Next.js App Router when a JavaScript layout exists", () => {
+    mockExistsSync.mockImplementation((path) => pathEndsWith(path, "app/layout.js"));
+    expect(hasFrameworkEntryPoint("/app", "next", "app")).toBe(true);
+  });
+
   it("returns false for Next.js App Router when only _document exists (matches transform)", () => {
     mockExistsSync.mockImplementation((path) => pathEndsWith(path, "pages/_document.tsx"));
     expect(hasFrameworkEntryPoint("/app", "next", "app")).toBe(false);
@@ -128,6 +133,30 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
     expect(result.success).toBe(true);
     expect(result.noChanges).toBe(true);
+  });
+
+  it("should not duplicate existing setup when force is enabled", () => {
+    const layoutWithReactGrab = `import Script from "next/script";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <head>
+        <Script src="//unpkg.com/react-grab/dist/index.global.js" />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}`;
+
+    mockExistsSync.mockImplementation((path) => String(path).endsWith("layout.tsx"));
+    mockReadFileSync.mockReturnValue(layoutWithReactGrab);
+
+    const result = previewTransform("/test", "next", "app", true, true);
+
+    expect(result.success).toBe(true);
+    expect(result.noChanges).toBe(true);
+    expect(result.newContent).toBeUndefined();
   });
 
   it("should fail when layout file not found", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Distinguish dependency presence from actual React Grab setup in CLI project detection.
- Make `init` only short-circuit when React Grab is configured in a layout/document/entry/instrumentation file.
- Expand configured-file detection to cover `src/pages/_document` and `.js/.jsx` entry files, with regression tests.

## Verification
- `pnpm dlx --package @antfu/ni nr build`
- `pnpm dlx --package @antfu/ni nr test:cli`
- `pnpm dlx --package @antfu/ni nr format`
- `pnpm dlx --package @antfu/ni nr lint`
- `pnpm dlx --package @antfu/ni nr typecheck`
- `pnpm dlx --package @antfu/ni nr test` (passed after installing Playwright Chromium; 2 flaky tests reported and retried successfully)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-665674c4-6289-4b18-8c04-3a35c984ab79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-665674c4-6289-4b18-8c04-3a35c984ab79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CLI init/setup checks so `init` only exits when a real `react-grab` setup is present, strengthens detection across files/import styles, and updates transforms to avoid duplicates and place options in the right file per framework.

- **Bug Fixes**
  - Added `isReactGrabConfigured`; `configure` now errors when setup is missing with a prompt to run `react-grab init`. `init` only short-circuits when setup exists; `--force` re-runs setup checks. Success message reflects when no layout changes were needed.
  - Hardened detection via shared helpers: strip comments, ignore type-only imports; match dynamic/static imports (incl. subpaths and `react-grab/core`), `require`, and `<Script>/<script>` (incl. template literals).
  - Broadened coverage: scan Next `layout`/`_document` (`.ts/.js/.tsx/.jsx`), instrumentation files (`.ts/.js/.tsx/.jsx/.mts/.cts/.mjs/.cjs`) including all `instrumentation-client*` candidates, entry files, `index.html`, and TanStack `__root`. Option injection targets the file that actually contains `react-grab`, preferring `instrumentation-client*` when layout isn’t wired.
  - Monorepo handling: `findReactProjects` uses the enclosing workspace root, includes the local project even if not listed, and marks `isMonorepo` for workspace packages.
  - Transform updates: remove force-based paths; avoid duplicating setup; preserve `void`; normalize subpath imports to `import("react-grab").then((m) => m.init(...))` (Vite) and `import("react-grab/core").then(({ init }) => init(...))` (TanStack), avoiding double-chaining. Tests expanded and Windows path detection tests fixed.

<sup>Written for commit 1b6ac7dabbbfde0a0818f0184b6c388b75f23536. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

