### PR TITLE
Handle unit values in style input

### DIFF
--- a/packages/react-grab/e2e/edit-panel.spec.ts
+++ b/packages/react-grab/e2e/edit-panel.spec.ts
@@ -804,6 +804,19 @@ test.describe("Style Panel", () => {
       expect(await getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "padding-right")).toBe(
         "50px",
       );
+
+      await reactGrab.page.waitForTimeout(IDLE_BUFFER_MS);
+      await reactGrab.page.keyboard.type("60px");
+      await reactGrab.page.waitForTimeout(80);
+
+      expect(await getEditPanelCompactAttr(reactGrab.page)).toBe("true");
+      expect(await getActivePropertyKey(reactGrab.page)).toBe(activePropertyKey);
+      expect(await getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "padding-left")).toBe(
+        "60px",
+      );
+      expect(await getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "padding-right")).toBe(
+        "60px",
+      );
     });
 
     test("compact unit edit keeps a searched active property targeted", async ({ reactGrab }) => {

--- a/packages/react-grab/e2e/edit-panel.spec.ts
+++ b/packages/react-grab/e2e/edit-panel.spec.ts
@@ -768,6 +768,26 @@ test.describe("Style Panel", () => {
       );
     });
 
+    test("compact inline numeric edit accepts matching CSS units", async ({ reactGrab }) => {
+      await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      await reactGrab.page.keyboard.press("ArrowRight");
+      await reactGrab.page.waitForTimeout(80);
+      const activePropertyKey = await getActivePropertyKey(reactGrab.page);
+      expect(activePropertyKey).toBe("padding-left,padding-right");
+
+      await reactGrab.page.keyboard.type("50px");
+      await reactGrab.page.waitForTimeout(80);
+
+      expect(await getEditPanelCompactAttr(reactGrab.page)).toBe("true");
+      expect(await getActivePropertyKey(reactGrab.page)).toBe(activePropertyKey);
+      expect(await getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "padding-left")).toBe(
+        "50px",
+      );
+      expect(await getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "padding-right")).toBe(
+        "50px",
+      );
+    });
+
     test("type-to-edit: hover + type m then t → margin-top focused", async ({ reactGrab }) => {
       await reactGrab.activate();
       await reactGrab.hoverElement(BUTTON_SELECTOR);

--- a/packages/react-grab/e2e/edit-panel.spec.ts
+++ b/packages/react-grab/e2e/edit-panel.spec.ts
@@ -806,7 +806,9 @@ test.describe("Style Panel", () => {
       );
 
       await reactGrab.page.waitForTimeout(IDLE_BUFFER_MS);
-      await reactGrab.page.keyboard.type("60px");
+      await reactGrab.page.keyboard.type("6");
+      await reactGrab.page.waitForTimeout(IDLE_BUFFER_MS);
+      await reactGrab.page.keyboard.type("0px");
       await reactGrab.page.waitForTimeout(80);
 
       expect(await getEditPanelCompactAttr(reactGrab.page)).toBe("true");

--- a/packages/react-grab/e2e/edit-panel.spec.ts
+++ b/packages/react-grab/e2e/edit-panel.spec.ts
@@ -786,6 +786,30 @@ test.describe("Style Panel", () => {
       );
     });
 
+    test("compact unitless replacement keeps paused second digits", async ({ reactGrab }) => {
+      await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      await reactGrab.page.keyboard.press("ArrowRight");
+      await reactGrab.page.waitForTimeout(80);
+      const activePropertyKey = await getActivePropertyKey(reactGrab.page);
+      expect(activePropertyKey).toBe("padding-left,padding-right");
+
+      await reactGrab.page.keyboard.type("24");
+      await reactGrab.page.waitForTimeout(IDLE_BUFFER_MS);
+      await reactGrab.page.keyboard.type("3");
+      await reactGrab.page.waitForTimeout(IDLE_BUFFER_MS);
+      await reactGrab.page.keyboard.type("6");
+      await reactGrab.page.waitForTimeout(80);
+
+      expect(await getEditPanelCompactAttr(reactGrab.page)).toBe("true");
+      expect(await getActivePropertyKey(reactGrab.page)).toBe(activePropertyKey);
+      expect(await getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "padding-left")).toBe(
+        "36px",
+      );
+      expect(await getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "padding-right")).toBe(
+        "36px",
+      );
+    });
+
     test("compact inline numeric edit accepts matching CSS units", async ({ reactGrab }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
       await reactGrab.page.keyboard.press("ArrowRight");

--- a/packages/react-grab/e2e/edit-panel.spec.ts
+++ b/packages/react-grab/e2e/edit-panel.spec.ts
@@ -740,6 +740,24 @@ test.describe("Style Panel", () => {
       expect(await isEditPanelCompact(reactGrab.page)).toBe(false);
     });
 
+    test("full search does not direct-apply unit values", async ({ reactGrab }) => {
+      await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      expect(await isEditPanelCompact(reactGrab.page)).toBe(false);
+      const paddingLeftBeforeTyping = await getInlineStyleProperty(
+        reactGrab.page,
+        BUTTON_SELECTOR,
+        "padding-left",
+      );
+
+      await reactGrab.page.keyboard.type("50px");
+      await reactGrab.page.waitForTimeout(80);
+
+      expect(await getEditPanelCompactAttr(reactGrab.page)).toBe("false");
+      expect(await getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "padding-left")).toBe(
+        paddingLeftBeforeTyping,
+      );
+    });
+
     test("compact inline numeric edit survives decimal drafts", async ({ reactGrab }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
       await reactGrab.page.keyboard.press("ArrowRight");

--- a/packages/react-grab/e2e/edit-panel.spec.ts
+++ b/packages/react-grab/e2e/edit-panel.spec.ts
@@ -806,6 +806,32 @@ test.describe("Style Panel", () => {
       );
     });
 
+    test("compact unit edit keeps a searched active property targeted", async ({ reactGrab }) => {
+      await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      await setSearchInputValue(reactGrab.page, "font size");
+      await expect.poll(() => getActivePropertyKey(reactGrab.page)).toBe("font-size");
+      const paddingLeftBeforeTyping = await getInlineStyleProperty(
+        reactGrab.page,
+        BUTTON_SELECTOR,
+        "padding-left",
+      );
+
+      await reactGrab.page.keyboard.press("ArrowRight");
+      await reactGrab.page.waitForTimeout(80);
+      expect(await getEditPanelCompactAttr(reactGrab.page)).toBe("true");
+      await setSearchInputValue(reactGrab.page, "50px");
+      await reactGrab.page.waitForTimeout(80);
+
+      expect(await getEditPanelCompactAttr(reactGrab.page)).toBe("true");
+      expect(await getActivePropertyKey(reactGrab.page)).toBe("font-size");
+      expect(await getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "font-size")).toBe(
+        "50px",
+      );
+      expect(await getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "padding-left")).toBe(
+        paddingLeftBeforeTyping,
+      );
+    });
+
     test("type-to-edit: hover + type m then t → margin-top focused", async ({ reactGrab }) => {
       await reactGrab.activate();
       await reactGrab.hoverElement(BUTTON_SELECTOR);

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -183,6 +183,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     clearTimeout(inlineNumericReplaceTimerId);
     inlineNumericReplaceTimerId = setTimeout(() => {
       shouldReplaceInlineNumericInput = true;
+      searchInputRef?.focus({ preventScroll: true });
     }, EDIT_INLINE_NUMERIC_REPLACE_IDLE_MS);
   };
 

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -601,8 +601,11 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
               value={searchQuery()}
               onInput={(event) => {
                 const nextSearchQuery = event.currentTarget.value;
+                if (autoApply.tryApplyNumericValue(nextSearchQuery)) {
+                  setSearchQuery(nextSearchQuery);
+                  return;
+                }
                 setSearchQuery(nextSearchQuery);
-                if (autoApply.tryApplyNumericValue(nextSearchQuery)) return;
                 if (autoApply.isInlineNumericDraft(nextSearchQuery)) return;
                 setActiveIndex(nextSearchQuery.trim() === "" ? firstNumericActiveIndex() : 0);
                 setIsCompact(false);

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -652,12 +652,14 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
                   keepInlineNumericSearchQuery();
                   setSearchQuery(nextSearchQuery);
                   queueInlineNumericReplacement();
+                  ensureSearchFocused();
                   return;
                 }
                 cancelInlineNumericReplacement();
                 setSearchQuery(nextSearchQuery);
                 if (autoApply.isInlineNumericDraft(nextSearchQuery)) {
                   keepInlineNumericSearchQuery();
+                  ensureSearchFocused();
                   return;
                 }
                 setInlineNumericSearchQuery(null);

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -90,8 +90,12 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
   const preview = props.state.preview;
 
   const [searchQuery, setSearchQuery] = createSignal(props.state.initialSearchQuery ?? "");
+  const [isInlineNumericSearchBypassed, setIsInlineNumericSearchBypassed] = createSignal(false);
   const [activeKey, setActiveKey] = createSignal<"left" | "right" | null>(null);
-  const tweakStore = createTweakStore({ initialProperties, searchQuery });
+  const tweakStore = createTweakStore({
+    initialProperties,
+    searchQuery: () => (isInlineNumericSearchBypassed() ? "" : searchQuery()),
+  });
   // Colors are pinned on top but aren't slider-steppable, so the arrow-key
   // cursor lands on the first numeric row instead.
   const firstNumericActiveIndex = (): number => {
@@ -602,11 +606,16 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
               onInput={(event) => {
                 const nextSearchQuery = event.currentTarget.value;
                 if (autoApply.tryApplyNumericValue(nextSearchQuery)) {
+                  setIsInlineNumericSearchBypassed(true);
                   setSearchQuery(nextSearchQuery);
                   return;
                 }
                 setSearchQuery(nextSearchQuery);
-                if (autoApply.isInlineNumericDraft(nextSearchQuery)) return;
+                if (autoApply.isInlineNumericDraft(nextSearchQuery)) {
+                  setIsInlineNumericSearchBypassed(true);
+                  return;
+                }
+                setIsInlineNumericSearchBypassed(false);
                 setActiveIndex(nextSearchQuery.trim() === "" ? firstNumericActiveIndex() : 0);
                 setIsCompact(false);
                 autoApply.applyTailwindClass(nextSearchQuery);

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -183,7 +183,6 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     clearTimeout(inlineNumericReplaceTimerId);
     inlineNumericReplaceTimerId = setTimeout(() => {
       shouldReplaceInlineNumericInput = true;
-      searchInputRef?.focus({ preventScroll: true });
     }, EDIT_INLINE_NUMERIC_REPLACE_IDLE_MS);
   };
 
@@ -198,6 +197,27 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     if (!/^[-.\d]/.test(appendedQuery)) return nextSearchQuery;
     cancelInlineNumericReplacement();
     return appendedQuery;
+  };
+
+  const tryReplaceInlineNumericFromKey = (event: KeyboardEvent): boolean => {
+    if (!shouldReplaceInlineNumericInput) return false;
+    if (event.metaKey || event.ctrlKey || event.altKey) return false;
+    if (!/^[-.\d]$/.test(event.key)) return false;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    cancelInlineNumericReplacement();
+    const nextSearchQuery = event.key;
+    if (searchInputRef) searchInputRef.value = nextSearchQuery;
+    if (autoApply.tryApplyNumericValue(nextSearchQuery)) {
+      keepInlineNumericSearchQuery();
+      setSearchQuery(nextSearchQuery);
+      queueInlineNumericReplacement();
+      ensureSearchFocused();
+      return true;
+    }
+    setSearchQuery(nextSearchQuery);
+    ensureSearchFocused();
+    return true;
   };
 
   const expandPanel = () => {
@@ -459,6 +479,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
 
     const handleWindowKeyDown = (event: KeyboardEvent) => {
       if (isEventFromOverlay(event, "data-react-grab-input")) return;
+      if (tryReplaceInlineNumericFromKey(event)) return;
       handleSearchKeyDown(event);
     };
     const handleWindowKeyUp = (event: KeyboardEvent) => {

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -186,6 +186,11 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     }, EDIT_INLINE_NUMERIC_REPLACE_IDLE_MS);
   };
 
+  const queueInlineNumericReplacementForQuery = (query: string) => {
+    if (/[a-z%]+$/i.test(query.trim())) queueInlineNumericReplacement();
+    else cancelInlineNumericReplacement();
+  };
+
   const replaceInlineNumericPrefix = (nextSearchQuery: string): string => {
     if (!shouldReplaceInlineNumericInput) return nextSearchQuery;
     const currentSearchQuery = searchQuery();
@@ -211,7 +216,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     if (autoApply.tryApplyNumericValue(nextSearchQuery)) {
       keepInlineNumericSearchQuery();
       setSearchQuery(nextSearchQuery);
-      queueInlineNumericReplacement();
+      queueInlineNumericReplacementForQuery(nextSearchQuery);
       ensureSearchFocused();
       return true;
     }
@@ -673,17 +678,18 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
                 if (autoApply.tryApplyNumericValue(nextSearchQuery)) {
                   keepInlineNumericSearchQuery();
                   setSearchQuery(nextSearchQuery);
-                  queueInlineNumericReplacement();
+                  queueInlineNumericReplacementForQuery(nextSearchQuery);
                   ensureSearchFocused();
                   return;
                 }
                 cancelInlineNumericReplacement();
-                setSearchQuery(nextSearchQuery);
                 if (autoApply.isInlineNumericDraft(nextSearchQuery)) {
                   keepInlineNumericSearchQuery();
+                  setSearchQuery(nextSearchQuery);
                   ensureSearchFocused();
                   return;
                 }
+                setSearchQuery(nextSearchQuery);
                 setInlineNumericSearchQuery(null);
                 setActiveIndex(nextSearchQuery.trim() === "" ? firstNumericActiveIndex() : 0);
                 expandPanel();

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -90,11 +90,11 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
   const preview = props.state.preview;
 
   const [searchQuery, setSearchQuery] = createSignal(props.state.initialSearchQuery ?? "");
-  const [isInlineNumericSearchBypassed, setIsInlineNumericSearchBypassed] = createSignal(false);
+  const [inlineNumericSearchQuery, setInlineNumericSearchQuery] = createSignal<string | null>(null);
   const [activeKey, setActiveKey] = createSignal<"left" | "right" | null>(null);
   const tweakStore = createTweakStore({
     initialProperties,
-    searchQuery: () => (isInlineNumericSearchBypassed() ? "" : searchQuery()),
+    searchQuery: () => inlineNumericSearchQuery() ?? searchQuery(),
   });
   // Colors are pinned on top but aren't slider-steppable, so the arrow-key
   // cursor lands on the first numeric row instead.
@@ -164,6 +164,15 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
         searchInputRef.focus({ preventScroll: true });
       }
     });
