### PR TITLE
Guide style prompt toward canonical changes

### DIFF
--- a/packages/react-grab/e2e/edit-panel.spec.ts
+++ b/packages/react-grab/e2e/edit-panel.spec.ts
@@ -1058,6 +1058,9 @@ test.describe("Style Panel", () => {
       expect(inlineStyleAfterTweak.length).toBeGreaterThan(0);
       await clickHeaderCopyButton(reactGrab.page);
       await expect.poll(() => isEditPanelVisible(reactGrab.page)).toBe(false);
+      await expect
+        .poll(() => reactGrab.getClipboardContent())
+        .toContain("padding-bottom/pb instead of margin-bottom/mb");
 
       const afterCommit = await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR);
       expect(afterCommit).toBe(inlineStyleAfterTweak);

--- a/packages/react-grab/e2e/edit-panel.spec.ts
+++ b/packages/react-grab/e2e/edit-panel.spec.ts
@@ -1060,7 +1060,7 @@ test.describe("Style Panel", () => {
       await expect.poll(() => isEditPanelVisible(reactGrab.page)).toBe(false);
       await expect
         .poll(() => reactGrab.getClipboardContent())
-        .toContain("padding-bottom/pb instead of margin-bottom/mb");
+        .toContain("padding-bottom/pb over margin-bottom/mb");
 
       const afterCommit = await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR);
       expect(afterCommit).toBe(inlineStyleAfterTweak);

--- a/packages/react-grab/e2e/edit-panel.spec.ts
+++ b/packages/react-grab/e2e/edit-panel.spec.ts
@@ -1060,7 +1060,7 @@ test.describe("Style Panel", () => {
       await expect.poll(() => isEditPanelVisible(reactGrab.page)).toBe(false);
       await expect
         .poll(() => reactGrab.getClipboardContent())
-        .toContain("padding-bottom/pb over margin-bottom/mb");
+        .toContain("best expresses the underlying layout intent");
 
       const afterCommit = await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR);
       expect(afterCommit).toBe(inlineStyleAfterTweak);

--- a/packages/react-grab/src/utils/format-edit-prompt.ts
+++ b/packages/react-grab/src/utils/format-edit-prompt.ts
@@ -30,7 +30,10 @@ const formatEntryHeader = (pendingEditsEntry: PendingEditsEntry): string =>
 export const formatSessionEditsPrompt = (pendingEditsEntries: PendingEditsEntry[]): string => {
   if (pendingEditsEntries.length === 0) return "";
 
-  const sections: string[] = ["Apply these style changes:"];
+  const sections: string[] = [
+    "Apply these style changes:",
+    "Use the captured CSS as the visual intent, then make the most canonical source change. For example, update padding-bottom/pb instead of margin-bottom/mb when the space belongs inside the element.",
+  ];
 
   if (pendingEditsEntries.length === 1) {
     const header = formatEntryHeader(pendingEditsEntries[0]);

--- a/packages/react-grab/src/utils/format-edit-prompt.ts
+++ b/packages/react-grab/src/utils/format-edit-prompt.ts
@@ -31,7 +31,7 @@ export const formatSessionEditsPrompt = (pendingEditsEntries: PendingEditsEntry[
   if (pendingEditsEntries.length === 0) return "";
 
   const sections: string[] = [
-    "Apply these style changes canonically (CSS = visual intent; use padding-bottom/pb over margin-bottom/mb for internal space):",
+    "Apply these style changes canonically (CSS = visual intent; choose the source change that best expresses the underlying layout intent):",
   ];
 
   if (pendingEditsEntries.length === 1) {

--- a/packages/react-grab/src/utils/format-edit-prompt.ts
+++ b/packages/react-grab/src/utils/format-edit-prompt.ts
@@ -31,8 +31,7 @@ export const formatSessionEditsPrompt = (pendingEditsEntries: PendingEditsEntry[
   if (pendingEditsEntries.length === 0) return "";
 
   const sections: string[] = [
-    "Apply these style changes:",
-    "Use the captured CSS as the visual intent, then make the most canonical source change. For example, update padding-bottom/pb instead of margin-bottom/mb when the space belongs inside the element.",
+    "Apply these style changes canonically (CSS = visual intent; use padding-bottom/pb over margin-bottom/mb for internal space):",
   ];
 
   if (pendingEditsEntries.length === 1) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add compact, generic canonical-source guidance to generated style prompts
- Cover the canonical layout-intent guidance in the edit panel copy flow test

## Validation
- `npm exec --package=@antfu/ni@latest -- nr build`
- `pnpm --filter react-grab test -- e2e/edit-panel.spec.ts -g "header Copy button appears after a pending tweak and submits"`
- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-681b43f0-dfe2-48f9-871b-ac055954300f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-681b43f0-dfe2-48f9-871b-ac055954300f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generalize the style prompt header to steer edits toward visual intent, asking for the source change that best expresses the layout intent. Update the E2E to verify the new guidance appears in the edit panel copy flow.

- **New Features**
  - Replace the prompt header with: "Apply these style changes canonically (CSS = visual intent; choose the source change that best expresses the underlying layout intent):" in `packages/react-grab/src/utils/format-edit-prompt.ts`.
  - Update `packages/react-grab/e2e/edit-panel.spec.ts` to assert the clipboard includes "best expresses the underlying layout intent".

<sup>Written for commit 9f3144e14c2a43ae490dbc50856e93adf6c82c31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

