### PR TITLE
feat(edit): Figma-style canvas transform handles in style mode

### DIFF
--- a/packages/react-grab/e2e/edit-panel-helpers.ts
+++ b/packages/react-grab/e2e/edit-panel-helpers.ts
@@ -13,6 +13,8 @@ export const DISCARD_PROMPT_IDLE_MS = 2000;
 export const BUTTON_SELECTOR = "[data-testid='nested-button']";
 export const CARD_SELECTOR = "[data-testid='nested-card']";
 
+export const TRANSFORM_OVERLAY_ATTR = "data-react-grab-transform-overlay";
+
 export const isEditPanelVisible = async (page: Page): Promise<boolean> =>
   page.evaluate(
     ({ attrName, panelAttr }) => {
@@ -22,6 +24,42 @@ export const isEditPanelVisible = async (page: Page): Promise<boolean> =>
       return shadowRoot.querySelector(`[${panelAttr}]`) !== null;
     },
     { attrName: ATTRIBUTE_NAME, panelAttr: EDIT_PANEL_ATTR },
+  );
+
+export const isTransformOverlayVisible = async (page: Page): Promise<boolean> =>
+  page.evaluate(
+    ({ attrName, overlayAttr }) => {
+      const host = document.querySelector(`[${attrName}]`);
+      const shadowRoot = host?.shadowRoot;
+      const overlay = shadowRoot?.querySelector<HTMLElement>(`[${overlayAttr}]`);
+      if (!overlay) return false;
+      const bounds = overlay.getBoundingClientRect();
+      return bounds.width > 0 && bounds.height > 0;
+    },
+    { attrName: ATTRIBUTE_NAME, overlayAttr: TRANSFORM_OVERLAY_ATTR },
+  );
+
+export interface HandleCenter {
+  x: number;
+  y: number;
+}
+
+export const getTransformHandleCenter = async (
+  page: Page,
+  handleLabel: string,
+): Promise<HandleCenter> =>
+  page.evaluate(
+    ({ attrName, overlayAttr, label }) => {
+      const host = document.querySelector(`[${attrName}]`);
+      const shadowRoot = host?.shadowRoot;
+      const handle = shadowRoot?.querySelector<HTMLElement>(
+        `[${overlayAttr}] [aria-label="${label}"]`,
+      );
+      if (!handle) throw new Error(`Transform handle "${label}" not found`);
+      const bounds = handle.getBoundingClientRect();
+      return { x: bounds.left + bounds.width / 2, y: bounds.top + bounds.height / 2 };
+    },
+    { attrName: ATTRIBUTE_NAME, overlayAttr: TRANSFORM_OVERLAY_ATTR, label: handleLabel },
   );
 
 export const getVisiblePropertyKeys = async (page: Page): Promise<string[]> =>

