### PR TITLE
Display transparent color values as transparent

### DIFF
--- a/packages/react-grab/e2e/edit-panel-color.spec.ts
+++ b/packages/react-grab/e2e/edit-panel-color.spec.ts
@@ -38,7 +38,8 @@ test.describe("Style Panel Color Controls", () => {
   test("transparent color values are labeled as transparent", async ({ reactGrab }) => {
     const { page } = reactGrab;
     await openEditPanel(reactGrab, PLAIN_TEXT_SELECTOR);
-    await page.locator(`[${EDIT_PANEL_ATTR}] [${EDIT_PROPERTY_ATTR}="background-color"]`).click();
+    await setSearchInputValue(page, "background");
+    await expect.poll(() => getActivePropertyKey(page)).toBe("background-color");
 
     await expect.poll(() => getActivePropertyValue(page)).toBe("transparent");
   });

--- a/packages/react-grab/e2e/edit-panel-color.spec.ts
+++ b/packages/react-grab/e2e/edit-panel-color.spec.ts
@@ -4,6 +4,7 @@ import {
   BUTTON_SELECTOR,
   EDIT_PANEL_ATTR,
   EDIT_PROPERTY_ATTR,
+  getActivePropertyValue,
   clearEditStorage,
   getActivePropertyKey,
   getInlineStyleProperty,
@@ -32,6 +33,14 @@ test.describe("Style Panel Color Controls", () => {
     const propertyKeys = await getVisiblePropertyKeys(reactGrab.page);
     expect(propertyKeys).toContain("background-color");
     expect(propertyKeys).toContain("color");
+  });
+
+  test("transparent color values are labeled as transparent", async ({ reactGrab }) => {
+    const { page } = reactGrab;
+    await openEditPanel(reactGrab, PLAIN_TEXT_SELECTOR);
+    await page.locator(`[${EDIT_PANEL_ATTR}] [${EDIT_PROPERTY_ATTR}="background-color"]`).click();
+
+    await expect.poll(() => getActivePropertyValue(page)).toBe("transparent");
   });
 
   test("typing bg-[#hex] applies the background color", async ({ reactGrab }) => {

--- a/packages/react-grab/src/components/edit-panel/color-picker.tsx
+++ b/packages/react-grab/src/components/edit-panel/color-picker.tsx
@@ -20,7 +20,7 @@ interface ColorPickerProps {
   emphasized?: boolean;
 }
 
-const HEX_CLASS = "text-[12px] leading-4 font-medium tabular-nums uppercase";
+const HEX_CLASS = "text-[12px] leading-4 font-medium tabular-nums";
 
 export const ColorPicker: Component<ColorPickerProps> = (props) => {
   const [draftText, setDraftText] = createSignal<string | null>(null);

--- a/packages/react-grab/src/components/edit-panel/color-picker.tsx
+++ b/packages/react-grab/src/components/edit-panel/color-picker.tsx
@@ -1,5 +1,6 @@
 import { createSignal, onCleanup, onMount, Show, type Component } from "solid-js";
 import { IME_COMPOSING_KEY_CODE } from "../../constants.js";
+import { formatColorLabel } from "../../utils/format-color-label.js";
 import { parseAnyColor } from "../../utils/parse-any-color.js";
 import { EDIT_LABEL_CLASS } from "./constants.js";
 
@@ -24,6 +25,7 @@ const HEX_CLASS = "text-[12px] leading-4 font-medium tabular-nums uppercase";
 export const ColorPicker: Component<ColorPickerProps> = (props) => {
   const [draftText, setDraftText] = createSignal<string | null>(null);
   const isEditing = () => draftText() !== null;
+  const displayValue = () => formatColorLabel(props.value);
   let nativePickerRef: HTMLInputElement | undefined;
 
   // isMounted gates the native picker's `onInput` against firing
@@ -97,14 +99,15 @@ export const ColorPicker: Component<ColorPickerProps> = (props) => {
           fallback={
             <span
               class={`${HEX_CLASS} text-[var(--rg-text-primary)] cursor-text`}
+              data-react-grab-value={displayValue()}
               onPointerDown={(event) => event.stopPropagation()}
               onClick={(event) => {
                 event.preventDefault();
                 event.stopPropagation();
-                setDraftText(props.value.replace(/^#/, "").toUpperCase());
+                setDraftText(displayValue());
               }}
             >
-              {props.value.toUpperCase()}
+              {displayValue()}
             </span>
           }
         >

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -192,6 +192,7 @@ export const TEXTAREA_MAX_HEIGHT_PX = 95;
 export const EDIT_PROPERTY_LIST_MAX_HEIGHT_PX = 280;
 export const EDIT_PROPERTY_MAX_COUNT = 40;
 export const EDIT_TRANSPARENT_COLOR_HEX = "#00000000";
+export const EDIT_TRANSPARENT_COLOR_LABEL = "transparent";
 export const EDIT_ROOT_FONT_SIZE_PX = 16;
 export const EDIT_PANEL_MIN_WIDTH_PX = 200;
 export const EDIT_PANEL_MAX_WIDTH_PX = 320;

--- a/packages/react-grab/src/utils/format-color-label.ts
+++ b/packages/react-grab/src/utils/format-color-label.ts
@@ -1,0 +1,6 @@
+import { EDIT_TRANSPARENT_COLOR_HEX, EDIT_TRANSPARENT_COLOR_LABEL } from "../constants.js";
+
+export const formatColorLabel = (colorValue: string): string =>
+  colorValue.toLowerCase() === EDIT_TRANSPARENT_COLOR_HEX
+    ? EDIT_TRANSPARENT_COLOR_LABEL
+    : colorValue.toUpperCase();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a shared formatter for editable color labels
- Show the transparent color sentinel as `transparent` instead of `#00000000`
- Let the color formatter own value casing instead of CSS text-transform
- Add E2E coverage for transparent background color labels

## Testing
- `npx --yes -p @antfu/ni nr build`
- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format`
- `pnpm --filter react-grab test e2e/edit-panel-color.spec.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fb5bf3e-f98f-4057-98af-ecca519df46e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fb5bf3e-f98f-4057-98af-ecca519df46e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show transparent color values as `transparent` in the edit panel instead of the `#00000000` sentinel. Centralizes label formatting (including casing) and adds E2E coverage to keep labels consistent.

- **Bug Fixes**
  - Display `#00000000` as `transparent` in color labels.
  - Use `formatColorLabel` for display, click-to-edit, and casing (remove forced uppercase styling).
  - Add `data-react-grab-value` for consistent reads and update E2E to assert the active value is `transparent`.

<sup>Written for commit 34b9919c22725500f1b7b1cd00dd0071a6400f3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

