### PR TITLE
feat(react-grab): ghost-highlight similar component instances on shift-hover

### DIFF
--- a/packages/react-grab/src/components/overlay-canvas.tsx
+++ b/packages/react-grab/src/components/overlay-canvas.tsx
@@ -14,6 +14,10 @@ import {
   OPACITY_CONVERGENCE_THRESHOLD,
   OVERLAY_BORDER_COLOR_DEFAULT,
   OVERLAY_FILL_COLOR_DEFAULT,
+  OVERLAY_BORDER_COLOR_GHOST,
+  OVERLAY_FILL_COLOR_GHOST,
+  GHOST_LINE_DASH_PX,
+  GHOST_OPACITY,
   BASELINE_FRAME_DURATION_MS,
 } from "../constants.js";
 import { nativeCancelAnimationFrame, nativeRequestAnimationFrame } from "../utils/native-raf.js";
@@ -32,11 +36,16 @@ const LAYER_STYLES = {
     fillColor: OVERLAY_FILL_COLOR_DRAG,
     lerpFactor: DRAG_LERP_FACTOR,
   },
+  ghost: {
+    borderColor: OVERLAY_BORDER_COLOR_GHOST,
+    fillColor: OVERLAY_FILL_COLOR_GHOST,
+    lerpFactor: SELECTION_LERP_FACTOR,
+  },
   selection: DEFAULT_LAYER_STYLE,
   grabbed: DEFAULT_LAYER_STYLE,
 } as const;
 
-type LayerName = "drag" | "selection" | "grabbed";
+type LayerName = "drag" | "ghost" | "selection" | "grabbed";
 
 interface OffscreenLayer {
   canvas: OffscreenCanvas | null;
@@ -62,6 +71,9 @@ interface OverlayCanvasProps {
 
   selectionShouldSnap?: boolean;
 
+  ghostVisible?: boolean;
+  ghostBounds?: OverlayBounds[];
+
   dragVisible?: boolean;
   dragBounds?: OverlayBounds;
 
@@ -85,11 +97,13 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
 
   const layers: Record<LayerName, OffscreenLayer> = {
     drag: { canvas: null, context: null },
+    ghost: { canvas: null, context: null },
     selection: { canvas: null, context: null },
     grabbed: { canvas: null, context: null },
   };
 
   let selectionAnimations: AnimatedBounds[] = [];
+  let ghostAnimations: AnimatedBounds[] = [];
   let dragAnimation: AnimatedBounds | null = null;
   let grabbedAnimations: AnimatedBounds[] = [];
 
@@ -191,6 +205,7 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
     fillColor: string,
     strokeColor: string,
     opacity: number = 1,
+    lineDashLengthPx: number = 0,
   ) => {
     if (rectWidth <= 0 || rectHeight <= 0) return;
 
@@ -209,7 +224,9 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
     context.fill();
     context.strokeStyle = strokeColor;
     context.lineWidth = 1;
+    if (lineDashLengthPx > 0) context.setLineDash([lineDashLengthPx, lineDashLengthPx]);
     context.stroke();
+    if (lineDashLengthPx > 0) context.setLineDash([]);
     if (shouldSetGlobalAlpha) context.globalAlpha = 1;
   };
 
@@ -261,6 +278,33 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
     }
   };
 