--- a/packages/react-grab/e2e/edit-panel.spec.ts
+++ b/packages/react-grab/e2e/edit-panel.spec.ts
@@ -222,7 +222,9 @@ test.describe("Style Panel", () => {
 
     test("click outside dismisses the panel", async ({ reactGrab }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
-      await reactGrab.page.mouse.click(5, 5);
+      // A click that lands on empty space (no grabbable element) dismisses;
+      // clicking another element instead retargets the panel to it.
+      await dispatchOutsideDismiss(reactGrab.page);
       await expect.poll(() => isEditPanelVisible(reactGrab.page)).toBe(false);
     });
 
@@ -1094,7 +1096,9 @@ test.describe("Style Panel", () => {
       expect(await isEditPanelVisible(reactGrab.page)).toBe(true);
     });
 
-    test("clicking another element does not change selection", async ({ reactGrab }) => {
+    test("clicking another element keeps the style panel open (retargets)", async ({
+      reactGrab,
+    }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
       const panelStateBeforeClick = await reactGrab.page.evaluate(
         ({ attrName }) => {
@@ -1110,6 +1114,8 @@ test.describe("Style Panel", () => {
       await reactGrab.page.locator(CARD_SELECTOR).first().click({ force: true });
       await reactGrab.page.waitForTimeout(150);
 
+      // Style mode now lets you click another element to retarget the panel,
+      // so it stays open instead of deselecting.
       const stateAfter = await reactGrab.page.evaluate(
         ({ attrName, buttonSelector }) => {
           const host = document.querySelector(`[${attrName}]`);
@@ -1123,6 +1129,7 @@ test.describe("Style Panel", () => {
         },
         { attrName: ATTRIBUTE_NAME, buttonSelector: BUTTON_SELECTOR },
       );
+      expect(stateAfter.panelStillOpen).toBe(true);
       expect(stateAfter.buttonStillExists).toBe(true);
     });
   });

--- a/packages/react-grab/e2e/edit-panel.spec.ts
+++ b/packages/react-grab/e2e/edit-panel.spec.ts
@@ -1240,6 +1240,89 @@ test.describe("Style Panel", () => {
     });
   });
 
+  test.describe("Batched edits across elements", () => {
+    const CARD_TITLE_SELECTOR = "[data-testid='card-title']";
+
+    const tweakActiveProperty = async (reactGrab: { page: import("@playwright/test").Page }) => {
+      await reactGrab.page.keyboard.press("ArrowRight");
+      await reactGrab.page.waitForTimeout(80);
+    };
+
+    const retargetTo = async (
+      reactGrab: { page: import("@playwright/test").Page },
+      selector: string,
+    ) => {
+      await reactGrab.page.locator(selector).first().click({ force: true });
+      await reactGrab.page.waitForTimeout(150);
+    };
+
+    test("retarget keeps the previous element's edits applied instead of reverting", async ({
+      reactGrab,
+    }) => {
+      await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      const buttonBeforeTweak = await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR);
+      await tweakActiveProperty(reactGrab);
+      const buttonAfterTweak = await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR);
+      expect(buttonAfterTweak).not.toBe(buttonBeforeTweak);
+
+      await retargetTo(reactGrab, CARD_TITLE_SELECTOR);
+
+      expect(await isEditPanelVisible(reactGrab.page)).toBe(true);
+      // The button was not the click target, so its edits must be retained.
+      expect(await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR)).toBe(buttonAfterTweak);
+      // A freshly retargeted element with batched edits still offers Copy.
+      expect(await isHeaderCopyButtonVisible(reactGrab.page)).toBe(true);
+    });
+
+    test("copy after retarget includes edits from every touched element", async ({ reactGrab }) => {
+      await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      await tweakActiveProperty(reactGrab);
+
+      await retargetTo(reactGrab, CARD_TITLE_SELECTOR);
+      await tweakActiveProperty(reactGrab);
+
+      // Arrow-stepping collapses the panel (hiding the header Copy button), so
+      // submit via Enter, which copies the batched session regardless.
+      await reactGrab.page.keyboard.press("Enter");
+      await expect.poll(() => isEditPanelVisible(reactGrab.page)).toBe(false);
+
+      const clipboard = await reactGrab.getClipboardContent();
+      expect(clipboard).toContain("best expresses the underlying layout intent");
+      // Two CSS blocks prove both elements' edits were batched into one prompt.
+      expect(clipboard.split("```css").length - 1).toBeGreaterThanOrEqual(2);
+    });
+
+    test("discard after retarget reverts edits on both elements", async ({ reactGrab }) => {
+      await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      const buttonBeforeTweak = await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR);
+      await tweakActiveProperty(reactGrab);
+      expect(await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR)).not.toBe(
+        buttonBeforeTweak,
+      );
+
+      const titleBeforeTweak = await getInlineStyleAttribute(reactGrab.page, CARD_TITLE_SELECTOR);
+      await retargetTo(reactGrab, CARD_TITLE_SELECTOR);
+      await tweakActiveProperty(reactGrab);
+      expect(await getInlineStyleAttribute(reactGrab.page, CARD_TITLE_SELECTOR)).not.toBe(
+        titleBeforeTweak,
+      );
+
+      // First outside dismiss opens the discard prompt; the second confirms it.
+      await dispatchOutsideDismiss(reactGrab.page);
+      await reactGrab.page.waitForTimeout(80);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(true);
+      await dispatchOutsideDismiss(reactGrab.page);
+      await expect.poll(() => isEditPanelVisible(reactGrab.page)).toBe(false);
+
+      expect(await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR)).toBe(
+        buttonBeforeTweak,
+      );
+      expect(await getInlineStyleAttribute(reactGrab.page, CARD_TITLE_SELECTOR)).toBe(
+        titleBeforeTweak,
+      );
+    });
+  });
+
   test.describe("Comment plugin coexistence", () => {
     test("registerCommentAction restores the Comment context menu item", async ({ reactGrab }) => {
       await reactGrab.page.evaluate(() => {

--- a/packages/react-grab/e2e/transform-overlay.spec.ts
+++ b/packages/react-grab/e2e/transform-overlay.spec.ts
@@ -59,7 +59,7 @@ test.describe("Transform Overlay", () => {
     expect(await getInlineStyleProperty(page, TARGET_SELECTOR, "width")).not.toBe("");
   });
 
-  test("dragging the frame body translates the element", async ({ reactGrab }) => {
+  test("dragging the frame body moves the element via tracked left/top", async ({ reactGrab }) => {
     const { page } = reactGrab;
     await openEditPanel(reactGrab, TARGET_SELECTOR);
     await expect.poll(() => isTransformOverlayVisible(page)).toBe(true);
@@ -79,8 +79,8 @@ test.describe("Transform Overlay", () => {
     await page.mouse.move(overlayCenter.x + 50, overlayCenter.y + 30, { steps: 6 });
     await page.mouse.up();
 
-    expect(await getInlineStyleProperty(page, TARGET_SELECTOR, "transform")).toContain(
-      "translate(",
-    );
+    // x/y are tracked as real style properties, not a transform.
+    expect(await getInlineStyleProperty(page, TARGET_SELECTOR, "left")).not.toBe("");
+    expect(await getInlineStyleProperty(page, TARGET_SELECTOR, "top")).not.toBe("");
   });
 });

--- a/packages/react-grab/e2e/transform-overlay.spec.ts
+++ b/packages/react-grab/e2e/transform-overlay.spec.ts
@@ -59,28 +59,60 @@ test.describe("Transform Overlay", () => {
     expect(await getInlineStyleProperty(page, TARGET_SELECTOR, "width")).not.toBe("");
   });
 
-  test("dragging the frame body moves the element via tracked left/top", async ({ reactGrab }) => {
+  test("dragging the frame body reinserts the element in the DOM", async ({ reactGrab }) => {
     const { page } = reactGrab;
+    const SIBLING_SELECTOR = "[data-testid='deeply-nested-text']";
     await openEditPanel(reactGrab, TARGET_SELECTOR);
     await expect.poll(() => isTransformOverlayVisible(page)).toBe(true);
 
-    const overlayCenter = await page.evaluate(() => {
-      const host = document.querySelector("[data-react-grab]");
-      const overlay = host?.shadowRoot?.querySelector<HTMLElement>(
-        "[data-react-grab-transform-overlay]",
-      );
-      if (!overlay) throw new Error("overlay not found");
-      const bounds = overlay.getBoundingClientRect();
-      return { x: bounds.left + bounds.width / 2, y: bounds.top + bounds.height / 2 };
-    });
+    // The button starts after its sibling paragraph in the same container.
+    const orderBefore = await page.evaluate(
+      ({ moved, sibling }) => {
+        const movedElement = document.querySelector(moved);
+        const siblingElement = document.querySelector(sibling);
+        return movedElement?.previousElementSibling === siblingElement;
+      },
+      { moved: TARGET_SELECTOR, sibling: SIBLING_SELECTOR },
+    );
+    expect(orderBefore).toBe(true);
 
-    await page.mouse.move(overlayCenter.x, overlayCenter.y);
+    const points = await page.evaluate(
+      ({ moved, sibling }) => {
+        const host = document.querySelector("[data-react-grab]");
+        const overlay = host?.shadowRoot?.querySelector<HTMLElement>(
+          "[data-react-grab-transform-overlay]",
+        );
+        const siblingElement = document.querySelector(sibling);
+        if (!overlay || !siblingElement) throw new Error("overlay or sibling missing");
+        void moved;
+        const overlayBounds = overlay.getBoundingClientRect();
+        const siblingBounds = siblingElement.getBoundingClientRect();
+        return {
+          from: {
+            x: overlayBounds.left + overlayBounds.width / 2,
+            y: overlayBounds.top + overlayBounds.height / 2,
+          },
+          // Upper half of the sibling → insert before it.
+          to: { x: siblingBounds.left + 4, y: siblingBounds.top + 2 },
+        };
+      },
+      { moved: TARGET_SELECTOR, sibling: SIBLING_SELECTOR },
+    );
+
+    await page.mouse.move(points.from.x, points.from.y);
     await page.mouse.down();
-    await page.mouse.move(overlayCenter.x + 50, overlayCenter.y + 30, { steps: 6 });
+    await page.mouse.move(points.to.x, points.to.y, { steps: 8 });
     await page.mouse.up();
 
-    // x/y are tracked as real style properties, not a transform.
-    expect(await getInlineStyleProperty(page, TARGET_SELECTOR, "left")).not.toBe("");
-    expect(await getInlineStyleProperty(page, TARGET_SELECTOR, "top")).not.toBe("");
+    // The button is now reinserted before the paragraph in the DOM.
+    const movedBefore = await page.evaluate(
+      ({ moved, sibling }) => {
+        const movedElement = document.querySelector(moved);
+        const siblingElement = document.querySelector(sibling);
+        return movedElement?.nextElementSibling === siblingElement;
+      },
+      { moved: TARGET_SELECTOR, sibling: SIBLING_SELECTOR },
+    );
+    expect(movedBefore).toBe(true);
   });
 });

--- a/packages/react-grab/e2e/transform-overlay.spec.ts
+++ b/packages/react-grab/e2e/transform-overlay.spec.ts
@@ -6,6 +6,7 @@ import {
   getInlineStyleProperty,
   getTransformHandleCenter,
   isEditPanelCompact,
+  isEditPanelVisible,
   isTransformOverlayVisible,
   openEditPanel,
 } from "./edit-panel-helpers.js";
@@ -161,6 +162,19 @@ test.describe("Transform Overlay", () => {
       { moved: TARGET_SELECTOR, sibling: SIBLING_SELECTOR },
     );
     expect(movedBefore).toBe(true);
+  });
+
+  test("deselects when the selected element is removed from the DOM", async ({ reactGrab }) => {
+    const { page } = reactGrab;
+    await openEditPanel(reactGrab, TARGET_SELECTOR);
+    await expect.poll(() => isTransformOverlayVisible(page)).toBe(true);
+
+    await page.evaluate((selector) => {
+      document.querySelector(selector)?.remove();
+    }, TARGET_SELECTOR);
+
+    await expect.poll(() => isEditPanelVisible(page)).toBe(false);
+    expect(await isTransformOverlayVisible(page)).toBe(false);
   });
 
   test("shows a drag ghost while moving and clears it on drop", async ({ reactGrab }) => {

--- a/packages/react-grab/e2e/transform-overlay.spec.ts
+++ b/packages/react-grab/e2e/transform-overlay.spec.ts
@@ -164,6 +164,41 @@ test.describe("Transform Overlay", () => {
     expect(movedBefore).toBe(true);
   });
 
+  test("clicking the frame without dragging does not move the element", async ({ reactGrab }) => {
+    const { page } = reactGrab;
+    const SIBLING_SELECTOR = "[data-testid='deeply-nested-text']";
+    await openEditPanel(reactGrab, TARGET_SELECTOR);
+    await expect.poll(() => isTransformOverlayVisible(page)).toBe(true);
+
+    const orderBefore = await page.evaluate(
+      ({ moved, sibling }) =>
+        document.querySelector(moved)?.previousElementSibling === document.querySelector(sibling),
+      { moved: TARGET_SELECTOR, sibling: SIBLING_SELECTOR },
+    );
+    expect(orderBefore).toBe(true);
+
+    const center = await page.evaluate(() => {
+      const host = document.querySelector("[data-react-grab]");
+      const overlay = host?.shadowRoot?.querySelector<HTMLElement>(
+        "[data-react-grab-transform-overlay]",
+      );
+      if (!overlay) throw new Error("overlay not found");
+      const bounds = overlay.getBoundingClientRect();
+      return { x: bounds.left + bounds.width / 2, y: bounds.top + bounds.height / 2 };
+    });
+
+    // A click (down + up, no drag) must not reinsert the element.
+    await page.mouse.click(center.x, center.y);
+    await page.waitForTimeout(120);
+
+    const orderAfter = await page.evaluate(
+      ({ moved, sibling }) =>
+        document.querySelector(moved)?.previousElementSibling === document.querySelector(sibling),
+      { moved: TARGET_SELECTOR, sibling: SIBLING_SELECTOR },
+    );
+    expect(orderAfter).toBe(true);
+  });
+
   test("clicking another element retargets the panel and overlay to it", async ({ reactGrab }) => {
     const { page } = reactGrab;
     const OTHER_SELECTOR = "[data-testid='deeply-nested-text']";

--- a/packages/react-grab/e2e/transform-overlay.spec.ts
+++ b/packages/react-grab/e2e/transform-overlay.spec.ts
@@ -59,20 +59,6 @@ test.describe("Transform Overlay", () => {
     expect(await getInlineStyleProperty(page, TARGET_SELECTOR, "width")).not.toBe("");
   });
 
-  test("dragging the rotate handle applies a rotate transform", async ({ reactGrab }) => {
-    const { page } = reactGrab;
-    await openEditPanel(reactGrab, TARGET_SELECTOR);
-    await expect.poll(() => isTransformOverlayVisible(page)).toBe(true);
-
-    const rotateHandle = await getTransformHandleCenter(page, "Rotate element");
-    await page.mouse.move(rotateHandle.x, rotateHandle.y);
-    await page.mouse.down();
-    await page.mouse.move(rotateHandle.x + 80, rotateHandle.y + 60, { steps: 8 });
-    await page.mouse.up();
-
-    expect(await getInlineStyleProperty(page, TARGET_SELECTOR, "transform")).toContain("rotate(");
-  });
-
   test("dragging the frame body translates the element", async ({ reactGrab }) => {
     const { page } = reactGrab;
     await openEditPanel(reactGrab, TARGET_SELECTOR);

--- a/packages/react-grab/e2e/transform-overlay.spec.ts
+++ b/packages/react-grab/e2e/transform-overlay.spec.ts
@@ -199,6 +199,52 @@ test.describe("Transform Overlay", () => {
     expect(orderAfter).toBe(true);
   });
 
+  test("escaping without copying reverts a move and closes the panel", async ({ reactGrab }) => {
+    const { page } = reactGrab;
+    const SIBLING_SELECTOR = "[data-testid='deeply-nested-text']";
+    await openEditPanel(reactGrab, TARGET_SELECTOR);
+    await expect.poll(() => isTransformOverlayVisible(page)).toBe(true);
+
+    const wasAfterSibling = () =>
+      page.evaluate(
+        ({ moved, sibling }) =>
+          document.querySelector(moved)?.previousElementSibling === document.querySelector(sibling),
+        { moved: TARGET_SELECTOR, sibling: SIBLING_SELECTOR },
+      );
+    expect(await wasAfterSibling()).toBe(true);
+
+    const points = await page.evaluate(
+      ({ sibling }) => {
+        const host = document.querySelector("[data-react-grab]");
+        const overlay = host?.shadowRoot?.querySelector<HTMLElement>(
+          "[data-react-grab-transform-overlay]",
+        );
+        const sib = document.querySelector(sibling)!.getBoundingClientRect();
+        const ob = overlay!.getBoundingClientRect();
+        return {
+          from: { x: ob.left + ob.width / 2, y: ob.top + ob.height / 2 },
+          to: { x: sib.left + 8, y: sib.top + 2 },
+        };
+      },
+      { sibling: SIBLING_SELECTOR },
+    );
+    await page.mouse.move(points.from.x, points.from.y);
+    await page.mouse.down();
+    await page.mouse.move(points.to.x, points.to.y, { steps: 10 });
+    await page.mouse.up();
+    // The move reinserted the element before its sibling.
+    expect(await wasAfterSibling()).toBe(false);
+
+    // Escape (with discard confirmation) closes the panel and reverts the move.
+    for (let attempt = 0; attempt < 3; attempt++) {
+      await page.keyboard.press("Escape");
+      await page.waitForTimeout(120);
+      if (!(await isEditPanelVisible(page))) break;
+    }
+    expect(await isEditPanelVisible(page)).toBe(false);
+    expect(await wasAfterSibling()).toBe(true);
+  });
+
   test("clicking another element retargets the panel and overlay to it", async ({ reactGrab }) => {
     const { page } = reactGrab;
     const OTHER_SELECTOR = "[data-testid='deeply-nested-text']";

--- a/packages/react-grab/e2e/transform-overlay.spec.ts
+++ b/packages/react-grab/e2e/transform-overlay.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test } from "./fixtures.js";
+import {
+  BUTTON_SELECTOR,
+  clearEditStorage,
+  getInlineStyleProperty,
+  getTransformHandleCenter,
+  isTransformOverlayVisible,
+  openEditPanel,
+} from "./edit-panel-helpers.js";
+
+// A leaf element so the right-click that opens the panel reliably selects
+// this exact node (a container would resolve to whichever child is hovered).
+const TARGET_SELECTOR = BUTTON_SELECTOR;
+
+const getOffsetWidth = (page: import("@playwright/test").Page, selector: string): Promise<number> =>
+  page.evaluate((elementSelector) => {
+    const element = document.querySelector(elementSelector);
+    return element instanceof HTMLElement ? element.offsetWidth : 0;
+  }, selector);
+
+const getOffsetHeight = (
+  page: import("@playwright/test").Page,
+  selector: string,
+): Promise<number> =>
+  page.evaluate((elementSelector) => {
+    const element = document.querySelector(elementSelector);
+    return element instanceof HTMLElement ? element.offsetHeight : 0;
+  }, selector);
+
+test.describe("Transform Overlay", () => {
+  test.beforeEach(async ({ reactGrab }) => {
+    await clearEditStorage(reactGrab.page);
+  });
+
+  test("renders a Figma-style handle frame over the styled element", async ({ reactGrab }) => {
+    await openEditPanel(reactGrab, TARGET_SELECTOR);
+
+    await expect.poll(() => isTransformOverlayVisible(reactGrab.page)).toBe(true);
+  });
+
+  test("dragging the south-east handle grows width and height", async ({ reactGrab }) => {
+    const { page } = reactGrab;
+    await openEditPanel(reactGrab, TARGET_SELECTOR);
+    await expect.poll(() => isTransformOverlayVisible(page)).toBe(true);
+
+    const startWidth = await getOffsetWidth(page, TARGET_SELECTOR);
+    const startHeight = await getOffsetHeight(page, TARGET_SELECTOR);
+
+    const handle = await getTransformHandleCenter(page, "Resize se");
+    await page.mouse.move(handle.x, handle.y);
+    await page.mouse.down();
+    await page.mouse.move(handle.x + 60, handle.y + 40, { steps: 6 });
+    await page.mouse.up();
+
+    await expect.poll(() => getOffsetWidth(page, TARGET_SELECTOR)).toBeGreaterThan(startWidth + 20);
+    await expect
+      .poll(() => getOffsetHeight(page, TARGET_SELECTOR))
+      .toBeGreaterThan(startHeight + 10);
+    expect(await getInlineStyleProperty(page, TARGET_SELECTOR, "width")).not.toBe("");
+  });
+
+  test("dragging the rotate handle applies a rotate transform", async ({ reactGrab }) => {
+    const { page } = reactGrab;
+    await openEditPanel(reactGrab, TARGET_SELECTOR);
+    await expect.poll(() => isTransformOverlayVisible(page)).toBe(true);
+
+    const rotateHandle = await getTransformHandleCenter(page, "Rotate element");
+    await page.mouse.move(rotateHandle.x, rotateHandle.y);
+    await page.mouse.down();
+    await page.mouse.move(rotateHandle.x + 80, rotateHandle.y + 60, { steps: 8 });
+    await page.mouse.up();
+
+    expect(await getInlineStyleProperty(page, TARGET_SELECTOR, "transform")).toContain("rotate(");
+  });
+
+  test("dragging the frame body translates the element", async ({ reactGrab }) => {
+    const { page } = reactGrab;
+    await openEditPanel(reactGrab, TARGET_SELECTOR);
+    await expect.poll(() => isTransformOverlayVisible(page)).toBe(true);
+
+    const overlayCenter = await page.evaluate(() => {
+      const host = document.querySelector("[data-react-grab]");
+      const overlay = host?.shadowRoot?.querySelector<HTMLElement>(
+        "[data-react-grab-transform-overlay]",
+      );
+      if (!overlay) throw new Error("overlay not found");
+      const bounds = overlay.getBoundingClientRect();
+      return { x: bounds.left + bounds.width / 2, y: bounds.top + bounds.height / 2 };
+    });
+
+    await page.mouse.move(overlayCenter.x, overlayCenter.y);
+    await page.mouse.down();
+    await page.mouse.move(overlayCenter.x + 50, overlayCenter.y + 30, { steps: 6 });
+    await page.mouse.up();
+
+    expect(await getInlineStyleProperty(page, TARGET_SELECTOR, "transform")).toContain(
+      "translate(",
+    );
+  });
+});

--- a/packages/react-grab/e2e/transform-overlay.spec.ts
+++ b/packages/react-grab/e2e/transform-overlay.spec.ts
@@ -115,4 +115,38 @@ test.describe("Transform Overlay", () => {
     );
     expect(movedBefore).toBe(true);
   });
+
+  test("shows a drag ghost while moving and clears it on drop", async ({ reactGrab }) => {
+    const { page } = reactGrab;
+    await openEditPanel(reactGrab, TARGET_SELECTOR);
+    await expect.poll(() => isTransformOverlayVisible(page)).toBe(true);
+
+    const isGhostVisible = () =>
+      page.evaluate(() => {
+        const host = document.querySelector("[data-react-grab]");
+        const ghost = host?.shadowRoot?.querySelector<HTMLElement>("[data-react-grab-drag-ghost]");
+        if (!ghost) return false;
+        const bounds = ghost.getBoundingClientRect();
+        return bounds.width > 0 && bounds.height > 0;
+      });
+
+    const start = await page.evaluate(() => {
+      const host = document.querySelector("[data-react-grab]");
+      const overlay = host?.shadowRoot?.querySelector<HTMLElement>(
+        "[data-react-grab-transform-overlay]",
+      );
+      if (!overlay) throw new Error("overlay not found");
+      const bounds = overlay.getBoundingClientRect();
+      return { x: bounds.left + bounds.width / 2, y: bounds.top + bounds.height / 2 };
+    });
+
+    expect(await isGhostVisible()).toBe(false);
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await page.mouse.move(start.x + 30, start.y - 40, { steps: 6 });
+    expect(await isGhostVisible()).toBe(true);
+
+    await page.mouse.up();
+    expect(await isGhostVisible()).toBe(false);
+  });
 });

--- a/packages/react-grab/e2e/transform-overlay.spec.ts
+++ b/packages/react-grab/e2e/transform-overlay.spec.ts
@@ -2,8 +2,10 @@ import { expect, test } from "./fixtures.js";
 import {
   BUTTON_SELECTOR,
   clearEditStorage,
+  getActivePropertyKey,
   getInlineStyleProperty,
   getTransformHandleCenter,
+  isEditPanelCompact,
   isTransformOverlayVisible,
   openEditPanel,
 } from "./edit-panel-helpers.js";
@@ -57,6 +59,23 @@ test.describe("Transform Overlay", () => {
       .poll(() => getOffsetHeight(page, TARGET_SELECTOR))
       .toBeGreaterThan(startHeight + 10);
     expect(await getInlineStyleProperty(page, TARGET_SELECTOR, "width")).not.toBe("");
+  });
+
+  test("resizing compacts the panel onto the dimension being edited", async ({ reactGrab }) => {
+    const { page } = reactGrab;
+    await openEditPanel(reactGrab, TARGET_SELECTOR);
+    await expect.poll(() => isTransformOverlayVisible(page)).toBe(true);
+    expect(await isEditPanelCompact(page)).toBe(false);
+
+    // Drag the east-west bias of the SE handle so width changes most.
+    const handle = await getTransformHandleCenter(page, "Resize se");
+    await page.mouse.move(handle.x, handle.y);
+    await page.mouse.down();
+    await page.mouse.move(handle.x + 80, handle.y + 10, { steps: 6 });
+    await page.mouse.up();
+
+    expect(await isEditPanelCompact(page)).toBe(true);
+    expect(await getActivePropertyKey(page)).toBe("width");
   });
 
   test("dragging the frame body reinserts the element in the DOM", async ({ reactGrab }) => {

--- a/packages/react-grab/e2e/transform-overlay.spec.ts
+++ b/packages/react-grab/e2e/transform-overlay.spec.ts
@@ -61,6 +61,34 @@ test.describe("Transform Overlay", () => {
     expect(await getInlineStyleProperty(page, TARGET_SELECTOR, "width")).not.toBe("");
   });
 
+  test("Alt-resizing scales symmetrically about the center", async ({ reactGrab }) => {
+    const { page } = reactGrab;
+    await openEditPanel(reactGrab, TARGET_SELECTOR);
+    await expect.poll(() => isTransformOverlayVisible(page)).toBe(true);
+
+    const rectBefore = await page.evaluate((selector) => {
+      const bounds = document.querySelector(selector)!.getBoundingClientRect();
+      return { left: bounds.left, width: bounds.width };
+    }, TARGET_SELECTOR);
+
+    const handle = await getTransformHandleCenter(page, "Resize se");
+    await page.keyboard.down("Alt");
+    await page.mouse.move(handle.x, handle.y);
+    await page.mouse.down();
+    await page.mouse.move(handle.x + 60, handle.y + 40, { steps: 6 });
+    await page.mouse.up();
+    await page.keyboard.up("Alt");
+
+    const rectAfter = await page.evaluate((selector) => {
+      const bounds = document.querySelector(selector)!.getBoundingClientRect();
+      return { left: bounds.left, width: bounds.width };
+    }, TARGET_SELECTOR);
+
+    // Symmetric growth pushes the left edge outward instead of pinning it.
+    expect(rectAfter.width).toBeGreaterThan(rectBefore.width + 20);
+    expect(rectAfter.left).toBeLessThan(rectBefore.left - 5);
+  });
+
   test("resizing compacts the panel onto the dimension being edited", async ({ reactGrab }) => {
     const { page } = reactGrab;
     await openEditPanel(reactGrab, TARGET_SELECTOR);

--- a/packages/react-grab/e2e/transform-overlay.spec.ts
+++ b/packages/react-grab/e2e/transform-overlay.spec.ts
@@ -62,6 +62,39 @@ test.describe("Transform Overlay", () => {
     expect(await getInlineStyleProperty(page, TARGET_SELECTOR, "width")).not.toBe("");
   });
 
+  test("keeps the anchored edge pinned when the element can't take the requested size", async ({
+    reactGrab,
+  }) => {
+    const { page } = reactGrab;
+    await openEditPanel(reactGrab, TARGET_SELECTOR);
+    await expect.poll(() => isTransformOverlayVisible(page)).toBe(true);
+
+    // Cap the width so the element can't grow horizontally — a stand-in for the
+    // flex/grid/min-max constraints that make real layouts "glitchy". The NW
+    // handle must keep the right edge pinned instead of sliding the element
+    // left by the (unachievable) requested delta.
+    const rightBefore = await page.evaluate((selector) => {
+      const element = document.querySelector(selector);
+      if (!(element instanceof HTMLElement)) return null;
+      element.style.maxWidth = `${element.offsetWidth}px`;
+      return element.getBoundingClientRect().right;
+    }, TARGET_SELECTOR);
+
+    const handle = await getTransformHandleCenter(page, "Resize nw");
+    await page.mouse.move(handle.x, handle.y);
+    await page.mouse.down();
+    await page.mouse.move(handle.x - 80, handle.y - 10, { steps: 6 });
+    await page.mouse.up();
+
+    const rightAfter = await page.evaluate((selector) => {
+      const element = document.querySelector(selector);
+      return element instanceof HTMLElement ? element.getBoundingClientRect().right : null;
+    }, TARGET_SELECTOR);
+
+    expect(rightBefore).not.toBeNull();
+    expect(Math.abs((rightAfter ?? 0) - (rightBefore ?? 0))).toBeLessThanOrEqual(2);
+  });
+
   test("Alt-resizing scales symmetrically about the center", async ({ reactGrab }) => {
     const { page } = reactGrab;
     await openEditPanel(reactGrab, TARGET_SELECTOR);

--- a/packages/react-grab/e2e/transform-overlay.spec.ts
+++ b/packages/react-grab/e2e/transform-overlay.spec.ts
@@ -164,6 +164,38 @@ test.describe("Transform Overlay", () => {
     expect(movedBefore).toBe(true);
   });
 
+  test("clicking another element retargets the panel and overlay to it", async ({ reactGrab }) => {
+    const { page } = reactGrab;
+    const OTHER_SELECTOR = "[data-testid='deeply-nested-text']";
+    await openEditPanel(reactGrab, TARGET_SELECTOR);
+    await expect.poll(() => isTransformOverlayVisible(page)).toBe(true);
+
+    const other = await page.evaluate((selector) => {
+      const bounds = document.querySelector(selector)!.getBoundingClientRect();
+      return {
+        // Click near the left edge so the click can't land on the
+        // toolbar-anchored (centered) panel.
+        x: bounds.left + 8,
+        y: bounds.top + bounds.height / 2,
+        width: Math.round(bounds.width),
+      };
+    }, OTHER_SELECTOR);
+
+    await page.mouse.click(other.x, other.y);
+    await page.waitForTimeout(150);
+
+    // The panel stays open and the overlay now frames the clicked element.
+    expect(await isEditPanelVisible(page)).toBe(true);
+    const overlayWidth = await page.evaluate(() => {
+      const host = document.querySelector("[data-react-grab]");
+      const overlay = host?.shadowRoot?.querySelector<HTMLElement>(
+        "[data-react-grab-transform-overlay]",
+      );
+      return overlay ? Math.round(overlay.getBoundingClientRect().width) : -1;
+    });
+    expect(Math.abs(overlayWidth - other.width)).toBeLessThan(4);
+  });
+
   test("deselects when the selected element is removed from the DOM", async ({ reactGrab }) => {
     const { page } = reactGrab;
     await openEditPanel(reactGrab, TARGET_SELECTOR);

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -195,6 +195,11 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
       const property = propertyByKey.get(cssProperty);
       if (property) commit(property, value);
     },
+    focusProperty: (cssProperty) => {
+      const index = filteredProperties().findIndex((property) => property.key === cssProperty);
+      if (index >= 0) setActiveIndex(index);
+      setIsCompact(true);
+    },
   });
 
   const isShiftHeld = createShiftTracker();

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -49,10 +49,7 @@ import { stepProperty } from "./step-property.js";
 import { createTailwindAutoApply } from "./tailwind-autoapply.js";
 import { createTweakStore } from "./tweak-store.js";
 import { TransformOverlay } from "../transform-overlay/index.js";
-import {
-  createTransformController,
-  formatTransformValue,
-} from "../transform-overlay/transform-controller.js";
+import { createTransformController } from "../transform-overlay/transform-controller.js";
 
 interface EditPanelProps {
   state: EditPanelState | null;
@@ -106,8 +103,28 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     return numericIndex > 0 ? numericIndex : 0;
   };
   const [activeIndex, setActiveIndex] = createSignal(firstNumericActiveIndex());
-  const [hasTransformChanges, setHasTransformChanges] = createSignal(false);
-  const hasPendingTweaks = createMemo(() => tweakStore.hasPendingTweaks() || hasTransformChanges());
+
+  // Created before the memos that read it: createMemo evaluates eagerly, so a
+  // later `const` would hit the temporal dead zone. `commit`/`markAsInteracting`
+  // are only reached through deferred drag callbacks, so referencing them via
+  // closures here is safe even though they are defined further down.
+  const sizeProperties: Record<"width" | "height", EditableProperty | undefined> = {
+    width: initialProperties.find((property) => property.key === "width"),
+    height: initialProperties.find((property) => property.key === "height"),
+  };
+  const transformController = createTransformController({
+    getElement: () => props.state.element,
+    preview,
+    commitSize: (cssProperty, valuePx) => {
+      const property = sizeProperties[cssProperty];
+      if (property?.kind === "numeric") commit(property, valuePx);
+    },
+    onInteract: () => markAsInteracting(),
+  });
+
+  const hasPendingTweaks = createMemo(
+    () => tweakStore.hasPendingTweaks() || transformController.hasChanged(),
+  );
   const [isCompact, setIsCompact] = createSignal(false);
 
   let activeKeyTimerId: ReturnType<typeof setTimeout> | undefined;
@@ -189,19 +206,6 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     if (options.shouldCompact) setIsCompact(true);
   };
 
-  const propertyByKey = new Map(initialProperties.map((property) => [property.key, property]));
-
-  const transformController = createTransformController({
-    getElement: () => props.state.element,
-    preview,
-    commitSize: (cssProperty, valuePx) => {
-      const property = propertyByKey.get(cssProperty);
-      if (property?.kind === "numeric") commit(property, valuePx);
-    },
-    onInteract: markAsInteracting,
-    onChange: () => setHasTransformChanges(transformController.hasChanged()),
-  });
-
   const isShiftHeld = createShiftTracker();
 
   const commitTweak = (
@@ -269,14 +273,8 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
 
   const handleSubmit = () => {
     const pendingEdits = tweakStore.buildPendingEdits();
-    if (transformController.hasChanged()) {
-      pendingEdits.push({
-        kind: "transform",
-        key: "transform",
-        cssProperties: ["transform"],
-        value: formatTransformValue(transformController.values()),
-      });
-    }
+    const transformEdit = transformController.buildPendingEdit();
+    if (transformEdit) pendingEdits.push(transformEdit);
     const entry = {
       filePath: props.state.filePath ?? "",
       lineNumber: props.state.lineNumber ?? 0,

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -188,11 +188,14 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     if (options.shouldCompact) setIsCompact(true);
   };
 
-  const propertyByKey = new Map(initialProperties.map((property) => [property.key, property]));
   const transformController = createTransformController({
     getElement: () => props.state.element,
+    // The canvas overlay edits width/height/left/top/position through the same
+    // tweak store as the panel rows (top/left fall back to 0 and position is an
+    // enum in property-definitions, so the rows exist); a missing key just means
+    // that property isn't editable for this element, so skip it.
     commitStyle: (cssProperty, value) => {
-      const property = propertyByKey.get(cssProperty);
+      const property = tweakStore.getProperty(cssProperty);
       if (property) commit(property, value);
     },
     focusProperty: (cssProperty) => {

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -551,246 +551,246 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     <>
       <TransformOverlay controller={transformController} />
       <Show when={dropdown.shouldMount()}>
-      <div
-        ref={containerRef}
-        role="dialog"
-        aria-modal="true"
-        aria-label="Style element"
-        data-react-grab-ignore-events
-        data-react-grab-edit-panel
-        data-rg-compact={isCompact() ? "true" : "false"}
-        class={cn(
-          "fixed font-sans text-[13px] antialiased [filter:var(--rg-drop-shadow)] select-none",
-          dropdown.isAnimatedIn()
-            ? "transition-[opacity,transform] duration-220 ease-spring"
-            : "transition-[opacity,transform] duration-120 ease-drawer",
-        )}
-        style={{
-          top: `${dropdown.displayPosition().top}px`,
-          left: `${dropdown.displayPosition().left}px`,
-          "z-index": `${Z_INDEX_OVERLAY}`,
-          "pointer-events": dropdown.isAnimatedIn() ? "auto" : "none",
-          "transform-origin": DROPDOWN_EDGE_TRANSFORM_ORIGIN[dropdown.lastAnchorEdge()],
-          opacity: dropdown.isAnimatedIn() ? "1" : "0",
-          transform: dropdown.isAnimatedIn() ? "scale(1)" : "scale(0.92)",
-          "--rg-edit-list-max-h": `${EDIT_PROPERTY_LIST_MAX_HEIGHT_PX}px`,
-        }}
-        onPointerDown={suppressMenuEvent}
-        onMouseDown={suppressMenuEvent}
-        onClick={suppressMenuEvent}
-        onContextMenu={suppressMenuEvent}
-      >
         <div
-          ref={panelSurfaceRef}
-          class="contain-layout flex flex-col justify-center items-start rounded-[14px] overflow-hidden antialiased w-fit h-fit [font-synthesis:none] [corner-shape:superellipse(1.25)] bg-[var(--rg-panel-bg)]"
+          ref={containerRef}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Style element"
+          data-react-grab-ignore-events
+          data-react-grab-edit-panel
+          data-rg-compact={isCompact() ? "true" : "false"}
+          class={cn(
+            "fixed font-sans text-[13px] antialiased [filter:var(--rg-drop-shadow)] select-none",
+            dropdown.isAnimatedIn()
+              ? "transition-[opacity,transform] duration-220 ease-spring"
+              : "transition-[opacity,transform] duration-120 ease-drawer",
+          )}
           style={{
-            "min-width": isCompact() ? undefined : `${EDIT_PANEL_MIN_WIDTH_PX}px`,
-            "max-width": `${EDIT_PANEL_MAX_WIDTH_PX}px`,
-            transform: `translateX(${stepController.heldDirection() * EDIT_VALUE_BUMP_PX}px)`,
-            transition: `transform ${EDIT_VALUE_BUMP_MS}ms ${EDIT_SLIDER_SPRING_EASING}`,
+            top: `${dropdown.displayPosition().top}px`,
+            left: `${dropdown.displayPosition().left}px`,
+            "z-index": `${Z_INDEX_OVERLAY}`,
+            "pointer-events": dropdown.isAnimatedIn() ? "auto" : "none",
+            "transform-origin": DROPDOWN_EDGE_TRANSFORM_ORIGIN[dropdown.lastAnchorEdge()],
+            opacity: dropdown.isAnimatedIn() ? "1" : "0",
+            transform: dropdown.isAnimatedIn() ? "scale(1)" : "scale(0.92)",
+            "--rg-edit-list-max-h": `${EDIT_PROPERTY_LIST_MAX_HEIGHT_PX}px`,
           }}
+          onPointerDown={suppressMenuEvent}
+          onMouseDown={suppressMenuEvent}
+          onClick={suppressMenuEvent}
+          onContextMenu={suppressMenuEvent}
         >
-          <Show
-            when={isPendingDismiss()}
-            fallback={
-              <Show when={!isCompact()}>
-                <div
-                  class={cn(
-                    "contain-layout shrink-0 flex items-center gap-1 pt-1.5 pb-1 h-fit px-2",
-                    hasPendingTweaks() ? "w-full self-stretch justify-between" : "w-fit",
-                  )}
-                  onMouseEnter={() => setIsHeaderHovered(true)}
-                  onMouseLeave={() => setIsHeaderHovered(false)}
-                >
-                  <TagBadge
-                    tagName={tagDisplay().tagName}
-                    componentName={tagDisplay().componentName}
-                    isClickable={false}
-                    onClick={() => {}}
-                    shrink
-                  />
-                  <Show when={hasPendingTweaks()}>
-                    <button
-                      data-react-grab-ignore-events
-                      data-react-grab-copy-button
-                      type="button"
-                      class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[var(--rg-surface-hover)] [border-width:0.5px] border-solid border-[var(--rg-border-button)] cursor-pointer transition-all hover:bg-[var(--rg-surface-active)] press-scale h-[17px]"
-                      onClick={(event) => {
-                        event.preventDefault();
-                        event.stopPropagation();
-                        handleSubmit();
-                      }}
-                    >
-                      <span class="text-[var(--rg-text-primary)] text-[13px] leading-3.5 font-sans font-medium">
-                        Copy
-                      </span>
-                    </button>
-                  </Show>
-                </div>
-              </Show>
-            }
-          >
-            <div
-              role="alertdialog"
-              aria-modal="true"
-              aria-labelledby="rg-discard-prompt-title"
-              class="contain-layout shrink-0 flex items-center justify-between gap-2 pt-1.5 pb-1 px-2 w-full self-stretch"
-            >
-              <span
-                id="rg-discard-prompt-title"
-                class="text-[var(--rg-text-primary)] text-[13px] leading-4 font-sans font-medium"
-              >
-                Discard edits?
-              </span>
-              <div class="flex items-center gap-[5px]">
-                <button
-                  data-react-grab-ignore-events
-                  data-react-grab-discard-button="cancel"
-                  type="button"
-                  class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[var(--rg-surface-hover)] [border-width:0.5px] border-solid border-[var(--rg-border-button)] cursor-pointer transition-all hover:bg-[var(--rg-surface-active)] press-scale h-[17px]"
-                  onClick={(event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    discardConfirmation.hide();
-                  }}
-                >
-                  <span class="text-[var(--rg-text-primary)] text-[13px] leading-3.5 font-sans font-medium">
-                    No
-                  </span>
-                </button>
-                <button
-                  data-react-grab-ignore-events
-                  data-react-grab-discard-button="confirm"
-                  type="button"
-                  class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[var(--rg-error-bg)] cursor-pointer transition-all hover:bg-[var(--rg-error-bg-hover)] press-scale h-[17px]"
-                  onClick={(event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    closePanel("discard");
-                  }}
-                >
-                  <span class="text-[var(--rg-error-text)] text-[13px] leading-3.5 font-sans font-medium">
-                    Yes
-                  </span>
-                </button>
-              </div>
-            </div>
-          </Show>
-
           <div
-            class={
-              isSearchInputHidden()
-                ? ""
-                : "[font-synthesis:none] contain-layout shrink-0 flex flex-col items-start px-2 py-1.5 w-full self-stretch [border-top-width:0.5px] border-t-solid border-t-[var(--rg-border-subtle)] antialiased"
-            }
-            style={isSearchInputHidden() ? HIDDEN_FOCUS_PRESERVING_STYLE : undefined}
+            ref={panelSurfaceRef}
+            class="contain-layout flex flex-col justify-center items-start rounded-[14px] overflow-hidden antialiased w-fit h-fit [font-synthesis:none] [corner-shape:superellipse(1.25)] bg-[var(--rg-panel-bg)]"
+            style={{
+              "min-width": isCompact() ? undefined : `${EDIT_PANEL_MIN_WIDTH_PX}px`,
+              "max-width": `${EDIT_PANEL_MAX_WIDTH_PX}px`,
+              transform: `translateX(${stepController.heldDirection() * EDIT_VALUE_BUMP_PX}px)`,
+              transition: `transform ${EDIT_VALUE_BUMP_MS}ms ${EDIT_SLIDER_SPRING_EASING}`,
+            }}
           >
-            <textarea
-              ref={(element) => {
-                searchInputRef = element;
-              }}
-              data-react-grab-ignore-events
-              data-react-grab-input
-              aria-label="Search properties"
-              aria-keyshortcuts="Enter Escape ArrowUp ArrowDown ArrowLeft ArrowRight Tab"
-              autocapitalize="none"
-              autocorrect="off"
-              autocomplete="off"
-              spellcheck={false}
-              tabIndex={isSearchInputHidden() ? -1 : 0}
-              class="text-[var(--rg-text-primary)] text-[13px] leading-4 font-medium bg-transparent border-none resize-none w-full p-0 m-0 outline-none"
-              style={{
-                "caret-color": "var(--rg-text-primary)",
-                "field-sizing": "content",
-                "min-height": "16px",
-                "max-height": "16px",
-                "scrollbar-width": "none",
-              }}
-              value={searchQuery()}
-              onInput={(event) => {
-                const nextSearchQuery = replaceInlineNumericPrefix(event.currentTarget.value);
-                if (nextSearchQuery !== event.currentTarget.value) {
-                  event.currentTarget.value = nextSearchQuery;
-                }
-                if (autoApply.tryApplyNumericValue(nextSearchQuery)) {
-                  keepInlineNumericSearchQuery();
-                  setSearchQuery(nextSearchQuery);
-                  queueInlineNumericReplacementForQuery(nextSearchQuery);
-                  ensureSearchFocused();
-                  return;
-                }
-                cancelInlineNumericReplacement();
-                if (autoApply.isInlineNumericDraft(nextSearchQuery)) {
-                  keepInlineNumericSearchQuery();
-                  setSearchQuery(nextSearchQuery);
-                  ensureSearchFocused();
-                  return;
-                }
-                setSearchQuery(nextSearchQuery);
-                setInlineNumericSearchQuery(null);
-                setActiveIndex(nextSearchQuery.trim() === "" ? firstNumericActiveIndex() : 0);
-                expandPanel();
-                autoApply.applyTailwindClass(nextSearchQuery);
-              }}
-              onKeyDown={handleSearchKeyDown}
-              placeholder={
-                isCompact() ? (activeProperty()?.label ?? "Search property") : "Search property"
+            <Show
+              when={isPendingDismiss()}
+              fallback={
+                <Show when={!isCompact()}>
+                  <div
+                    class={cn(
+                      "contain-layout shrink-0 flex items-center gap-1 pt-1.5 pb-1 h-fit px-2",
+                      hasPendingTweaks() ? "w-full self-stretch justify-between" : "w-fit",
+                    )}
+                    onMouseEnter={() => setIsHeaderHovered(true)}
+                    onMouseLeave={() => setIsHeaderHovered(false)}
+                  >
+                    <TagBadge
+                      tagName={tagDisplay().tagName}
+                      componentName={tagDisplay().componentName}
+                      isClickable={false}
+                      onClick={() => {}}
+                      shrink
+                    />
+                    <Show when={hasPendingTweaks()}>
+                      <button
+                        data-react-grab-ignore-events
+                        data-react-grab-copy-button
+                        type="button"
+                        class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[var(--rg-surface-hover)] [border-width:0.5px] border-solid border-[var(--rg-border-button)] cursor-pointer transition-all hover:bg-[var(--rg-surface-active)] press-scale h-[17px]"
+                        onClick={(event) => {
+                          event.preventDefault();
+                          event.stopPropagation();
+                          handleSubmit();
+                        }}
+                      >
+                        <span class="text-[var(--rg-text-primary)] text-[13px] leading-3.5 font-sans font-medium">
+                          Copy
+                        </span>
+                      </button>
+                    </Show>
+                  </div>
+                </Show>
               }
-              rows={1}
-            />
-          </div>
+            >
+              <div
+                role="alertdialog"
+                aria-modal="true"
+                aria-labelledby="rg-discard-prompt-title"
+                class="contain-layout shrink-0 flex items-center justify-between gap-2 pt-1.5 pb-1 px-2 w-full self-stretch"
+              >
+                <span
+                  id="rg-discard-prompt-title"
+                  class="text-[var(--rg-text-primary)] text-[13px] leading-4 font-sans font-medium"
+                >
+                  Discard edits?
+                </span>
+                <div class="flex items-center gap-[5px]">
+                  <button
+                    data-react-grab-ignore-events
+                    data-react-grab-discard-button="cancel"
+                    type="button"
+                    class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[var(--rg-surface-hover)] [border-width:0.5px] border-solid border-[var(--rg-border-button)] cursor-pointer transition-all hover:bg-[var(--rg-surface-active)] press-scale h-[17px]"
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      discardConfirmation.hide();
+                    }}
+                  >
+                    <span class="text-[var(--rg-text-primary)] text-[13px] leading-3.5 font-sans font-medium">
+                      No
+                    </span>
+                  </button>
+                  <button
+                    data-react-grab-ignore-events
+                    data-react-grab-discard-button="confirm"
+                    type="button"
+                    class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[var(--rg-error-bg)] cursor-pointer transition-all hover:bg-[var(--rg-error-bg-hover)] press-scale h-[17px]"
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      closePanel("discard");
+                    }}
+                  >
+                    <span class="text-[var(--rg-error-text)] text-[13px] leading-3.5 font-sans font-medium">
+                      Yes
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </Show>
 
-          <Show when={filteredProperties().length > 0}>
             <div
               class={
-                isCompact()
+                isSearchInputHidden()
                   ? ""
-                  : "[font-synthesis:none] contain-layout shrink-0 flex flex-col items-start w-full self-stretch antialiased"
+                  : "[font-synthesis:none] contain-layout shrink-0 flex flex-col items-start px-2 py-1.5 w-full self-stretch [border-top-width:0.5px] border-t-solid border-t-[var(--rg-border-subtle)] antialiased"
               }
-              style={isCompact() ? HIDDEN_FOCUS_PRESERVING_STYLE : undefined}
+              style={isSearchInputHidden() ? HIDDEN_FOCUS_PRESERVING_STYLE : undefined}
             >
-              <PropertyList
-                properties={filteredProperties()}
-                activeIndex={activeIndex()}
-                activeKey={activeKey()}
-                onHoverIndex={setActiveIndex}
-                onSelect={handleSelectProperty}
-                onStep={stepFromPointer}
-                onCommit={commitActive}
-                onColorPickerRegister={registerColorPickerTrigger}
-                onEditComplete={ensureSearchFocused}
-                onInvalidCommit={playShake}
-                onInteract={markAsInteracting}
-                isAdjusting={isTransientInteraction}
-                activeTailwindLabel={activeTailwindLabel()}
+              <textarea
+                ref={(element) => {
+                  searchInputRef = element;
+                }}
+                data-react-grab-ignore-events
+                data-react-grab-input
+                aria-label="Search properties"
+                aria-keyshortcuts="Enter Escape ArrowUp ArrowDown ArrowLeft ArrowRight Tab"
+                autocapitalize="none"
+                autocorrect="off"
+                autocomplete="off"
+                spellcheck={false}
+                tabIndex={isSearchInputHidden() ? -1 : 0}
+                class="text-[var(--rg-text-primary)] text-[13px] leading-4 font-medium bg-transparent border-none resize-none w-full p-0 m-0 outline-none"
+                style={{
+                  "caret-color": "var(--rg-text-primary)",
+                  "field-sizing": "content",
+                  "min-height": "16px",
+                  "max-height": "16px",
+                  "scrollbar-width": "none",
+                }}
+                value={searchQuery()}
+                onInput={(event) => {
+                  const nextSearchQuery = replaceInlineNumericPrefix(event.currentTarget.value);
+                  if (nextSearchQuery !== event.currentTarget.value) {
+                    event.currentTarget.value = nextSearchQuery;
+                  }
+                  if (autoApply.tryApplyNumericValue(nextSearchQuery)) {
+                    keepInlineNumericSearchQuery();
+                    setSearchQuery(nextSearchQuery);
+                    queueInlineNumericReplacementForQuery(nextSearchQuery);
+                    ensureSearchFocused();
+                    return;
+                  }
+                  cancelInlineNumericReplacement();
+                  if (autoApply.isInlineNumericDraft(nextSearchQuery)) {
+                    keepInlineNumericSearchQuery();
+                    setSearchQuery(nextSearchQuery);
+                    ensureSearchFocused();
+                    return;
+                  }
+                  setSearchQuery(nextSearchQuery);
+                  setInlineNumericSearchQuery(null);
+                  setActiveIndex(nextSearchQuery.trim() === "" ? firstNumericActiveIndex() : 0);
+                  expandPanel();
+                  autoApply.applyTailwindClass(nextSearchQuery);
+                }}
+                onKeyDown={handleSearchKeyDown}
+                placeholder={
+                  isCompact() ? (activeProperty()?.label ?? "Search property") : "Search property"
+                }
+                rows={1}
               />
             </div>
-          </Show>
 
-          <Show when={isCompact() && activeProperty()}>
-            {(compactProperty) => (
+            <Show when={filteredProperties().length > 0}>
               <div
-                class="flex items-center justify-center w-full px-3 py-1.5 min-h-[28px]"
-                onMouseDown={(event) => event.preventDefault()}
+                class={
+                  isCompact()
+                    ? ""
+                    : "[font-synthesis:none] contain-layout shrink-0 flex flex-col items-start w-full self-stretch antialiased"
+                }
+                style={isCompact() ? HIDDEN_FOCUS_PRESERVING_STYLE : undefined}
               >
-                <ActivePropertyControl
-                  property={compactProperty()}
+                <PropertyList
+                  properties={filteredProperties()}
+                  activeIndex={activeIndex()}
                   activeKey={activeKey()}
+                  onHoverIndex={setActiveIndex}
+                  onSelect={handleSelectProperty}
                   onStep={stepFromPointer}
                   onCommit={commitActive}
+                  onColorPickerRegister={registerColorPickerTrigger}
                   onEditComplete={ensureSearchFocused}
                   onInvalidCommit={playShake}
                   onInteract={markAsInteracting}
-                  onColorPickerRegister={registerColorPickerTrigger}
-                  showLabel={false}
-                  tailwindLabel={activeTailwindLabel()}
-                  emphasized
+                  isAdjusting={isTransientInteraction}
+                  activeTailwindLabel={activeTailwindLabel()}
                 />
               </div>
-            )}
-          </Show>
+            </Show>
+
+            <Show when={isCompact() && activeProperty()}>
+              {(compactProperty) => (
+                <div
+                  class="flex items-center justify-center w-full px-3 py-1.5 min-h-[28px]"
+                  onMouseDown={(event) => event.preventDefault()}
+                >
+                  <ActivePropertyControl
+                    property={compactProperty()}
+                    activeKey={activeKey()}
+                    onStep={stepFromPointer}
+                    onCommit={commitActive}
+                    onEditComplete={ensureSearchFocused}
+                    onInvalidCommit={playShake}
+                    onInteract={markAsInteracting}
+                    onColorPickerRegister={registerColorPickerTrigger}
+                    showLabel={false}
+                    tailwindLabel={activeTailwindLabel()}
+                    emphasized
+                  />
+                </div>
+              )}
+            </Show>
+          </div>
         </div>
-      </div>
       </Show>
     </>
   );

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -103,20 +103,13 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     return numericIndex > 0 ? numericIndex : 0;
   };
   const [activeIndex, setActiveIndex] = createSignal(firstNumericActiveIndex());
-
-  // Plain getters, not memos: they read `transformController`, which is created
-  // lower down in natural source order (after `commit`). Memos evaluate eagerly
-  // during setup and would hit the controller's temporal dead zone; cheap
-  // boolean getters defer the read until render/effects run, by which point the
-  // controller exists. The downstream `setInteracting` signal dedupes, so the
-  // lost memo caching costs nothing observable.
-  const hasPendingTweaks = () => tweakStore.hasPendingTweaks() || transformController.hasChanged();
+  const hasPendingTweaks = createMemo(() => tweakStore.hasPendingTweaks());
   const [isCompact, setIsCompact] = createSignal(false);
 
   let activeKeyTimerId: ReturnType<typeof setTimeout> | undefined;
   let interactingIdleTimerId: ReturnType<typeof setTimeout> | undefined;
   const [isTransientInteraction, setIsTransientInteraction] = createSignal(false);
-  const isInteracting = () => isTransientInteraction() || hasPendingTweaks();
+  const isInteracting = createMemo(() => isTransientInteraction() || hasPendingTweaks());
   const [isHeaderHovered, setIsHeaderHovered] = createSignal(false);
 
   const tagDisplay = createMemo(() =>
@@ -147,7 +140,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     }, EDIT_PANEL_ACTIVE_KEY_FLASH_MS);
   };
 
-  const effectiveInteracting = () => isInteracting() && !isHeaderHovered();
+  const effectiveInteracting = createMemo(() => isInteracting() && !isHeaderHovered());
 
   createEffect(() => {
     const nextInteracting = effectiveInteracting();
@@ -192,18 +185,13 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     if (options.shouldCompact) setIsCompact(true);
   };
 
-  const sizeProperties: Record<"width" | "height", EditableProperty | undefined> = {
-    width: initialProperties.find((property) => property.key === "width"),
-    height: initialProperties.find((property) => property.key === "height"),
-  };
+  const propertyByKey = new Map(initialProperties.map((property) => [property.key, property]));
   const transformController = createTransformController({
     getElement: () => props.state.element,
-    preview,
-    commitSize: (cssProperty, valuePx) => {
-      const property = sizeProperties[cssProperty];
-      if (property?.kind === "numeric") commit(property, valuePx);
+    commitStyle: (cssProperty, value) => {
+      const property = propertyByKey.get(cssProperty);
+      if (property) commit(property, value);
     },
-    onInteract: markAsInteracting,
   });
 
   const isShiftHeld = createShiftTracker();
@@ -273,8 +261,6 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
 
   const handleSubmit = () => {
     const pendingEdits = tweakStore.buildPendingEdits();
-    const transformEdit = transformController.buildPendingEdit();
-    if (transformEdit) pendingEdits.push(transformEdit);
     const entry = {
       filePath: props.state.filePath ?? "",
       lineNumber: props.state.lineNumber ?? 0,

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -200,6 +200,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
       if (index >= 0) setActiveIndex(index);
       setIsCompact(true);
     },
+    onInvalid: () => props.onDismiss(),
   });
 
   const isShiftHeld = createShiftTracker();

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -48,6 +48,11 @@ import { createStepController } from "./step-controller.js";
 import { stepProperty } from "./step-property.js";
 import { createTailwindAutoApply } from "./tailwind-autoapply.js";
 import { createTweakStore } from "./tweak-store.js";
+import { TransformOverlay } from "../transform-overlay/index.js";
+import {
+  createTransformController,
+  formatTransformValue,
+} from "../transform-overlay/transform-controller.js";
 
 interface EditPanelProps {
   state: EditPanelState | null;
@@ -101,7 +106,8 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     return numericIndex > 0 ? numericIndex : 0;
   };
   const [activeIndex, setActiveIndex] = createSignal(firstNumericActiveIndex());
-  const hasPendingTweaks = createMemo(() => tweakStore.hasPendingTweaks());
+  const [hasTransformChanges, setHasTransformChanges] = createSignal(false);
+  const hasPendingTweaks = createMemo(() => tweakStore.hasPendingTweaks() || hasTransformChanges());
   const [isCompact, setIsCompact] = createSignal(false);
 
   let activeKeyTimerId: ReturnType<typeof setTimeout> | undefined;
@@ -183,6 +189,19 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     if (options.shouldCompact) setIsCompact(true);
   };
 
+  const propertyByKey = new Map(initialProperties.map((property) => [property.key, property]));
+
+  const transformController = createTransformController({
+    getElement: () => props.state.element,
+    preview,
+    commitSize: (cssProperty, valuePx) => {
+      const property = propertyByKey.get(cssProperty);
+      if (property?.kind === "numeric") commit(property, valuePx);
+    },
+    onInteract: markAsInteracting,
+    onChange: () => setHasTransformChanges(transformController.hasChanged()),
+  });
+
   const isShiftHeld = createShiftTracker();
 
   const commitTweak = (
@@ -250,6 +269,14 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
 
   const handleSubmit = () => {
     const pendingEdits = tweakStore.buildPendingEdits();
+    if (transformController.hasChanged()) {
+      pendingEdits.push({
+        kind: "transform",
+        key: "transform",
+        cssProperties: ["transform"],
+        value: formatTransformValue(transformController.values()),
+      });
+    }
     const entry = {
       filePath: props.state.filePath ?? "",
       lineNumber: props.state.lineNumber ?? 0,
@@ -442,231 +469,234 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
   };
 
   return (
-    <Show when={dropdown.shouldMount()}>
-      <div
-        ref={containerRef}
-        role="dialog"
-        aria-modal="true"
-        aria-label="Style element"
-        data-react-grab-ignore-events
-        data-react-grab-edit-panel
-        data-rg-compact={isCompact() ? "true" : "false"}
-        class={cn(
-          "fixed font-sans text-[13px] antialiased [filter:var(--rg-drop-shadow)] select-none",
-          dropdown.isAnimatedIn()
-            ? "transition-[opacity,transform] duration-220 ease-spring"
-            : "transition-[opacity,transform] duration-120 ease-drawer",
-        )}
-        style={{
-          top: `${dropdown.displayPosition().top}px`,
-          left: `${dropdown.displayPosition().left}px`,
-          "z-index": `${Z_INDEX_OVERLAY}`,
-          "pointer-events": dropdown.isAnimatedIn() ? "auto" : "none",
-          "transform-origin": DROPDOWN_EDGE_TRANSFORM_ORIGIN[dropdown.lastAnchorEdge()],
-          opacity: dropdown.isAnimatedIn() ? "1" : "0",
-          transform: dropdown.isAnimatedIn() ? "scale(1)" : "scale(0.92)",
-          "--rg-edit-list-max-h": `${EDIT_PROPERTY_LIST_MAX_HEIGHT_PX}px`,
-        }}
-        onPointerDown={suppressMenuEvent}
-        onMouseDown={suppressMenuEvent}
-        onClick={suppressMenuEvent}
-        onContextMenu={suppressMenuEvent}
-      >
+    <>
+      <TransformOverlay controller={transformController} />
+      <Show when={dropdown.shouldMount()}>
         <div
-          ref={panelSurfaceRef}
-          class="contain-layout flex flex-col justify-center items-start rounded-[14px] overflow-hidden antialiased w-fit h-fit [font-synthesis:none] [corner-shape:superellipse(1.25)] bg-[var(--rg-panel-bg)]"
+          ref={containerRef}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Style element"
+          data-react-grab-ignore-events
+          data-react-grab-edit-panel
+          data-rg-compact={isCompact() ? "true" : "false"}
+          class={cn(
+            "fixed font-sans text-[13px] antialiased [filter:var(--rg-drop-shadow)] select-none",
+            dropdown.isAnimatedIn()
+              ? "transition-[opacity,transform] duration-220 ease-spring"
+              : "transition-[opacity,transform] duration-120 ease-drawer",
+          )}
           style={{
-            "min-width": isCompact() ? undefined : `${EDIT_PANEL_MIN_WIDTH_PX}px`,
-            "max-width": `${EDIT_PANEL_MAX_WIDTH_PX}px`,
-            transform: `translateX(${stepController.heldDirection() * EDIT_VALUE_BUMP_PX}px)`,
-            transition: `transform ${EDIT_VALUE_BUMP_MS}ms ${EDIT_SLIDER_SPRING_EASING}`,
+            top: `${dropdown.displayPosition().top}px`,
+            left: `${dropdown.displayPosition().left}px`,
+            "z-index": `${Z_INDEX_OVERLAY}`,
+            "pointer-events": dropdown.isAnimatedIn() ? "auto" : "none",
+            "transform-origin": DROPDOWN_EDGE_TRANSFORM_ORIGIN[dropdown.lastAnchorEdge()],
+            opacity: dropdown.isAnimatedIn() ? "1" : "0",
+            transform: dropdown.isAnimatedIn() ? "scale(1)" : "scale(0.92)",
+            "--rg-edit-list-max-h": `${EDIT_PROPERTY_LIST_MAX_HEIGHT_PX}px`,
           }}
+          onPointerDown={suppressMenuEvent}
+          onMouseDown={suppressMenuEvent}
+          onClick={suppressMenuEvent}
+          onContextMenu={suppressMenuEvent}
         >
-          <Show
-            when={isPendingDismiss()}
-            fallback={
-              <Show when={!isCompact()}>
-                <div
-                  class={cn(
-                    "contain-layout shrink-0 flex items-center gap-1 pt-1.5 pb-1 h-fit px-2",
-                    hasPendingTweaks() ? "w-full self-stretch justify-between" : "w-fit",
-                  )}
-                  onMouseEnter={() => setIsHeaderHovered(true)}
-                  onMouseLeave={() => setIsHeaderHovered(false)}
-                >
-                  <TagBadge
-                    tagName={tagDisplay().tagName}
-                    componentName={tagDisplay().componentName}
-                    isClickable={false}
-                    onClick={() => {}}
-                    shrink
-                  />
-                  <Show when={hasPendingTweaks()}>
-                    <button
-                      data-react-grab-ignore-events
-                      data-react-grab-copy-button
-                      type="button"
-                      class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[var(--rg-surface-hover)] [border-width:0.5px] border-solid border-[var(--rg-border-button)] cursor-pointer transition-all hover:bg-[var(--rg-surface-active)] press-scale h-[17px]"
-                      onClick={(event) => {
-                        event.preventDefault();
-                        event.stopPropagation();
-                        handleSubmit();
-                      }}
-                    >
-                      <span class="text-[var(--rg-text-primary)] text-[13px] leading-3.5 font-sans font-medium">
-                        Copy
-                      </span>
-                    </button>
-                  </Show>
-                </div>
-              </Show>
-            }
-          >
-            <div
-              role="alertdialog"
-              aria-modal="true"
-              aria-labelledby="rg-discard-prompt-title"
-              class="contain-layout shrink-0 flex items-center justify-between gap-2 pt-1.5 pb-1 px-2 w-full self-stretch"
-            >
-              <span
-                id="rg-discard-prompt-title"
-                class="text-[var(--rg-text-primary)] text-[13px] leading-4 font-sans font-medium"
-              >
-                Discard edits?
-              </span>
-              <div class="flex items-center gap-[5px]">
-                <button
-                  data-react-grab-ignore-events
-                  data-react-grab-discard-button="cancel"
-                  type="button"
-                  class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[var(--rg-surface-hover)] [border-width:0.5px] border-solid border-[var(--rg-border-button)] cursor-pointer transition-all hover:bg-[var(--rg-surface-active)] press-scale h-[17px]"
-                  onClick={(event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    discardConfirmation.hide();
-                  }}
-                >
-                  <span class="text-[var(--rg-text-primary)] text-[13px] leading-3.5 font-sans font-medium">
-                    No
-                  </span>
-                </button>
-                <button
-                  data-react-grab-ignore-events
-                  data-react-grab-discard-button="confirm"
-                  type="button"
-                  class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[var(--rg-error-bg)] cursor-pointer transition-all hover:bg-[var(--rg-error-bg-hover)] press-scale h-[17px]"
-                  onClick={(event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    closePanel("discard");
-                  }}
-                >
-                  <span class="text-[var(--rg-error-text)] text-[13px] leading-3.5 font-sans font-medium">
-                    Yes
-                  </span>
-                </button>
-              </div>
-            </div>
-          </Show>
-
           <div
-            class={
-              isSearchInputHidden()
-                ? ""
-                : "[font-synthesis:none] contain-layout shrink-0 flex flex-col items-start px-2 py-1.5 w-full self-stretch [border-top-width:0.5px] border-t-solid border-t-[var(--rg-border-subtle)] antialiased"
-            }
-            style={isSearchInputHidden() ? HIDDEN_FOCUS_PRESERVING_STYLE : undefined}
+            ref={panelSurfaceRef}
+            class="contain-layout flex flex-col justify-center items-start rounded-[14px] overflow-hidden antialiased w-fit h-fit [font-synthesis:none] [corner-shape:superellipse(1.25)] bg-[var(--rg-panel-bg)]"
+            style={{
+              "min-width": isCompact() ? undefined : `${EDIT_PANEL_MIN_WIDTH_PX}px`,
+              "max-width": `${EDIT_PANEL_MAX_WIDTH_PX}px`,
+              transform: `translateX(${stepController.heldDirection() * EDIT_VALUE_BUMP_PX}px)`,
+              transition: `transform ${EDIT_VALUE_BUMP_MS}ms ${EDIT_SLIDER_SPRING_EASING}`,
+            }}
           >
-            <textarea
-              ref={(element) => {
-                searchInputRef = element;
-              }}
-              data-react-grab-ignore-events
-              data-react-grab-input
-              aria-label="Search properties"
-              aria-keyshortcuts="Enter Escape ArrowUp ArrowDown ArrowLeft ArrowRight Tab"
-              autocapitalize="none"
-              autocorrect="off"
-              autocomplete="off"
-              spellcheck={false}
-              tabIndex={isSearchInputHidden() ? -1 : 0}
-              class="text-[var(--rg-text-primary)] text-[13px] leading-4 font-medium bg-transparent border-none resize-none w-full p-0 m-0 outline-none"
-              style={{
-                "caret-color": "var(--rg-text-primary)",
-                "field-sizing": "content",
-                "min-height": "16px",
-                "max-height": "16px",
-                "scrollbar-width": "none",
-              }}
-              value={searchQuery()}
-              onInput={(event) => {
-                const nextSearchQuery = event.currentTarget.value;
-                setSearchQuery(nextSearchQuery);
-                if (autoApply.tryApplyNumericValue(nextSearchQuery)) return;
-                if (autoApply.isInlineNumericDraft(nextSearchQuery)) return;
-                setActiveIndex(nextSearchQuery.trim() === "" ? firstNumericActiveIndex() : 0);
-                setIsCompact(false);
-                autoApply.applyTailwindClass(nextSearchQuery);
-              }}
-              onKeyDown={handleSearchKeyDown}
-              placeholder={
-                isCompact() ? (activeProperty()?.label ?? "Search property") : "Search property"
+            <Show
+              when={isPendingDismiss()}
+              fallback={
+                <Show when={!isCompact()}>
+                  <div
+                    class={cn(
+                      "contain-layout shrink-0 flex items-center gap-1 pt-1.5 pb-1 h-fit px-2",
+                      hasPendingTweaks() ? "w-full self-stretch justify-between" : "w-fit",
+                    )}
+                    onMouseEnter={() => setIsHeaderHovered(true)}
+                    onMouseLeave={() => setIsHeaderHovered(false)}
+                  >
+                    <TagBadge
+                      tagName={tagDisplay().tagName}
+                      componentName={tagDisplay().componentName}
+                      isClickable={false}
+                      onClick={() => {}}
+                      shrink
+                    />
+                    <Show when={hasPendingTweaks()}>
+                      <button
+                        data-react-grab-ignore-events
+                        data-react-grab-copy-button
+                        type="button"
+                        class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[var(--rg-surface-hover)] [border-width:0.5px] border-solid border-[var(--rg-border-button)] cursor-pointer transition-all hover:bg-[var(--rg-surface-active)] press-scale h-[17px]"
+                        onClick={(event) => {
+                          event.preventDefault();
+                          event.stopPropagation();
+                          handleSubmit();
+                        }}
+                      >
+                        <span class="text-[var(--rg-text-primary)] text-[13px] leading-3.5 font-sans font-medium">
+                          Copy
+                        </span>
+                      </button>
+                    </Show>
+                  </div>
+                </Show>
               }
-              rows={1}
-            />
-          </div>
+            >
+              <div
+                role="alertdialog"
+                aria-modal="true"
+                aria-labelledby="rg-discard-prompt-title"
+                class="contain-layout shrink-0 flex items-center justify-between gap-2 pt-1.5 pb-1 px-2 w-full self-stretch"
+              >
+                <span
+                  id="rg-discard-prompt-title"
+                  class="text-[var(--rg-text-primary)] text-[13px] leading-4 font-sans font-medium"
+                >
+                  Discard edits?
+                </span>
+                <div class="flex items-center gap-[5px]">
+                  <button
+                    data-react-grab-ignore-events
+                    data-react-grab-discard-button="cancel"
+                    type="button"
+                    class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[var(--rg-surface-hover)] [border-width:0.5px] border-solid border-[var(--rg-border-button)] cursor-pointer transition-all hover:bg-[var(--rg-surface-active)] press-scale h-[17px]"
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      discardConfirmation.hide();
+                    }}
+                  >
+                    <span class="text-[var(--rg-text-primary)] text-[13px] leading-3.5 font-sans font-medium">
+                      No
+                    </span>
+                  </button>
+                  <button
+                    data-react-grab-ignore-events
+                    data-react-grab-discard-button="confirm"
+                    type="button"
+                    class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[var(--rg-error-bg)] cursor-pointer transition-all hover:bg-[var(--rg-error-bg-hover)] press-scale h-[17px]"
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      closePanel("discard");
+                    }}
+                  >
+                    <span class="text-[var(--rg-error-text)] text-[13px] leading-3.5 font-sans font-medium">
+                      Yes
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </Show>
 
-          <Show when={filteredProperties().length > 0}>
             <div
               class={
-                isCompact()
+                isSearchInputHidden()
                   ? ""
-                  : "[font-synthesis:none] contain-layout shrink-0 flex flex-col items-start w-full self-stretch antialiased"
+                  : "[font-synthesis:none] contain-layout shrink-0 flex flex-col items-start px-2 py-1.5 w-full self-stretch [border-top-width:0.5px] border-t-solid border-t-[var(--rg-border-subtle)] antialiased"
               }
-              style={isCompact() ? HIDDEN_FOCUS_PRESERVING_STYLE : undefined}
+              style={isSearchInputHidden() ? HIDDEN_FOCUS_PRESERVING_STYLE : undefined}
             >
-              <PropertyList
-                properties={filteredProperties()}
-                activeIndex={activeIndex()}
-                activeKey={activeKey()}
-                onHoverIndex={setActiveIndex}
-                onSelect={handleSelectProperty}
-                onStep={stepFromPointer}
-                onCommit={commitActive}
-                onColorPickerRegister={registerColorPickerTrigger}
-                onEditComplete={ensureSearchFocused}
-                onInvalidCommit={playShake}
-                onInteract={markAsInteracting}
-                isAdjusting={isTransientInteraction}
-                activeTailwindLabel={activeTailwindLabel()}
+              <textarea
+                ref={(element) => {
+                  searchInputRef = element;
+                }}
+                data-react-grab-ignore-events
+                data-react-grab-input
+                aria-label="Search properties"
+                aria-keyshortcuts="Enter Escape ArrowUp ArrowDown ArrowLeft ArrowRight Tab"
+                autocapitalize="none"
+                autocorrect="off"
+                autocomplete="off"
+                spellcheck={false}
+                tabIndex={isSearchInputHidden() ? -1 : 0}
+                class="text-[var(--rg-text-primary)] text-[13px] leading-4 font-medium bg-transparent border-none resize-none w-full p-0 m-0 outline-none"
+                style={{
+                  "caret-color": "var(--rg-text-primary)",
+                  "field-sizing": "content",
+                  "min-height": "16px",
+                  "max-height": "16px",
+                  "scrollbar-width": "none",
+                }}
+                value={searchQuery()}
+                onInput={(event) => {
+                  const nextSearchQuery = event.currentTarget.value;
+                  setSearchQuery(nextSearchQuery);
+                  if (autoApply.tryApplyNumericValue(nextSearchQuery)) return;
+                  if (autoApply.isInlineNumericDraft(nextSearchQuery)) return;
+                  setActiveIndex(nextSearchQuery.trim() === "" ? firstNumericActiveIndex() : 0);
+                  setIsCompact(false);
+                  autoApply.applyTailwindClass(nextSearchQuery);
+                }}
+                onKeyDown={handleSearchKeyDown}
+                placeholder={
+                  isCompact() ? (activeProperty()?.label ?? "Search property") : "Search property"
+                }
+                rows={1}
               />
             </div>
-          </Show>
 
-          <Show when={isCompact() && activeProperty()}>
-            {(compactProperty) => (
+            <Show when={filteredProperties().length > 0}>
               <div
-                class="flex items-center justify-center w-full px-3 py-1.5 min-h-[28px]"
-                onMouseDown={(event) => event.preventDefault()}
+                class={
+                  isCompact()
+                    ? ""
+                    : "[font-synthesis:none] contain-layout shrink-0 flex flex-col items-start w-full self-stretch antialiased"
+                }
+                style={isCompact() ? HIDDEN_FOCUS_PRESERVING_STYLE : undefined}
               >
-                <ActivePropertyControl
-                  property={compactProperty()}
+                <PropertyList
+                  properties={filteredProperties()}
+                  activeIndex={activeIndex()}
                   activeKey={activeKey()}
+                  onHoverIndex={setActiveIndex}
+                  onSelect={handleSelectProperty}
                   onStep={stepFromPointer}
                   onCommit={commitActive}
+                  onColorPickerRegister={registerColorPickerTrigger}
                   onEditComplete={ensureSearchFocused}
                   onInvalidCommit={playShake}
                   onInteract={markAsInteracting}
-                  onColorPickerRegister={registerColorPickerTrigger}
-                  showLabel={false}
-                  tailwindLabel={activeTailwindLabel()}
-                  emphasized
+                  isAdjusting={isTransientInteraction}
+                  activeTailwindLabel={activeTailwindLabel()}
                 />
               </div>
-            )}
-          </Show>
+            </Show>
+
+            <Show when={isCompact() && activeProperty()}>
+              {(compactProperty) => (
+                <div
+                  class="flex items-center justify-center w-full px-3 py-1.5 min-h-[28px]"
+                  onMouseDown={(event) => event.preventDefault()}
+                >
+                  <ActivePropertyControl
+                    property={compactProperty()}
+                    activeKey={activeKey()}
+                    onStep={stepFromPointer}
+                    onCommit={commitActive}
+                    onEditComplete={ensureSearchFocused}
+                    onInvalidCommit={playShake}
+                    onInteract={markAsInteracting}
+                    onColorPickerRegister={registerColorPickerTrigger}
+                    showLabel={false}
+                    tailwindLabel={activeTailwindLabel()}
+                    emphasized
+                  />
+                </div>
+              )}
+            </Show>
+          </div>
         </div>
-      </div>
-    </Show>
+      </Show>
+    </>
   );
 };

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -103,13 +103,16 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     return numericIndex > 0 ? numericIndex : 0;
   };
   const [activeIndex, setActiveIndex] = createSignal(firstNumericActiveIndex());
-  const hasPendingTweaks = createMemo(() => tweakStore.hasPendingTweaks());
+  // Plain getters (not memos) so they can read `transformController`, created
+  // below in natural order: a memo evaluates eagerly during setup and would hit
+  // the controller's temporal dead zone. The reads stay cheap booleans.
+  const hasPendingTweaks = () => tweakStore.hasPendingTweaks() || transformController.hasMoved();
   const [isCompact, setIsCompact] = createSignal(false);
 
   let activeKeyTimerId: ReturnType<typeof setTimeout> | undefined;
   let interactingIdleTimerId: ReturnType<typeof setTimeout> | undefined;
   const [isTransientInteraction, setIsTransientInteraction] = createSignal(false);
-  const isInteracting = createMemo(() => isTransientInteraction() || hasPendingTweaks());
+  const isInteracting = () => isTransientInteraction() || hasPendingTweaks();
   const [isHeaderHovered, setIsHeaderHovered] = createSignal(false);
 
   const tagDisplay = createMemo(() =>
@@ -140,7 +143,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     }, EDIT_PANEL_ACTIVE_KEY_FLASH_MS);
   };
 
-  const effectiveInteracting = createMemo(() => isInteracting() && !isHeaderHovered());
+  const effectiveInteracting = () => isInteracting() && !isHeaderHovered();
 
   createEffect(() => {
     const nextInteracting = effectiveInteracting();
@@ -259,14 +262,21 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     () => isCompact() && searchQuery() !== "" && autoApply.isInlineNumericEdit(),
   );
 
+  // Distinguishes a copy (keep the DOM reinsertion) from any dismiss path
+  // (restore it in onCleanup), mirroring preview.forget vs preview.restore.
+  let didSubmit = false;
+
   const handleSubmit = () => {
+    didSubmit = true;
     const pendingEdits = tweakStore.buildPendingEdits();
     const entry = {
       filePath: props.state.filePath ?? "",
       lineNumber: props.state.lineNumber ?? 0,
       edits: pendingEdits,
     };
-    props.onSubmit(formatSessionEditsPrompt(pendingEdits.length > 0 ? [entry] : []));
+    const cssPrompt = formatSessionEditsPrompt(pendingEdits.length > 0 ? [entry] : []);
+    const movePrompt = transformController.describeMove();
+    props.onSubmit([movePrompt, cssPrompt].filter(Boolean).join("\n\n"));
   };
 
   const discardConfirmation = createDiscardConfirmation();
@@ -444,6 +454,8 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
       dropdown.clearAnimationHandles();
       setIsTransientInteraction(false);
       preview.forget();
+      // A copy keeps the reinsertion; every dismiss path restores it.
+      if (!didSubmit) transformController.restore();
     });
   });
 

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -22,10 +22,14 @@ import {
   Z_INDEX_OVERLAY,
 } from "../../constants.js";
 import type {
+  ArchivedEdit,
+  ArchivedEdits,
   DropdownAnchor,
   EditableProperty,
   EditPanelState,
+  EditTeardownReason,
   OverlayDismissSource,
+  PendingEditsEntry,
 } from "../../types.js";
 import { clampToRange } from "../../utils/clamp-to-range.js";
 import { cn } from "../../utils/cn.js";
@@ -58,6 +62,9 @@ interface EditPanelProps {
   onDismiss: () => void;
   onSubmit: (prompt: string) => void;
   onInteractingChange?: (interacting: boolean) => void;
+  teardownReason: () => EditTeardownReason;
+  onArchive: (item: ArchivedEdit) => void;
+  archived: () => ArchivedEdits;
 }
 
 export const EditPanel: Component<EditPanelProps> = (props) => (
@@ -71,6 +78,9 @@ export const EditPanel: Component<EditPanelProps> = (props) => (
             onDismiss={props.onDismiss}
             onSubmit={props.onSubmit}
             onInteractingChange={props.onInteractingChange}
+            teardownReason={props.teardownReason}
+            onArchive={props.onArchive}
+            archived={props.archived}
           />
         )}
       </Show>
@@ -84,6 +94,9 @@ interface EditPanelBodyProps {
   onDismiss: () => void;
   onSubmit: (prompt: string) => void;
   onInteractingChange?: (interacting: boolean) => void;
+  teardownReason: () => EditTeardownReason;
+  onArchive: (item: ArchivedEdit) => void;
+  archived: () => ArchivedEdits;
 }
 
 const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
@@ -91,6 +104,19 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
 
   let searchInputRef: HTMLTextAreaElement | undefined;
   const preview = props.state.preview;
+  // This body is keyed on its element, but `props.state` still resolves to the
+  // session's current state — which, during a retarget teardown, is already the
+  // next element. Mirror our own source into plain vars (guarded by element
+  // identity) so archiving in onCleanup reports this element, not the next one.
+  const ownElement = props.state.element;
+  let ownFilePath = props.state.filePath ?? "";
+  let ownLineNumber = props.state.lineNumber ?? 0;
+  createEffect(() => {
+    const current = props.state;
+    if (current.element !== ownElement) return;
+    ownFilePath = current.filePath ?? "";
+    ownLineNumber = current.lineNumber ?? 0;
+  });
 
   const [searchQuery, setSearchQuery] = createSignal(props.state.initialSearchQuery ?? "");
   const [inlineNumericSearchQuery, setInlineNumericSearchQuery] = createSignal<string | null>(null);
@@ -112,6 +138,13 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
   // below in natural order: a memo evaluates eagerly during setup and would hit
   // the controller's temporal dead zone. The reads stay cheap booleans.
   const hasPendingTweaks = () => tweakStore.hasPendingTweaks() || transformController.hasMoved();
+  // Edits batched from elements the user already switched away from. They feed
+  // the Copy affordance and discard flow even when this element is untouched.
+  const hasArchivedEdits = () => {
+    const archived = props.archived();
+    return archived.entries.length > 0 || archived.movePrompts.length > 0;
+  };
+  const hasAnyEdits = () => hasPendingTweaks() || hasArchivedEdits();
   const [isCompact, setIsCompact] = createSignal(false);
 
   let activeKeyTimerId: ReturnType<typeof setTimeout> | undefined;
@@ -343,21 +376,18 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     () => isCompact() && searchQuery() !== "" && autoApply.isInlineNumericEdit(),
   );
 
-  // Distinguishes a copy (keep the DOM reinsertion) from any dismiss path
-  // (restore it in onCleanup), mirroring preview.forget vs preview.restore.
-  let didSubmit = false;
-
   const handleSubmit = () => {
-    didSubmit = true;
+    const archived = props.archived();
+    const entries: PendingEditsEntry[] = [...archived.entries];
     const pendingEdits = tweakStore.buildPendingEdits();
-    const entry = {
-      filePath: props.state.filePath ?? "",
-      lineNumber: props.state.lineNumber ?? 0,
-      edits: pendingEdits,
-    };
-    const cssPrompt = formatSessionEditsPrompt(pendingEdits.length > 0 ? [entry] : []);
+    if (pendingEdits.length > 0) {
+      entries.push({ filePath: ownFilePath, lineNumber: ownLineNumber, edits: pendingEdits });
+    }
+    const movePrompts = [...archived.movePrompts];
     const movePrompt = transformController.describeMove();
-    props.onSubmit([movePrompt, cssPrompt].filter(Boolean).join("\n\n"));
+    if (movePrompt) movePrompts.push(movePrompt);
+    const cssPrompt = formatSessionEditsPrompt(entries);
+    props.onSubmit([...movePrompts, cssPrompt].filter(Boolean).join("\n\n"));
   };
 
   const discardConfirmation = createDiscardConfirmation();
@@ -384,7 +414,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
       closePanel("discard");
       return;
     }
-    if (!hasPendingTweaks()) {
+    if (!hasAnyEdits()) {
       closePanel(preview.hasAppliedStyles() ? "discard" : "preserve");
       return;
     }
@@ -451,7 +481,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
       // and the pending change is discarded instead of copied.
       const isUntweakedColor =
         property?.kind === "color" && !tweakStore.hasChangedTweakFor(property.key);
-      if (isUntweakedColor && colorPickerTrigger && !hasPendingTweaks()) {
+      if (isUntweakedColor && colorPickerTrigger && !hasAnyEdits()) {
         colorPickerTrigger();
         return;
       }
@@ -536,9 +566,27 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
       discardConfirmation.cleanup();
       dropdown.clearAnimationHandles();
       setIsTransientInteraction(false);
+      if (props.teardownReason() === "retarget") {
+        // Switching elements: keep this element's edits applied and hand them to
+        // the session so they join the copied prompt and revert together on
+        // discard. Skip preview.forget() — its baseline must survive that revert.
+        props.onArchive({
+          entry: {
+            filePath: ownFilePath,
+            lineNumber: ownLineNumber,
+            edits: tweakStore.buildPendingEdits(),
+          },
+          movePrompt: transformController.describeMove(),
+          restore: () => {
+            preview.restore();
+            transformController.restore();
+          },
+        });
+        return;
+      }
       preview.forget();
       // A copy keeps the reinsertion; every dismiss path restores it.
-      if (!didSubmit) transformController.restore();
+      if (props.teardownReason() !== "submit") transformController.restore();
     });
   });
 
@@ -597,7 +645,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
                   <div
                     class={cn(
                       "contain-layout shrink-0 flex items-center gap-1 pt-1.5 pb-1 h-fit px-2",
-                      hasPendingTweaks() ? "w-full self-stretch justify-between" : "w-fit",
+                      hasAnyEdits() ? "w-full self-stretch justify-between" : "w-fit",
                     )}
                     onMouseEnter={() => setIsHeaderHovered(true)}
                     onMouseLeave={() => setIsHeaderHovered(false)}
@@ -609,7 +657,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
                       onClick={() => {}}
                       shrink
                     />
-                    <Show when={hasPendingTweaks()}>
+                    <Show when={hasAnyEdits()}>
                       <button
                         data-react-grab-ignore-events
                         data-react-grab-copy-button

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -104,33 +104,19 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
   };
   const [activeIndex, setActiveIndex] = createSignal(firstNumericActiveIndex());
 