+  };
+
+  const keepInlineNumericSearchQuery = () => {
+    if (inlineNumericSearchQuery() === null) setInlineNumericSearchQuery(searchQuery());
+  };
+
+  const expandPanel = () => {
+    setInlineNumericSearchQuery(null);
+    setIsCompact(false);
   };
 
   interface CommitOptions {
@@ -294,7 +303,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     // Escape stops there (so a stray Escape can't nuke pending changes on
     // the collapsed view); an outside click continues to the discard prompt.
     const wasCompact = isCompact();
-    setIsCompact(false);
+    expandPanel();
     if (source === "keyboard" && wasCompact) return;
     discardConfirmation.show();
     playShake();
@@ -304,7 +313,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     const properties = filteredProperties();
     if (properties.length === 0) return;
     setActiveIndex((current) => (current + direction + properties.length) % properties.length);
-    setIsCompact(false);
+    expandPanel();
   };
 
   let colorPickerTriggers: Array<() => void> = [];
@@ -606,18 +615,18 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
               onInput={(event) => {
                 const nextSearchQuery = event.currentTarget.value;
                 if (autoApply.tryApplyNumericValue(nextSearchQuery)) {
-                  setIsInlineNumericSearchBypassed(true);
+                  keepInlineNumericSearchQuery();
                   setSearchQuery(nextSearchQuery);
                   return;
                 }
                 setSearchQuery(nextSearchQuery);
                 if (autoApply.isInlineNumericDraft(nextSearchQuery)) {
-                  setIsInlineNumericSearchBypassed(true);
+                  keepInlineNumericSearchQuery();
                   return;
                 }
-                setIsInlineNumericSearchBypassed(false);
+                setInlineNumericSearchQuery(null);
                 setActiveIndex(nextSearchQuery.trim() === "" ? firstNumericActiveIndex() : 0);
-                setIsCompact(false);
+                expandPanel();
                 autoApply.applyTailwindClass(nextSearchQuery);
               }}
               onKeyDown={handleSearchKeyDown}

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -187,8 +187,11 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
   };
 
   const queueInlineNumericReplacementForQuery = (query: string) => {
-    if (/[a-z%]+$/i.test(query.trim())) queueInlineNumericReplacement();
-    else cancelInlineNumericReplacement();
+    const trimmedQuery = query.trim();
+    const numericDigits = trimmedQuery.replace(/^-/, "").replace(".", "");
+    if (/[a-z%]+$/i.test(trimmedQuery) || numericDigits.length > 1) {
+      queueInlineNumericReplacement();
+    } else cancelInlineNumericReplacement();
   };
 
   const replaceInlineNumericPrefix = (nextSearchQuery: string): string => {

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -11,6 +11,7 @@ import {
   DROPDOWN_EDGE_TRANSFORM_ORIGIN,
   EDIT_PANEL_ACTIVE_KEY_FLASH_MS,
   EDIT_PANEL_ADJUSTING_IDLE_MS,
+  EDIT_INLINE_NUMERIC_REPLACE_IDLE_MS,
   EDIT_PANEL_MAX_WIDTH_PX,
   EDIT_PANEL_MIN_WIDTH_PX,
   EDIT_PROPERTY_LIST_MAX_HEIGHT_PX,
@@ -110,6 +111,8 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
 
   let activeKeyTimerId: ReturnType<typeof setTimeout> | undefined;
   let interactingIdleTimerId: ReturnType<typeof setTimeout> | undefined;
+  let inlineNumericReplaceTimerId: ReturnType<typeof setTimeout> | undefined;
+  let shouldReplaceInlineNumericInput = false;
   const [isTransientInteraction, setIsTransientInteraction] = createSignal(false);
   const isInteracting = createMemo(() => isTransientInteraction() || hasPendingTweaks());
   const [isHeaderHovered, setIsHeaderHovered] = createSignal(false);
@@ -170,7 +173,34 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     if (inlineNumericSearchQuery() === null) setInlineNumericSearchQuery(searchQuery());
   };
 
+  const cancelInlineNumericReplacement = () => {
+    shouldReplaceInlineNumericInput = false;
+    clearTimeout(inlineNumericReplaceTimerId);
+  };
+
+  const queueInlineNumericReplacement = () => {
+    shouldReplaceInlineNumericInput = false;
+    clearTimeout(inlineNumericReplaceTimerId);
+    inlineNumericReplaceTimerId = setTimeout(() => {
+      shouldReplaceInlineNumericInput = true;
+    }, EDIT_INLINE_NUMERIC_REPLACE_IDLE_MS);
+  };
+
+  const replaceInlineNumericPrefix = (nextSearchQuery: string): string => {
+    if (!shouldReplaceInlineNumericInput) return nextSearchQuery;
+    const currentSearchQuery = searchQuery();
+    if (!currentSearchQuery || !nextSearchQuery.startsWith(currentSearchQuery)) {
+      cancelInlineNumericReplacement();
+      return nextSearchQuery;
+    }
+    const appendedQuery = nextSearchQuery.slice(currentSearchQuery.length);
+    if (!/^[-.\d]/.test(appendedQuery)) return nextSearchQuery;
+    cancelInlineNumericReplacement();
+    return appendedQuery;
+  };
+
   const expandPanel = () => {
+    cancelInlineNumericReplacement();
     setInlineNumericSearchQuery(null);
     setIsCompact(false);
   };
@@ -442,6 +472,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
       window.removeEventListener("keyup", handleWindowKeyUp, { capture: true });
       clearTimeout(activeKeyTimerId);
       clearTimeout(interactingIdleTimerId);
+      clearTimeout(inlineNumericReplaceTimerId);
       discardConfirmation.cleanup();
       dropdown.clearAnimationHandles();
       setIsTransientInteraction(false);
@@ -613,12 +644,17 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
               }}
               value={searchQuery()}
               onInput={(event) => {
-                const nextSearchQuery = event.currentTarget.value;
+                const nextSearchQuery = replaceInlineNumericPrefix(event.currentTarget.value);
+                if (nextSearchQuery !== event.currentTarget.value) {
+                  event.currentTarget.value = nextSearchQuery;
+                }
                 if (autoApply.tryApplyNumericValue(nextSearchQuery)) {
                   keepInlineNumericSearchQuery();
                   setSearchQuery(nextSearchQuery);
+                  queueInlineNumericReplacement();
                   return;
                 }
+                cancelInlineNumericReplacement();
                 setSearchQuery(nextSearchQuery);
                 if (autoApply.isInlineNumericDraft(nextSearchQuery)) {
                   keepInlineNumericSearchQuery();

--- a/packages/react-grab/src/components/edit-panel/tailwind-autoapply.ts
+++ b/packages/react-grab/src/components/edit-panel/tailwind-autoapply.ts
@@ -10,7 +10,6 @@ import { clampToRange } from "../../utils/clamp-to-range.js";
 import { expandAggregateLonghands } from "../../utils/expand-aggregate-longhands.js";
 import { roundEditableNumericValue } from "../../utils/format-css-value.js";
 import { isNumericDraftQuery } from "../../utils/is-numeric-draft-query.js";
-import { isNumericQuery } from "../../utils/is-numeric-query.js";
 import { parseAnyColor } from "../../utils/parse-any-color.js";
 import {
   normalizeTailwindClassInput,
@@ -184,16 +183,15 @@ export const createTailwindAutoApply = (
   const isInlineNumericEdit = createMemo(() => isInlineNumericDraft(searchQuery()));
 
   const tryApplyNumericToActive = (query: string): boolean => {
+    if (!isCompact()) return false;
     const property = activeProperty();
     if (property?.kind !== "numeric") return false;
     const parsed = parseInlineNumericValue(query);
     if (!parsed) return false;
-    if (!isCompact() && !parsed.unit) return false;
     const propertyUnit = property.unit.toLowerCase();
     if (parsed.unit !== "" && parsed.unit !== propertyUnit) {
       return isUnitDraftForProperty(parsed.unit, property.unit);
     }
-    if (parsed.unit === "" && !isNumericQuery(query)) return false;
     const nextValue = clampedFor(property, parsed.value);
     if (nextValue !== property.value) commit(property, nextValue);
     return true;

--- a/packages/react-grab/src/components/edit-panel/tailwind-autoapply.ts
+++ b/packages/react-grab/src/components/edit-panel/tailwind-autoapply.ts
@@ -22,6 +22,7 @@ import {
 
 const TAILWIND_CLASS_PATTERN = /^([a-z-]+)-(-?\d+(?:\.\d+)?)$/;
 const TAILWIND_ARBITRARY_PATTERN = /^(.+?)-\[(.+)]$/;
+const INLINE_NUMERIC_VALUE_PATTERN = /^(-?\d*\.?\d+)\s*([a-zA-Z%]*)$/;
 // A px/rem unit (or an explicit length:/size: data-type hint) marks a
 // value as a length. Bare unitless values (opacity-[0.5], leading-[1.5])
 // are ambiguous and em is element-relative, so those are skipped.
@@ -135,6 +136,11 @@ interface TailwindAutoApplyController {
   applyTailwindClass: (query: string) => void;
 }
 
+interface InlineNumericValue {
+  value: number;
+  unit: string;
+}
+
 export const createTailwindAutoApply = (
   options: TailwindAutoApplyOptions,
 ): TailwindAutoApplyController => {
@@ -150,22 +156,45 @@ export const createTailwindAutoApply = (
     return findNumericLonghands(initialProperties, cssKey).length > 0;
   };
 
+  const parseInlineNumericValue = (query: string): InlineNumericValue | null => {
+    const valueMatch = query
+      .trim()
+      .replace(/(\d),(\d)/g, "$1.$2")
+      .match(INLINE_NUMERIC_VALUE_PATTERN);
+    if (!valueMatch) return null;
+    const value = Number.parseFloat(valueMatch[1]);
+    if (!Number.isFinite(value)) return null;
+    return { value, unit: valueMatch[2].toLowerCase() };
+  };
+
+  const isUnitDraftForProperty = (unit: string, propertyUnit: string): boolean => {
+    if (!unit) return true;
+    return propertyUnit.toLowerCase().startsWith(unit);
+  };
+
   const isInlineNumericDraft = (query: string): boolean => {
     if (!isCompact()) return false;
     const property = activeProperty();
     if (property?.kind !== "numeric") return false;
+    const parsed = parseInlineNumericValue(query);
+    if (parsed) return isUnitDraftForProperty(parsed.unit, property.unit);
     return isNumericDraftQuery(query);
   };
 
   const isInlineNumericEdit = createMemo(() => isInlineNumericDraft(searchQuery()));
 
   const tryApplyNumericToActive = (query: string): boolean => {
-    if (!isInlineNumericDraft(query) || !isNumericQuery(query)) return false;
     const property = activeProperty();
     if (property?.kind !== "numeric") return false;
-    const parsed = Number.parseFloat(query);
-    if (!Number.isFinite(parsed)) return false;
-    const nextValue = clampedFor(property, parsed);
+    const parsed = parseInlineNumericValue(query);
+    if (!parsed) return false;
+    if (!isCompact() && !parsed.unit) return false;
+    const propertyUnit = property.unit.toLowerCase();
+    if (parsed.unit !== "" && parsed.unit !== propertyUnit) {
+      return isUnitDraftForProperty(parsed.unit, property.unit);
+    }
+    if (parsed.unit === "" && !isNumericQuery(query)) return false;
+    const nextValue = clampedFor(property, parsed.value);
     if (nextValue !== property.value) commit(property, nextValue);
     return true;
   };

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -204,7 +204,7 @@ export const EDIT_SHIFT_STEP_MULTIPLIER = 10;
 export const EDIT_PANEL_ADJUSTING_IDLE_MS = 150;
 export const EDIT_DISCARD_PROMPT_IDLE_MS = 2000;
 export const EDIT_PANEL_ACTIVE_KEY_FLASH_MS = 100;
-export const EDIT_INLINE_NUMERIC_REPLACE_IDLE_MS = 150;
+export const EDIT_INLINE_NUMERIC_REPLACE_IDLE_MS = 500;
 export const EDIT_SLIDER_CLICK_THRESHOLD_PX = 3;
 export const EDIT_SLIDER_HASH_MARK_COUNT = 9;
 // Rubber-band: cursor must overshoot DEAD_ZONE_PX before the track

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -204,6 +204,7 @@ export const EDIT_SHIFT_STEP_MULTIPLIER = 10;
 export const EDIT_PANEL_ADJUSTING_IDLE_MS = 150;
 export const EDIT_DISCARD_PROMPT_IDLE_MS = 2000;
 export const EDIT_PANEL_ACTIVE_KEY_FLASH_MS = 100;
+export const EDIT_INLINE_NUMERIC_REPLACE_IDLE_MS = 150;
 export const EDIT_SLIDER_CLICK_THRESHOLD_PX = 3;
 export const EDIT_SLIDER_HASH_MARK_COUNT = 9;
 // Rubber-band: cursor must overshoot DEAD_ZONE_PX before the track

--- a/packages/react-grab/src/utils/is-numeric-query.ts
+++ b/packages/react-grab/src/utils/is-numeric-query.ts
@@ -1,3 +1,3 @@
-const NUMERIC_QUERY_PATTERN = /^-?\d*\.?\d+$/;
+const NUMERIC_QUERY_PATTERN = /^-?\d*\.?\d+(?:[a-z%]+)?$/i;
 
 export const isNumericQuery = (query: string): boolean => NUMERIC_QUERY_PATTERN.test(query);

--- a/packages/react-grab/src/utils/is-numeric-query.ts
+++ b/packages/react-grab/src/utils/is-numeric-query.ts
@@ -1,3 +1,3 @@
-const NUMERIC_QUERY_PATTERN = /^-?\d*\.?\d+(?:[a-z%]+)?$/i;
+const NUMERIC_QUERY_PATTERN = /^-?\d*\.?\d+$/;
 
 export const isNumericQuery = (query: string): boolean => NUMERIC_QUERY_PATTERN.test(query);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Treat unit-suffixed numeric style inputs like `50px` as direct active-property edits in compact inline edit mode
- Keep full search mode as search-only for unit-bearing values
- Restore shared numeric query detection to bare numbers and keep CSS-unit parsing local to inline style editing
- Preserve the active filtered property list during compact inline unit drafts so partial values like `50p` keep the intended row targeted
- Clear inline draft filtering state when expanding the panel
- Allow subsequent compact unit typing to replace the prior inline value instead of appending to it
- Avoid delayed focus stealing by handling replacement-start numeric keys only when a compact inline value is ready to be replaced
- Address Bugbot/Cubic findings for draft-filter capture order and paused unitless replacement digits
- Add E2E coverage for compact unit-suffixed numeric input, unitless paused replacement digits, subsequent compact unit typing, the full-mode guard, and searched-row targeting

## Verification
- `npx -p @antfu/ni nr build`
- `npx -p @antfu/ni nr test -- e2e/edit-panel.spec.ts` from `packages/react-grab` (73 passed; later 73 passed with one known unrelated flaky retry)
- `npx -p @antfu/ni nr format`
- `npx -p @antfu/ni nr lint`
- `npx -p @antfu/ni nr typecheck`
- `npx -p @antfu/ni nr test` (652 passed with 2 known unrelated flaky retries)
- GitHub checks: all passing
- Review threads: none unresolved
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-115d0c6e-360c-4dfd-b619-ee3ae36ef524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-115d0c6e-360c-4dfd-b619-ee3ae36ef524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle CSS unit-suffixed and unitless values in the style panel with stable compact inline edits, auto-refocus, and idle-based replacement. In compact mode, inputs like 50px (and plain numbers) update the active numeric property and keep the target; full search stays search-only.

- **New Features**
  - Accept unit-suffixed inputs (e.g., 50px, 1.5rem, 100%) in compact inline edit; allow partial unit drafts that match the property unit, normalize decimal commas, clamp values, and keep the intended property targeted (even after a prior search). Drafts are scoped to compact via a separate buffer and never direct-apply in full search.
  - Add a 500ms idle window that replaces the prior compact value on subsequent typing (including unitless retyping), keeps the search input focused, and only starts replacement when a compact value is ready to avoid focus stealing. Preserve digits typed across idle pauses.

<sup>Written for commit 3f19276213fc3eb906c6aa9a5d7bd587b1445129. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