+  const renderGhostLayer = () => {
+    const layer = layers.ghost;
+    if (!layer.context) return;
+
+    const context = layer.context;
+    context.clearRect(0, 0, canvasWidth, canvasHeight);
+
+    if (!props.ghostVisible) return;
+
+    const style = LAYER_STYLES.ghost;
+
+    for (const animation of ghostAnimations) {
+      drawRoundedRectangle(
+        context,
+        animation.current.x,
+        animation.current.y,
+        animation.current.width,
+        animation.current.height,
+        animation.borderRadius,
+        style.fillColor,
+        style.borderColor,
+        animation.opacity,
+        GHOST_LINE_DASH_PX,
+      );
+    }
+  };
+
   const renderBoundsLayer = (
     layerName: keyof typeof LAYER_STYLES,
     animations: AnimatedBounds[],
@@ -296,10 +340,11 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
     mainContext.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
 
     renderDragLayer();
+    renderGhostLayer();
     renderSelectionLayer();
     renderBoundsLayer("grabbed", grabbedAnimations);
 
-    const layerRenderOrder: LayerName[] = ["drag", "selection", "grabbed"];
+    const layerRenderOrder: LayerName[] = ["drag", "ghost", "selection", "grabbed"];
     for (const layerName of layerRenderOrder) {
       const layer = layers[layerName];
       if (layer.canvas) {
@@ -372,6 +417,14 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
     for (const animation of selectionAnimations) {
       if (animation.isInitialized) {
         if (interpolateBounds(animation, selectionLerpForFrame)) {
+          shouldContinueAnimating = true;
+        }
+      }
+    }
+
+    for (const animation of ghostAnimations) {
+      if (animation.isInitialized) {
+        if (interpolateBounds(animation, selectionLerpForFrame, { interpolateOpacity: true })) {
           shouldContinueAnimating = true;
         }
       }
@@ -494,6 +547,41 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
           }
 
           return createAnimatedBounds(animationId, bounds);
+        });
+
+        scheduleAnimationFrame();
+      },
+    ),
+  );
+
+  createEffect(
+    on(
+      () => [props.ghostVisible, props.ghostBounds] as const,
+      ([isVisible, bounds]) => {
+        if (!isVisible || !bounds || bounds.length === 0) {
+          ghostAnimations = [];
+          scheduleAnimationFrame();
+          return;
+        }
+
+        const existingGhostById = new Map<string, AnimatedBounds>();
+        for (const animation of ghostAnimations) {
+          existingGhostById.set(animation.id, animation);
+        }
+
+        ghostAnimations = bounds.map((ghostBounds, index) => {
+          const animationId = `ghost-${index}`;
+          const existingAnimation = existingGhostById.get(animationId);
+
+          if (existingAnimation) {
+            updateAnimationTarget(existingAnimation, ghostBounds, GHOST_OPACITY);
+            return existingAnimation;
+          }
+
+          return createAnimatedBounds(animationId, ghostBounds, {
+            opacity: 0,
+            targetOpacity: GHOST_OPACITY,
+          });
         });
 
         scheduleAnimationFrame();

--- a/packages/react-grab/src/components/renderer.tsx
+++ b/packages/react-grab/src/components/renderer.tsx
@@ -24,6 +24,8 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
         selectionBounds={props.selectionBounds}
         selectionBoundsMultiple={props.selectionBoundsMultiple}
         selectionShouldSnap={props.selectionShouldSnap}
+        ghostVisible={props.ghostVisible}
+        ghostBounds={props.ghostBounds}
         dragVisible={props.dragVisible}
         dragBounds={props.dragBounds}
         grabbedBoxes={props.grabbedBoxes}

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -53,6 +53,10 @@ export const OVERLAY_BORDER_COLOR_DRAG = overlayColor(0.4);
 export const OVERLAY_FILL_COLOR_DRAG = overlayColor(0.05);
 export const OVERLAY_BORDER_COLOR_DEFAULT = overlayColor(0.5);
 export const OVERLAY_FILL_COLOR_DEFAULT = overlayColor(0.08);
+export const OVERLAY_BORDER_COLOR_GHOST = overlayColor(0.35);
+export const OVERLAY_FILL_COLOR_GHOST = overlayColor(0.04);
+export const GHOST_LINE_DASH_PX = 4;
+export const GHOST_OPACITY = 0.7;
 export const FROZEN_GLOW_COLOR = overlayColor(0.15);
 export const FROZEN_GLOW_EDGE_PX = 50;
 

--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -9,6 +9,8 @@ import {
 } from "bippy/source";
 import {
   getFiberFromHostInstance,
+  getNearestHostFiber,
+  getType,
   isInstrumentationActive,
   getDisplayName,
   isCompositeFiber,
@@ -360,6 +362,65 @@ export const getComponentDisplayName = (element: Element): string | null => {
   }
 
   return null;
+};
+
+const getNearestUsefulComponentFiber = (element: Element): Fiber | null => {
+  const fiber = getFiberFromHostInstance(findNearestFiberElement(element));
+  if (!fiber) return null;
+
+  let currentFiber: Fiber | null = fiber;
+  while (currentFiber) {
+    if (isCompositeFiber(currentFiber)) {
+      const name = getDisplayName(currentFiber.type);
+      if (name && isUsefulComponentName(name)) return currentFiber;
+    }
+    currentFiber = currentFiber.return;
+  }
+
+  return null;
+};
+
+/**
+ * Finds the host elements rendered by every other instance of the same
+ * component as the one nearest to `element`. Walks up to the component the
+ * user is pointing at, then traverses the fiber tree from its root collecting
+ * the nearest host node of each fiber that shares the same component type.
+ */
+export const findSimilarComponentElements = (element: Element): Element[] => {
+  if (!isInstrumentationActive()) return [];
+
+  const targetFiber = getNearestUsefulComponentFiber(element);
+  if (!targetFiber) return [];
+
+  const targetType = getType(targetFiber.type);
+  if (!targetType) return [];
+
+  let rootFiber: Fiber = targetFiber;
+  while (rootFiber.return) {
+    rootFiber = rootFiber.return;
+  }
+
+  const sourceHostElement = findNearestFiberElement(element);
+  const seenElements = new Set<Element>();
+  const similarElements: Element[] = [];
+
+  traverseFiber(rootFiber, (currentFiber) => {
+    if (currentFiber === targetFiber) return;
+    if (!isCompositeFiber(currentFiber)) return;
+    if (getType(currentFiber.type) !== targetType) return;
+
+    const hostFiber = getNearestHostFiber(currentFiber);
+    const hostElement = hostFiber?.stateNode;
+    if (!(hostElement instanceof Element)) return;
+    if (hostElement === sourceHostElement) return;
+    if (seenElements.has(hostElement)) return;
+    if (!hostElement.isConnected) return;
+
+    seenElements.add(hostElement);
+    similarElements.push(hostElement);
+  });
+
+  return similarElements;
 };
 
 interface StackContextOptions {

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -31,6 +31,7 @@ import {
   getStackContext,
   getNearestComponentName,
   getComponentDisplayName,
+  findSimilarComponentElements,
   isNextProjectRuntime,
   resolveSource,
 } from "./context.js";
@@ -462,6 +463,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
     let previousSpaceDragPointerPage: Position | null = null;
     const [isShiftMultiSelecting, setIsShiftMultiSelecting] = createSignal(false);
+    const [isShiftKeyHeld, setIsShiftKeyHeld] = createSignal(false);
     let lastWindowFocusTimestamp = 0;
     let isCopyFeedbackCooldownActive = false;
     let copyFeedbackCooldownTimerId: number | null = null;
@@ -1039,6 +1041,30 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       return frozenElementsBounds();
     });
 
+    const similarComponentElements = createMemo((): Element[] => {
+      if (!isShiftKeyHeld() || !isRendererActive()) return [];
+      if (isShiftMultiSelecting() || isFrozenPhase() || isPromptMode() || isDragging()) return [];
+      if (store.pendingCommentMode || isPendingContextMenuSelect()) return [];
+
+      const element = targetElement();
+      if (!element || isRootElement(element)) return [];
+
+      return findSimilarComponentElements(element);
+    });
+
+    const ghostElementBoundsAccessors = mapArray(similarComponentElements, (element) =>
+      createMemo(() => {
+        void viewportVersion();
+        return createElementBounds(element);
+      }),
+    );
+
+    const ghostBounds = createMemo((): OverlayBounds[] =>
+      ghostElementBoundsAccessors().map((readBounds) => readBounds()),
+    );
+
+    const ghostVisible = createMemo(() => similarComponentElements().length > 0);
+
     const frozenLabelEntryAccessors = mapArray(
       () => store.frozenElements,
       (element) => {
@@ -1345,6 +1371,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       editMode.resetWithDiscard();
       dismissToolbarMenu();
       stopShiftMultiSelecting();
+      setIsShiftKeyHeld(false);
       clearArrowNavigation();
       keyboardSelectedElement = null;
       setIsPendingContextMenuSelect(false);
@@ -2346,6 +2373,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       "keydown",
       (event: KeyboardEvent) => {
         blockEnterIfNeeded(event);
+        setIsShiftKeyHeld(event.shiftKey);
 
         if (!isEnabled()) {
           if (isTargetKeyCombination(event, pluginRegistry.store.options) && !event.repeat) {
@@ -2438,6 +2466,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       "keyup",
       (event: KeyboardEvent) => {
         if (blockEnterIfNeeded(event)) return;
+        setIsShiftKeyHeld(event.shiftKey);
 
         if (isSpaceActivationKey(event) && isDragRepositioning()) {
           stopSpaceDragRepositioning();
@@ -2570,6 +2599,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         if (!event.isPrimary) return;
         const isTouchPointer = event.pointerType === "touch";
         actions.setTouchMode(isTouchPointer);
+        setIsShiftKeyHeld(event.shiftKey);
         if (isEventFromOverlay(event, "data-react-grab-ignore-events")) return;
         if (isModalPopoverOpen()) return;
         if (isSelectionInteractionLocked()) return;
@@ -2761,6 +2791,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       // navigation guard don't stay blocked indefinitely. Frozen elements
       // are intentionally preserved so the user can resume on refocus.
       stopShiftMultiSelecting();
+      setIsShiftKeyHeld(false);
     });
 
     eventListenerManager.addWindowListener("focus", () => {
@@ -3506,6 +3537,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
                 selectionShouldSnap={
                   store.frozenElements.length > 0 || dragPreviewBounds().length > 0
                 }
+                ghostVisible={ghostVisible()}
+                ghostBounds={ghostBounds()}
                 selectionElementsCount={store.frozenElements.length}
                 frozenLabelEntries={frozenLabelEntries()}
                 pendingShiftPreviewEntry={pendingShiftPreviewEntry() ?? undefined}

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -1042,12 +1042,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     });
 
     const similarComponentElements = createMemo((): Element[] => {
-      if (!isShiftKeyHeld() || !isRendererActive()) return [];
+      if (!isShiftKeyHeld() || !isRendererActive() || isSelectionInteractionLocked()) return [];
       if (isShiftMultiSelecting() || isFrozenPhase() || isPromptMode() || isDragging()) return [];
       if (store.pendingCommentMode || isPendingContextMenuSelect()) return [];
 
-      const element = targetElement();
-      if (!element || isRootElement(element)) return [];
+      const element = store.detectedElement;
+      if (!isElementConnected(element) || isRootElement(element)) return [];
 
       return findSimilarComponentElements(element);
     });

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -455,6 +455,8 @@ export interface ReactGrabRendererProps {
   selectionBoundsMultiple?: OverlayBounds[];
   selectionShouldSnap?: boolean;
   selectionElementsCount?: number;
+  ghostVisible?: boolean;
+  ghostBounds?: OverlayBounds[];
   frozenLabelEntries?: FrozenLabelEntry[];
   pendingShiftPreviewEntry?: FrozenLabelEntry;
   selectionFilePath?: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

When you hold **Shift** while hovering over an element (in active grab mode), React Grab now finds the nearest React component for the hovered element, traverses the fiber tree from its root with bippy to locate every other instance of the *same* component, and renders dashed "ghost" highlights over each instance's nearest DOM node.

This makes it easy to see, at a glance, everywhere a given component is rendered on the page.

## How

- **`core/context.ts`** — new `findSimilarComponentElements(element)`:
  - Walks up to the nearest useful composite fiber (the component you're pointing at) and resolves its canonical type via bippy's `getType`.
  - Climbs `fiber.return` to the tree root, then `traverseFiber`s the whole tree collecting composite fibers whose `getType` matches.
  - For each match, resolves the nearest host node via bippy's `getNearestHostFiber(...).stateNode`, skipping the originally hovered node, disconnected nodes, and duplicates.
- **`components/overlay-canvas.tsx`** — new compositor `ghost` layer drawn beneath the live selection box, using a dashed stroke and reduced opacity so it reads as a secondary, "ghosted" highlight. Ghosts fade in via opacity and follow scroll/viewport changes like the selection layer.
- **`core/index.tsx`** — tracks whether Shift is held (pointermove / keydown / keyup, reset on deactivate and window blur), derives `similarComponentElements` reactively (only while hovering — not during multi-select, drag, prompt, frozen, or context-menu phases), and feeds `ghostBounds` / `ghostVisible` to the renderer.
- **`constants.ts`** — ghost overlay colors, dash length, and opacity.
- **`types.ts` / `renderer.tsx`** — thread the new `ghostVisible` / `ghostBounds` props through.

The feature is purely additive and visual; it does not change selection/copy behavior or the existing Shift-click multi-select.

## Verification

- `pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm format` all pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89132cea-b581-4407-8641-8a69f5161abc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89132cea-b581-4407-8641-8a69f5161abc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Shift-hover ghost highlighting in `react-grab` to show all other instances of the same React component. Also decouples similar-component detection from scroll/viewport updates to avoid extra fiber traversals.

- **New Features**
  - Hold Shift while hovering to see dashed “ghost” boxes over every other instance of the hovered component.
  - Uses `bippy` to resolve the component type, traverse the fiber tree, and collect nearest host nodes (skips the hovered one, duplicates, and disconnected nodes).
  - New ghost layer in `overlay-canvas` with dashed stroke, low opacity, and fade-in; rendered beneath selection and synced with scroll.
  - Tracks Shift state and disables ghosting during multi-select, drag, prompt, frozen, and context-menu phases; threads `ghostVisible`/`ghostBounds` and ghost style constants through `types`, `renderer`, and canvas.

- **Refactors**
  - Similar-component detection is decoupled from viewport/scroll updates; only ghost bounds reflow with scroll, while detection runs only when Shift-hover state or hover target changes.

<sup>Written for commit d0445514c09a472ea829236ecaf34903e957a9d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