-  // Created before the memos that read it: createMemo evaluates eagerly, so a
-  // later `const` would hit the temporal dead zone. `commit`/`markAsInteracting`
-  // are only reached through deferred drag callbacks, so referencing them via
-  // closures here is safe even though they are defined further down.
-  const sizeProperties: Record<"width" | "height", EditableProperty | undefined> = {
-    width: initialProperties.find((property) => property.key === "width"),
-    height: initialProperties.find((property) => property.key === "height"),
-  };
-  const transformController = createTransformController({
-    getElement: () => props.state.element,
-    preview,
-    commitSize: (cssProperty, valuePx) => {
-      const property = sizeProperties[cssProperty];
-      if (property?.kind === "numeric") commit(property, valuePx);
-    },
-    onInteract: () => markAsInteracting(),
-  });
-
-  const hasPendingTweaks = createMemo(
-    () => tweakStore.hasPendingTweaks() || transformController.hasChanged(),
-  );
+  // Plain getters, not memos: they read `transformController`, which is created
+  // lower down in natural source order (after `commit`). Memos evaluate eagerly
+  // during setup and would hit the controller's temporal dead zone; cheap
+  // boolean getters defer the read until render/effects run, by which point the
+  // controller exists. The downstream `setInteracting` signal dedupes, so the
+  // lost memo caching costs nothing observable.
+  const hasPendingTweaks = () => tweakStore.hasPendingTweaks() || transformController.hasChanged();
   const [isCompact, setIsCompact] = createSignal(false);
 
   let activeKeyTimerId: ReturnType<typeof setTimeout> | undefined;
   let interactingIdleTimerId: ReturnType<typeof setTimeout> | undefined;
   const [isTransientInteraction, setIsTransientInteraction] = createSignal(false);
-  const isInteracting = createMemo(() => isTransientInteraction() || hasPendingTweaks());
+  const isInteracting = () => isTransientInteraction() || hasPendingTweaks();
   const [isHeaderHovered, setIsHeaderHovered] = createSignal(false);
 
   const tagDisplay = createMemo(() =>
@@ -161,7 +147,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     }, EDIT_PANEL_ACTIVE_KEY_FLASH_MS);
   };
 
-  const effectiveInteracting = createMemo(() => isInteracting() && !isHeaderHovered());
+  const effectiveInteracting = () => isInteracting() && !isHeaderHovered();
 
   createEffect(() => {
     const nextInteracting = effectiveInteracting();
@@ -205,6 +191,20 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     if (options.shouldFocus) ensureSearchFocused();
     if (options.shouldCompact) setIsCompact(true);
   };
+
+  const sizeProperties: Record<"width" | "height", EditableProperty | undefined> = {
+    width: initialProperties.find((property) => property.key === "width"),
+    height: initialProperties.find((property) => property.key === "height"),
+  };
+  const transformController = createTransformController({
+    getElement: () => props.state.element,
+    preview,
+    commitSize: (cssProperty, valuePx) => {
+      const property = sizeProperties[cssProperty];
+      if (property?.kind === "numeric") commit(property, valuePx);
+    },
+    onInteract: markAsInteracting,
+  });
 
   const isShiftHeld = createShiftTracker();
 

--- a/packages/react-grab/src/components/edit-panel/tweak-store.ts
+++ b/packages/react-grab/src/components/edit-panel/tweak-store.ts
@@ -16,6 +16,7 @@ interface CreateTweakStoreOptions {
 
 interface TweakStore {
   filteredProperties: () => EditableProperty[];
+  getProperty: (key: string) => EditableProperty | undefined;
   applyTweak: (property: EditableProperty, nextValue: number | string) => void;
   buildPendingEdits: () => PendingEdit[];
   hasPendingTweaks: () => boolean;
@@ -157,6 +158,7 @@ export const createTweakStore = (options: CreateTweakStoreOptions): TweakStore =
 
   return {
     filteredProperties,
+    getProperty: (key) => propertyByKey.get(key),
     applyTweak,
     buildPendingEdits,
     hasPendingTweaks,

--- a/packages/react-grab/src/components/renderer.tsx
+++ b/packages/react-grab/src/components/renderer.tsx
@@ -180,6 +180,9 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
         onDismiss={props.onEditPanelDismiss ?? (() => {})}
         onSubmit={props.onEditPanelSubmit ?? (() => {})}
         onInteractingChange={props.onEditPanelInteractingChange}
+        teardownReason={props.editPanelTeardownReason ?? (() => "dismiss")}
+        onArchive={props.onEditPanelArchive ?? (() => {})}
+        archived={props.editPanelArchived ?? (() => ({ entries: [], movePrompts: [] }))}
       />
     </>
   );

--- a/packages/react-grab/src/components/selection-label/index.tsx
+++ b/packages/react-grab/src/components/selection-label/index.tsx
@@ -24,6 +24,7 @@ import {
 import { autoResizeTextarea } from "../../utils/auto-resize-textarea.js";
 import { getArrowSize } from "../../utils/get-arrow-size.js";
 import { isKeyboardEventTriggeredByInput } from "../../utils/is-keyboard-event-triggered-by-input.js";
+import { onViewportChange } from "../../utils/on-viewport-change.js";
 import { cn } from "../../utils/cn.js";
 import { getTagDisplay } from "../../utils/get-tag-display.js";
 import { IconSubmit } from "../icons/icon-submit.jsx";
@@ -100,6 +101,7 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
   };
 
   let resizeObserver: ResizeObserver | undefined;
+  let stopViewportTracking: (() => void) | undefined;
 
   const handleTagHoverChange = (hovered: boolean) => {
     isTagCurrentlyHovered = hovered;
@@ -146,10 +148,7 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
       setPanelWidth(panelRef.getBoundingClientRect().width);
       resizeObserver.observe(panelRef);
     }
-    window.addEventListener("scroll", handleViewportChange, true);
-    window.addEventListener("resize", handleViewportChange);
-    window.visualViewport?.addEventListener("resize", handleViewportChange);
-    window.visualViewport?.addEventListener("scroll", handleViewportChange);
+    stopViewportTracking = onViewportChange(handleViewportChange);
     if (props.onToggleExpand) {
       window.addEventListener("keydown", handleGlobalKeyDown, { capture: true });
     }
@@ -157,10 +156,7 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
 
   onCleanup(() => {
     resizeObserver?.disconnect();
-    window.removeEventListener("scroll", handleViewportChange, true);
-    window.removeEventListener("resize", handleViewportChange);
-    window.visualViewport?.removeEventListener("resize", handleViewportChange);
-    window.visualViewport?.removeEventListener("scroll", handleViewportChange);
+    stopViewportTracking?.();
     // removeEventListener is a no-op for a listener that was never added,
     // so it does not need to mirror the onMount onToggleExpand guard. If
     // props.onToggleExpand were ever reactive between mount and cleanup,

--- a/packages/react-grab/src/components/transform-overlay/index.tsx
+++ b/packages/react-grab/src/components/transform-overlay/index.tsx
@@ -1,4 +1,4 @@
-import { For, type Component } from "solid-js";
+import { For, Show, type Component } from "solid-js";
 import {
   TRANSFORM_FRAME_BORDER_PX,
   TRANSFORM_HANDLE_SIZE_PX,
@@ -29,6 +29,7 @@ interface TransformOverlayProps {
 
 export const TransformOverlay: Component<TransformOverlayProps> = (props) => {
   const frame = props.controller.frame;
+  const indicator = props.controller.insertionIndicator;
 
   const beginInteraction = (event: PointerEvent, start: (event: PointerEvent) => void) => {
     if (event.button !== 0) return;
@@ -38,62 +39,83 @@ export const TransformOverlay: Component<TransformOverlayProps> = (props) => {
   };
 
   return (
-    <div
-      data-react-grab-ignore-events
-      data-react-grab-transform-overlay
-      style={{
-        position: "fixed",
-        left: `${frame().centerX}px`,
-        top: `${frame().centerY}px`,
-        width: `${frame().width}px`,
-        height: `${frame().height}px`,
-        transform: "translate(-50%, -50%)",
-        "z-index": `${Z_INDEX_TRANSFORM_OVERLAY}`,
-        "pointer-events": "none",
-      }}
-      onContextMenu={suppressMenuEvent}
-    >
-      <div
-        aria-label="Move element"
-        style={{
-          position: "absolute",
-          inset: "0",
-          border: `${TRANSFORM_FRAME_BORDER_PX}px solid ${TRANSFORM_OVERLAY_ACCENT}`,
-          "box-sizing": "border-box",
-          cursor: "move",
-          "pointer-events": "auto",
-          "touch-action": "none",
-        }}
-        onPointerDown={(event) => beginInteraction(event, props.controller.startMove)}
-      />
-
-      <For each={HANDLES}>
-        {(handle) => (
+    <>
+      <Show when={indicator()}>
+        {(line) => (
           <div
-            aria-label={`Resize ${handle.id}`}
+            data-react-grab-ignore-events
+            data-react-grab-insertion-indicator
             style={{
-              position: "absolute",
-              left: `${handle.leftPercent}%`,
-              top: `${handle.topPercent}%`,
-              width: `${TRANSFORM_HANDLE_SIZE_PX}px`,
-              height: `${TRANSFORM_HANDLE_SIZE_PX}px`,
-              transform: "translate(-50%, -50%)",
-              background: "var(--rg-panel-bg)",
-              border: `${TRANSFORM_FRAME_BORDER_PX}px solid ${TRANSFORM_OVERLAY_ACCENT}`,
-              "box-sizing": "border-box",
-              "border-radius": "2px",
-              cursor: handle.cursor,
-              "pointer-events": "auto",
-              "touch-action": "none",
+              position: "fixed",
+              left: `${line().left}px`,
+              top: `${line().top}px`,
+              width: `${line().width}px`,
+              height: `${line().height}px`,
+              background: TRANSFORM_OVERLAY_ACCENT,
+              "border-radius": "9999px",
+              "z-index": `${Z_INDEX_TRANSFORM_OVERLAY}`,
+              "pointer-events": "none",
             }}
-            onPointerDown={(event) =>
-              beginInteraction(event, (pointerEvent) =>
-                props.controller.startResize(pointerEvent, handle.id),
-              )
-            }
           />
         )}
-      </For>
-    </div>
+      </Show>
+      <div
+        data-react-grab-ignore-events
+        data-react-grab-transform-overlay
+        style={{
+          position: "fixed",
+          left: `${frame().centerX}px`,
+          top: `${frame().centerY}px`,
+          width: `${frame().width}px`,
+          height: `${frame().height}px`,
+          transform: "translate(-50%, -50%)",
+          "z-index": `${Z_INDEX_TRANSFORM_OVERLAY}`,
+          "pointer-events": "none",
+        }}
+        onContextMenu={suppressMenuEvent}
+      >
+        <div
+          aria-label="Move element"
+          style={{
+            position: "absolute",
+            inset: "0",
+            border: `${TRANSFORM_FRAME_BORDER_PX}px solid ${TRANSFORM_OVERLAY_ACCENT}`,
+            "box-sizing": "border-box",
+            cursor: "move",
+            "pointer-events": "auto",
+            "touch-action": "none",
+          }}
+          onPointerDown={(event) => beginInteraction(event, props.controller.startMove)}
+        />
+
+        <For each={HANDLES}>
+          {(handle) => (
+            <div
+              aria-label={`Resize ${handle.id}`}
+              style={{
+                position: "absolute",
+                left: `${handle.leftPercent}%`,
+                top: `${handle.topPercent}%`,
+                width: `${TRANSFORM_HANDLE_SIZE_PX}px`,
+                height: `${TRANSFORM_HANDLE_SIZE_PX}px`,
+                transform: "translate(-50%, -50%)",
+                background: "var(--rg-panel-bg)",
+                border: `${TRANSFORM_FRAME_BORDER_PX}px solid ${TRANSFORM_OVERLAY_ACCENT}`,
+                "box-sizing": "border-box",
+                "border-radius": "2px",
+                cursor: handle.cursor,
+                "pointer-events": "auto",
+                "touch-action": "none",
+              }}
+              onPointerDown={(event) =>
+                beginInteraction(event, (pointerEvent) =>
+                  props.controller.startResize(pointerEvent, handle.id),
+                )
+              }
+            />
+          )}
+        </For>
+      </div>
+    </>
   );
 };

--- a/packages/react-grab/src/components/transform-overlay/index.tsx
+++ b/packages/react-grab/src/components/transform-overlay/index.tsx
@@ -3,8 +3,6 @@ import {
   TRANSFORM_FRAME_BORDER_PX,
   TRANSFORM_HANDLE_SIZE_PX,
   TRANSFORM_OVERLAY_ACCENT,
-  TRANSFORM_ROTATE_HANDLE_OFFSET_PX,
-  TRANSFORM_ROTATE_HANDLE_SIZE_PX,
   Z_INDEX_TRANSFORM_OVERLAY,
 } from "../../constants.js";
 import type { TransformHandleId } from "../../types.js";
@@ -20,13 +18,9 @@ interface HandleDescriptor {
 
 const HANDLES: readonly HandleDescriptor[] = [
   { id: "nw", leftPercent: 0, topPercent: 0, cursor: "nwse-resize" },
-  { id: "n", leftPercent: 50, topPercent: 0, cursor: "ns-resize" },
   { id: "ne", leftPercent: 100, topPercent: 0, cursor: "nesw-resize" },
-  { id: "e", leftPercent: 100, topPercent: 50, cursor: "ew-resize" },
   { id: "se", leftPercent: 100, topPercent: 100, cursor: "nwse-resize" },
-  { id: "s", leftPercent: 50, topPercent: 100, cursor: "ns-resize" },
   { id: "sw", leftPercent: 0, topPercent: 100, cursor: "nesw-resize" },
-  { id: "w", leftPercent: 0, topPercent: 50, cursor: "ew-resize" },
 ];
 
 interface TransformOverlayProps {
@@ -53,8 +47,7 @@ export const TransformOverlay: Component<TransformOverlayProps> = (props) => {
         top: `${frame().centerY}px`,
         width: `${frame().width}px`,
         height: `${frame().height}px`,
-        transform: `translate(-50%, -50%) rotate(${frame().rotate}deg)`,
-        "transform-origin": "center center",
+        transform: "translate(-50%, -50%)",
         "z-index": `${Z_INDEX_TRANSFORM_OVERLAY}`,
         "pointer-events": "none",
       }}
@@ -72,26 +65,6 @@ export const TransformOverlay: Component<TransformOverlayProps> = (props) => {
           "touch-action": "none",
         }}
         onPointerDown={(event) => beginInteraction(event, props.controller.startMove)}
-      />
-
-      <div
-        aria-label="Rotate element"
-        style={{
-          position: "absolute",
-          left: "50%",
-          top: `${-TRANSFORM_ROTATE_HANDLE_OFFSET_PX}px`,
-          width: `${TRANSFORM_ROTATE_HANDLE_SIZE_PX}px`,
-          height: `${TRANSFORM_ROTATE_HANDLE_SIZE_PX}px`,
-          transform: "translate(-50%, -50%)",
-          "border-radius": "50%",
-          background: "var(--rg-panel-bg)",
-          border: `${TRANSFORM_FRAME_BORDER_PX}px solid ${TRANSFORM_OVERLAY_ACCENT}`,
-          "box-sizing": "border-box",
-          cursor: "grab",
-          "pointer-events": "auto",
-          "touch-action": "none",
-        }}
-        onPointerDown={(event) => beginInteraction(event, props.controller.startRotate)}
       />
 
       <For each={HANDLES}>

--- a/packages/react-grab/src/components/transform-overlay/index.tsx
+++ b/packages/react-grab/src/components/transform-overlay/index.tsx
@@ -1,0 +1,141 @@
+import { For, onCleanup, onMount, type Component } from "solid-js";
+import {
+  TRANSFORM_FRAME_BORDER_PX,
+  TRANSFORM_HANDLE_SIZE_PX,
+  TRANSFORM_OVERLAY_ACCENT,
+  TRANSFORM_ROTATE_HANDLE_OFFSET_PX,
+  TRANSFORM_ROTATE_HANDLE_SIZE_PX,
+  Z_INDEX_TRANSFORM_OVERLAY,
+} from "../../constants.js";
+import type { TransformHandleId } from "../../types.js";
+import { nativeCancelAnimationFrame, nativeRequestAnimationFrame } from "../../utils/native-raf.js";
+import { suppressMenuEvent } from "../../utils/suppress-menu-event.js";
+import type { TransformController } from "./transform-controller.js";
+
+interface HandleDescriptor {
+  id: TransformHandleId;
+  leftPercent: number;
+  topPercent: number;
+  cursor: string;
+}
+
+const HANDLES: readonly HandleDescriptor[] = [
+  { id: "nw", leftPercent: 0, topPercent: 0, cursor: "nwse-resize" },
+  { id: "n", leftPercent: 50, topPercent: 0, cursor: "ns-resize" },
+  { id: "ne", leftPercent: 100, topPercent: 0, cursor: "nesw-resize" },
+  { id: "e", leftPercent: 100, topPercent: 50, cursor: "ew-resize" },
+  { id: "se", leftPercent: 100, topPercent: 100, cursor: "nwse-resize" },
+  { id: "s", leftPercent: 50, topPercent: 100, cursor: "ns-resize" },
+  { id: "sw", leftPercent: 0, topPercent: 100, cursor: "nesw-resize" },
+  { id: "w", leftPercent: 0, topPercent: 50, cursor: "ew-resize" },
+];
+
+interface TransformOverlayProps {
+  controller: TransformController;
+}
+
+export const TransformOverlay: Component<TransformOverlayProps> = (props) => {
+  let frameId: number | null = null;
+
+  onMount(() => {
+    const tick = () => {
+      props.controller.refreshFrame();
+      frameId = nativeRequestAnimationFrame(tick);
+    };
+    frameId = nativeRequestAnimationFrame(tick);
+
+    onCleanup(() => {
+      if (frameId !== null) nativeCancelAnimationFrame(frameId);
+    });
+  });
+
+  const frame = props.controller.frame;
+
+  const beginInteraction = (event: PointerEvent, start: (event: PointerEvent) => void) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+    start(event);
+  };
+
+  return (
+    <div
+      data-react-grab-ignore-events
+      data-react-grab-transform-overlay
+      style={{
+        position: "fixed",
+        left: `${frame().centerX}px`,
+        top: `${frame().centerY}px`,
+        width: `${frame().width}px`,
+        height: `${frame().height}px`,
+        transform: `translate(-50%, -50%) rotate(${frame().rotate}deg)`,
+        "transform-origin": "center center",
+        "z-index": `${Z_INDEX_TRANSFORM_OVERLAY}`,
+        "pointer-events": "none",
+      }}
+      onContextMenu={suppressMenuEvent}
+    >
+      <div
+        aria-label="Move element"
+        style={{
+          position: "absolute",
+          inset: "0",
+          border: `${TRANSFORM_FRAME_BORDER_PX}px solid ${TRANSFORM_OVERLAY_ACCENT}`,
+          "box-sizing": "border-box",
+          cursor: "move",
+          "pointer-events": "auto",
+          "touch-action": "none",
+        }}
+        onPointerDown={(event) => beginInteraction(event, props.controller.startMove)}
+      />
+
+      <div
+        aria-label="Rotate element"
+        style={{
+          position: "absolute",
+          left: "50%",
+          top: `${-TRANSFORM_ROTATE_HANDLE_OFFSET_PX}px`,
+          width: `${TRANSFORM_ROTATE_HANDLE_SIZE_PX}px`,
+          height: `${TRANSFORM_ROTATE_HANDLE_SIZE_PX}px`,
+          transform: "translate(-50%, -50%)",
+          "border-radius": "50%",
+          background: "var(--rg-panel-bg)",
+          border: `${TRANSFORM_FRAME_BORDER_PX}px solid ${TRANSFORM_OVERLAY_ACCENT}`,
+          "box-sizing": "border-box",
+          cursor: "grab",
+          "pointer-events": "auto",
+          "touch-action": "none",
+        }}
+        onPointerDown={(event) => beginInteraction(event, props.controller.startRotate)}
+      />
+
+      <For each={HANDLES}>
+        {(handle) => (
+          <div
+            aria-label={`Resize ${handle.id}`}
+            style={{
+              position: "absolute",
+              left: `${handle.leftPercent}%`,
+              top: `${handle.topPercent}%`,
+              width: `${TRANSFORM_HANDLE_SIZE_PX}px`,
+              height: `${TRANSFORM_HANDLE_SIZE_PX}px`,
+              transform: "translate(-50%, -50%)",
+              background: "var(--rg-panel-bg)",
+              border: `${TRANSFORM_FRAME_BORDER_PX}px solid ${TRANSFORM_OVERLAY_ACCENT}`,
+              "box-sizing": "border-box",
+              "border-radius": "2px",
+              cursor: handle.cursor,
+              "pointer-events": "auto",
+              "touch-action": "none",
+            }}
+            onPointerDown={(event) =>
+              beginInteraction(event, (pointerEvent) =>
+                props.controller.startResize(pointerEvent, handle.id),
+              )
+            }
+          />
+        )}
+      </For>
+    </div>
+  );
+};

--- a/packages/react-grab/src/components/transform-overlay/index.tsx
+++ b/packages/react-grab/src/components/transform-overlay/index.tsx
@@ -1,5 +1,7 @@
 import { For, Show, type Component } from "solid-js";
 import {
+  OVERLAY_BORDER_COLOR_DEFAULT,
+  OVERLAY_FILL_COLOR_DEFAULT,
   TRANSFORM_FRAME_BORDER_PX,
   TRANSFORM_HANDLE_SIZE_PX,
   TRANSFORM_OVERLAY_ACCENT,
@@ -30,6 +32,7 @@ interface TransformOverlayProps {
 export const TransformOverlay: Component<TransformOverlayProps> = (props) => {
   const frame = props.controller.frame;
   const indicator = props.controller.insertionIndicator;
+  const ghost = props.controller.dragGhost;
 
   const beginInteraction = (event: PointerEvent, start: (event: PointerEvent) => void) => {
     if (event.button !== 0) return;
@@ -40,6 +43,27 @@ export const TransformOverlay: Component<TransformOverlayProps> = (props) => {
 
   return (
     <>
+      <Show when={ghost()}>
+        {(box) => (
+          <div
+            data-react-grab-ignore-events
+            data-react-grab-drag-ghost
+            style={{
+              position: "fixed",
+              left: `${box().left}px`,
+              top: `${box().top}px`,
+              width: `${box().width}px`,
+              height: `${box().height}px`,
+              background: OVERLAY_FILL_COLOR_DEFAULT,
+              border: `${TRANSFORM_FRAME_BORDER_PX}px dashed ${OVERLAY_BORDER_COLOR_DEFAULT}`,
+              "box-sizing": "border-box",
+              "border-radius": "4px",
+              "z-index": `${Z_INDEX_TRANSFORM_OVERLAY}`,
+              "pointer-events": "none",
+            }}
+          />
+        )}
+      </Show>
       <Show when={indicator()}>
         {(line) => (
           <div

--- a/packages/react-grab/src/components/transform-overlay/index.tsx
+++ b/packages/react-grab/src/components/transform-overlay/index.tsx
@@ -1,4 +1,4 @@
-import { For, onCleanup, onMount, type Component } from "solid-js";
+import { For, type Component } from "solid-js";
 import {
   TRANSFORM_FRAME_BORDER_PX,
   TRANSFORM_HANDLE_SIZE_PX,
@@ -8,7 +8,6 @@ import {
   Z_INDEX_TRANSFORM_OVERLAY,
 } from "../../constants.js";
 import type { TransformHandleId } from "../../types.js";
-import { nativeCancelAnimationFrame, nativeRequestAnimationFrame } from "../../utils/native-raf.js";
 import { suppressMenuEvent } from "../../utils/suppress-menu-event.js";
 import type { TransformController } from "./transform-controller.js";
 
@@ -35,20 +34,6 @@ interface TransformOverlayProps {
 }
 
 export const TransformOverlay: Component<TransformOverlayProps> = (props) => {
-  let frameId: number | null = null;
-
-  onMount(() => {
-    const tick = () => {
-      props.controller.refreshFrame();
-      frameId = nativeRequestAnimationFrame(tick);
-    };
-    frameId = nativeRequestAnimationFrame(tick);
-
-    onCleanup(() => {
-      if (frameId !== null) nativeCancelAnimationFrame(frameId);
-    });
-  });
-
   const frame = props.controller.frame;
 
   const beginInteraction = (event: PointerEvent, start: (event: PointerEvent) => void) => {

--- a/packages/react-grab/src/components/transform-overlay/transform-controller.ts
+++ b/packages/react-grab/src/components/transform-overlay/transform-controller.ts
@@ -1,6 +1,13 @@
 import { createSignal, onCleanup, onMount, type Accessor } from "solid-js";
 import { TRANSFORM_MIN_SIZE_PX } from "../../constants.js";
-import type { TransformFrame, TransformHandleId } from "../../types.js";
+import type {
+  DropTarget,
+  TransformFrame,
+  TransformHandleId,
+  TransformInsertionIndicator,
+} from "../../types.js";
+import { describeElementForPrompt } from "../../utils/describe-element-for-prompt.js";
+import { findDropTarget } from "../../utils/find-drop-target.js";
 
 interface TransformControllerDependencies {
   getElement: () => Element;
@@ -12,8 +19,17 @@ interface TransformControllerDependencies {
 
 export interface TransformController {
   frame: Accessor<TransformFrame>;
+  insertionIndicator: Accessor<TransformInsertionIndicator | null>;
+  hasMoved: () => boolean;
+  describeMove: () => string;
+  restore: () => void;
   startMove: (event: PointerEvent) => void;
   startResize: (event: PointerEvent, handle: TransformHandleId) => void;
+}
+
+interface DomPosition {
+  parent: Node;
+  nextSibling: Node | null;
 }
 
 const HANDLE_DIRECTION: Record<TransformHandleId, { x: -1 | 1; y: -1 | 1 }> = {
@@ -30,6 +46,13 @@ export const createTransformController = (
   // tracking refresh allocation-free while still driving reactivity.
   const frameValue: TransformFrame = { centerX: 0, centerY: 0, width: 0, height: 0 };
   const [frame, setFrame] = createSignal(frameValue, { equals: false });
+  const [insertionIndicator, setInsertionIndicator] =
+    createSignal<TransformInsertionIndicator | null>(null);
+  const [didMove, setDidMove] = createSignal(false);
+
+  // The element's DOM slot before any move, so a discarded drag can be undone.
+  let originPosition: DomPosition | null = null;
+  let lastDrop: DropTarget | null = null;
 
   // x/y are written as `left`/`top` offsets from the element's starting
   // position; static elements get `position: relative` on first interaction so
@@ -61,6 +84,60 @@ export const createTransformController = (
     setFrame(frameValue);
   };
 
+  const bindDrag = (
+    onMove: (event: PointerEvent) => void,
+    onUp?: (event: PointerEvent) => void,
+  ): void => {
+    const handleMove = (event: PointerEvent) => {
+      event.preventDefault();
+      onMove(event);
+    };
+    const handleUp = (event: PointerEvent) => {
+      window.removeEventListener("pointermove", handleMove, { capture: true });
+      window.removeEventListener("pointerup", handleUp, { capture: true });
+      window.removeEventListener("pointercancel", handleUp, { capture: true });
+      onUp?.(event);
+    };
+    window.addEventListener("pointermove", handleMove, { capture: true });
+    window.addEventListener("pointerup", handleUp, { capture: true });
+    window.addEventListener("pointercancel", handleUp, { capture: true });
+  };
+
+  const reinsert = (drop: DropTarget): void => {
+    const element = dependencies.getElement();
+    const parent = drop.reference.parentNode;
+    if (!parent || element === drop.reference || element.contains(drop.reference)) return;
+    if (!originPosition) {
+      originPosition = { parent: element.parentNode!, nextSibling: element.nextSibling };
+    }
+    const referenceNode = drop.placement === "before" ? drop.reference : drop.reference.nextSibling;
+    if (referenceNode === element) return;
+    parent.insertBefore(element, referenceNode);
+    lastDrop = drop;
+    setDidMove(true);
+    refreshFrame();
+  };
+
+  const previewDropAt = (clientX: number, clientY: number): DropTarget | null => {
+    const drop = findDropTarget(clientX, clientY, dependencies.getElement());
+    setInsertionIndicator(drop ? drop.indicator : null);
+    return drop;
+  };
+
+  const startMove = (event: PointerEvent): void => {
+    previewDropAt(event.clientX, event.clientY);
+    bindDrag(
+      (moveEvent) => {
+        previewDropAt(moveEvent.clientX, moveEvent.clientY);
+      },
+      (upEvent) => {
+        const drop = previewDropAt(upEvent.clientX, upEvent.clientY);
+        if (drop) reinsert(drop);
+        setInsertionIndicator(null);
+      },
+    );
+  };
+
   const ensurePositioned = (): void => {
     if (isPositioned) return;
     dependencies.commitStyle("position", "relative");
@@ -72,33 +149,6 @@ export const createTransformController = (
     dependencies.commitStyle("left", Math.round(baseLeft + offset.x));
     dependencies.commitStyle("top", Math.round(baseTop + offset.y));
     refreshFrame();
-  };
-
-  const bindDrag = (onMove: (event: PointerEvent) => void): void => {
-    const handleMove = (event: PointerEvent) => {
-      event.preventDefault();
-      onMove(event);
-    };
-    const handleUp = () => {
-      window.removeEventListener("pointermove", handleMove, { capture: true });
-      window.removeEventListener("pointerup", handleUp, { capture: true });
-      window.removeEventListener("pointercancel", handleUp, { capture: true });
-    };
-    window.addEventListener("pointermove", handleMove, { capture: true });
-    window.addEventListener("pointerup", handleUp, { capture: true });
-    window.addEventListener("pointercancel", handleUp, { capture: true });
-  };
-
-  const startMove = (event: PointerEvent): void => {
-    const startPointerX = event.clientX;
-    const startPointerY = event.clientY;
-    const startOffsetX = offset.x;
-    const startOffsetY = offset.y;
-    bindDrag((moveEvent) => {
-      offset.x = startOffsetX + (moveEvent.clientX - startPointerX);
-      offset.y = startOffsetY + (moveEvent.clientY - startPointerY);
-      applyOffset();
-    });
   };
 
   const startResize = (event: PointerEvent, handle: TransformHandleId): void => {
@@ -140,10 +190,27 @@ export const createTransformController = (
     });
   };
 
+  const hasMoved = (): boolean => didMove();
+
+  const describeMove = (): string => {
+    if (!didMove() || !lastDrop) return "";
+    return `Move this element to be ${lastDrop.placement} ${describeElementForPrompt(lastDrop.reference)} in the DOM.`;
+  };
+
+  const restore = (): void => {
+    if (!originPosition) return;
+    const element = dependencies.getElement();
+    originPosition.parent.insertBefore(element, originPosition.nextSibling);
+    originPosition = null;
+    lastDrop = null;
+    setDidMove(false);
+    refreshFrame();
+  };
+
   // Track the element the way the selection label does (see selection-label):
   // viewport listeners catch scroll/zoom, a ResizeObserver catches size changes
   // from any source (canvas handles, panel sliders, content reflow). Drags
-  // refresh synchronously via applyOffset/refreshFrame.
+  // refresh synchronously via reinsert/applyOffset.
   onMount(() => {
     refreshFrame();
     const handleViewportChange = () => refreshFrame();
@@ -164,6 +231,10 @@ export const createTransformController = (
 
   return {
     frame,
+    insertionIndicator,
+    hasMoved,
+    describeMove,
+    restore,
     startMove,
     startResize,
   };

--- a/packages/react-grab/src/components/transform-overlay/transform-controller.ts
+++ b/packages/react-grab/src/components/transform-overlay/transform-controller.ts
@@ -1,5 +1,5 @@
 import { createSignal, onCleanup, onMount, type Accessor } from "solid-js";
-import { TRANSFORM_MIN_SIZE_PX } from "../../constants.js";
+import { DRAG_THRESHOLD_PX, TRANSFORM_MIN_SIZE_PX } from "../../constants.js";
 import type { DropTarget, TransformFrame, TransformHandleId, ViewportBox } from "../../types.js";
 import { describeElementForPrompt } from "../../utils/describe-element-for-prompt.js";
 import { findDropTarget } from "../../utils/find-drop-target.js";
@@ -158,6 +158,9 @@ export const createTransformController = (
     const ghostHeight = frameValue.height;
     const downX = event.clientX;
     const downY = event.clientY;
+    // A move only begins once the pointer crosses the drag threshold; a plain
+    // click must not reinsert the element (it should only move when dragged).
+    let isDragging = false;
     const updateGhost = (clientX: number, clientY: number): void => {
       setDragGhost({
         left: originLeft + (clientX - downX),
@@ -167,16 +170,23 @@ export const createTransformController = (
       });
     };
 
-    updateGhost(downX, downY);
-    previewDropAt(downX, downY);
     bindDrag(
       (moveEvent) => {
+        if (!isDragging) {
+          const hasCrossedThreshold =
+            Math.abs(moveEvent.clientX - downX) >= DRAG_THRESHOLD_PX ||
+            Math.abs(moveEvent.clientY - downY) >= DRAG_THRESHOLD_PX;
+          if (!hasCrossedThreshold) return;
+          isDragging = true;
+        }
         updateGhost(moveEvent.clientX, moveEvent.clientY);
         previewDropAt(moveEvent.clientX, moveEvent.clientY);
       },
       (upEvent) => {
-        const drop = previewDropAt(upEvent.clientX, upEvent.clientY);
-        if (drop) reinsert(drop);
+        if (isDragging) {
+          const drop = previewDropAt(upEvent.clientX, upEvent.clientY);
+          if (drop) reinsert(drop);
+        }
         setInsertionIndicator(null);
         setDragGhost(null);
       },

--- a/packages/react-grab/src/components/transform-overlay/transform-controller.ts
+++ b/packages/react-grab/src/components/transform-overlay/transform-controller.ts
@@ -1,5 +1,5 @@
 import { createSignal, onCleanup, onMount, type Accessor } from "solid-js";
-import { TRANSFORM_MIN_SIZE_PX, TRANSFORM_ROTATE_SNAP_DEG } from "../../constants.js";
+import { TRANSFORM_MIN_SIZE_PX } from "../../constants.js";
 import type {
   PendingEdit,
   PreviewStyles,
@@ -20,64 +20,29 @@ export interface TransformController {
   hasChanged: () => boolean;
   buildPendingEdit: () => PendingEdit | null;
   startMove: (event: PointerEvent) => void;
-  startRotate: (event: PointerEvent) => void;
   startResize: (event: PointerEvent, handle: TransformHandleId) => void;
 }
 
-const HANDLE_DIRECTION: Record<TransformHandleId, { x: -1 | 0 | 1; y: -1 | 0 | 1 }> = {
+const HANDLE_DIRECTION: Record<TransformHandleId, { x: -1 | 1; y: -1 | 1 }> = {
   nw: { x: -1, y: -1 },
-  n: { x: 0, y: -1 },
   ne: { x: 1, y: -1 },
-  e: { x: 1, y: 0 },
   se: { x: 1, y: 1 },
-  s: { x: 0, y: 1 },
   sw: { x: -1, y: 1 },
-  w: { x: -1, y: 0 },
 };
-
-const DEGREES_PER_RADIAN = 180 / Math.PI;
 
 const formatTransform = (values: TransformValues, round: boolean): string => {
   const translateX = round ? Math.round(values.translateX) : values.translateX;
   const translateY = round ? Math.round(values.translateY) : values.translateY;
-  const rotate = round ? Math.round(values.rotate) : values.rotate;
-  return `translate(${translateX}px, ${translateY}px) rotate(${rotate}deg)`;
-};
-
-// World-space position of the box corner/edge opposite the dragged handle.
-// `direction` points outward from center toward the dragged handle, so the
-// anchor lives at the negated local offset, projected onto the element's
-// (possibly rotated) local axes.
-const anchorWorldPoint = (
-  centerX: number,
-  centerY: number,
-  width: number,
-  height: number,
-  direction: { x: number; y: number },
-  axisCos: number,
-  axisSin: number,
-): { x: number; y: number } => {
-  const localX = (-direction.x * width) / 2;
-  const localY = (-direction.y * height) / 2;
-  return {
-    x: centerX + axisCos * localX + -axisSin * localY,
-    y: centerY + axisSin * localX + axisCos * localY,
-  };
+  return `translate(${translateX}px, ${translateY}px)`;
 };
 
 export const createTransformController = (
   dependencies: TransformControllerDependencies,
 ): TransformController => {
-  const transform: TransformValues = { translateX: 0, translateY: 0, rotate: 0 };
+  const transform: TransformValues = { translateX: 0, translateY: 0 };
   // A single mutated-in-place object behind an always-notify signal keeps the
-  // per-frame tracking loop allocation-free while still driving reactivity.
-  const frameValue: TransformFrame = {
-    centerX: 0,
-    centerY: 0,
-    width: 0,
-    height: 0,
-    rotate: 0,
-  };
+  // tracking refresh allocation-free while still driving reactivity.
+  const frameValue: TransformFrame = { centerX: 0, centerY: 0, width: 0, height: 0 };
   const [frame, setFrame] = createSignal(frameValue, { equals: false });
   // Bumped on every applied edit so `hasChanged` stays reactive without
   // mirroring the mutable `transform` into a second signal.
@@ -94,14 +59,10 @@ export const createTransformController = (
       element instanceof HTMLElement && element.offsetHeight > 0
         ? element.offsetHeight
         : rect.height;
-    // The axis-aligned bounding-box center equals the element's geometric
-    // center under a center-origin rotate + translate, so it stays accurate
-    // even once the element is rotated.
     target.centerX = rect.left + rect.width / 2;
     target.centerY = rect.top + rect.height / 2;
     target.width = layoutWidth;
     target.height = layoutHeight;
-    target.rotate = transform.rotate;
   };
 
   const refreshFrame = (): void => {
@@ -110,7 +71,6 @@ export const createTransformController = (
   };
 
   const applyTransform = (): void => {
-    dependencies.preview.apply(["transform-origin"], "center center");
     dependencies.preview.apply(["transform"], formatTransform(transform, false));
     refreshFrame();
     notifyTransformEdit();
@@ -144,22 +104,6 @@ export const createTransformController = (
     });
   };
 
-  const startRotate = (event: PointerEvent): void => {
-    refreshFrame();
-    const centerX = frameValue.centerX;
-    const centerY = frameValue.centerY;
-    const startAngle = Math.atan2(event.clientY - centerY, event.clientX - centerX);
-    const startRotate = transform.rotate;
-    bindDrag((moveEvent) => {
-      const angle = Math.atan2(moveEvent.clientY - centerY, moveEvent.clientX - centerX);
-      const nextRotate = startRotate + (angle - startAngle) * DEGREES_PER_RADIAN;
-      transform.rotate = moveEvent.shiftKey
-        ? Math.round(nextRotate / TRANSFORM_ROTATE_SNAP_DEG) * TRANSFORM_ROTATE_SNAP_DEG
-        : nextRotate;
-      applyTransform();
-    });
-  };
-
   const startResize = (event: PointerEvent, handle: TransformHandleId): void => {
     refreshFrame();
     const direction = HANDLE_DIRECTION[handle];
@@ -169,73 +113,46 @@ export const createTransformController = (
     const startTranslateY = transform.translateY;
     const startPointerX = event.clientX;
     const startPointerY = event.clientY;
-
-    const radians = (transform.rotate * Math.PI) / 180;
-    const axisCos = Math.cos(radians);
-    const axisSin = Math.sin(radians);
-    const anchorWorld = anchorWorldPoint(
-      frameValue.centerX,
-      frameValue.centerY,
-      startWidth,
-      startHeight,
-      direction,
-      axisCos,
-      axisSin,
-    );
+    // World position of the corner opposite the dragged handle; it must stay
+    // pinned in the viewport as the box grows/shrinks.
+    const anchorWorldX = frameValue.centerX - (direction.x * startWidth) / 2;
+    const anchorWorldY = frameValue.centerY - (direction.y * startHeight) / 2;
 
     bindDrag((moveEvent) => {
-      const pointerDeltaX = moveEvent.clientX - startPointerX;
-      const pointerDeltaY = moveEvent.clientY - startPointerY;
-      const localDeltaX = pointerDeltaX * axisCos + pointerDeltaY * axisSin;
-      const localDeltaY = pointerDeltaX * -axisSin + pointerDeltaY * axisCos;
-
-      const nextWidth =
-        direction.x === 0
-          ? startWidth
-          : Math.max(TRANSFORM_MIN_SIZE_PX, startWidth + direction.x * localDeltaX);
-      const nextHeight =
-        direction.y === 0
-          ? startHeight
-          : Math.max(TRANSFORM_MIN_SIZE_PX, startHeight + direction.y * localDeltaY);
+      const nextWidth = Math.max(
+        TRANSFORM_MIN_SIZE_PX,
+        startWidth + direction.x * (moveEvent.clientX - startPointerX),
+      );
+      const nextHeight = Math.max(
+        TRANSFORM_MIN_SIZE_PX,
+        startHeight + direction.y * (moveEvent.clientY - startPointerY),
+      );
 
       // Reset translate to its baseline so the post-resize measurement reflects
       // only the browser's own layout reflow, then commit the new dimensions.
       transform.translateX = startTranslateX;
       transform.translateY = startTranslateY;
-      if (direction.x !== 0) dependencies.commitSize("width", Math.round(nextWidth));
-      if (direction.y !== 0) dependencies.commitSize("height", Math.round(nextHeight));
+      dependencies.commitSize("width", Math.round(nextWidth));
+      dependencies.commitSize("height", Math.round(nextHeight));
       applyTransform();
 
-      // Layout may have shifted the box; nudge translate so the anchored edge
-      // (opposite the dragged handle) stays pinned in viewport space. A pure
-      // corner resize therefore also emits a small translate alongside
-      // width/height — that is geometrically faithful, not a bug.
-      const measuredAnchor = anchorWorldPoint(
-        frameValue.centerX,
-        frameValue.centerY,
-        frameValue.width,
-        frameValue.height,
-        direction,
-        axisCos,
-        axisSin,
-      );
-      transform.translateX = startTranslateX + (anchorWorld.x - measuredAnchor.x);
-      transform.translateY = startTranslateY + (anchorWorld.y - measuredAnchor.y);
+      // Layout may have shifted the box; nudge translate so the anchored corner
+      // stays pinned. A pure grow from the top-left needs no nudge (static
+      // layout already pins it); growing from the top/left does.
+      const measuredAnchorX = frameValue.centerX - (direction.x * frameValue.width) / 2;
+      const measuredAnchorY = frameValue.centerY - (direction.y * frameValue.height) / 2;
+      transform.translateX = startTranslateX + (anchorWorldX - measuredAnchorX);
+      transform.translateY = startTranslateY + (anchorWorldY - measuredAnchorY);
       applyTransform();
     });
   };
 
   // Round before testing so a pure resize, whose anchor compensation can leave
   // sub-pixel translate residue, does not report a change (and `buildPendingEdit`
-  // would emit a no-op `translate(0px, 0px) rotate(0deg)`). "Changed" and
-  // "emitted" therefore agree on the same rounded values.
+  // would emit a no-op `translate(0px, 0px)`).
   const hasChanged = (): boolean => {
     trackTransformEdits();
-    return (
-      Math.round(transform.translateX) !== 0 ||
-      Math.round(transform.translateY) !== 0 ||
-      Math.round(transform.rotate) !== 0
-    );
+    return Math.round(transform.translateX) !== 0 || Math.round(transform.translateY) !== 0;
   };
 
   const buildPendingEdit = (): PendingEdit | null => {
@@ -276,7 +193,6 @@ export const createTransformController = (
     hasChanged,
     buildPendingEdit,
     startMove,
-    startRotate,
     startResize,
   };
 };

--- a/packages/react-grab/src/components/transform-overlay/transform-controller.ts
+++ b/packages/react-grab/src/components/transform-overlay/transform-controller.ts
@@ -178,6 +178,25 @@ export const createTransformController = (
   const startResize = (event: PointerEvent, handle: TransformHandleId): void => {
     refreshFrame();
     const direction = HANDLE_DIRECTION[handle];
+    // The frame is the border-box (offsetWidth/Height); the inline `width`
+    // value, however, addresses the content box unless box-sizing is
+    // border-box. Subtract padding+border so the committed value lands the
+    // border-box exactly under the cursor instead of overshooting.
+    const computed = getComputedStyle(dependencies.getElement());
+    const isBorderBox = computed.boxSizing === "border-box";
+    const extraX = isBorderBox
+      ? 0
+      : parseFloat(computed.paddingLeft) +
+        parseFloat(computed.paddingRight) +
+        parseFloat(computed.borderLeftWidth) +
+        parseFloat(computed.borderRightWidth);
+    const extraY = isBorderBox
+      ? 0
+      : parseFloat(computed.paddingTop) +
+        parseFloat(computed.paddingBottom) +
+        parseFloat(computed.borderTopWidth) +
+        parseFloat(computed.borderBottomWidth);
+
     const startWidth = frameValue.width;
     const startHeight = frameValue.height;
     const startOffsetX = offset.x;
@@ -187,35 +206,56 @@ export const createTransformController = (
     let didFocus = false;
 
     bindDrag((moveEvent) => {
+      // Holding Alt/Option scales symmetrically about the center (both edges
+      // move); otherwise the edge opposite the handle stays anchored.
+      const fromCenter = moveEvent.altKey;
+      const growthScale = fromCenter ? 2 : 1;
       const nextWidth = Math.round(
         Math.max(
           TRANSFORM_MIN_SIZE_PX,
-          startWidth + direction.x * (moveEvent.clientX - startPointerX),
+          startWidth + growthScale * direction.x * (moveEvent.clientX - startPointerX),
         ),
       );
       const nextHeight = Math.round(
         Math.max(
           TRANSFORM_MIN_SIZE_PX,
-          startHeight + direction.y * (moveEvent.clientY - startPointerY),
+          startHeight + growthScale * direction.y * (moveEvent.clientY - startPointerY),
         ),
       );
-      dependencies.commitStyle("width", nextWidth);
-      dependencies.commitStyle("height", nextHeight);
+      const widthDelta = nextWidth - startWidth;
+      const heightDelta = nextHeight - startHeight;
+
+      dependencies.commitStyle(
+        "width",
+        Math.max(TRANSFORM_MIN_SIZE_PX, Math.round(nextWidth - extraX)),
+      );
+      dependencies.commitStyle(
+        "height",
+        Math.max(TRANSFORM_MIN_SIZE_PX, Math.round(nextHeight - extraY)),
+      );
 
       // Once the size is on the tweak store, collapse the panel onto whichever
       // dimension the drag is changing most so its live value stays visible.
       if (!didFocus) {
-        const widthDelta = Math.abs(nextWidth - startWidth);
-        const heightDelta = Math.abs(nextHeight - startHeight);
-        dependencies.focusProperty(widthDelta >= heightDelta ? "width" : "height");
+        dependencies.focusProperty(
+          Math.abs(widthDelta) >= Math.abs(heightDelta) ? "width" : "height",
+        );
         didFocus = true;
+      }
+
+      if (fromCenter) {
+        // Keep the center pinned by shifting position half the growth.
+        offset.x = startOffsetX - widthDelta / 2;
+        offset.y = startOffsetY - heightDelta / 2;
+        applyOffset();
+        return;
       }
 
       // A plain box only extends its right/bottom edges when it grows, so
       // dragging a top/left edge must also shift the element's position to keep
       // the opposite (anchored) edge pinned. Right/bottom handles need no shift.
-      if (direction.x === -1) offset.x = startOffsetX - (nextWidth - startWidth);
-      if (direction.y === -1) offset.y = startOffsetY - (nextHeight - startHeight);
+      if (direction.x === -1) offset.x = startOffsetX - widthDelta;
+      if (direction.y === -1) offset.y = startOffsetY - heightDelta;
       if (direction.x === -1 || direction.y === -1) {
         applyOffset();
       } else {

--- a/packages/react-grab/src/components/transform-overlay/transform-controller.ts
+++ b/packages/react-grab/src/components/transform-overlay/transform-controller.ts
@@ -1,0 +1,210 @@
+import { createSignal, type Accessor } from "solid-js";
+import { TRANSFORM_MIN_SIZE_PX, TRANSFORM_ROTATE_SNAP_DEG } from "../../constants.js";
+import type {
+  PreviewStyles,
+  TransformFrame,
+  TransformHandleId,
+  TransformValues,
+} from "../../types.js";
+
+interface TransformControllerDependencies {
+  getElement: () => Element;
+  preview: PreviewStyles;
+  commitSize: (cssProperty: "width" | "height", valuePx: number) => void;
+  onInteract: () => void;
+  onChange: () => void;
+}
+
+export interface TransformController {
+  frame: Accessor<TransformFrame>;
+  refreshFrame: () => void;
+  values: () => TransformValues;
+  hasChanged: () => boolean;
+  startMove: (event: PointerEvent) => void;
+  startRotate: (event: PointerEvent) => void;
+  startResize: (event: PointerEvent, handle: TransformHandleId) => void;
+}
+
+const HANDLE_DIRECTION: Record<TransformHandleId, { x: -1 | 0 | 1; y: -1 | 0 | 1 }> = {
+  nw: { x: -1, y: -1 },
+  n: { x: 0, y: -1 },
+  ne: { x: 1, y: -1 },
+  e: { x: 1, y: 0 },
+  se: { x: 1, y: 1 },
+  s: { x: 0, y: 1 },
+  sw: { x: -1, y: 1 },
+  w: { x: -1, y: 0 },
+};
+
+const DEGREES_PER_RADIAN = 180 / Math.PI;
+
+export const createTransformController = (
+  dependencies: TransformControllerDependencies,
+): TransformController => {
+  const transform: TransformValues = { translateX: 0, translateY: 0, rotate: 0 };
+  // A single mutated-in-place object behind an always-notify signal keeps the
+  // per-frame tracking loop allocation-free while still driving reactivity.
+  const frameValue: TransformFrame = {
+    centerX: 0,
+    centerY: 0,
+    width: 0,
+    height: 0,
+    rotate: 0,
+  };
+  const [frame, setFrame] = createSignal(frameValue, { equals: false });
+
+  const measureFrameInto = (target: TransformFrame): void => {
+    const element = dependencies.getElement();
+    const rect = element.getBoundingClientRect();
+    const layoutWidth =
+      element instanceof HTMLElement && element.offsetWidth > 0 ? element.offsetWidth : rect.width;
+    const layoutHeight =
+      element instanceof HTMLElement && element.offsetHeight > 0
+        ? element.offsetHeight
+        : rect.height;
+    // The axis-aligned bounding-box center equals the element's geometric
+    // center under a center-origin rotate + translate, so it stays accurate
+    // even once the element is rotated.
+    target.centerX = rect.left + rect.width / 2;
+    target.centerY = rect.top + rect.height / 2;
+    target.width = layoutWidth;
+    target.height = layoutHeight;
+    target.rotate = transform.rotate;
+  };
+
+  const refreshFrame = (): void => {
+    measureFrameInto(frameValue);
+    setFrame(frameValue);
+  };
+
+  const applyTransform = (): void => {
+    dependencies.preview.apply(["transform-origin"], "center center");
+    dependencies.preview.apply(
+      ["transform"],
+      `translate(${transform.translateX}px, ${transform.translateY}px) rotate(${transform.rotate}deg)`,
+    );
+    refreshFrame();
+    dependencies.onInteract();
+    dependencies.onChange();
+  };
+
+  const bindDrag = (onMove: (event: PointerEvent) => void): void => {
+    const handleMove = (event: PointerEvent) => {
+      event.preventDefault();
+      onMove(event);
+    };
+    const handleUp = () => {
+      window.removeEventListener("pointermove", handleMove, { capture: true });
+      window.removeEventListener("pointerup", handleUp, { capture: true });
+      window.removeEventListener("pointercancel", handleUp, { capture: true });
+    };
+    window.addEventListener("pointermove", handleMove, { capture: true });
+    window.addEventListener("pointerup", handleUp, { capture: true });
+    window.addEventListener("pointercancel", handleUp, { capture: true });
+  };
+
+  const startMove = (event: PointerEvent): void => {
+    const startPointerX = event.clientX;
+    const startPointerY = event.clientY;
+    const startTranslateX = transform.translateX;
+    const startTranslateY = transform.translateY;
+    bindDrag((moveEvent) => {
+      transform.translateX = startTranslateX + (moveEvent.clientX - startPointerX);
+      transform.translateY = startTranslateY + (moveEvent.clientY - startPointerY);
+      applyTransform();
+    });
+  };
+
+  const startRotate = (event: PointerEvent): void => {
+    refreshFrame();
+    const centerX = frameValue.centerX;
+    const centerY = frameValue.centerY;
+    const startAngle = Math.atan2(event.clientY - centerY, event.clientX - centerX);
+    const startRotate = transform.rotate;
+    bindDrag((moveEvent) => {
+      const angle = Math.atan2(moveEvent.clientY - centerY, moveEvent.clientX - centerX);
+      const nextRotate = startRotate + (angle - startAngle) * DEGREES_PER_RADIAN;
+      transform.rotate = moveEvent.shiftKey
+        ? Math.round(nextRotate / TRANSFORM_ROTATE_SNAP_DEG) * TRANSFORM_ROTATE_SNAP_DEG
+        : nextRotate;
+      applyTransform();
+    });
+  };
+
+  const startResize = (event: PointerEvent, handle: TransformHandleId): void => {
+    refreshFrame();
+    const direction = HANDLE_DIRECTION[handle];
+    const startWidth = frameValue.width;
+    const startHeight = frameValue.height;
+    const startCenterX = frameValue.centerX;
+    const startCenterY = frameValue.centerY;
+    const startTranslateX = transform.translateX;
+    const startTranslateY = transform.translateY;
+    const startPointerX = event.clientX;
+    const startPointerY = event.clientY;
+
+    const radians = (transform.rotate * Math.PI) / 180;
+    const axisXCos = Math.cos(radians);
+    const axisXSin = Math.sin(radians);
+    // Local +x axis is (axisXCos, axisXSin); local +y axis is its perpendicular.
+    const anchorLocalX = (-direction.x * startWidth) / 2;
+    const anchorLocalY = (-direction.y * startHeight) / 2;
+    const anchorWorldX = startCenterX + axisXCos * anchorLocalX + -axisXSin * anchorLocalY;
+    const anchorWorldY = startCenterY + axisXSin * anchorLocalX + axisXCos * anchorLocalY;
+
+    bindDrag((moveEvent) => {
+      const pointerDeltaX = moveEvent.clientX - startPointerX;
+      const pointerDeltaY = moveEvent.clientY - startPointerY;
+      const localDeltaX = pointerDeltaX * axisXCos + pointerDeltaY * axisXSin;
+      const localDeltaY = pointerDeltaX * -axisXSin + pointerDeltaY * axisXCos;
+
+      const nextWidth =
+        direction.x === 0
+          ? startWidth
+          : Math.max(TRANSFORM_MIN_SIZE_PX, startWidth + direction.x * localDeltaX);
+      const nextHeight =
+        direction.y === 0
+          ? startHeight
+          : Math.max(TRANSFORM_MIN_SIZE_PX, startHeight + direction.y * localDeltaY);
+
+      // Reset translate to its baseline so the post-resize measurement reflects
+      // only the browser's own layout reflow, then commit the new dimensions.
+      transform.translateX = startTranslateX;
+      transform.translateY = startTranslateY;
+      if (direction.x !== 0) dependencies.commitSize("width", Math.round(nextWidth));
+      if (direction.y !== 0) dependencies.commitSize("height", Math.round(nextHeight));
+      applyTransform();
+
+      // Layout may have shifted the box; nudge translate so the anchored edge
+      // (opposite the dragged handle) stays pinned in viewport space.
+      const measuredWidth = frameValue.width;
+      const measuredHeight = frameValue.height;
+      const measuredAnchorLocalX = (-direction.x * measuredWidth) / 2;
+      const measuredAnchorLocalY = (-direction.y * measuredHeight) / 2;
+      const measuredAnchorWorldX =
+        frameValue.centerX + axisXCos * measuredAnchorLocalX + -axisXSin * measuredAnchorLocalY;
+      const measuredAnchorWorldY =
+        frameValue.centerY + axisXSin * measuredAnchorLocalX + axisXCos * measuredAnchorLocalY;
+
+      transform.translateX = startTranslateX + (anchorWorldX - measuredAnchorWorldX);
+      transform.translateY = startTranslateY + (anchorWorldY - measuredAnchorWorldY);
+      applyTransform();
+    });
+  };
+
+  const hasChanged = (): boolean =>
+    transform.translateX !== 0 || transform.translateY !== 0 || transform.rotate !== 0;
+
+  return {
+    frame,
+    refreshFrame,
+    values: () => transform,
+    hasChanged,
+    startMove,
+    startRotate,
+    startResize,
+  };
+};
+
+export const formatTransformValue = (values: TransformValues): string =>
+  `translate(${Math.round(values.translateX)}px, ${Math.round(values.translateY)}px) rotate(${Math.round(values.rotate)}deg)`;

--- a/packages/react-grab/src/components/transform-overlay/transform-controller.ts
+++ b/packages/react-grab/src/components/transform-overlay/transform-controller.ts
@@ -1,24 +1,17 @@
 import { createSignal, onCleanup, onMount, type Accessor } from "solid-js";
 import { TRANSFORM_MIN_SIZE_PX } from "../../constants.js";
-import type {
-  PendingEdit,
-  PreviewStyles,
-  TransformFrame,
-  TransformHandleId,
-  TransformValues,
-} from "../../types.js";
+import type { TransformFrame, TransformHandleId } from "../../types.js";
 
 interface TransformControllerDependencies {
   getElement: () => Element;
-  preview: PreviewStyles;
-  commitSize: (cssProperty: "width" | "height", valuePx: number) => void;
-  onInteract: () => void;
+  commitStyle: (
+    cssProperty: "width" | "height" | "left" | "top" | "position",
+    value: number | string,
+  ) => void;
 }
 
 export interface TransformController {
   frame: Accessor<TransformFrame>;
-  hasChanged: () => boolean;
-  buildPendingEdit: () => PendingEdit | null;
   startMove: (event: PointerEvent) => void;
   startResize: (event: PointerEvent, handle: TransformHandleId) => void;
 }
@@ -30,25 +23,23 @@ const HANDLE_DIRECTION: Record<TransformHandleId, { x: -1 | 1; y: -1 | 1 }> = {
   sw: { x: -1, y: 1 },
 };
 
-const formatTransform = (values: TransformValues, round: boolean): string => {
-  const translateX = round ? Math.round(values.translateX) : values.translateX;
-  const translateY = round ? Math.round(values.translateY) : values.translateY;
-  return `translate(${translateX}px, ${translateY}px)`;
-};
-
 export const createTransformController = (
   dependencies: TransformControllerDependencies,
 ): TransformController => {
-  const transform: TransformValues = { translateX: 0, translateY: 0 };
   // A single mutated-in-place object behind an always-notify signal keeps the
   // tracking refresh allocation-free while still driving reactivity.
   const frameValue: TransformFrame = { centerX: 0, centerY: 0, width: 0, height: 0 };
   const [frame, setFrame] = createSignal(frameValue, { equals: false });
-  // Bumped on every applied edit so `hasChanged` stays reactive without
-  // mirroring the mutable `transform` into a second signal.
-  const [trackTransformEdits, notifyTransformEdit] = createSignal<void>(undefined, {
-    equals: false,
-  });
+
+  // x/y are written as `left`/`top` offsets from the element's starting
+  // position; static elements get `position: relative` on first interaction so
+  // those offsets take effect. Read the base once — layout is settled by the
+  // time the style panel opens.
+  const baseStyle = getComputedStyle(dependencies.getElement());
+  const baseLeft = Number.parseFloat(baseStyle.left) || 0;
+  const baseTop = Number.parseFloat(baseStyle.top) || 0;
+  let isPositioned = baseStyle.position !== "static";
+  const offset = { x: 0, y: 0 };
 
   const measureFrameInto = (target: TransformFrame): void => {
     const element = dependencies.getElement();
@@ -70,11 +61,17 @@ export const createTransformController = (
     setFrame(frameValue);
   };
 
-  const applyTransform = (): void => {
-    dependencies.preview.apply(["transform"], formatTransform(transform, false));
+  const ensurePositioned = (): void => {
+    if (isPositioned) return;
+    dependencies.commitStyle("position", "relative");
+    isPositioned = true;
+  };
+
+  const applyOffset = (): void => {
+    ensurePositioned();
+    dependencies.commitStyle("left", Math.round(baseLeft + offset.x));
+    dependencies.commitStyle("top", Math.round(baseTop + offset.y));
     refreshFrame();
-    notifyTransformEdit();
-    dependencies.onInteract();
   };
 
   const bindDrag = (onMove: (event: PointerEvent) => void): void => {
@@ -95,12 +92,12 @@ export const createTransformController = (
   const startMove = (event: PointerEvent): void => {
     const startPointerX = event.clientX;
     const startPointerY = event.clientY;
-    const startTranslateX = transform.translateX;
-    const startTranslateY = transform.translateY;
+    const startOffsetX = offset.x;
+    const startOffsetY = offset.y;
     bindDrag((moveEvent) => {
-      transform.translateX = startTranslateX + (moveEvent.clientX - startPointerX);
-      transform.translateY = startTranslateY + (moveEvent.clientY - startPointerY);
-      applyTransform();
+      offset.x = startOffsetX + (moveEvent.clientX - startPointerX);
+      offset.y = startOffsetY + (moveEvent.clientY - startPointerY);
+      applyOffset();
     });
   };
 
@@ -109,67 +106,44 @@ export const createTransformController = (
     const direction = HANDLE_DIRECTION[handle];
     const startWidth = frameValue.width;
     const startHeight = frameValue.height;
-    const startTranslateX = transform.translateX;
-    const startTranslateY = transform.translateY;
+    const startOffsetX = offset.x;
+    const startOffsetY = offset.y;
     const startPointerX = event.clientX;
     const startPointerY = event.clientY;
-    // World position of the corner opposite the dragged handle; it must stay
-    // pinned in the viewport as the box grows/shrinks.
-    const anchorWorldX = frameValue.centerX - (direction.x * startWidth) / 2;
-    const anchorWorldY = frameValue.centerY - (direction.y * startHeight) / 2;
 
     bindDrag((moveEvent) => {
-      const nextWidth = Math.max(
-        TRANSFORM_MIN_SIZE_PX,
-        startWidth + direction.x * (moveEvent.clientX - startPointerX),
+      const nextWidth = Math.round(
+        Math.max(
+          TRANSFORM_MIN_SIZE_PX,
+          startWidth + direction.x * (moveEvent.clientX - startPointerX),
+        ),
       );
-      const nextHeight = Math.max(
-        TRANSFORM_MIN_SIZE_PX,
-        startHeight + direction.y * (moveEvent.clientY - startPointerY),
+      const nextHeight = Math.round(
+        Math.max(
+          TRANSFORM_MIN_SIZE_PX,
+          startHeight + direction.y * (moveEvent.clientY - startPointerY),
+        ),
       );
+      dependencies.commitStyle("width", nextWidth);
+      dependencies.commitStyle("height", nextHeight);
 
-      // Reset translate to its baseline so the post-resize measurement reflects
-      // only the browser's own layout reflow, then commit the new dimensions.
-      transform.translateX = startTranslateX;
-      transform.translateY = startTranslateY;
-      dependencies.commitSize("width", Math.round(nextWidth));
-      dependencies.commitSize("height", Math.round(nextHeight));
-      applyTransform();
-
-      // Layout may have shifted the box; nudge translate so the anchored corner
-      // stays pinned. A pure grow from the top-left needs no nudge (static
-      // layout already pins it); growing from the top/left does.
-      const measuredAnchorX = frameValue.centerX - (direction.x * frameValue.width) / 2;
-      const measuredAnchorY = frameValue.centerY - (direction.y * frameValue.height) / 2;
-      transform.translateX = startTranslateX + (anchorWorldX - measuredAnchorX);
-      transform.translateY = startTranslateY + (anchorWorldY - measuredAnchorY);
-      applyTransform();
+      // A plain box only extends its right/bottom edges when it grows, so
+      // dragging a top/left edge must also shift the element's position to keep
+      // the opposite (anchored) edge pinned. Right/bottom handles need no shift.
+      if (direction.x === -1) offset.x = startOffsetX - (nextWidth - startWidth);
+      if (direction.y === -1) offset.y = startOffsetY - (nextHeight - startHeight);
+      if (direction.x === -1 || direction.y === -1) {
+        applyOffset();
+      } else {
+        refreshFrame();
+      }
     });
-  };
-
-  // Round before testing so a pure resize, whose anchor compensation can leave
-  // sub-pixel translate residue, does not report a change (and `buildPendingEdit`
-  // would emit a no-op `translate(0px, 0px)`).
-  const hasChanged = (): boolean => {
-    trackTransformEdits();
-    return Math.round(transform.translateX) !== 0 || Math.round(transform.translateY) !== 0;
-  };
-
-  const buildPendingEdit = (): PendingEdit | null => {
-    if (!hasChanged()) return null;
-    return {
-      kind: "transform",
-      key: "transform",
-      cssProperties: ["transform"],
-      value: formatTransform(transform, true),
-    };
   };
 
   // Track the element the way the selection label does (see selection-label):
   // viewport listeners catch scroll/zoom, a ResizeObserver catches size changes
-  // from any source (canvas handles, panel sliders, content reflow). This avoids
-  // an always-on per-frame getBoundingClientRect poll — drags already refresh
-  // synchronously via applyTransform.
+  // from any source (canvas handles, panel sliders, content reflow). Drags
+  // refresh synchronously via applyOffset/refreshFrame.
   onMount(() => {
     refreshFrame();
     const handleViewportChange = () => refreshFrame();
@@ -190,8 +164,6 @@ export const createTransformController = (
 
   return {
     frame,
-    hasChanged,
-    buildPendingEdit,
     startMove,
     startResize,
   };

--- a/packages/react-grab/src/components/transform-overlay/transform-controller.ts
+++ b/packages/react-grab/src/components/transform-overlay/transform-controller.ts
@@ -16,6 +16,8 @@ interface TransformControllerDependencies {
     cssProperty: "width" | "height" | "left" | "top" | "position",
     value: number | string,
   ) => void;
+  // Collapse the panel onto the dimension being resized, like keyboard stepping.
+  focusProperty: (cssProperty: "width" | "height") => void;
 }
 
 export interface TransformController {
@@ -182,6 +184,7 @@ export const createTransformController = (
     const startOffsetY = offset.y;
     const startPointerX = event.clientX;
     const startPointerY = event.clientY;
+    let didFocus = false;
 
     bindDrag((moveEvent) => {
       const nextWidth = Math.round(
@@ -198,6 +201,15 @@ export const createTransformController = (
       );
       dependencies.commitStyle("width", nextWidth);
       dependencies.commitStyle("height", nextHeight);
+
+      // Once the size is on the tweak store, collapse the panel onto whichever
+      // dimension the drag is changing most so its live value stays visible.
+      if (!didFocus) {
+        const widthDelta = Math.abs(nextWidth - startWidth);
+        const heightDelta = Math.abs(nextHeight - startHeight);
+        dependencies.focusProperty(widthDelta >= heightDelta ? "width" : "height");
+        didFocus = true;
+      }
 
       // A plain box only extends its right/bottom edges when it grows, so
       // dragging a top/left edge must also shift the element's position to keep

--- a/packages/react-grab/src/components/transform-overlay/transform-controller.ts
+++ b/packages/react-grab/src/components/transform-overlay/transform-controller.ts
@@ -1,25 +1,25 @@
-import { createSignal, type Accessor } from "solid-js";
+import { createSignal, onCleanup, onMount, type Accessor } from "solid-js";
 import { TRANSFORM_MIN_SIZE_PX, TRANSFORM_ROTATE_SNAP_DEG } from "../../constants.js";
 import type {
+  PendingEdit,
   PreviewStyles,
   TransformFrame,
   TransformHandleId,
   TransformValues,
 } from "../../types.js";
+import { nativeCancelAnimationFrame, nativeRequestAnimationFrame } from "../../utils/native-raf.js";
 
 interface TransformControllerDependencies {
   getElement: () => Element;
   preview: PreviewStyles;
   commitSize: (cssProperty: "width" | "height", valuePx: number) => void;
   onInteract: () => void;
-  onChange: () => void;
 }
 
 export interface TransformController {
   frame: Accessor<TransformFrame>;
-  refreshFrame: () => void;
-  values: () => TransformValues;
   hasChanged: () => boolean;
+  buildPendingEdit: () => PendingEdit | null;
   startMove: (event: PointerEvent) => void;
   startRotate: (event: PointerEvent) => void;
   startResize: (event: PointerEvent, handle: TransformHandleId) => void;
@@ -38,6 +38,34 @@ const HANDLE_DIRECTION: Record<TransformHandleId, { x: -1 | 0 | 1; y: -1 | 0 | 1
 
 const DEGREES_PER_RADIAN = 180 / Math.PI;
 
+const formatTransform = (values: TransformValues, round: boolean): string => {
+  const translateX = round ? Math.round(values.translateX) : values.translateX;
+  const translateY = round ? Math.round(values.translateY) : values.translateY;
+  const rotate = round ? Math.round(values.rotate) : values.rotate;
+  return `translate(${translateX}px, ${translateY}px) rotate(${rotate}deg)`;
+};
+
+// World-space position of the box corner/edge opposite the dragged handle.
+// `direction` points outward from center toward the dragged handle, so the
+// anchor lives at the negated local offset, projected onto the element's
+// (possibly rotated) local axes.
+const anchorWorldPoint = (
+  centerX: number,
+  centerY: number,
+  width: number,
+  height: number,
+  direction: { x: number; y: number },
+  axisCos: number,
+  axisSin: number,
+): { x: number; y: number } => {
+  const localX = (-direction.x * width) / 2;
+  const localY = (-direction.y * height) / 2;
+  return {
+    x: centerX + axisCos * localX + -axisSin * localY,
+    y: centerY + axisSin * localX + axisCos * localY,
+  };
+};
+
 export const createTransformController = (
   dependencies: TransformControllerDependencies,
 ): TransformController => {
@@ -52,6 +80,11 @@ export const createTransformController = (
     rotate: 0,
   };
   const [frame, setFrame] = createSignal(frameValue, { equals: false });
+  // Bumped on every applied edit so `hasChanged` stays reactive without
+  // mirroring the mutable `transform` into a second signal.
+  const [trackTransformEdits, notifyTransformEdit] = createSignal<void>(undefined, {
+    equals: false,
+  });
 
   const measureFrameInto = (target: TransformFrame): void => {
     const element = dependencies.getElement();
@@ -79,13 +112,10 @@ export const createTransformController = (
 
   const applyTransform = (): void => {
     dependencies.preview.apply(["transform-origin"], "center center");
-    dependencies.preview.apply(
-      ["transform"],
-      `translate(${transform.translateX}px, ${transform.translateY}px) rotate(${transform.rotate}deg)`,
-    );
+    dependencies.preview.apply(["transform"], formatTransform(transform, false));
     refreshFrame();
+    notifyTransformEdit();
     dependencies.onInteract();
-    dependencies.onChange();
   };
 
   const bindDrag = (onMove: (event: PointerEvent) => void): void => {
@@ -136,27 +166,29 @@ export const createTransformController = (
     const direction = HANDLE_DIRECTION[handle];
     const startWidth = frameValue.width;
     const startHeight = frameValue.height;
-    const startCenterX = frameValue.centerX;
-    const startCenterY = frameValue.centerY;
     const startTranslateX = transform.translateX;
     const startTranslateY = transform.translateY;
     const startPointerX = event.clientX;
     const startPointerY = event.clientY;
 
     const radians = (transform.rotate * Math.PI) / 180;
-    const axisXCos = Math.cos(radians);
-    const axisXSin = Math.sin(radians);
-    // Local +x axis is (axisXCos, axisXSin); local +y axis is its perpendicular.
-    const anchorLocalX = (-direction.x * startWidth) / 2;
-    const anchorLocalY = (-direction.y * startHeight) / 2;
-    const anchorWorldX = startCenterX + axisXCos * anchorLocalX + -axisXSin * anchorLocalY;
-    const anchorWorldY = startCenterY + axisXSin * anchorLocalX + axisXCos * anchorLocalY;
+    const axisCos = Math.cos(radians);
+    const axisSin = Math.sin(radians);
+    const anchorWorld = anchorWorldPoint(
+      frameValue.centerX,
+      frameValue.centerY,
+      startWidth,
+      startHeight,
+      direction,
+      axisCos,
+      axisSin,
+    );
 
     bindDrag((moveEvent) => {
       const pointerDeltaX = moveEvent.clientX - startPointerX;
       const pointerDeltaY = moveEvent.clientY - startPointerY;
-      const localDeltaX = pointerDeltaX * axisXCos + pointerDeltaY * axisXSin;
-      const localDeltaY = pointerDeltaX * -axisXSin + pointerDeltaY * axisXCos;
+      const localDeltaX = pointerDeltaX * axisCos + pointerDeltaY * axisSin;
+      const localDeltaY = pointerDeltaX * -axisSin + pointerDeltaY * axisCos;
 
       const nextWidth =
         direction.x === 0
@@ -176,35 +208,55 @@ export const createTransformController = (
       applyTransform();
 
       // Layout may have shifted the box; nudge translate so the anchored edge
-      // (opposite the dragged handle) stays pinned in viewport space.
-      const measuredWidth = frameValue.width;
-      const measuredHeight = frameValue.height;
-      const measuredAnchorLocalX = (-direction.x * measuredWidth) / 2;
-      const measuredAnchorLocalY = (-direction.y * measuredHeight) / 2;
-      const measuredAnchorWorldX =
-        frameValue.centerX + axisXCos * measuredAnchorLocalX + -axisXSin * measuredAnchorLocalY;
-      const measuredAnchorWorldY =
-        frameValue.centerY + axisXSin * measuredAnchorLocalX + axisXCos * measuredAnchorLocalY;
-
-      transform.translateX = startTranslateX + (anchorWorldX - measuredAnchorWorldX);
-      transform.translateY = startTranslateY + (anchorWorldY - measuredAnchorWorldY);
+      // (opposite the dragged handle) stays pinned in viewport space. A pure
+      // corner resize therefore also emits a small translate alongside
+      // width/height — that is geometrically faithful, not a bug.
+      const measuredAnchor = anchorWorldPoint(
+        frameValue.centerX,
+        frameValue.centerY,
+        frameValue.width,
+        frameValue.height,
+        direction,
+        axisCos,
+        axisSin,
+      );
+      transform.translateX = startTranslateX + (anchorWorld.x - measuredAnchor.x);
+      transform.translateY = startTranslateY + (anchorWorld.y - measuredAnchor.y);
       applyTransform();
     });
   };
 
-  const hasChanged = (): boolean =>
-    transform.translateX !== 0 || transform.translateY !== 0 || transform.rotate !== 0;
+  const hasChanged = (): boolean => {
+    trackTransformEdits();
+    return transform.translateX !== 0 || transform.translateY !== 0 || transform.rotate !== 0;
+  };
+
+  const buildPendingEdit = (): PendingEdit | null => {
+    if (!hasChanged()) return null;
+    return {
+      kind: "transform",
+      key: "transform",
+      cssProperties: ["transform"],
+      value: formatTransform(transform, true),
+    };
+  };
+
+  onMount(() => {
+    let frameId: number | null = nativeRequestAnimationFrame(function tick() {
+      refreshFrame();
+      frameId = nativeRequestAnimationFrame(tick);
+    });
+    onCleanup(() => {
+      if (frameId !== null) nativeCancelAnimationFrame(frameId);
+    });
+  });
 
   return {
     frame,
-    refreshFrame,
-    values: () => transform,
     hasChanged,
+    buildPendingEdit,
     startMove,
     startRotate,
     startResize,
   };
 };
-
-export const formatTransformValue = (values: TransformValues): string =>
-  `translate(${Math.round(values.translateX)}px, ${Math.round(values.translateY)}px) rotate(${Math.round(values.rotate)}deg)`;

--- a/packages/react-grab/src/components/transform-overlay/transform-controller.ts
+++ b/packages/react-grab/src/components/transform-overlay/transform-controller.ts
@@ -57,18 +57,23 @@ export const createTransformController = (
   let originPosition: DomPosition | null = null;
   let lastDrop: DropTarget | null = null;
 
+  // Capture the element once. It is stable for this controller's lifetime (the
+  // panel's keyed <Show> recreates the controller when the selected element
+  // changes), and reading `dependencies.getElement()` during teardown would
+  // touch the disposed panel state and throw "Stale read from <Show>".
+  const element = dependencies.getElement();
+
   // x/y are written as `left`/`top` offsets from the element's starting
   // position; static elements get `position: relative` on first interaction so
   // those offsets take effect. Read the base once — layout is settled by the
   // time the style panel opens.
-  const baseStyle = getComputedStyle(dependencies.getElement());
+  const baseStyle = getComputedStyle(element);
   const baseLeft = Number.parseFloat(baseStyle.left) || 0;
   const baseTop = Number.parseFloat(baseStyle.top) || 0;
   let isPositioned = baseStyle.position !== "static";
   const offset = { x: 0, y: 0 };
 
   const measureFrameInto = (target: TransformFrame): void => {
-    const element = dependencies.getElement();
     const rect = element.getBoundingClientRect();
     const layoutWidth =
       element instanceof HTMLElement && element.offsetWidth > 0 ? element.offsetWidth : rect.width;
@@ -83,7 +88,7 @@ export const createTransformController = (
   };
 
   const ensureConnected = (): boolean => {
-    if (isElementConnected(dependencies.getElement())) return true;
+    if (isElementConnected(element)) return true;
     dependencies.onInvalid();
     return false;
   };
@@ -125,7 +130,6 @@ export const createTransformController = (
   };
 
   const reinsert = (drop: DropTarget): void => {
-    const element = dependencies.getElement();
     const parent = drop.reference.parentNode;
     const elementParent = element.parentNode;
     if (!parent || !elementParent || element === drop.reference || element.contains(drop.reference))
@@ -144,7 +148,7 @@ export const createTransformController = (
   };
 
   const previewDropAt = (clientX: number, clientY: number): DropTarget | null => {
-    const drop = findDropTarget(clientX, clientY, dependencies.getElement());
+    const drop = findDropTarget(clientX, clientY, element);
     setInsertionIndicator(drop ? drop.indicator : null);
     return drop;
   };
@@ -214,7 +218,7 @@ export const createTransformController = (
     // value, however, addresses the content box unless box-sizing is
     // border-box. Subtract padding+border so the committed value lands the
     // border-box exactly under the cursor instead of overshooting.
-    const computed = getComputedStyle(dependencies.getElement());
+    const computed = getComputedStyle(element);
     const isBorderBox = computed.boxSizing === "border-box";
     const extraX = isBorderBox
       ? 0
@@ -300,7 +304,6 @@ export const createTransformController = (
 
   const restore = (): void => {
     if (!originPosition) return;
-    const element = dependencies.getElement();
     // Only move a still-connected element back to its origin; never re-attach a
     // node the app/React already removed (restore runs on every dismiss,
     // including the deselect triggered when the element is detached).
@@ -309,8 +312,9 @@ export const createTransformController = (
     }
     originPosition = null;
     lastDrop = null;
-    setDidMove(false);
-    if (isElementConnected(element)) refreshFrame();
+    // Intentionally no signal writes: restore runs during the panel's teardown
+    // (onCleanup), and notifying a disposing <Show> throws "Stale read from
+    // <Show>", which would abort the dismiss and strip the revert.
   };
 
   // Keep the frame glued to the element: viewport changes (scroll/zoom) plus a
@@ -320,11 +324,11 @@ export const createTransformController = (
     refreshFrame();
     const stopViewportTracking = onViewportChange(refreshFrame);
     const resizeObserver = new ResizeObserver(() => refreshFrame());
-    resizeObserver.observe(dependencies.getElement());
+    resizeObserver.observe(element);
     // A ResizeObserver does not fire when its target is removed, so watch the
     // document tree for the element being detached and deselect if so.
     const mutationObserver = new MutationObserver(() => {
-      if (!isElementConnected(dependencies.getElement())) dependencies.onInvalid();
+      if (!isElementConnected(element)) dependencies.onInvalid();
     });
     mutationObserver.observe(document.documentElement, { childList: true, subtree: true });
     onCleanup(() => {

--- a/packages/react-grab/src/components/transform-overlay/transform-controller.ts
+++ b/packages/react-grab/src/components/transform-overlay/transform-controller.ts
@@ -1,15 +1,10 @@
 import { createSignal, onCleanup, onMount, type Accessor } from "solid-js";
 import { TRANSFORM_MIN_SIZE_PX } from "../../constants.js";
-import type {
-  DropTarget,
-  TransformDragGhost,
-  TransformFrame,
-  TransformHandleId,
-  TransformInsertionIndicator,
-} from "../../types.js";
+import type { DropTarget, TransformFrame, TransformHandleId, ViewportBox } from "../../types.js";
 import { describeElementForPrompt } from "../../utils/describe-element-for-prompt.js";
 import { findDropTarget } from "../../utils/find-drop-target.js";
 import { isElementConnected } from "../../utils/is-element-connected.js";
+import { onViewportChange } from "../../utils/on-viewport-change.js";
 
 interface TransformControllerDependencies {
   getElement: () => Element;
@@ -26,8 +21,8 @@ interface TransformControllerDependencies {
 
 export interface TransformController {
   frame: Accessor<TransformFrame>;
-  insertionIndicator: Accessor<TransformInsertionIndicator | null>;
-  dragGhost: Accessor<TransformDragGhost | null>;
+  insertionIndicator: Accessor<ViewportBox | null>;
+  dragGhost: Accessor<ViewportBox | null>;
   hasMoved: () => boolean;
   describeMove: () => string;
   restore: () => void;
@@ -54,9 +49,8 @@ export const createTransformController = (
   // tracking refresh allocation-free while still driving reactivity.
   const frameValue: TransformFrame = { centerX: 0, centerY: 0, width: 0, height: 0 };
   const [frame, setFrame] = createSignal(frameValue, { equals: false });
-  const [insertionIndicator, setInsertionIndicator] =
-    createSignal<TransformInsertionIndicator | null>(null);
-  const [dragGhost, setDragGhost] = createSignal<TransformDragGhost | null>(null);
+  const [insertionIndicator, setInsertionIndicator] = createSignal<ViewportBox | null>(null);
+  const [dragGhost, setDragGhost] = createSignal<ViewportBox | null>(null);
   const [didMove, setDidMove] = createSignal(false);
 
   // The element's DOM slot before any move, so a discarded drag can be undone.
@@ -122,9 +116,11 @@ export const createTransformController = (
   const reinsert = (drop: DropTarget): void => {
     const element = dependencies.getElement();
     const parent = drop.reference.parentNode;
-    if (!parent || element === drop.reference || element.contains(drop.reference)) return;
+    const elementParent = element.parentNode;
+    if (!parent || !elementParent || element === drop.reference || element.contains(drop.reference))
+      return;
     if (!originPosition) {
-      originPosition = { parent: element.parentNode!, nextSibling: element.nextSibling };
+      originPosition = { parent: elementParent, nextSibling: element.nextSibling };
     }
     const referenceNode = drop.placement === "before" ? drop.reference : drop.reference.nextSibling;
     if (referenceNode === element) return;
@@ -256,20 +252,15 @@ export const createTransformController = (
         didFocus = true;
       }
 
-      if (fromCenter) {
-        // Keep the center pinned by shifting position half the growth.
-        offset.x = startOffsetX - widthDelta / 2;
-        offset.y = startOffsetY - heightDelta / 2;
-        applyOffset();
-        return;
-      }
-
-      // A plain box only extends its right/bottom edges when it grows, so
-      // dragging a top/left edge must also shift the element's position to keep
-      // the opposite (anchored) edge pinned. Right/bottom handles need no shift.
-      if (direction.x === -1) offset.x = startOffsetX - widthDelta;
-      if (direction.y === -1) offset.y = startOffsetY - heightDelta;
-      if (direction.x === -1 || direction.y === -1) {
+      // How much of each dimension's growth the position must absorb to keep the
+      // intended edge fixed: half when scaling about the center (Alt), all of it
+      // when dragging the top/left edge (so the opposite edge stays pinned), and
+      // none when dragging the bottom/right edge (the box just extends).
+      const anchorX = fromCenter ? 0.5 : direction.x === -1 ? 1 : 0;
+      const anchorY = fromCenter ? 0.5 : direction.y === -1 ? 1 : 0;
+      offset.x = startOffsetX - anchorX * widthDelta;
+      offset.y = startOffsetY - anchorY * heightDelta;
+      if (anchorX !== 0 || anchorY !== 0) {
         applyOffset();
       } else {
         refreshFrame();
@@ -296,17 +287,12 @@ export const createTransformController = (
     if (isElementConnected(element)) refreshFrame();
   };
 
-  // Track the element the way the selection label does (see selection-label):
-  // viewport listeners catch scroll/zoom, a ResizeObserver catches size changes
-  // from any source (canvas handles, panel sliders, content reflow). Drags
-  // refresh synchronously via reinsert/applyOffset.
+  // Keep the frame glued to the element: viewport changes (scroll/zoom) plus a
+  // ResizeObserver for size changes from any source (canvas handles, panel
+  // sliders, content reflow). Drags refresh synchronously via reinsert/applyOffset.
   onMount(() => {
     refreshFrame();
-    const handleViewportChange = () => refreshFrame();
-    window.addEventListener("scroll", handleViewportChange, true);
-    window.addEventListener("resize", handleViewportChange);
-    window.visualViewport?.addEventListener("resize", handleViewportChange);
-    window.visualViewport?.addEventListener("scroll", handleViewportChange);
+    const stopViewportTracking = onViewportChange(refreshFrame);
     const resizeObserver = new ResizeObserver(() => refreshFrame());
     resizeObserver.observe(dependencies.getElement());
     // A ResizeObserver does not fire when its target is removed, so watch the
@@ -316,10 +302,7 @@ export const createTransformController = (
     });
     mutationObserver.observe(document.documentElement, { childList: true, subtree: true });
     onCleanup(() => {
-      window.removeEventListener("scroll", handleViewportChange, true);
-      window.removeEventListener("resize", handleViewportChange);
-      window.visualViewport?.removeEventListener("resize", handleViewportChange);
-      window.visualViewport?.removeEventListener("scroll", handleViewportChange);
+      stopViewportTracking();
       resizeObserver.disconnect();
       mutationObserver.disconnect();
     });

--- a/packages/react-grab/src/components/transform-overlay/transform-controller.ts
+++ b/packages/react-grab/src/components/transform-overlay/transform-controller.ts
@@ -2,6 +2,7 @@ import { createSignal, onCleanup, onMount, type Accessor } from "solid-js";
 import { TRANSFORM_MIN_SIZE_PX } from "../../constants.js";
 import type {
   DropTarget,
+  TransformDragGhost,
   TransformFrame,
   TransformHandleId,
   TransformInsertionIndicator,
@@ -20,6 +21,7 @@ interface TransformControllerDependencies {
 export interface TransformController {
   frame: Accessor<TransformFrame>;
   insertionIndicator: Accessor<TransformInsertionIndicator | null>;
+  dragGhost: Accessor<TransformDragGhost | null>;
   hasMoved: () => boolean;
   describeMove: () => string;
   restore: () => void;
@@ -48,6 +50,7 @@ export const createTransformController = (
   const [frame, setFrame] = createSignal(frameValue, { equals: false });
   const [insertionIndicator, setInsertionIndicator] =
     createSignal<TransformInsertionIndicator | null>(null);
+  const [dragGhost, setDragGhost] = createSignal<TransformDragGhost | null>(null);
   const [didMove, setDidMove] = createSignal(false);
 
   // The element's DOM slot before any move, so a discarded drag can be undone.
@@ -125,15 +128,34 @@ export const createTransformController = (
   };
 
   const startMove = (event: PointerEvent): void => {
-    previewDropAt(event.clientX, event.clientY);
+    refreshFrame();
+    const originLeft = frameValue.centerX - frameValue.width / 2;
+    const originTop = frameValue.centerY - frameValue.height / 2;
+    const ghostWidth = frameValue.width;
+    const ghostHeight = frameValue.height;
+    const downX = event.clientX;
+    const downY = event.clientY;
+    const updateGhost = (clientX: number, clientY: number): void => {
+      setDragGhost({
+        left: originLeft + (clientX - downX),
+        top: originTop + (clientY - downY),
+        width: ghostWidth,
+        height: ghostHeight,
+      });
+    };
+
+    updateGhost(downX, downY);
+    previewDropAt(downX, downY);
     bindDrag(
       (moveEvent) => {
+        updateGhost(moveEvent.clientX, moveEvent.clientY);
         previewDropAt(moveEvent.clientX, moveEvent.clientY);
       },
       (upEvent) => {
         const drop = previewDropAt(upEvent.clientX, upEvent.clientY);
         if (drop) reinsert(drop);
         setInsertionIndicator(null);
+        setDragGhost(null);
       },
     );
   };
@@ -232,6 +254,7 @@ export const createTransformController = (
   return {
     frame,
     insertionIndicator,
+    dragGhost,
     hasMoved,
     describeMove,
     restore,

--- a/packages/react-grab/src/components/transform-overlay/transform-controller.ts
+++ b/packages/react-grab/src/components/transform-overlay/transform-controller.ts
@@ -7,7 +7,6 @@ import type {
   TransformHandleId,
   TransformValues,
 } from "../../types.js";
-import { nativeCancelAnimationFrame, nativeRequestAnimationFrame } from "../../utils/native-raf.js";
 
 interface TransformControllerDependencies {
   getElement: () => Element;
@@ -226,9 +225,17 @@ export const createTransformController = (
     });
   };
 
+  // Round before testing so a pure resize, whose anchor compensation can leave
+  // sub-pixel translate residue, does not report a change (and `buildPendingEdit`
+  // would emit a no-op `translate(0px, 0px) rotate(0deg)`). "Changed" and
+  // "emitted" therefore agree on the same rounded values.
   const hasChanged = (): boolean => {
     trackTransformEdits();
-    return transform.translateX !== 0 || transform.translateY !== 0 || transform.rotate !== 0;
+    return (
+      Math.round(transform.translateX) !== 0 ||
+      Math.round(transform.translateY) !== 0 ||
+      Math.round(transform.rotate) !== 0
+    );
   };
 
   const buildPendingEdit = (): PendingEdit | null => {
@@ -241,13 +248,26 @@ export const createTransformController = (
     };
   };
 
+  // Track the element the way the selection label does (see selection-label):
+  // viewport listeners catch scroll/zoom, a ResizeObserver catches size changes
+  // from any source (canvas handles, panel sliders, content reflow). This avoids
+  // an always-on per-frame getBoundingClientRect poll — drags already refresh
+  // synchronously via applyTransform.
   onMount(() => {
-    let frameId: number | null = nativeRequestAnimationFrame(function tick() {
-      refreshFrame();
-      frameId = nativeRequestAnimationFrame(tick);
-    });
+    refreshFrame();
+    const handleViewportChange = () => refreshFrame();
+    window.addEventListener("scroll", handleViewportChange, true);
+    window.addEventListener("resize", handleViewportChange);
+    window.visualViewport?.addEventListener("resize", handleViewportChange);
+    window.visualViewport?.addEventListener("scroll", handleViewportChange);
+    const resizeObserver = new ResizeObserver(() => refreshFrame());
+    resizeObserver.observe(dependencies.getElement());
     onCleanup(() => {
-      if (frameId !== null) nativeCancelAnimationFrame(frameId);
+      window.removeEventListener("scroll", handleViewportChange, true);
+      window.removeEventListener("resize", handleViewportChange);
+      window.visualViewport?.removeEventListener("resize", handleViewportChange);
+      window.visualViewport?.removeEventListener("scroll", handleViewportChange);
+      resizeObserver.disconnect();
     });
   });
 

--- a/packages/react-grab/src/components/transform-overlay/transform-controller.ts
+++ b/packages/react-grab/src/components/transform-overlay/transform-controller.ts
@@ -94,23 +94,34 @@ export const createTransformController = (
     setFrame(frameValue);
   };
 
+  // Tear down the in-progress drag's window listeners. Tracked so a drag that
+  // is still live when the controller unmounts (e.g. the element is removed
+  // mid-drag) does not leak listeners holding a stale closure.
+  let activeDragTeardown: (() => void) | null = null;
+
   const bindDrag = (
     onMove: (event: PointerEvent) => void,
     onUp?: (event: PointerEvent) => void,
   ): void => {
+    activeDragTeardown?.();
     const handleMove = (event: PointerEvent) => {
       event.preventDefault();
       onMove(event);
     };
-    const handleUp = (event: PointerEvent) => {
+    const teardown = () => {
       window.removeEventListener("pointermove", handleMove, { capture: true });
       window.removeEventListener("pointerup", handleUp, { capture: true });
       window.removeEventListener("pointercancel", handleUp, { capture: true });
+      activeDragTeardown = null;
+    };
+    const handleUp = (event: PointerEvent) => {
+      teardown();
       onUp?.(event);
     };
     window.addEventListener("pointermove", handleMove, { capture: true });
     window.addEventListener("pointerup", handleUp, { capture: true });
     window.addEventListener("pointercancel", handleUp, { capture: true });
+    activeDragTeardown = teardown;
   };
 
   const reinsert = (drop: DropTarget): void => {
@@ -119,11 +130,13 @@ export const createTransformController = (
     const elementParent = element.parentNode;
     if (!parent || !elementParent || element === drop.reference || element.contains(drop.reference))
       return;
+    const referenceNode = drop.placement === "before" ? drop.reference : drop.reference.nextSibling;
+    // Skip a no-op reinsert so an unchanged DOM order isn't flagged as a move.
+    if (referenceNode === element) return;
+    if (element.parentNode === parent && element.nextSibling === referenceNode) return;
     if (!originPosition) {
       originPosition = { parent: elementParent, nextSibling: element.nextSibling };
     }
-    const referenceNode = drop.placement === "before" ? drop.reference : drop.reference.nextSibling;
-    if (referenceNode === element) return;
     parent.insertBefore(element, referenceNode);
     lastDrop = drop;
     setDidMove(true);
@@ -278,7 +291,10 @@ export const createTransformController = (
   const restore = (): void => {
     if (!originPosition) return;
     const element = dependencies.getElement();
-    if (originPosition.parent.isConnected) {
+    // Only move a still-connected element back to its origin; never re-attach a
+    // node the app/React already removed (restore runs on every dismiss,
+    // including the deselect triggered when the element is detached).
+    if (isElementConnected(element) && originPosition.parent.isConnected) {
       originPosition.parent.insertBefore(element, originPosition.nextSibling);
     }
     originPosition = null;
@@ -305,6 +321,7 @@ export const createTransformController = (
       stopViewportTracking();
       resizeObserver.disconnect();
       mutationObserver.disconnect();
+      activeDragTeardown?.();
     });
   });
 

--- a/packages/react-grab/src/components/transform-overlay/transform-controller.ts
+++ b/packages/react-grab/src/components/transform-overlay/transform-controller.ts
@@ -9,6 +9,7 @@ import type {
 } from "../../types.js";
 import { describeElementForPrompt } from "../../utils/describe-element-for-prompt.js";
 import { findDropTarget } from "../../utils/find-drop-target.js";
+import { isElementConnected } from "../../utils/is-element-connected.js";
 
 interface TransformControllerDependencies {
   getElement: () => Element;
@@ -18,6 +19,9 @@ interface TransformControllerDependencies {
   ) => void;
   // Collapse the panel onto the dimension being resized, like keyboard stepping.
   focusProperty: (cssProperty: "width" | "height") => void;
+  // The selected element left the document (e.g. removed by a re-render); the
+  // panel should deselect rather than track a dead node.
+  onInvalid: () => void;
 }
 
 export interface TransformController {
@@ -84,7 +88,14 @@ export const createTransformController = (
     target.height = layoutHeight;
   };
 
+  const ensureConnected = (): boolean => {
+    if (isElementConnected(dependencies.getElement())) return true;
+    dependencies.onInvalid();
+    return false;
+  };
+
   const refreshFrame = (): void => {
+    if (!ensureConnected()) return;
     measureFrameInto(frameValue);
     setFrame(frameValue);
   };
@@ -130,6 +141,7 @@ export const createTransformController = (
   };
 
   const startMove = (event: PointerEvent): void => {
+    if (!ensureConnected()) return;
     refreshFrame();
     const originLeft = frameValue.centerX - frameValue.width / 2;
     const originTop = frameValue.centerY - frameValue.height / 2;
@@ -176,6 +188,7 @@ export const createTransformController = (
   };
 
   const startResize = (event: PointerEvent, handle: TransformHandleId): void => {
+    if (!ensureConnected()) return;
     refreshFrame();
     const direction = HANDLE_DIRECTION[handle];
     // The frame is the border-box (offsetWidth/Height); the inline `width`
@@ -274,11 +287,13 @@ export const createTransformController = (
   const restore = (): void => {
     if (!originPosition) return;
     const element = dependencies.getElement();
-    originPosition.parent.insertBefore(element, originPosition.nextSibling);
+    if (originPosition.parent.isConnected) {
+      originPosition.parent.insertBefore(element, originPosition.nextSibling);
+    }
     originPosition = null;
     lastDrop = null;
     setDidMove(false);
-    refreshFrame();
+    if (isElementConnected(element)) refreshFrame();
   };
 
   // Track the element the way the selection label does (see selection-label):
@@ -294,12 +309,19 @@ export const createTransformController = (
     window.visualViewport?.addEventListener("scroll", handleViewportChange);
     const resizeObserver = new ResizeObserver(() => refreshFrame());
     resizeObserver.observe(dependencies.getElement());
+    // A ResizeObserver does not fire when its target is removed, so watch the
+    // document tree for the element being detached and deselect if so.
+    const mutationObserver = new MutationObserver(() => {
+      if (!isElementConnected(dependencies.getElement())) dependencies.onInvalid();
+    });
+    mutationObserver.observe(document.documentElement, { childList: true, subtree: true });
     onCleanup(() => {
       window.removeEventListener("scroll", handleViewportChange, true);
       window.removeEventListener("resize", handleViewportChange);
       window.visualViewport?.removeEventListener("resize", handleViewportChange);
       window.visualViewport?.removeEventListener("scroll", handleViewportChange);
       resizeObserver.disconnect();
+      mutationObserver.disconnect();
     });
   });
 

--- a/packages/react-grab/src/components/transform-overlay/transform-controller.ts
+++ b/packages/react-grab/src/components/transform-overlay/transform-controller.ts
@@ -246,38 +246,48 @@ export const createTransformController = (
       // move); otherwise the edge opposite the handle stays anchored.
       const fromCenter = moveEvent.altKey;
       const growthScale = fromCenter ? 2 : 1;
-      const nextWidth = Math.round(
+      const requestedWidth = Math.round(
         Math.max(
           TRANSFORM_MIN_SIZE_PX,
           startWidth + growthScale * direction.x * (moveEvent.clientX - startPointerX),
         ),
       );
-      const nextHeight = Math.round(
+      const requestedHeight = Math.round(
         Math.max(
           TRANSFORM_MIN_SIZE_PX,
           startHeight + growthScale * direction.y * (moveEvent.clientY - startPointerY),
         ),
       );
-      const widthDelta = nextWidth - startWidth;
-      const heightDelta = nextHeight - startHeight;
 
       dependencies.commitStyle(
         "width",
-        Math.max(TRANSFORM_MIN_SIZE_PX, Math.round(nextWidth - extraX)),
+        Math.max(TRANSFORM_MIN_SIZE_PX, Math.round(requestedWidth - extraX)),
       );
       dependencies.commitStyle(
         "height",
-        Math.max(TRANSFORM_MIN_SIZE_PX, Math.round(nextHeight - extraY)),
+        Math.max(TRANSFORM_MIN_SIZE_PX, Math.round(requestedHeight - extraY)),
       );
 
       // Once the size is on the tweak store, collapse the panel onto whichever
       // dimension the drag is changing most so its live value stays visible.
       if (!didFocus) {
         dependencies.focusProperty(
-          Math.abs(widthDelta) >= Math.abs(heightDelta) ? "width" : "height",
+          Math.abs(requestedWidth - startWidth) >= Math.abs(requestedHeight - startHeight)
+            ? "width"
+            : "height",
         );
         didFocus = true;
       }
+
+      // Anchor the opposite edge using the element's ACTUAL post-layout size,
+      // not the requested one. When a layout constrains the element (flex/grid
+      // distribution, min/max-width, content), the requested delta overshoots
+      // and the position would slide the element out from under the cursor —
+      // the main source of "glitchy" resizing on real pages. Measuring first
+      // keeps the anchored edge pinned even when the element can't grow.
+      measureFrameInto(frameValue);
+      const actualWidthDelta = frameValue.width - startWidth;
+      const actualHeightDelta = frameValue.height - startHeight;
 
       // How much of each dimension's growth the position must absorb to keep the
       // intended edge fixed: half when scaling about the center (Alt), all of it
@@ -285,12 +295,12 @@ export const createTransformController = (
       // none when dragging the bottom/right edge (the box just extends).
       const anchorX = fromCenter ? 0.5 : direction.x === -1 ? 1 : 0;
       const anchorY = fromCenter ? 0.5 : direction.y === -1 ? 1 : 0;
-      offset.x = startOffsetX - anchorX * widthDelta;
-      offset.y = startOffsetY - anchorY * heightDelta;
       if (anchorX !== 0 || anchorY !== 0) {
+        offset.x = startOffsetX - anchorX * actualWidthDelta;
+        offset.y = startOffsetY - anchorY * actualHeightDelta;
         applyOffset();
       } else {
-        refreshFrame();
+        setFrame(frameValue);
       }
     });
   };

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -238,16 +238,12 @@ export const EDIT_SEARCH_POSITION_PENALTY = 100;
 export const EDIT_SEARCH_LENGTH_PENALTY = 1;
 export const EDIT_COMPACT_SLIDER_MIN_WIDTH_PX = 96;
 
-// Figma-style transform overlay shown over the selected element while the
-// style panel is open. Square handles sit on the 4 corners + 4 edge
-// midpoints; a detached circular handle floats above the top edge to rotate.
+// Transform overlay shown over the selected element while the style panel is
+// open: a draggable frame to move the element plus square handles on its four
+// corners to resize it.
 export const TRANSFORM_HANDLE_SIZE_PX = 9;
-export const TRANSFORM_ROTATE_HANDLE_SIZE_PX = 12;
-export const TRANSFORM_ROTATE_HANDLE_OFFSET_PX = 22;
 export const TRANSFORM_FRAME_BORDER_PX = 1;
 export const TRANSFORM_MIN_SIZE_PX = 4;
-// Holding Shift snaps rotation to this increment, matching Figma.
-export const TRANSFORM_ROTATE_SNAP_DEG = 15;
 export const TRANSFORM_OVERLAY_ACCENT = "#ec4899";
 
 export const CSS_VALUE_DECIMAL_PLACES = 2;

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -248,7 +248,7 @@ export const TRANSFORM_FRAME_BORDER_PX = 1;
 export const TRANSFORM_MIN_SIZE_PX = 4;
 // Holding Shift snaps rotation to this increment, matching Figma.
 export const TRANSFORM_ROTATE_SNAP_DEG = 15;
-export const TRANSFORM_OVERLAY_ACCENT = "#0c8ce9";
+export const TRANSFORM_OVERLAY_ACCENT = "#ec4899";
 
 export const CSS_VALUE_DECIMAL_PLACES = 2;
 export const OPACITY_PERCENT_MAX = 100;

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -41,6 +41,9 @@ export const AUTO_SCROLL_SPEED_PX = 10;
 
 export const Z_INDEX_OVERLAY = 2147483647;
 export const Z_INDEX_OVERLAY_CANVAS = 2147483645;
+// Transform handles sit above the selection canvas but below the style
+// panel so the panel's controls always win pointer events on overlap.
+export const Z_INDEX_TRANSFORM_OVERLAY = 2147483646;
 
 export const DRAG_LERP_FACTOR = 0.7;
 export const BASELINE_FRAME_DURATION_MS = 1000 / 60;
@@ -234,6 +237,18 @@ export const EDIT_SEARCH_SUBSTRING_SCORE = 1000;
 export const EDIT_SEARCH_POSITION_PENALTY = 100;
 export const EDIT_SEARCH_LENGTH_PENALTY = 1;
 export const EDIT_COMPACT_SLIDER_MIN_WIDTH_PX = 96;
+
+// Figma-style transform overlay shown over the selected element while the
+// style panel is open. Square handles sit on the 4 corners + 4 edge
+// midpoints; a detached circular handle floats above the top edge to rotate.
+export const TRANSFORM_HANDLE_SIZE_PX = 9;
+export const TRANSFORM_ROTATE_HANDLE_SIZE_PX = 12;
+export const TRANSFORM_ROTATE_HANDLE_OFFSET_PX = 22;
+export const TRANSFORM_FRAME_BORDER_PX = 1;
+export const TRANSFORM_MIN_SIZE_PX = 4;
+// Holding Shift snaps rotation to this increment, matching Figma.
+export const TRANSFORM_ROTATE_SNAP_DEG = 15;
+export const TRANSFORM_OVERLAY_ACCENT = "#0c8ce9";
 
 export const CSS_VALUE_DECIMAL_PLACES = 2;
 export const OPACITY_PERCENT_MAX = 100;

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -244,7 +244,9 @@ export const EDIT_COMPACT_SLIDER_MIN_WIDTH_PX = 96;
 export const TRANSFORM_HANDLE_SIZE_PX = 9;
 export const TRANSFORM_FRAME_BORDER_PX = 1;
 export const TRANSFORM_MIN_SIZE_PX = 4;
-export const TRANSFORM_OVERLAY_ACCENT = "#ec4899";
+// Reuse react-grab's overlay pink (same hue as the selection box) at full
+// opacity so the handles read as a solid accent.
+export const TRANSFORM_OVERLAY_ACCENT = overlayColor(1);
 // Thickness of the line marking where a dragged element will be reinserted.
 export const TRANSFORM_INDICATOR_THICKNESS_PX = 2;
 export const ELEMENT_DESCRIPTOR_TEXT_MAX_LENGTH = 24;

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -245,6 +245,9 @@ export const TRANSFORM_HANDLE_SIZE_PX = 9;
 export const TRANSFORM_FRAME_BORDER_PX = 1;
 export const TRANSFORM_MIN_SIZE_PX = 4;
 export const TRANSFORM_OVERLAY_ACCENT = "#ec4899";
+// Thickness of the line marking where a dragged element will be reinserted.
+export const TRANSFORM_INDICATOR_THICKNESS_PX = 2;
+export const ELEMENT_DESCRIPTOR_TEXT_MAX_LENGTH = 24;
 
 export const CSS_VALUE_DECIMAL_PLACES = 2;
 export const OPACITY_PERCENT_MAX = 100;

--- a/packages/react-grab/src/core/edit-mode.ts
+++ b/packages/react-grab/src/core/edit-mode.ts
@@ -42,6 +42,8 @@ interface EditModeDependencies {
 export interface EditModeController {
   state: Accessor<EditPanelState | null>;
   trigger: (element: Element, position: Position, overrides?: EditModeOverrides) => boolean;
+  retarget: (element: Element, position: Position, overrides?: EditModeOverrides) => boolean;
+  updateSource: (element: Element, filePath?: string, lineNumber?: number) => void;
   dismiss: () => void;
   closePreservingRenderer: () => void;
   submit: (prompt: string) => void;
@@ -69,13 +71,11 @@ export const createEditModeController = (
     clearAll();
   };
 
-  const trigger = (
+  const buildStateForElement = (
     element: Element,
     position: Position,
-    overrides: EditModeOverrides = {},
+    overrides: EditModeOverrides,
   ): boolean => {
-    // Re-entry would desync the existing preview from the panel's tweak store.
-    if (state() !== null) return false;
     const properties = buildEditableProperties(element);
     if (properties.length === 0) return false;
 
@@ -113,8 +113,41 @@ export const createEditModeController = (
     dependencies.actions.setPointer(position);
     dependencies.actions.setFrozenElement(element);
     dependencies.actions.freeze();
+    return true;
+  };
+
+  const trigger = (
+    element: Element,
+    position: Position,
+    overrides: EditModeOverrides = {},
+  ): boolean => {
+    // Re-entry would desync the existing preview from the panel's tweak store.
+    if (state() !== null) return false;
+    if (!buildStateForElement(element, position, overrides)) return false;
     dependencies.onOpen?.();
     return true;
+  };
+
+  // Switch the open panel to a different element (click-to-select another
+  // element while styling). The current preview is reverted before the new
+  // element takes over; the renderer stays active, so onOpen tracking keeps
+  // running rather than tearing down and re-creating.
+  const retarget = (
+    element: Element,
+    position: Position,
+    overrides: EditModeOverrides = {},
+  ): boolean => {
+    const current = state();
+    if (current?.element === element) return false;
+    current?.preview.restore();
+    return buildStateForElement(element, position, overrides);
+  };
+
+  const updateSource = (element: Element, filePath?: string, lineNumber?: number): void => {
+    setState((current) => {
+      if (!current || current.element !== element) return current;
+      return { ...current, filePath, lineNumber };
+    });
   };
 
   const submit = (prompt: string) => {
@@ -152,6 +185,8 @@ export const createEditModeController = (
   return {
     state,
     trigger,
+    retarget,
+    updateSource,
     dismiss,
     closePreservingRenderer,
     submit,

--- a/packages/react-grab/src/core/edit-mode.ts
+++ b/packages/react-grab/src/core/edit-mode.ts
@@ -1,5 +1,12 @@
 import { createSignal, type Accessor } from "solid-js";
-import type { EditPanelState, Position } from "../types.js";
+import type {
+  ArchivedEdit,
+  ArchivedEdits,
+  EditPanelState,
+  EditTeardownReason,
+  PendingEditsEntry,
+  Position,
+} from "../types.js";
 import { buildEditableProperties } from "../utils/build-editable-properties.js";
 import { createElementBounds } from "../utils/create-element-bounds.js";
 import { getTagName } from "../utils/get-tag-name.js";
@@ -48,6 +55,9 @@ export interface EditModeController {
   closePreservingRenderer: () => void;
   submit: (prompt: string) => void;
   resetWithDiscard: () => void;
+  teardownReason: Accessor<EditTeardownReason>;
+  archive: (item: ArchivedEdit) => void;
+  getArchived: () => ArchivedEdits;
   isOpen: Accessor<boolean>;
   isInteracting: Accessor<boolean>;
   setInteracting: (interacting: boolean) => void;
@@ -59,6 +69,45 @@ export const createEditModeController = (
   const [state, setState] = createSignal<EditPanelState | null>(null);
   const [isInteracting, setIsInteracting] = createSignal(false);
 
+  // Why the active panel will be torn down next. The panel reads this in its
+  // cleanup to decide whether to keep its edits (retarget/submit) or revert
+  // them (dismiss). Defaults to "dismiss" so any unexpected teardown reverts.
+  const [teardownReason, setTeardownReason] = createSignal<EditTeardownReason>("dismiss");
+
+  // Edits from elements the user switched away from during this session. Kept
+  // applied and folded into the copied prompt; reverted together on discard.
+  let archivedEntries: PendingEditsEntry[] = [];
+  let archivedMovePrompts: string[] = [];
+  let archivedRestores: Array<() => void> = [];
+
+  const clearArchive = () => {
+    archivedEntries = [];
+    archivedMovePrompts = [];
+    archivedRestores = [];
+  };
+
+  const restoreArchived = () => {
+    // LIFO so re-inserted elements unwind in the reverse of how they stacked.
+    for (let index = archivedRestores.length - 1; index >= 0; index -= 1) {
+      archivedRestores[index]();
+    }
+    clearArchive();
+  };
+
+  const archive = (item: ArchivedEdit) => {
+    const hasStyleEdits = item.entry.edits.length > 0;
+    const hasMove = item.movePrompt.length > 0;
+    if (!hasStyleEdits && !hasMove) return;
+    if (hasStyleEdits) archivedEntries.push(item.entry);
+    if (hasMove) archivedMovePrompts.push(item.movePrompt);
+    archivedRestores.push(item.restore);
+  };
+
+  const getArchived = (): ArchivedEdits => ({
+    entries: archivedEntries,
+    movePrompts: archivedMovePrompts,
+  });
+
   const clearAll = () => {
     const wasOpen = state() !== null;
     setState(null);
@@ -67,7 +116,11 @@ export const createEditModeController = (
   };
 
   const clearWithPreviewRestore = () => {
+    // Revert everything: the active element's preview plus every element whose
+    // edits were batched earlier in the session.
+    setTeardownReason("dismiss");
     state()?.preview.restore();
+    restoreArchived();
     clearAll();
   };
 
@@ -129,9 +182,10 @@ export const createEditModeController = (
   };
 
   // Switch the open panel to a different element (click-to-select another
-  // element while styling). The current preview is reverted before the new
-  // element takes over; the renderer stays active, so onOpen tracking keeps
-  // running rather than tearing down and re-creating.
+  // element while styling). The current element's edits are batched (kept
+  // applied and recorded for the copied prompt) rather than reverted, so a
+  // session can accumulate tweaks across many elements. The renderer stays
+  // active, so onOpen tracking keeps running rather than tearing down.
   const retarget = (
     element: Element,
     position: Position,
@@ -140,11 +194,15 @@ export const createEditModeController = (
     const current = state();
     if (current?.element === element) return false;
     // Confirm the new element is editable before tearing down the current
-    // selection — otherwise a non-editable target would revert the current
-    // element's preview while leaving the panel pointed at it.
+    // selection — otherwise a non-editable target would batch the current
+    // element's edits while leaving the panel pointed at it.
     if (buildEditableProperties(element).length === 0) return false;
-    current?.preview.restore();
-    return buildStateForElement(element, position, overrides);
+    // The outgoing panel's cleanup reads this reason and archives its own
+    // edits; restore to the default once the new panel is in place.
+    setTeardownReason("retarget");
+    const didRetarget = buildStateForElement(element, position, overrides);
+    setTeardownReason("dismiss");
+    return didRetarget;
   };
 
   const updateSource = (element: Element, filePath?: string, lineNumber?: number): void => {
@@ -158,7 +216,12 @@ export const createEditModeController = (
     const currentState = state();
     if (!currentState) return;
     const element = currentState.element;
+    // Keep both the current and archived edits applied; the prompt already
+    // folded the archive in, so drop it without reverting.
+    setTeardownReason("submit");
+    clearArchive();
     clearAll();
+    setTeardownReason("dismiss");
     if (!dependencies.store.wasActivatedByToggle) {
       dependencies.actions.unfreeze();
     }
@@ -195,6 +258,9 @@ export const createEditModeController = (
     closePreservingRenderer,
     submit,
     resetWithDiscard: clearWithPreviewRestore,
+    teardownReason,
+    archive,
+    getArchived,
     isOpen: () => state() !== null,
     isInteracting,
     setInteracting: setIsInteracting,

--- a/packages/react-grab/src/core/edit-mode.ts
+++ b/packages/react-grab/src/core/edit-mode.ts
@@ -139,6 +139,10 @@ export const createEditModeController = (
   ): boolean => {
     const current = state();
     if (current?.element === element) return false;
+    // Confirm the new element is editable before tearing down the current
+    // selection — otherwise a non-editable target would revert the current
+    // element's preview while leaving the panel pointed at it.
+    if (buildEditableProperties(element).length === 0) return false;
     current?.preview.restore();
     return buildStateForElement(element, position, overrides);
   };

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -3622,6 +3622,9 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
                 onEditPanelDismiss={editMode.dismiss}
                 onEditPanelSubmit={editMode.submit}
                 onEditPanelInteractingChange={editMode.setInteracting}
+                editPanelTeardownReason={editMode.teardownReason}
+                onEditPanelArchive={editMode.archive}
+                editPanelArchived={editMode.getArchived}
               />
             );
           }, rendererRoot);

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -1454,6 +1454,26 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       overrides: EditModeOverrides = {},
     ): boolean => editMode.trigger(element, position, overrides);
 
+    // Click-to-select another element while the style panel is open: swap the
+    // panel, overlay, and frozen selection to the clicked element and resolve
+    // its source for the copy prompt.
+    const retargetEditMode = (element: Element, position: Position): void => {
+      freezeAllAnimations([element]);
+      actions.setSelectionSource(null, null);
+      const didRetarget = editMode.retarget(element, position, {
+        tagName: getTagName(element) || undefined,
+        componentName: getComponentDisplayName(element) ?? undefined,
+      });
+      if (!didRetarget) return;
+      void resolveSource(element).then((source) => {
+        editMode.updateSource(
+          element,
+          source?.filePath ?? undefined,
+          source?.lineNumber ?? undefined,
+        );
+      });
+    };
+
     const currentSelectionEditOverrides = (element: Element): EditModeOverrides => ({
       filePath: store.selectionFilePath ?? undefined,
       lineNumber: store.selectionLineNumber ?? undefined,
@@ -2601,6 +2621,20 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         if (!event.isPrimary) return;
         actions.setTouchMode(event.pointerType === "touch");
         if (isEventFromOverlay(event, "data-react-grab-ignore-events")) return;
+
+        // In style mode a click on a different element retargets the panel to
+        // it instead of starting a selection; a click on empty space falls
+        // through to the panel's own outside-click dismiss.
+        if (editMode.isOpen()) {
+          const clickedElement = getElementAtPosition(event.clientX, event.clientY);
+          if (clickedElement && clickedElement !== editMode.state()?.element) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            retargetEditMode(clickedElement, { x: event.clientX, y: event.clientY });
+          }
+          return;
+        }
+
         if (isModalPopoverOpen()) return;
 
         if (isPromptMode()) {

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -431,6 +431,15 @@ export interface TransformInsertionIndicator {
   height: number;
 }
 
+// Translucent box following the cursor during a move drag, showing where the
+// element is being dragged before it snaps into its reinsertion slot.
+export interface TransformDragGhost {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
 export interface DropTarget {
   reference: Element;
   placement: DropPlacement;

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -421,6 +421,22 @@ export interface OverlayBounds {
 
 export type TransformHandleId = "nw" | "ne" | "se" | "sw";
 
+export type DropPlacement = "before" | "after";
+
+// Viewport-space line marking where the dragged element will be reinserted.
+export interface TransformInsertionIndicator {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export interface DropTarget {
+  reference: Element;
+  placement: DropPlacement;
+  indicator: TransformInsertionIndicator;
+}
+
 // Viewport-space description of the manipulable box. `centerX`/`centerY` are
 // the element's geometric center; `width`/`height` are its layout box.
 export interface TransformFrame {

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -240,6 +240,24 @@ export interface PendingEditsEntry {
   edits: PendingEdits;
 }
 
+// Why a style panel instance is being torn down — drives whether its edits are
+// kept and batched (retarget), reverted (dismiss), or kept on copy (submit).
+export type EditTeardownReason = "retarget" | "dismiss" | "submit";
+
+// An element's edits captured when switching away from it, so the session can
+// keep them applied, include them in the copied prompt, and revert them all on
+// discard.
+export interface ArchivedEdit {
+  entry: PendingEditsEntry;
+  movePrompt: string;
+  restore: () => void;
+}
+
+export interface ArchivedEdits {
+  entries: PendingEditsEntry[];
+  movePrompts: string[];
+}
+
 export interface PreviewStyles {
   apply: (cssProperties: readonly string[], cssValue: string) => void;
   restore: () => void;
@@ -545,6 +563,9 @@ export interface ReactGrabRendererProps {
   onEditPanelDismiss?: () => void;
   onEditPanelSubmit?: (prompt: string) => void;
   onEditPanelInteractingChange?: (interacting: boolean) => void;
+  editPanelTeardownReason?: () => EditTeardownReason;
+  onEditPanelArchive?: (item: ArchivedEdit) => void;
+  editPanelArchived?: () => ArchivedEdits;
 }
 
 export interface GrabbedBox {

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -230,9 +230,9 @@ interface EnumPendingEdit {
   value: string;
 }
 
-// Canvas transform edits (move/rotate) carry a pre-formatted CSS value
-// such as `translate(8px, -4px) rotate(15deg)` because, unlike numeric
-// rows, the value is a function expression rather than a number+unit.
+// Canvas transform edits (move) carry a pre-formatted CSS value such as
+// `translate(8px, -4px)` because, unlike numeric rows, the value is a
+// function expression rather than a number+unit.
 interface TransformPendingEdit {
   kind: "transform";
   key: string;
@@ -433,23 +433,20 @@ export interface OverlayBounds {
   y: number;
 }
 
-export type TransformHandleId = "nw" | "n" | "ne" | "e" | "se" | "s" | "sw" | "w";
+export type TransformHandleId = "nw" | "ne" | "se" | "sw";
 
 export interface TransformValues {
   translateX: number;
   translateY: number;
-  rotate: number;
 }
 
-// Viewport-space description of the manipulable box. `centerX`/`centerY`
-// are the rotated element's geometric center; `width`/`height` are the
-// element's unrotated layout box so the handle frame can rotate around it.
+// Viewport-space description of the manipulable box. `centerX`/`centerY` are
+// the element's geometric center; `width`/`height` are its layout box.
 export interface TransformFrame {
   centerX: number;
   centerY: number;
   width: number;
   height: number;
-  rotate: number;
 }
 
 export type SelectionLabelStatus = "idle" | "copying" | "copied" | "fading" | "error";

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -230,21 +230,7 @@ interface EnumPendingEdit {
   value: string;
 }
 
-// Canvas transform edits (move) carry a pre-formatted CSS value such as
-// `translate(8px, -4px)` because, unlike numeric rows, the value is a
-// function expression rather than a number+unit.
-interface TransformPendingEdit {
-  kind: "transform";
-  key: string;
-  cssProperties: readonly string[];
-  value: string;
-}
-
-export type PendingEdit =
-  | NumericPendingEdit
-  | ColorPendingEdit
-  | EnumPendingEdit
-  | TransformPendingEdit;
+export type PendingEdit = NumericPendingEdit | ColorPendingEdit | EnumPendingEdit;
 
 export type PendingEdits = PendingEdit[];
 
@@ -434,11 +420,6 @@ export interface OverlayBounds {
 }
 
 export type TransformHandleId = "nw" | "ne" | "se" | "sw";
-
-export interface TransformValues {
-  translateX: number;
-  translateY: number;
-}
 
 // Viewport-space description of the manipulable box. `centerX`/`centerY` are
 // the element's geometric center; `width`/`height` are its layout box.

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -423,17 +423,9 @@ export type TransformHandleId = "nw" | "ne" | "se" | "sw";
 
 export type DropPlacement = "before" | "after";
 
-// Viewport-space line marking where the dragged element will be reinserted.
-export interface TransformInsertionIndicator {
-  left: number;
-  top: number;
-  width: number;
-  height: number;
-}
-
-// Translucent box following the cursor during a move drag, showing where the
-// element is being dragged before it snaps into its reinsertion slot.
-export interface TransformDragGhost {
+// A plain viewport-space rectangle. Used both for the insertion indicator line
+// (where a dragged element will be reinserted) and the move drag ghost.
+export interface ViewportBox {
   left: number;
   top: number;
   width: number;
@@ -443,7 +435,7 @@ export interface TransformDragGhost {
 export interface DropTarget {
   reference: Element;
   placement: DropPlacement;
-  indicator: TransformInsertionIndicator;
+  indicator: ViewportBox;
 }
 
 // Viewport-space description of the manipulable box. `centerX`/`centerY` are

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -230,7 +230,21 @@ interface EnumPendingEdit {
   value: string;
 }
 
-export type PendingEdit = NumericPendingEdit | ColorPendingEdit | EnumPendingEdit;
+// Canvas transform edits (move/rotate) carry a pre-formatted CSS value
+// such as `translate(8px, -4px) rotate(15deg)` because, unlike numeric
+// rows, the value is a function expression rather than a number+unit.
+interface TransformPendingEdit {
+  kind: "transform";
+  key: string;
+  cssProperties: readonly string[];
+  value: string;
+}
+
+export type PendingEdit =
+  | NumericPendingEdit
+  | ColorPendingEdit
+  | EnumPendingEdit
+  | TransformPendingEdit;
 
 export type PendingEdits = PendingEdit[];
 
@@ -417,6 +431,25 @@ export interface OverlayBounds {
   width: number;
   x: number;
   y: number;
+}
+
+export type TransformHandleId = "nw" | "n" | "ne" | "e" | "se" | "s" | "sw" | "w";
+
+export interface TransformValues {
+  translateX: number;
+  translateY: number;
+  rotate: number;
+}
+
+// Viewport-space description of the manipulable box. `centerX`/`centerY`
+// are the rotated element's geometric center; `width`/`height` are the
+// element's unrotated layout box so the handle frame can rotate around it.
+export interface TransformFrame {
+  centerX: number;
+  centerY: number;
+  width: number;
+  height: number;
+  rotate: number;
 }
 
 export type SelectionLabelStatus = "idle" | "copying" | "copied" | "fading" | "error";

--- a/packages/react-grab/src/utils/describe-element-for-prompt.ts
+++ b/packages/react-grab/src/utils/describe-element-for-prompt.ts
@@ -1,0 +1,16 @@
+import { ELEMENT_DESCRIPTOR_TEXT_MAX_LENGTH } from "../constants.js";
+
+// A short, human/agent-readable handle for an element used in the DOM-move
+// instruction, e.g. `<button.cta "Submit">`. Intentionally selector-ish rather
+// than a precise CSS selector — it just needs to identify the reference node.
+export const describeElementForPrompt = (element: Element): string => {
+  const tag = element.tagName.toLowerCase();
+  const id = element.id ? `#${element.id}` : "";
+  const firstClass = element.classList[0] ? `.${element.classList[0]}` : "";
+  const text = element.textContent?.trim().replace(/\s+/g, " ") ?? "";
+  const snippet =
+    text.length > 0
+      ? ` "${text.slice(0, ELEMENT_DESCRIPTOR_TEXT_MAX_LENGTH)}${text.length > ELEMENT_DESCRIPTOR_TEXT_MAX_LENGTH ? "…" : ""}"`
+      : "";
+  return `<${tag}${id}${firstClass}>${snippet}`;
+};

--- a/packages/react-grab/src/utils/find-drop-target.ts
+++ b/packages/react-grab/src/utils/find-drop-target.ts
@@ -1,9 +1,6 @@
 import { TRANSFORM_INDICATOR_THICKNESS_PX } from "../constants.js";
 import type { DropTarget } from "../types.js";
-import {
-  resumePointerEventsFreeze,
-  suspendPointerEventsFreeze,
-} from "./pointer-events-freeze.js";
+import { resumePointerEventsFreeze, suspendPointerEventsFreeze } from "./pointer-events-freeze.js";
 
 // While frozen the page has `pointer-events: none`, so hit-testing must briefly
 // lift it (it is restored synchronously before returning).

--- a/packages/react-grab/src/utils/find-drop-target.ts
+++ b/packages/react-grab/src/utils/find-drop-target.ts
@@ -1,0 +1,74 @@
+import { TRANSFORM_INDICATOR_THICKNESS_PX } from "../constants.js";
+import type { DropTarget } from "../types.js";
+import {
+  resumePointerEventsFreeze,
+  suspendPointerEventsFreeze,
+} from "./pointer-events-freeze.js";
+
+// While frozen the page has `pointer-events: none`, so hit-testing must briefly
+// lift it (it is restored synchronously before returning).
+const elementsUnderPoint = (clientX: number, clientY: number): Element[] => {
+  suspendPointerEventsFreeze();
+  try {
+    return document.elementsFromPoint(clientX, clientY);
+  } finally {
+    resumePointerEventsFreeze();
+  }
+};
+
+// Walks the elements under the cursor (top-most first) and returns the first
+// one the dragged element can be reinserted next to: a connected, page-owned
+// sibling-level node that is neither the dragged element, its descendant, nor
+// its ancestor. The chosen placement (before/after) follows the parent's main
+// axis so the insertion indicator reads naturally in rows and columns.
+export const findDropTarget = (
+  clientX: number,
+  clientY: number,
+  draggedElement: Element,
+): DropTarget | null => {
+  const candidates = elementsUnderPoint(clientX, clientY);
+  for (const candidate of candidates) {
+    if (!(candidate instanceof HTMLElement)) continue;
+    if (candidate === draggedElement) continue;
+    if (draggedElement.contains(candidate) || candidate.contains(draggedElement)) continue;
+    if (candidate === document.body || candidate === document.documentElement) continue;
+    if (candidate.closest("[data-react-grab]")) continue;
+    const parent = candidate.parentElement;
+    if (!parent) continue;
+
+    const rect = candidate.getBoundingClientRect();
+    const parentStyle = getComputedStyle(parent);
+    const isRow =
+      parentStyle.display.includes("flex") && parentStyle.flexDirection.startsWith("row");
+
+    const half = TRANSFORM_INDICATOR_THICKNESS_PX / 2;
+    if (isRow) {
+      const placeBefore = clientX < rect.left + rect.width / 2;
+      const lineX = placeBefore ? rect.left : rect.right;
+      return {
+        reference: candidate,
+        placement: placeBefore ? "before" : "after",
+        indicator: {
+          left: lineX - half,
+          top: rect.top,
+          width: TRANSFORM_INDICATOR_THICKNESS_PX,
+          height: rect.height,
+        },
+      };
+    }
+
+    const placeBefore = clientY < rect.top + rect.height / 2;
+    const lineY = placeBefore ? rect.top : rect.bottom;
+    return {
+      reference: candidate,
+      placement: placeBefore ? "before" : "after",
+      indicator: {
+        left: rect.left,
+        top: lineY - half,
+        width: rect.width,
+        height: TRANSFORM_INDICATOR_THICKNESS_PX,
+      },
+    };
+  }
+  return null;
+};

--- a/packages/react-grab/src/utils/find-drop-target.ts
+++ b/packages/react-grab/src/utils/find-drop-target.ts
@@ -35,13 +35,17 @@ export const findDropTarget = (
 
     const rect = candidate.getBoundingClientRect();
     const parentStyle = getComputedStyle(parent);
-    const isRow =
-      parentStyle.display.includes("flex") && parentStyle.flexDirection.startsWith("row");
+    const isFlex = parentStyle.display.includes("flex");
+    const isRow = isFlex && parentStyle.flexDirection.startsWith("row");
+    // In a *-reverse flex container DOM order runs opposite to visual order, so
+    // the side the cursor is on maps to the opposite insertBefore/after.
+    const isReversed = isFlex && parentStyle.flexDirection.endsWith("-reverse");
 
     const half = TRANSFORM_INDICATOR_THICKNESS_PX / 2;
     if (isRow) {
-      const placeBefore = clientX < rect.left + rect.width / 2;
-      const lineX = placeBefore ? rect.left : rect.right;
+      const cursorOnLeadingSide = clientX < rect.left + rect.width / 2;
+      const lineX = cursorOnLeadingSide ? rect.left : rect.right;
+      const placeBefore = isReversed ? !cursorOnLeadingSide : cursorOnLeadingSide;
       return {
         reference: candidate,
         placement: placeBefore ? "before" : "after",
@@ -54,8 +58,9 @@ export const findDropTarget = (
       };
     }
 
-    const placeBefore = clientY < rect.top + rect.height / 2;
-    const lineY = placeBefore ? rect.top : rect.bottom;
+    const cursorOnLeadingSide = clientY < rect.top + rect.height / 2;
+    const lineY = cursorOnLeadingSide ? rect.top : rect.bottom;
+    const placeBefore = isReversed ? !cursorOnLeadingSide : cursorOnLeadingSide;
     return {
       reference: candidate,
       placement: placeBefore ? "before" : "after",

--- a/packages/react-grab/src/utils/format-edit-prompt.ts
+++ b/packages/react-grab/src/utils/format-edit-prompt.ts
@@ -3,13 +3,7 @@ import type { PendingEdit, PendingEditsEntry } from "../types.js";
 import { formatDisplayValue } from "./format-css-value.js";
 
 const formatCssValue = (pendingEdit: PendingEdit): string => {
-  if (
-    pendingEdit.kind === "color" ||
-    pendingEdit.kind === "enum" ||
-    pendingEdit.kind === "transform"
-  ) {
-    return pendingEdit.value;
-  }
+  if (pendingEdit.kind === "color" || pendingEdit.kind === "enum") return pendingEdit.value;
   if (pendingEdit.key === "opacity" && pendingEdit.unit === "%") {
     return formatDisplayValue(pendingEdit.value / OPACITY_PERCENT_MAX);
   }

--- a/packages/react-grab/src/utils/format-edit-prompt.ts
+++ b/packages/react-grab/src/utils/format-edit-prompt.ts
@@ -3,7 +3,13 @@ import type { PendingEdit, PendingEditsEntry } from "../types.js";
 import { formatDisplayValue } from "./format-css-value.js";
 
 const formatCssValue = (pendingEdit: PendingEdit): string => {
-  if (pendingEdit.kind === "color" || pendingEdit.kind === "enum") return pendingEdit.value;
+  if (
+    pendingEdit.kind === "color" ||
+    pendingEdit.kind === "enum" ||
+    pendingEdit.kind === "transform"
+  ) {
+    return pendingEdit.value;
+  }
   if (pendingEdit.key === "opacity" && pendingEdit.unit === "%") {
     return formatDisplayValue(pendingEdit.value / OPACITY_PERCENT_MAX);
   }

--- a/packages/react-grab/src/utils/on-viewport-change.ts
+++ b/packages/react-grab/src/utils/on-viewport-change.ts
@@ -1,0 +1,16 @@
+// Subscribes to the events that move an element within the viewport — page
+// scroll (capture, to catch any scrollable ancestor), window resize, and the
+// visual viewport's resize/scroll (pinch-zoom, mobile URL bar). Returns a
+// cleanup function. Used by overlays that must stay glued to a tracked element.
+export const onViewportChange = (onChange: () => void): (() => void) => {
+  window.addEventListener("scroll", onChange, true);
+  window.addEventListener("resize", onChange);
+  window.visualViewport?.addEventListener("resize", onChange);
+  window.visualViewport?.addEventListener("scroll", onChange);
+  return () => {
+    window.removeEventListener("scroll", onChange, true);
+    window.removeEventListener("resize", onChange);
+    window.visualViewport?.removeEventListener("resize", onChange);
+    window.visualViewport?.removeEventListener("scroll", onChange);
+  };
+};

--- a/packages/react-grab/src/utils/property-definitions.ts
+++ b/packages/react-grab/src/utils/property-definitions.ts
@@ -70,6 +70,10 @@ export const FALLBACK_ZERO_PX: ReadonlySet<TrackedProperty> = new Set([
   "gap",
   "row-gap",
   "column-gap",
+  // `top`/`left` are `auto` until positioned; treat that as 0 so they are
+  // always editable (the canvas move tool tracks the element's x/y here).
+  "top",
+  "left",
 ]);
 
 export const POSITION_KEYS: ReadonlySet<string> = new Set([
@@ -329,6 +333,17 @@ export const FONT_FAMILY_DEFINITION = {
 } as const;
 
 export const ENUM_PROPERTIES: ReadonlyArray<EnumPropertyDefinition> = [
+  {
+    key: "position",
+    label: "position",
+    options: [
+      { value: "static", label: "static" },
+      { value: "relative", label: "relative" },
+      { value: "absolute", label: "absolute" },
+      { value: "fixed", label: "fixed" },
+      { value: "sticky", label: "sticky" },
+    ],
+  },
   {
     key: "display",
     label: "display",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Figma-like canvas editing layer to the **Style** panel: a transform overlay with corner resize handles and drag-to-reorder, with all changes routed through the same tweak store as the panel rows and reflected live in the DOM.

### Capabilities

- **Resize** via the four corner handles (box-sizing aware; `Alt`/`Option` scales symmetrically about the center). Resizing compacts the panel onto the dimension being edited.
- **Move** by dragging the frame body: the element is reinserted into the DOM relative to siblings (flex-direction aware, including `*-reverse`), with a live drag ghost and insertion indicator. A plain click never moves the element (drag threshold).
- **Position tracking**: moves commit `left`/`top` (and `position: relative` when needed) through the tweak store, so they show up as panel rows.
- **Click-to-retarget**: clicking another element while the panel is open switches the target instead of dismissing.
- **Auto-deselect** when the selected element leaves the DOM (`MutationObserver`).
- **Escape / discard** reverts every uncopied change (inline styles and DOM moves).

### Batched edits across elements

Switching the panel to another element keeps the previous element's edits applied and records them in a session-level batch held by the edit-mode controller, rather than reverting on retarget:

- **Copy** folds every touched element's CSS edits (and DOM-move descriptions) into a single prompt.
- **Discard** reverts the whole batch in LIFO order.
- The Copy affordance and discard confirmation account for batched edits even when the currently-targeted element is untouched.

### Glitchy-resize fix on constrained layouts

Anchored resize handles (NW/NE/SW and `Alt`) previously offset `left`/`top` by the *requested* size delta. When a layout constrains the element (flex/grid distribution, `min`/`max-width`, content), that delta overshoots and the position slid the element out from under the cursor — the main cause of "glitchy" resizing on real pages. The handler now measures the element's **actual post-layout size** and anchors from that, so the pinned edge stays put even when the element can't grow.

## Testing

- `pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm format` — all clean.
- `pnpm test` — full Playwright suite green, including new cases for batched edits across elements and for keeping the anchored edge pinned on a width-capped element, plus the existing edit-panel, transform-overlay, and toolbar suites.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d0776b1-fa1f-4274-8226-fdfdd8eae41c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d0776b1-fa1f-4274-8226-fdfdd8eae41c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Figma-style transform overlay to Style mode so you can resize and move elements directly on the canvas. Retargeting now batches edits across elements, and copy/discard apply to the whole session.

- New Features
  - Resize with 4 corner handles; writes inline width/height; Alt-drag scales about center; sizing respects content-box/border-box; panel compacts to the changing dimension.
  - Move by dragging the frame; shows a drag ghost; reinserts before/after the target with an insertion line; copied prompt includes the move instruction; restores the original DOM slot on dismiss.
  - Click another element to retarget; panel stays open; previous element’s edits are batched; Copy includes all edits and DOM moves; Discard reverts the batch in LIFO order.

- Bug Fixes
  - Only move on an actual drag; clicks on the frame no longer reinsert the element.
  - Skip no-op DOM moves so unchanged order isn’t flagged; only restore the original slot if the node is still connected.
  - In flex `*-reverse` containers, before/after is flipped correctly for reinsertion.
  - Resizing keeps the opposite edge pinned when layout constraints block the requested size.
  - Retarget only to editable elements; clean up drag listeners; guard against disconnected nodes; Escape after a move reverts and closes without crashing.

<sup>Written for commit d5b8f605ef8bc7c2d4a91f00891c6b48bda8987e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

