### PR TITLE
Add snapshot DOM-to-image capture subsystem

### DIFF
--- a/packages/react-grab/src/snapshot/LICENSE
+++ b/packages/react-grab/src/snapshot/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 ZumerLab
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/react-grab/src/snapshot/api/pre-cache.ts
+++ b/packages/react-grab/src/snapshot/api/pre-cache.ts
@@ -1,0 +1,134 @@
+import {
+  getStyle,
+  inlineSingleBackgroundEntry,
+  precacheCommonTags,
+  isSafari,
+} from "../utils/index.js";
+import {
+  embedCustomFonts,
+  collectUsedFontVariants,
+  collectUsedCodepoints,
+  ensureFontsReady,
+} from "../modules/fonts.js";
+import { snapFetch } from "../modules/snap-fetch.js";
+import { cache, applyCachePolicy, EvictingMap } from "../core/cache.js";
+import { inlineBackgroundImages } from "../modules/background.js";
+import type { SnapshotPreCacheOptions } from "../types.js";
+
+export const preCache = async (
+  root: Element | Document = document,
+  options: SnapshotPreCacheOptions = {},
+): Promise<void> => {
+  const { embedFonts = true, useProxy = "" } = options;
+  const cacheMode = options.cache ?? options.cacheOpt ?? "full";
+
+  applyCachePolicy(cacheMode);
+
+  const rootElement: Element = root instanceof Document ? root.documentElement : root;
+
+  try {
+    await document.fonts?.ready;
+  } catch {}
+
+  try {
+    precacheCommonTags();
+  } catch {}
+
+  cache.session = cache.session || {};
+  if (!cache.session.styleCache) {
+    cache.session.styleCache = new WeakMap();
+  }
+  cache.image = cache.image || new EvictingMap(100);
+  cache.background = cache.background || new EvictingMap(100);
+
+  try {
+    await inlineBackgroundImages(rootElement as HTMLElement, undefined, cache.session.styleCache, {
+      useProxy,
+    });
+  } catch {}
+
+  let imgEls: HTMLImageElement[] = [];
+  let allEls: Element[] = [];
+  try {
+    if (root && root.nodeType === 1) {
+      const rootElement = root as Element;
+      const descendants = rootElement.querySelectorAll
+        ? Array.from(rootElement.querySelectorAll("*"))
+        : [];
+      allEls = [rootElement, ...descendants];
+      imgEls = [];
+      if (rootElement.tagName === "IMG" && rootElement.getAttribute("src")) {
+        imgEls.push(rootElement as HTMLImageElement);
+      }
+      imgEls.push(...Array.from(rootElement.querySelectorAll<HTMLImageElement>("img[src]")));
+    } else if (root && root.querySelectorAll) {
+      imgEls = Array.from(root.querySelectorAll<HTMLImageElement>("img[src]"));
+      allEls = Array.from(root.querySelectorAll("*"));
+    }
+  } catch {}
+
+  const promises: Promise<unknown>[] = [];
+
+  for (const img of imgEls) {
+    const src = img?.currentSrc || img?.src;
+    if (!src) continue;
+    if (!cache.image.has(src)) {
+      const p = Promise.resolve()
+        .then(async () => {
+          const res = await snapFetch(src, { as: "dataURL", useProxy });
+          if (res?.ok && typeof res.data === "string") {
+            cache.image.set(src, res.data);
+          }
+        })
+        .catch(() => {});
+      promises.push(p);
+    }
+  }
+
+  for (const el of allEls) {
+    let bg = "";
+    try {
+      bg = (el as HTMLElement).style?.backgroundImage || "";
+      if (!bg || bg === "none") {
+        bg = getStyle(el).backgroundImage;
+      }
+    } catch {}
+    if (bg && bg !== "none") {
+      const urlEntries = bg.match(/url\((?:[^()"']+|"(?:[^"]*)"|'(?:[^']*)')\)/gi) || [];
+      for (const entry of urlEntries) {
+        const p = Promise.resolve()
+          .then(() => inlineSingleBackgroundEntry(entry, { ...options, useProxy }))
+          .catch(() => {});
+        promises.push(p);
+      }
+    }
+  }
+
+  if (embedFonts) {
+    try {
+      const required = collectUsedFontVariants(rootElement);
+      const usedCodepoints = collectUsedCodepoints(rootElement);
+
+      const safari = typeof isSafari === "function" ? isSafari() : Boolean(isSafari);
+      if (safari) {
+        const families = new Set(
+          Array.from(required)
+            .map((k) => String(k).split("__")[0])
+            .filter(Boolean),
+        );
+        await ensureFontsReady(families, 3);
+      }
+
+      await embedCustomFonts({
+        required,
+        usedCodepoints,
+        exclude: options.excludeFonts,
+        localFonts: options.localFonts,
+        useProxy: options.useProxy ?? useProxy,
+        fontStylesheetDomains: options.fontStylesheetDomains,
+      });
+    } catch {}
+  }
+
+  await Promise.allSettled(promises);
+};

--- a/packages/react-grab/src/snapshot/api/snapshot.ts
+++ b/packages/react-grab/src/snapshot/api/snapshot.ts
@@ -1,0 +1,319 @@
+import { captureDOM } from "../core/capture.js";
+import { extendIconFonts } from "../modules/icon-fonts.js";
+import { createContext } from "../core/context.js";
+import { isSafari } from "../utils/browser.js";
+import { debugWarn } from "../utils/debug.js";
+import { registerPlugins, runHook, runAll, attachSessionPlugins } from "../core/plugins.js";
+import { collectUsedFontVariants, ensureFontsReady } from "../modules/fonts.js";
+import { toImg, toSvg } from "../exporters/to-img.js";
+import { toCanvas } from "../exporters/to-canvas.js";
+import { toBlob } from "../exporters/to-blob.js";
+import { rasterize } from "../modules/rasterize.js";
+import { download } from "../exporters/download.js";
+import type {
+  SnapshotOptions,
+  SnapshotCaptureContext,
+  SnapshotCaptureResult,
+  SnapshotExportMap,
+  SnapshotPluginUse,
+} from "../types.js";
+export { preCache } from "./pre-cache.js";
+
+interface SnapshotApi {
+  (element: Element, options?: SnapshotOptions): Promise<SnapshotCaptureResult>;
+  capture: (
+    el: Element,
+    context: SnapshotCaptureContext,
+    token?: symbol,
+  ) => Promise<SnapshotCaptureResult>;
+  plugins: (...defs: SnapshotPluginUse[]) => SnapshotApi;
+  toRaw: (el: Element, options?: SnapshotOptions) => Promise<string>;
+  toImg: (el: Element, options?: SnapshotOptions) => Promise<HTMLImageElement>;
+  toSvg: (el: Element, options?: SnapshotOptions) => Promise<HTMLImageElement>;
+  toCanvas: (el: Element, options?: SnapshotOptions) => Promise<HTMLCanvasElement>;
+  toBlob: (el: Element, options?: SnapshotOptions) => Promise<Blob>;
+  toPng: (el: Element, options?: SnapshotOptions) => Promise<HTMLImageElement>;
+  toJpg: (el: Element, options?: SnapshotOptions) => Promise<HTMLImageElement>;
+  toWebp: (el: Element, options?: SnapshotOptions) => Promise<HTMLImageElement>;
+  download: (el: Element, options?: SnapshotOptions) => Promise<void>;
+}
+
+const INTERNAL_TOKEN = Symbol("snapshot.internal");
+const INTERNAL_EXPORT_TOKEN = Symbol("snapshot.internal.silent");
+
+let _safariWarmup = false;
+
+const main = async (
+  element: Element,
+  userOptions?: SnapshotOptions,
+): Promise<SnapshotCaptureResult> => {
+  if (!element) throw new Error("Element cannot be null or undefined");
+
+  const context = createContext(userOptions);
+
+  attachSessionPlugins(context, userOptions && userOptions.plugins);
+
+  if (isSafari() && (context.embedFonts === true || hasBackgroundOrMask(element))) {
+    if (context.embedFonts) {
+      try {
+        const required = collectUsedFontVariants(element);
+        const families = new Set(
+          [...required].map((k) => String(k).split("__")[0]).filter(Boolean),
+        );
+        await ensureFontsReady(families, 1);
+      } catch {}
+    }
+    const attempts = context.safariWarmupAttempts ?? 3;
+    for (let i = 0; i < attempts; i++) {
+      try {
+        await safariWarmup(element, userOptions);
+      } catch {}
+    }
+  }
+
+  if (Array.isArray(context.iconFonts) && context.iconFonts.length > 0) {
+    extendIconFonts(context.iconFonts);
+  }
+
+  if (!context.snap) {
+    context.snap = {
+      toPng: (el, opts) => snapshot.toPng(el, opts),
+      toSvg: (el, opts) => snapshot.toSvg(el, opts),
+    };
+  }
+
+  return snapshot.capture(element, context, INTERNAL_TOKEN);
+};
+
+export const plugins = (...defs: SnapshotPluginUse[]): SnapshotApi => {
+  registerPlugins(...defs);
+  return snapshot;
+};
+
+export const snapshot: SnapshotApi = Object.assign(main, { plugins }) as SnapshotApi;
+
+snapshot.capture = async (el, context, _token) => {
+  if (_token !== INTERNAL_TOKEN) {
+    throw new Error("[snapshot.capture] is internal. Use snapshot(...) instead.");
+  }
+
+  const url = await captureDOM(el, context);
+
+  const coreExports: SnapshotExportMap = {
+    img: async (ctx, opts) => toImg(url, { ...ctx, ...(opts || {}) }),
+    svg: async (ctx, opts) => toSvg(url, { ...ctx, ...(opts || {}) }),
+    canvas: async (ctx, opts) => toCanvas(url, { ...ctx, ...(opts || {}) }),
+    blob: async (ctx, opts) => toBlob(url, { ...ctx, ...(opts || {}) }),
+    png: async (ctx, opts) => rasterize(url, { ...ctx, ...(opts || {}), format: "png" }),
+    jpeg: async (ctx, opts) => rasterize(url, { ...ctx, ...(opts || {}), format: "jpeg" }),
+    webp: async (ctx, opts) => rasterize(url, { ...ctx, ...(opts || {}), format: "webp" }),
+    download: async (ctx, opts) => download(url, { ...ctx, ...(opts || {}) }),
+  };
+
+  const pluginExports: Record<string, (opts?: SnapshotCaptureContext) => Promise<unknown>> = {};
+  for (const exportKey of ["img", "svg", "canvas", "blob", "png", "jpeg", "webp"]) {
+    pluginExports[exportKey] = async (opts) =>
+      coreExports[exportKey](context, {
+        ...(opts || {}),
+        [INTERNAL_EXPORT_TOKEN]: true,
+      } as SnapshotCaptureContext);
+  }
+  pluginExports.jpg = pluginExports.jpeg;
+
+  const defineCtx: SnapshotCaptureContext = {
+    ...context,
+    export: { url },
+    exports: pluginExports,
+  };
+
+  const providedMaps = await runAll("defineExports", defineCtx);
+  const provided: SnapshotExportMap = Object.assign(
+    {},
+    ...providedMaps
+      .filter((entry: unknown) => Boolean(entry) && typeof entry === "object")
+      .reverse(),
+  );
+
+  const exportsMap: SnapshotExportMap = { ...coreExports, ...provided };
+
+  if (exportsMap.jpeg && !exportsMap.jpg) {
+    exportsMap.jpg = (ctx, opts) => exportsMap.jpeg(ctx, opts);
+  }
+
+  const normalizeExportOptions = (
+    type: string,
+    opts?: Partial<SnapshotOptions>,
+  ): SnapshotCaptureContext => {
+    const next: SnapshotCaptureContext = { ...context, ...(opts || {}) };
+    const lossy = (s: string): boolean => s === "jpeg" || s === "jpg" || s === "webp";
+    const fmt = [type, next.format, next.type]
+      .map((v) => (typeof v === "string" ? v.toLowerCase() : ""))
+      .find(lossy);
+    if (fmt) {
+      const noBg = next.backgroundColor == null || next.backgroundColor === "transparent";
+      if (noBg) next.backgroundColor = "#ffffff";
+    }
+    return next;
+  };
+
+  let afterSnapFired = false;
+  let exportQueue: Promise<unknown> = Promise.resolve();
+  const runExport = <T = unknown>(type: string, opts?: Partial<SnapshotOptions>): Promise<T> => {
+    const job = async (): Promise<T> => {
+      const work = exportsMap[type];
+      if (!work) throw new Error(`[snapshot] Unknown export type: ${type}`);
+      const nextOpts = normalizeExportOptions(type, opts);
+      const ctx: SnapshotCaptureContext = { ...context, export: { type, options: nextOpts, url } };
+      await runHook("beforeExport", ctx);
+      const result2 = await work(ctx, nextOpts);
+      await runHook("afterExport", ctx, result2);
+      if (!afterSnapFired) {
+        afterSnapFired = true;
+        await runHook("afterSnap", context);
+      }
+      return result2 as T;
+    };
+    exportQueue = exportQueue.then(job);
+    return exportQueue as Promise<T>;
+  };
+
+  const result: SnapshotCaptureResult = {
+    url,
+    toRaw: () => url,
+    to: (type, opts) => runExport(type, opts),
+    toImg: (opts) => runExport<HTMLImageElement>("img", opts),
+    toSvg: (opts) => runExport<HTMLImageElement>("svg", opts),
+    toCanvas: (opts) => runExport<HTMLCanvasElement>("canvas", opts),
+    toBlob: (opts) => runExport<Blob>("blob", opts),
+    toPng: (opts) => runExport<HTMLImageElement>("png", opts),
+    toJpg: (opts) => runExport<HTMLImageElement>("jpg", opts),
+    toWebp: (opts) => runExport<HTMLImageElement>("webp", opts),
+    download: (opts) => runExport<void>("download", opts),
+  };
+
+  for (const key of Object.keys(exportsMap)) {
+    const helper = "to" + key.charAt(0).toUpperCase() + key.slice(1);
+    if (!result[helper]) {
+      result[helper] = (opts?: SnapshotCaptureContext) => runExport(key, opts);
+    }
+  }
+
+  return result;
+};
+
+snapshot.toRaw = (el, options) => snapshot(el, options).then((result) => result.toRaw());
+
+snapshot.toImg = (el, options) => snapshot(el, options).then((result) => result.toImg());
+snapshot.toSvg = (el, options) => snapshot(el, options).then((result) => result.toSvg());
+
+snapshot.toCanvas = (el, options) => snapshot(el, options).then((result) => result.toCanvas());
+
+snapshot.toBlob = (el, options) => snapshot(el, options).then((result) => result.toBlob());
+
+snapshot.toPng = (el, options) =>
+  snapshot(el, { ...options, format: "png" }).then((result) => result.toPng());
+
+snapshot.toJpg = (el, options) =>
+  snapshot(el, { ...options, format: "jpeg" }).then((result) => result.toJpg());
+
+snapshot.toWebp = (el, options) =>
+  snapshot(el, { ...options, format: "webp" }).then((result) => result.toWebp());
+
+snapshot.download = (el, options) => snapshot(el, options).then((result) => result.download());
+
+const safariWarmup = async (element: Element, baseOptions?: SnapshotOptions): Promise<void> => {
+  if (_safariWarmup) return;
+
+  const preflight = {
+    ...baseOptions,
+    fast: true,
+    embedFonts: true,
+    scale: 0.2,
+  };
+
+  let url: string | undefined;
+  try {
+    url = await captureDOM(element, preflight);
+  } catch (error) {
+    debugWarn(baseOptions, "safariWarmup pre-capture failed", error);
+  }
+
+  await new Promise<void>((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+  );
+
+  if (url) {
+    const readyUrl = url;
+    await new Promise<void>((resolve) => {
+      const img = new Image();
+      try {
+        img.decoding = "sync";
+        img.loading = "eager";
+      } catch (error) {
+        debugWarn(baseOptions, "safariWarmup img hints failed", error);
+      }
+      img.style.cssText =
+        "position:fixed;left:0px;top:0px;width:10px;height:10px;opacity:0.01;pointer-events:none;";
+      img.src = readyUrl;
+      document.body.appendChild(img);
+
+      void (async () => {
+        try {
+          if (typeof img.decode === "function") await img.decode();
+        } catch (error) {
+          debugWarn(baseOptions, "safariWarmup img.decode failed", error);
+        }
+        const start = performance.now();
+        while (!(img.complete && img.naturalWidth > 0) && performance.now() - start < 900) {
+          await new Promise((resolveDelay) => setTimeout(resolveDelay, 200));
+        }
+        await new Promise<void>((resolveFrame) => requestAnimationFrame(() => resolveFrame()));
+        try {
+          const c = document.createElement("canvas");
+          c.width = Math.max(1, img.naturalWidth || 10);
+          c.height = Math.max(1, img.naturalHeight || 10);
+          const ctx = c.getContext("2d");
+          if (ctx) ctx.drawImage(img, 0, 0);
+        } catch {}
+        await new Promise<void>((resolveFrame) => requestAnimationFrame(() => resolveFrame()));
+        try {
+          img.remove();
+        } catch (error) {
+          debugWarn(baseOptions, "safariWarmup img.remove failed", error);
+        }
+        resolve();
+      })();
+    });
+  }
+
+  element.querySelectorAll("canvas").forEach((c) => {
+    try {
+      const ctx = c.getContext("2d", { willReadFrequently: true });
+      if (ctx) {
+        ctx.getImageData(0, 0, 1, 1);
+      }
+    } catch (error) {
+      debugWarn(baseOptions, "safariWarmup canvas poke failed", error);
+    }
+  });
+
+  _safariWarmup = true;
+};
+
+const hasBackgroundOrMask = (el: Element): boolean => {
+  const walker = document.createTreeWalker(el, NodeFilter.SHOW_ELEMENT);
+  while (walker.nextNode()) {
+    const node = walker.currentNode as Element;
+    const cs = getComputedStyle(node);
+
+    const bg = cs.backgroundImage && cs.backgroundImage !== "none";
+    const styleWithWebkit = cs as CSSStyleDeclaration & { webkitMaskImage?: string };
+    const mask =
+      (cs.maskImage && cs.maskImage !== "none") ||
+      (styleWithWebkit.webkitMaskImage && styleWithWebkit.webkitMaskImage !== "none");
+
+    if (bg || mask) return true;
+    if (node.tagName === "CANVAS") return true;
+  }
+  return false;
+};

--- a/packages/react-grab/src/snapshot/api/snapshot.ts
+++ b/packages/react-grab/src/snapshot/api/snapshot.ts
@@ -173,7 +173,9 @@ snapshot.capture = async (el, context, _token) => {
       }
       return result2 as T;
     };
-    exportQueue = exportQueue.then(job);
+    // Run the next job whether the previous settled or rejected, so one failed export
+    // doesn't poison every later export queued on the same capture result.
+    exportQueue = exportQueue.then(job, job);
     return exportQueue as Promise<T>;
   };
 

--- a/packages/react-grab/src/snapshot/core/cache.ts
+++ b/packages/react-grab/src/snapshot/core/cache.ts
@@ -1,0 +1,112 @@
+import type { SnapshotCachePolicy, SnapshotSessionCache } from "../types.js";
+
+const MAX_IMAGE = 100;
+const MAX_BACKGROUND = 100;
+const MAX_RESOURCE = 150;
+const MAX_BASE_STYLE = 50;
+const MAX_DEFAULT_STYLE = 30;
+
+class EvictingMap<K, V> extends Map<K, V> {
+  _maxSize: number;
+  constructor(maxSize: number = 100, ...args: [entries?: Iterable<readonly [K, V]> | null]) {
+    super(...args);
+    this._maxSize = maxSize;
+  }
+  set(key: K, value: V): this {
+    if (this.size >= this._maxSize && !this.has(key)) {
+      const first = this.keys().next().value;
+      if (first !== undefined) this.delete(first);
+    }
+    return super.set(key, value);
+  }
+}
+
+interface SnapshotMeasureHint {
+  cssLen: number;
+  w0: number;
+  csh: number;
+  csw: number;
+}
+
+interface SnapshotCache {
+  image: EvictingMap<string, string>;
+  background: EvictingMap<string, string | null>;
+  resource: EvictingMap<string, string>;
+  defaultStyle: EvictingMap<string, Record<string, string>>;
+  baseStyle: EvictingMap<string, string>;
+  computedStyle: WeakMap<Element, Map<string | null, CSSStyleDeclaration>>;
+  measureHints: WeakMap<Element, SnapshotMeasureHint>;
+  font: Set<string>;
+  session: SnapshotSessionCache;
+}
+
+export const cache: SnapshotCache = {
+  image: new EvictingMap<string, string>(MAX_IMAGE),
+  background: new EvictingMap<string, string | null>(MAX_BACKGROUND),
+  resource: new EvictingMap<string, string>(MAX_RESOURCE),
+  defaultStyle: new EvictingMap<string, Record<string, string>>(MAX_DEFAULT_STYLE),
+  baseStyle: new EvictingMap<string, string>(MAX_BASE_STYLE),
+  computedStyle: new WeakMap<Element, Map<string | null, CSSStyleDeclaration>>(),
+  measureHints: new WeakMap<Element, SnapshotMeasureHint>(),
+  font: new Set<string>(),
+  session: {
+    styleMap: new Map<Element, string>(),
+    styleCache: new WeakMap<Element, CSSStyleDeclaration>(),
+    nodeMap: new Map<Element, Element>(),
+  },
+};
+
+export { EvictingMap };
+
+export const normalizeCachePolicy = (v: unknown): SnapshotCachePolicy => {
+  if (v === true) return "soft";
+  if (v === false) return "disabled";
+  if (typeof v === "string") {
+    const s = v.toLowerCase().trim();
+    if (s === "auto") return "auto";
+    if (s === "full") return "full";
+    if (s === "soft" || s === "disabled") return s;
+  }
+  return "soft";
+};
+
+export const applyCachePolicy = (policy: SnapshotCachePolicy = "soft"): void => {
+  cache.session.__counterEpoch = (cache.session.__counterEpoch || 0) + 1;
+  switch (policy) {
+    case "auto": {
+      cache.session.styleMap = new Map();
+      cache.session.nodeMap = new Map();
+      return;
+    }
+    case "soft": {
+      cache.session.styleMap = new Map();
+      cache.session.nodeMap = new Map();
+      cache.session.styleCache = new WeakMap();
+      return;
+    }
+    case "full": {
+      return;
+    }
+    case "disabled": {
+      cache.session.styleMap = new Map();
+      cache.session.nodeMap = new Map();
+      cache.session.styleCache = new WeakMap();
+
+      cache.computedStyle = new WeakMap();
+      cache.measureHints = new WeakMap();
+      cache.baseStyle = new EvictingMap<string, string>(MAX_BASE_STYLE);
+      cache.defaultStyle = new EvictingMap<string, Record<string, string>>(MAX_DEFAULT_STYLE);
+      cache.image = new EvictingMap<string, string>(MAX_IMAGE);
+      cache.background = new EvictingMap<string, string | null>(MAX_BACKGROUND);
+      cache.resource = new EvictingMap<string, string>(MAX_RESOURCE);
+      cache.font = new Set();
+      return;
+    }
+    default: {
+      cache.session.styleMap = new Map();
+      cache.session.nodeMap = new Map();
+      cache.session.styleCache = new WeakMap();
+      return;
+    }
+  }
+};

--- a/packages/react-grab/src/snapshot/core/capture.ts
+++ b/packages/react-grab/src/snapshot/core/capture.ts
@@ -1,0 +1,451 @@
+import { prepareClone } from "./prepare.js";
+import { inlineImages } from "../modules/images.js";
+import { inlineBackgroundImages } from "../modules/background.js";
+import { ligatureIconToImage } from "../modules/icon-fonts.js";
+import {
+  idle,
+  collectUsedTagNames,
+  generateDedupedBaseCSS,
+  isSafari,
+  getStyle,
+} from "../utils/index.js";
+import {
+  embedCustomFonts,
+  collectUsedFontVariants,
+  collectUsedCodepoints,
+  ensureFontsReady,
+} from "../modules/fonts.js";
+import { cache, applyCachePolicy } from "../core/cache.js";
+import { lineClampTree } from "../modules/line-clamp.js";
+import { runHook, getGlobalPlugins, normalizePlugin } from "./plugins.js";
+import { runPictureResolverBeforeClone } from "../modules/picture-resolver.js";
+import {
+  stripRootShadows,
+  neutralizeRootMarginCollapse,
+  sanitizeCloneForXHTML,
+  shrinkAutoSizeBoxes,
+  estimateKeptHeight,
+  limitDecimals,
+  collectScrollbarCSS,
+} from "../utils/capture-helpers.js";
+import {
+  parseBoxShadow,
+  parseFilterBlur,
+  parseOutline,
+  parseFilterDropShadows,
+  normalizeRootTransforms,
+  bboxWithOriginFull,
+  parseTransformOriginPx,
+  readIndividualTransforms,
+  readTotalTransformMatrix,
+  hasBBoxAffectingTransform,
+} from "../utils/transforms-helpers.js";
+import type { SnapshotCaptureContext, SnapshotPluginUse } from "../types.js";
+
+interface CaptureState {
+  element: Element;
+  options: SnapshotCaptureContext;
+  plugins?: SnapshotPluginUse[];
+  clone?: HTMLElement;
+  classCSS?: string;
+  styleCache?: WeakMap<Element, CSSStyleDeclaration>;
+  fontsCSS?: string;
+  baseCSS?: string;
+  scrollbarCSS?: string;
+  svgString?: string;
+  dataURL?: string;
+  [key: string]: unknown;
+}
+
+const hasPictureResolverPlugin = (options: SnapshotCaptureContext): boolean => {
+  if (Array.isArray(options.plugins)) {
+    for (const d of options.plugins) {
+      const inst = normalizePlugin(d);
+      if (inst?.name === "picture-resolver") return true;
+    }
+  }
+  return getGlobalPlugins().some((p) => p?.name === "picture-resolver");
+};
+
+export const captureDOM = async (
+  element: Element,
+  options: SnapshotCaptureContext,
+): Promise<string> => {
+  if (!element) throw new Error("Element cannot be null or undefined");
+  applyCachePolicy(options.cache);
+  const fast = options.fast;
+  const outerTransforms = options.outerTransforms !== false;
+
+  const outerShadows = Boolean(options.outerShadows);
+  let state: CaptureState = { element, options, plugins: options.plugins };
+
+  let clone!: HTMLElement;
+  let classCSS!: string;
+  let styleCache!: WeakMap<Element, CSSStyleDeclaration>;
+  let fontsCSS = "";
+  let baseCSS = "";
+  let dataURL = "";
+  let svgString = "";
+  let rootTransform2D: { a: number; b?: number; c?: number; d?: number } | null = null;
+  await runHook("beforeSnap", state);
+
+  let undoPictureResolver: (() => Promise<void>) | null = null;
+  if (options.resolvePicturePlaceholders !== false && !hasPictureResolverPlugin(options)) {
+    undoPictureResolver = await runPictureResolverBeforeClone(state.element, state.options);
+  }
+
+  await runHook("beforeClone", state);
+  const undoClamp = lineClampTree(state.element);
+  try {
+    ({ clone, classCSS, styleCache } = await prepareClone(state.element, state.options));
+
+    if (!outerTransforms && clone) {
+      rootTransform2D = normalizeRootTransforms(state.element, clone);
+    }
+    if (!outerShadows && clone) {
+      stripRootShadows(state.element, clone, state.options);
+    }
+    if (clone) {
+      neutralizeRootMarginCollapse(state.element, clone);
+    }
+  } finally {
+    undoClamp();
+  }
+
+  state = { clone, classCSS, styleCache, ...state };
+  await runHook("afterClone", state);
+  if (undoPictureResolver) await undoPictureResolver();
+  sanitizeCloneForXHTML(state.clone!);
+  if (state.options?.excludeMode === "remove") {
+    try {
+      shrinkAutoSizeBoxes(state.element, state.clone!, state.styleCache!);
+    } catch (e) {
+      console.warn("[snapshot] shrink pass failed:", e);
+    }
+  }
+  try {
+    await ligatureIconToImage(state.clone!, state.element);
+  } catch {}
+
+  await new Promise<void>((resolve) => {
+    idle(
+      async () => {
+        await inlineImages(state.clone!, state.options);
+        resolve();
+      },
+      { fast },
+    );
+  });
+
+  await new Promise<void>((resolve) => {
+    idle(
+      async () => {
+        await inlineBackgroundImages(
+          state.element as HTMLElement,
+          state.clone!,
+          state.styleCache!,
+          state.options,
+        );
+        resolve();
+      },
+      { fast },
+    );
+  });
+
+  if (options.embedFonts) {
+    await new Promise<void>((resolve) => {
+      idle(
+        async () => {
+          const required = collectUsedFontVariants(state.element);
+          const usedCodepoints = collectUsedCodepoints(state.element);
+          if (isSafari()) {
+            const families = new Set(
+              Array.from(required)
+                .map((k) => String(k).split("__")[0])
+                .filter(Boolean),
+            );
+            await ensureFontsReady(families, 1);
+          }
+          fontsCSS = await embedCustomFonts({
+            required,
+            usedCodepoints,
+            exclude: state.options.excludeFonts,
+            localFonts: state.options.localFonts,
+            useProxy: state.options.useProxy,
+            fontStylesheetDomains: state.options.fontStylesheetDomains as string[] | undefined,
+          });
+          resolve();
+        },
+        { fast },
+      );
+    });
+  }
+
+  const usedTags = collectUsedTagNames(state.clone!).sort();
+  const tagKey = usedTags.join(",");
+  if (cache.baseStyle.has(tagKey)) {
+    baseCSS = cache.baseStyle.get(tagKey) ?? "";
+  } else {
+    await new Promise<void>((resolve) => {
+      idle(
+        () => {
+          baseCSS = generateDedupedBaseCSS(usedTags);
+          cache.baseStyle.set(tagKey, baseCSS);
+          resolve();
+        },
+        { fast },
+      );
+    });
+  }
+  const scrollbarCSS = collectScrollbarCSS(state.element?.ownerDocument || document);
+  state = { fontsCSS, baseCSS, scrollbarCSS, ...state };
+  await runHook("beforeRender", state);
+
+  await new Promise<void>((resolve) => {
+    idle(
+      () => {
+        const csEl = getStyle(state.element);
+
+        const rect = state.element.getBoundingClientRect();
+        let w0 = Math.max(
+          1,
+          limitDecimals(
+            (state.element as HTMLElement).offsetWidth || parseFloat(csEl.width) || rect.width || 1,
+          ),
+        );
+        let h0 = Math.max(
+          1,
+          limitDecimals(
+            (state.element as HTMLElement).offsetHeight ||
+              parseFloat(csEl.height) ||
+              rect.height ||
+              1,
+          ),
+        );
+        const elDoc = state.element.ownerDocument || document;
+        const isRoot = state.element === elDoc.body || state.element === elDoc.documentElement;
+        if (isRoot) {
+          const docH = Math.max(
+            state.element.scrollHeight || 0,
+            elDoc.documentElement?.scrollHeight || 0,
+            elDoc.body?.scrollHeight || 0,
+          );
+          const docW = Math.max(
+            state.element.scrollWidth || 0,
+            elDoc.documentElement?.scrollWidth || 0,
+            elDoc.body?.scrollWidth || 0,
+          );
+          if (docH > 0) h0 = Math.max(h0, limitDecimals(docH));
+          if (docW > 0) w0 = Math.max(w0, limitDecimals(docW));
+          try {
+            const cssLen =
+              (state.scrollbarCSS || "").length +
+              (state.baseCSS || "").length +
+              (state.fontsCSS || "").length +
+              (state.classCSS || "").length;
+            const hint = cache.measureHints.get(state.element);
+            if (hint && hint.cssLen === cssLen && hint.w0 === w0) {
+              if (hint.csh > 0) h0 = Math.max(h0, limitDecimals(hint.csh));
+              if (hint.csw > 0) w0 = Math.max(w0, limitDecimals(hint.csw));
+            } else {
+              const wrap = elDoc.createElement("div");
+              wrap.style.cssText =
+                "position:absolute!important;left:-9999px!important;top:0!important;width:" +
+                w0 +
+                "px!important;overflow:visible!important;visibility:hidden!important;";
+              const styleNode = elDoc.createElement("style");
+              styleNode.textContent =
+                (state.scrollbarCSS || "") +
+                state.baseCSS! +
+                state.fontsCSS! +
+                "svg{overflow:visible;} foreignObject{overflow:visible;}" +
+                state.classCSS!;
+              wrap.appendChild(styleNode);
+              wrap.appendChild(state.clone!.cloneNode(true));
+              elDoc.body.appendChild(wrap);
+              const csh = wrap.scrollHeight;
+              const csw = wrap.scrollWidth;
+              elDoc.body.removeChild(wrap);
+              cache.measureHints.set(state.element, { cssLen, w0, csh, csw });
+              if (csh > 0) h0 = Math.max(h0, limitDecimals(csh));
+              if (csw > 0) w0 = Math.max(w0, limitDecimals(csw));
+            }
+          } catch {}
+        }
+        if (state.options?.excludeMode === "remove") {
+          const hEst = estimateKeptHeight(state.element, state.options);
+          const EPS = 1;
+          if (Number.isFinite(hEst) && hEst > 0) {
+            h0 = Math.max(1, Math.min(h0, limitDecimals(hEst + EPS)));
+          }
+        }
+        const coerceNum = (value: unknown, fallbackValue: number = NaN): number => {
+          const parsed = typeof value === "string" ? parseFloat(value) : value;
+          return typeof parsed === "number" && Number.isFinite(parsed) ? parsed : fallbackValue;
+        };
+
+        const optW = coerceNum(state.options.width);
+        const optH = coerceNum(state.options.height);
+        let w = w0,
+          h = h0;
+
+        const hasW = Number.isFinite(optW);
+        const hasH = Number.isFinite(optH);
+        const aspect0 = h0 > 0 ? w0 / h0 : 1;
+
+        if (hasW && hasH) {
+          w = Math.max(1, limitDecimals(optW));
+          h = Math.max(1, limitDecimals(optH));
+        } else if (hasW) {
+          w = Math.max(1, limitDecimals(optW));
+          h = Math.max(1, limitDecimals(w / (aspect0 || 1)));
+        } else if (hasH) {
+          h = Math.max(1, limitDecimals(optH));
+          w = Math.max(1, limitDecimals(h * (aspect0 || 1)));
+        } else {
+          w = w0;
+          h = h0;
+        }
+
+        let minX = 0,
+          minY = 0,
+          maxX = w0,
+          maxY = h0;
+
+        if (!outerTransforms && rootTransform2D && Number.isFinite(rootTransform2D.a)) {
+          const M2 = new DOMMatrix([
+            rootTransform2D.a,
+            rootTransform2D.b || 0,
+            rootTransform2D.c || 0,
+            rootTransform2D.d || 1,
+            0,
+            0,
+          ]);
+          const bb2 = bboxWithOriginFull(w0, h0, M2, 0, 0);
+          minX = limitDecimals(bb2.minX);
+          minY = limitDecimals(bb2.minY);
+          maxX = limitDecimals(bb2.maxX);
+          maxY = limitDecimals(bb2.maxY);
+        } else {
+          const useTFBBox = outerTransforms && hasTFBBox(state.element);
+          if (useTFBBox) {
+            const baseTransform2 =
+              csEl.transform && csEl.transform !== "none" ? csEl.transform : "";
+            const ind2 = readIndividualTransforms(state.element);
+            const TOTAL = readTotalTransformMatrix({
+              baseTransform: baseTransform2,
+              rotate: ind2.rotate || "0deg",
+              scale: ind2.scale,
+              translate: ind2.translate,
+            });
+            const { ox: ox2, oy: oy2 } = parseTransformOriginPx(csEl, w0, h0);
+            const M = TOTAL.is2D ? TOTAL : new DOMMatrix(TOTAL.toString());
+            const bb = bboxWithOriginFull(w0, h0, M, ox2, oy2);
+            minX = limitDecimals(bb.minX);
+            minY = limitDecimals(bb.minY);
+            maxX = limitDecimals(bb.maxX);
+            maxY = limitDecimals(bb.maxY);
+          }
+        }
+
+        const bleedShadow = parseBoxShadow(csEl);
+        const bleedBlur = parseFilterBlur(csEl);
+        const bleedOutline = parseOutline(csEl);
+        const drop = parseFilterDropShadows(csEl);
+
+        const bleed = !outerShadows
+          ? { top: 0, right: 0, bottom: 0, left: 0 }
+          : {
+              top: limitDecimals(
+                bleedShadow.top + bleedBlur.top + bleedOutline.top + drop.bleed.top,
+              ),
+              right: limitDecimals(
+                bleedShadow.right + bleedBlur.right + bleedOutline.right + drop.bleed.right,
+              ),
+              bottom: limitDecimals(
+                bleedShadow.bottom + bleedBlur.bottom + bleedOutline.bottom + drop.bleed.bottom,
+              ),
+              left: limitDecimals(
+                bleedShadow.left + bleedBlur.left + bleedOutline.left + drop.bleed.left,
+              ),
+            };
+
+        minX = limitDecimals(minX - bleed.left);
+        minY = limitDecimals(minY - bleed.top);
+        maxX = limitDecimals(maxX + bleed.right);
+        maxY = limitDecimals(maxY + bleed.bottom);
+
+        const vbW0 = Math.max(1, limitDecimals(maxX - minX));
+        const vbH0 = Math.max(1, limitDecimals(maxY - minY));
+        const scaleW = hasW || hasH ? limitDecimals(w / w0) : 1;
+        const scaleH = hasH || hasW ? limitDecimals(h / h0) : 1;
+        const outW = Math.max(1, limitDecimals(vbW0 * scaleW));
+        const outH = Math.max(1, limitDecimals(vbH0 * scaleH));
+
+        const svgNS = "http://www.w3.org/2000/svg";
+        const basePad = isSafari() && hasTFBBox(state.element) ? 1 : 0;
+        const extraPad = !outerTransforms ? 1 : 0;
+        const pad = limitDecimals(basePad + extraPad);
+
+        const fo = document.createElementNS(svgNS, "foreignObject");
+        const vbMinX = limitDecimals(minX);
+        const vbMinY = limitDecimals(minY);
+        fo.setAttribute("x", String(limitDecimals(-(vbMinX - pad))));
+        fo.setAttribute("y", String(limitDecimals(-(vbMinY - pad))));
+        fo.setAttribute("width", String(limitDecimals(w0 + pad * 2)));
+        fo.setAttribute("height", String(limitDecimals(h0 + pad * 2)));
+        fo.style.overflow = "visible";
+
+        const styleTag = document.createElement("style");
+        const foNormalize =
+          "svg{overflow:visible;} foreignObject{overflow:visible;} " +
+          "foreignObject>div{-webkit-text-size-adjust:100%!important;text-size-adjust:100%!important;}";
+        styleTag.textContent =
+          (state.scrollbarCSS || "") +
+          state.baseCSS! +
+          state.fontsCSS! +
+          foNormalize +
+          state.classCSS!;
+        fo.appendChild(styleTag);
+
+        const container = document.createElement("div");
+        container.setAttribute("xmlns", "http://www.w3.org/1999/xhtml");
+        container.style.cssText =
+          "all:initial;box-sizing:border-box;display:block;overflow:visible;" +
+          `width:${limitDecimals(w0)}px;height:${limitDecimals(h0)}px`;
+
+        container.appendChild(state.clone!);
+        fo.appendChild(container);
+
+        const serializer = new XMLSerializer();
+        const foString = serializer.serializeToString(fo);
+        const vbW = limitDecimals(vbW0 + pad * 2);
+        const vbH = limitDecimals(vbH0 + pad * 2);
+        const wantsSize = hasW || hasH;
+
+        options.meta = { w0, h0, vbW, vbH, targetW: w, targetH: h };
+
+        const svgOutW = isSafari() && wantsSize ? vbW : limitDecimals(outW + pad * 2);
+        const svgOutH = isSafari() && wantsSize ? vbH : limitDecimals(outH + pad * 2);
+
+        const rootFontSize = parseFloat(getStyle(elDoc.documentElement)?.fontSize) || 16;
+        const svgHeader = `<svg xmlns="${svgNS}" width="${svgOutW}" height="${svgOutH}" viewBox="0 0 ${vbW} ${vbH}" font-size="${rootFontSize}px">`;
+        const svgFooter = "</svg>";
+        svgString = svgHeader + foString + svgFooter;
+        dataURL = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgString)}`;
+        state = { svgString, dataURL, ...state };
+        resolve();
+      },
+      { fast },
+    );
+  });
+  await runHook("afterRender", state);
+
+  const sandbox = document.getElementById("snapshot-sandbox");
+  if (sandbox && sandbox.style.position === "absolute") sandbox.remove();
+  return state.dataURL!;
+};
+
+const hasTFBBox = (el: Element): boolean => {
+  return hasBBoxAffectingTransform(el);
+};

--- a/packages/react-grab/src/snapshot/core/clone.ts
+++ b/packages/react-grab/src/snapshot/core/clone.ts
@@ -1,0 +1,537 @@
+import { inlineAllStyles } from "../modules/styles.js";
+import { NO_CAPTURE_TAGS } from "../utils/css.js";
+import { resolveCSSVars, isInSvgTemplate } from "../modules/css-var.js";
+import { debugWarn } from "../utils/index.js";
+import {
+  idleCallback,
+  rewriteShadowCSS,
+  nextShadowScopeId,
+  extractShadowCSS,
+  injectScopedStyle,
+  freezeImgSrcset,
+  collectCustomPropsFromCSS,
+  buildSeedCustomPropsRule,
+  markSlottedSubtree,
+  rasterizeIframe,
+  getUnscaledDimensions,
+  createCheckboxRadioReplacement,
+} from "../utils/clone-helpers.js";
+import { isFirefox } from "../utils/browser.js";
+import type { SnapshotCaptureContext, SnapshotSessionCache } from "../types.js";
+
+const makeHideSpacer = (node: Element): HTMLDivElement => {
+  const { width, height } = getUnscaledDimensions(node);
+  let w = width,
+    h = height;
+  if (!w || !h) {
+    const rect = node.getBoundingClientRect();
+    w = w || rect.width || 0;
+    h = h || rect.height || 0;
+  }
+  const spacer = document.createElement("div");
+  spacer.style.cssText = `display:inline-block;width:${w}px;height:${h}px;visibility:hidden;`;
+  return spacer;
+};
+
+export const deepClone = async (
+  node: Node,
+  sessionCache: SnapshotSessionCache,
+  options: SnapshotCaptureContext,
+): Promise<Node | null> => {
+  if (!node) throw new Error("Invalid node");
+  const clonedAssignedNodes = new Set<Node>();
+  let pendingSelectValue: string | null = null;
+  let pendingTextAreaValue: string | null = null;
+  if (node.nodeType === Node.ELEMENT_NODE) {
+    const elementNode = node as Element;
+    const tag = (elementNode.localName || elementNode.tagName || "").toLowerCase();
+    if (
+      elementNode.id === "snapshot-sandbox" ||
+      elementNode.hasAttribute("data-snapshot-sandbox")
+    ) {
+      return null;
+    }
+    if (NO_CAPTURE_TAGS.has(tag)) {
+      return null;
+    }
+    if (tag === "foreignobject" && elementNode.parentElement?.closest?.("foreignObject")) {
+      debugWarn(
+        sessionCache,
+        "Nested <foreignObject> skipped (SVG spec limitation — not rendered by browsers)",
+      );
+      return null;
+    }
+  }
+  if (node.nodeType === Node.TEXT_NODE) {
+    return node.cloneNode(true);
+  }
+  if (node.nodeType !== Node.ELEMENT_NODE) {
+    return node.cloneNode(true);
+  }
+  const el = node as Element;
+  if (el.getAttribute("data-capture") === "exclude") {
+    if (options.excludeMode === "hide") {
+      return makeHideSpacer(el);
+    } else if (options.excludeMode === "remove") {
+      return null;
+    }
+  }
+  if (options.exclude && Array.isArray(options.exclude)) {
+    for (const selector of options.exclude) {
+      try {
+        if (el.matches?.(selector)) {
+          if (options.excludeMode === "hide") {
+            return makeHideSpacer(el);
+          } else if (options.excludeMode === "remove") {
+            return null;
+          }
+        }
+      } catch (err) {
+        console.warn(`Invalid selector in exclude option: ${selector}`, err);
+      }
+    }
+  }
+  if (typeof options.filter === "function") {
+    try {
+      if (!options.filter(el)) {
+        if (options.filterMode === "hide") {
+          return makeHideSpacer(el);
+        } else if (options.filterMode === "remove") {
+          return null;
+        }
+      }
+    } catch (err) {
+      console.warn("Error in filter function:", err);
+    }
+  }
+  if (el.tagName === "IFRAME") {
+    const iframeEl = el as HTMLIFrameElement;
+    let sameOrigin = false;
+    try {
+      sameOrigin = Boolean(iframeEl.contentDocument || iframeEl.contentWindow?.document);
+    } catch (e) {
+      debugWarn(sessionCache, "iframe same-origin probe failed", e);
+    }
+
+    if (sameOrigin) {
+      try {
+        const wrapper = await rasterizeIframe(iframeEl, sessionCache, options);
+        return wrapper;
+      } catch (err) {
+        console.warn("[Snapshot] iframe rasterization failed, fallback:", err);
+      }
+    }
+
+    if (!sameOrigin) {
+      console.warn(
+        "[snapshot] cross-origin <iframe> skipped (cannot access content). Use options.placeholders to show a placeholder instead.",
+        el,
+      );
+    }
+
+    if (options.placeholders) {
+      const { width, height } = getUnscaledDimensions(el);
+      const fallback = document.createElement("div");
+      fallback.style.cssText =
+        `width:${width}px;height:${height}px;` +
+        "background-image:repeating-linear-gradient(45deg,#ddd,#ddd 5px,#f9f9f9 5px,#f9f9f9 10px);" +
+        "display:flex;align-items:center;justify-content:center;font-size:12px;color:#555;border:1px solid #aaa;";
+      inlineAllStyles(el, fallback, sessionCache, options);
+      return fallback;
+    } else {
+      const { width, height } = getUnscaledDimensions(el);
+      const spacer = document.createElement("div");
+      spacer.style.cssText = `display:inline-block;width:${width}px;height:${height}px;visibility:hidden;`;
+      inlineAllStyles(el, spacer, sessionCache, options);
+      return spacer;
+    }
+  }
+
+  if (el.getAttribute("data-capture") === "placeholder") {
+    const clone2 = el.cloneNode(false) as Element;
+    sessionCache.nodeMap.set(clone2, el);
+    inlineAllStyles(el, clone2, sessionCache, options);
+    const placeholder = document.createElement("div");
+    placeholder.textContent = el.getAttribute("data-placeholder-text") || "";
+    placeholder.style.cssText =
+      "color:#666;font-size:12px;text-align:center;line-height:1.4;padding:0.5em;box-sizing:border-box;";
+    clone2.appendChild(placeholder);
+    return clone2;
+  }
+  if (el.tagName === "CANVAS") {
+    const canvasEl = el as HTMLCanvasElement;
+    let url = "";
+    try {
+      const ctx = canvasEl.getContext("2d", { willReadFrequently: true });
+      try {
+        if (ctx) ctx.getImageData(0, 0, 1, 1);
+      } catch {}
+      await new Promise((r) => requestAnimationFrame(r));
+
+      url = canvasEl.toDataURL("image/png");
+
+      if (!url || url === "data:,") {
+        try {
+          if (ctx) ctx.getImageData(0, 0, 1, 1);
+        } catch {}
+        await new Promise((r) => requestAnimationFrame(r));
+        url = canvasEl.toDataURL("image/png");
+
+        if (!url || url === "data:,") {
+          const scratch = document.createElement("canvas");
+          scratch.width = canvasEl.width;
+          scratch.height = canvasEl.height;
+          const sctx = scratch.getContext("2d");
+          if (sctx) {
+            sctx.drawImage(canvasEl, 0, 0);
+            url = scratch.toDataURL("image/png");
+          }
+        }
+      }
+    } catch (e) {
+      debugWarn(sessionCache, "Canvas toDataURL failed, using empty/fallback", e);
+    }
+
+    const img = document.createElement("img");
+    try {
+      img.decoding = "sync";
+      img.loading = "eager";
+    } catch (e) {
+      debugWarn(sessionCache, "img decoding/loading hints failed", e);
+    }
+    if (url) img.src = url;
+
+    img.width = canvasEl.width;
+    img.height = canvasEl.height;
+
+    const { width, height } = getUnscaledDimensions(el);
+    if (width > 0) img.style.width = `${width}px`;
+    if (height > 0) img.style.height = `${height}px`;
+
+    sessionCache.nodeMap.set(img, el);
+    inlineAllStyles(el, img, sessionCache, options);
+    return img;
+  }
+
+  if (el.tagName === "VIDEO") {
+    const videoEl = el as HTMLVideoElement;
+    let url = "";
+    try {
+      const canvas = document.createElement("canvas");
+      canvas.width = videoEl.videoWidth || videoEl.offsetWidth || 320;
+      canvas.height = videoEl.videoHeight || videoEl.offsetHeight || 240;
+      const ctx = canvas.getContext("2d");
+      if (ctx) {
+        ctx.drawImage(videoEl, 0, 0, canvas.width, canvas.height);
+        url = canvas.toDataURL("image/png");
+        if (!url || url === "data:,") url = "";
+      }
+    } catch (e) {
+      debugWarn(sessionCache, "Video frame capture failed, using poster fallback", e);
+    }
+
+    const img = document.createElement("img");
+    try {
+      img.decoding = "sync";
+      img.loading = "eager";
+    } catch {}
+    if (url) {
+      img.src = url;
+    } else if (videoEl.poster) {
+      img.src = videoEl.poster;
+    }
+
+    img.width = videoEl.videoWidth || videoEl.offsetWidth || 0;
+    img.height = videoEl.videoHeight || videoEl.offsetHeight || 0;
+
+    const { width, height } = getUnscaledDimensions(el);
+    if (width > 0) img.style.width = `${width}px`;
+    if (height > 0) img.style.height = `${height}px`;
+    img.style.objectFit = "contain";
+
+    sessionCache.nodeMap.set(img, el);
+    inlineAllStyles(el, img, sessionCache, options);
+    return img;
+  }
+
+  let clone: HTMLElement;
+  try {
+    clone = el.cloneNode(false) as HTMLElement;
+    if (clone.attributes?.length) {
+      try {
+        for (const attr of clone.attributes) {
+          /* eslint-disable no-control-regex */
+          if (/[\x00-\x08\x0B\x0C\x0E-\x1F\uFFFE\uFFFF]/.test(attr.value)) {
+            clone.setAttribute(
+              attr.name,
+              attr.value.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\uFFFE\uFFFF]/g, ""),
+            );
+          }
+          /* eslint-enable no-control-regex */
+        }
+      } catch {}
+    }
+    resolveCSSVars(el, clone);
+    sessionCache.nodeMap.set(clone, el);
+    if (el.tagName === "IMG") {
+      freezeImgSrcset(el as HTMLImageElement, clone as HTMLImageElement);
+      try {
+        const { width, height } = getUnscaledDimensions(el);
+        const w = Math.round(width || 0);
+        const h = Math.round(height || 0);
+        if (w) clone.dataset.snapshotWidth = String(w);
+        if (h) clone.dataset.snapshotHeight = String(h);
+      } catch (e) {
+        debugWarn(sessionCache, "getUnscaledDimensions for IMG failed", e);
+      }
+
+      try {
+        const authored = el.getAttribute("style") || "";
+        const cs = window.getComputedStyle(el);
+        const usesPercentOrAuto = (prop: string): boolean => {
+          const a = authored.match(new RegExp(`${prop}\\s*:\\s*([^;]+)`, "i"));
+          const v = a ? a[1].trim() : cs.getPropertyValue(prop);
+          return /%|auto/i.test(String(v || ""));
+        };
+
+        const w = parseInt(clone.dataset.snapshotWidth || "0", 10);
+        const h = parseInt(clone.dataset.snapshotHeight || "0", 10);
+
+        const needFreezeW = usesPercentOrAuto("width") || !w;
+        const needFreezeH = usesPercentOrAuto("height") || !h;
+
+        if (needFreezeW && w) clone.style.width = `${w}px`;
+        if (needFreezeH && h) clone.style.height = `${h}px`;
+
+        const objectFit = cs.getPropertyValue("object-fit");
+        const objectPosition = cs.getPropertyValue("object-position");
+        if (objectFit && objectFit !== "fill") {
+          clone.style.objectFit = objectFit;
+          if (objectPosition) clone.style.objectPosition = objectPosition;
+        } else {
+          if (w) clone.style.minWidth = `${w}px`;
+          if (h) clone.style.minHeight = `${h}px`;
+        }
+      } catch (e) {
+        debugWarn(sessionCache, "IMG dimension freeze failed", e);
+      }
+    }
+  } catch (err) {
+    console.error("[Snapshot] Failed to clone node:", node, err);
+    throw err;
+  }
+  let applyInputVisual: (() => void) | null = null;
+  if (el instanceof HTMLTextAreaElement) {
+    const { width, height } = getUnscaledDimensions(el);
+    const w = width || el.getBoundingClientRect().width || 0;
+    const h = height || el.getBoundingClientRect().height || 0;
+    if (w) clone.style.width = `${w}px`;
+    if (h) clone.style.height = `${h}px`;
+  }
+  if (el instanceof HTMLInputElement) {
+    const type = (el.type || "text").toLowerCase();
+    const isCheckboxOrRadio = type === "checkbox" || type === "radio";
+    if (isCheckboxOrRadio && isFirefox()) {
+      const { el: replacement, applyVisual } = createCheckboxRadioReplacement(el);
+      sessionCache.nodeMap.set(replacement, el);
+      applyInputVisual = applyVisual;
+      clone = replacement;
+    } else {
+      const inputClone = clone as HTMLInputElement;
+      inputClone.value = el.value;
+      inputClone.setAttribute("value", el.value);
+      if (el.checked !== void 0) {
+        inputClone.checked = el.checked;
+        if (el.checked) inputClone.setAttribute("checked", "");
+        if (el.indeterminate) inputClone.indeterminate = el.indeterminate;
+      }
+    }
+  }
+
+  if (
+    (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) &&
+    !el.value &&
+    el.placeholder
+  ) {
+    try {
+      const phStyle = window.getComputedStyle(el, "::placeholder");
+      const phColor = phStyle && phStyle.color;
+      if (phColor && phColor !== "rgba(0, 0, 0, 0)") {
+        const uid = "snapshot-ph-" + ((Math.random() * 1e6) | 0);
+        clone.classList.add(uid);
+        const styleEl = document.createElement("style");
+        styleEl.textContent = `.${uid}::placeholder{color:${phColor}!important;opacity:${phStyle.opacity || "1"}!important;-webkit-text-fill-color:${phColor}!important;}`;
+        clone.prepend(styleEl);
+      }
+    } catch {}
+  }
+
+  if (el instanceof HTMLSelectElement) {
+    pendingSelectValue = el.value;
+  }
+  if (el instanceof HTMLTextAreaElement) {
+    pendingTextAreaValue = el.value;
+  }
+  if (
+    el instanceof HTMLInputElement ||
+    el instanceof HTMLTextAreaElement ||
+    el instanceof HTMLSelectElement
+  ) {
+    if (el.disabled) clone.setAttribute("disabled", "");
+    if (el.required) clone.setAttribute("required", "");
+    if ((el as HTMLInputElement | HTMLTextAreaElement).readOnly) clone.setAttribute("readonly", "");
+    const inputNode = el as HTMLInputElement;
+    if (inputNode.min !== undefined && inputNode.min !== "")
+      clone.setAttribute("min", inputNode.min);
+    if (inputNode.max !== undefined && inputNode.max !== "")
+      clone.setAttribute("max", inputNode.max);
+    if (inputNode.pattern !== undefined && inputNode.pattern !== "")
+      clone.setAttribute("pattern", inputNode.pattern);
+    const ariaInvalid = el.getAttribute("aria-invalid");
+    if (ariaInvalid !== null) clone.setAttribute("aria-invalid", ariaInvalid);
+  }
+  if (!isInSvgTemplate(el)) {
+    inlineAllStyles(el, clone, sessionCache, options);
+  }
+  if (applyInputVisual) {
+    applyInputVisual();
+  }
+  if (el instanceof SVGElement && !isInSvgTemplate(el)) {
+    const SVG_PAINT_PROPS = [
+      "fill",
+      "stroke",
+      "stroke-width",
+      "stroke-dasharray",
+      "stroke-dashoffset",
+      "stroke-linecap",
+      "stroke-linejoin",
+      "stroke-miterlimit",
+      "opacity",
+      "fill-opacity",
+      "stroke-opacity",
+      "fill-rule",
+      "clip-rule",
+      "marker",
+      "marker-start",
+      "marker-mid",
+      "marker-end",
+      "visibility",
+      "display",
+    ];
+    try {
+      const cs = window.getComputedStyle(el);
+      for (const prop of SVG_PAINT_PROPS) {
+        const val = cs.getPropertyValue(prop);
+        if (val) clone.style.setProperty(prop, val);
+      }
+    } catch {}
+  }
+  if (el.shadowRoot) {
+    try {
+      const slots = el.shadowRoot.querySelectorAll("slot");
+      for (const s of slots) {
+        let assigned: Node[] = [];
+        try {
+          assigned = s.assignedNodes?.({ flatten: true }) || s.assignedNodes?.() || [];
+        } catch {
+          assigned = s.assignedNodes?.() || [];
+        }
+        for (const an of assigned) clonedAssignedNodes.add(an);
+      }
+    } catch {}
+    const scopeId = nextShadowScopeId(sessionCache);
+    const scopeSelector = `[data-sd="${scopeId}"]`;
+    try {
+      clone.setAttribute("data-sd", scopeId);
+    } catch {}
+    const rawCSS = extractShadowCSS(el.shadowRoot);
+    const rewritten = rewriteShadowCSS(rawCSS, scopeSelector);
+    const neededVars = collectCustomPropsFromCSS(rawCSS);
+    const seed = buildSeedCustomPropsRule(el, neededVars, scopeSelector);
+    injectScopedStyle(clone, seed + rewritten, scopeId);
+    const shadowFrag = document.createDocumentFragment();
+    const callback = (child: Node, resolve: (value: Node | null) => void): void => {
+      if (child.nodeType === Node.ELEMENT_NODE && (child as Element).tagName === "STYLE") {
+        return resolve(null);
+      } else {
+        deepClone(child, sessionCache, options)
+          .then((clonedChild) => {
+            resolve(clonedChild || null);
+          })
+          .catch(() => {
+            resolve(null);
+          });
+      }
+    };
+
+    const cloneList = await idleCallback(
+      Array.from(el.shadowRoot.childNodes),
+      callback,
+      options.fast as boolean,
+    );
+    shadowFrag.append(
+      ...cloneList.filter((clonedChild): clonedChild is Node => Boolean(clonedChild)),
+    );
+    clone.appendChild(shadowFrag);
+  }
+  if (el.tagName === "SLOT") {
+    const slotEl = el as HTMLSlotElement;
+    const assigned = slotEl.assignedNodes?.({ flatten: true }) || [];
+    const nodesToClone = assigned.length > 0 ? assigned : Array.from(el.childNodes);
+    const fragment = document.createDocumentFragment();
+
+    const callback = (child: Node, resolve: (value: Node | null) => void): void => {
+      deepClone(child, sessionCache, options)
+        .then((clonedChild) => {
+          if (clonedChild) {
+            markSlottedSubtree(clonedChild as Element);
+          }
+          resolve(clonedChild || null);
+        })
+        .catch(() => {
+          resolve(null);
+        });
+    };
+    const cloneList = await idleCallback(
+      Array.from(nodesToClone),
+      callback,
+      options.fast as boolean,
+    );
+    fragment.append(
+      ...cloneList.filter((clonedChild): clonedChild is Node => Boolean(clonedChild)),
+    );
+    return fragment;
+  }
+
+  const callback = (child: Node, resolve: (value: Node | null) => void): void => {
+    if (clonedAssignedNodes.has(child)) return resolve(null);
+    deepClone(child, sessionCache, options)
+      .then((clonedChild) => {
+        resolve(clonedChild || null);
+      })
+      .catch(() => {
+        resolve(null);
+      });
+  };
+  const cloneList = await idleCallback(
+    Array.from(el.childNodes),
+    callback,
+    options.fast as boolean,
+  );
+  clone.append(...cloneList.filter((clonedChild): clonedChild is Node => Boolean(clonedChild)));
+
+  if (pendingSelectValue !== null && clone instanceof HTMLSelectElement) {
+    clone.value = pendingSelectValue;
+    for (const opt of clone.options) {
+      if (opt.value === pendingSelectValue) {
+        opt.setAttribute("selected", "");
+      } else {
+        opt.removeAttribute("selected");
+      }
+    }
+  }
+  if (pendingTextAreaValue !== null && clone instanceof HTMLTextAreaElement) {
+    clone.textContent = pendingTextAreaValue;
+  }
+  return clone;
+};

--- a/packages/react-grab/src/snapshot/core/context.ts
+++ b/packages/react-grab/src/snapshot/core/context.ts
@@ -1,0 +1,69 @@
+import { normalizeCachePolicy } from "./cache.js";
+import type { SnapshotCaptureContext, SnapshotOptions, SnapshotCachePolicy } from "../types.js";
+
+export const createContext = (
+  options: SnapshotOptions | undefined = {},
+): SnapshotCaptureContext => {
+  const opts = options as SnapshotOptions & {
+    fontStylesheetDomains?: string[];
+    excludeStyleProps?: RegExp | ((prop: string) => boolean) | null;
+    filename?: string;
+  };
+
+  let resolvedFormat = opts.format ?? "png";
+  if (resolvedFormat === "jpg") resolvedFormat = "jpeg";
+  const cachePolicy: SnapshotCachePolicy = normalizeCachePolicy(opts.cache);
+
+  return {
+    debug: opts.debug ?? false,
+    fast: opts.fast ?? true,
+    scale: opts.scale ?? 1,
+
+    exclude: opts.exclude ?? [],
+    excludeMode: opts.excludeMode ?? "hide",
+    filter: (opts.filter ?? null) as SnapshotOptions["filter"],
+    filterMode: opts.filterMode ?? "hide",
+
+    placeholders: opts.placeholders !== false,
+
+    embedFonts: opts.embedFonts ?? false,
+    iconFonts: Array.isArray(opts.iconFonts)
+      ? opts.iconFonts
+      : opts.iconFonts
+        ? [opts.iconFonts]
+        : [],
+    localFonts: Array.isArray(opts.localFonts) ? opts.localFonts : [],
+    excludeFonts: opts.excludeFonts ?? undefined,
+    fontStylesheetDomains: Array.isArray(opts.fontStylesheetDomains)
+      ? opts.fontStylesheetDomains
+      : [],
+    fallbackURL: opts.fallbackURL ?? undefined,
+
+    cache: cachePolicy,
+
+    useProxy: typeof opts.useProxy === "string" ? opts.useProxy : "",
+
+    width: (opts.width ?? null) as SnapshotOptions["width"],
+    height: (opts.height ?? null) as SnapshotOptions["height"],
+    format: resolvedFormat,
+    type: opts.type ?? "svg",
+    quality: opts.quality ?? 0.92,
+    dpr: opts.dpr ?? (window.devicePixelRatio || 1),
+    backgroundColor: (opts.backgroundColor ??
+      (["jpeg", "webp"].includes(resolvedFormat)
+        ? "#ffffff"
+        : null)) as SnapshotOptions["backgroundColor"],
+    filename: opts.filename ?? "snapshot",
+
+    outerTransforms: opts.outerTransforms ?? true,
+    outerShadows: opts.outerShadows ?? false,
+
+    safariWarmupAttempts: Math.min(3, Math.max(1, (opts.safariWarmupAttempts ?? 3) | 0)),
+
+    excludeStyleProps: opts.excludeStyleProps ?? null,
+
+    resolvePicturePlaceholders: opts.resolvePicturePlaceholders !== false,
+    pictureResolver:
+      opts.pictureResolver && typeof opts.pictureResolver === "object" ? opts.pictureResolver : {},
+  };
+};

--- a/packages/react-grab/src/snapshot/core/plugins.ts
+++ b/packages/react-grab/src/snapshot/core/plugins.ts
@@ -1,0 +1,121 @@
+import type {
+  SnapshotPlugin,
+  SnapshotPluginUse,
+  SnapshotPluginFactory,
+  SnapshotCaptureContext,
+} from "../types.js";
+
+type SnapshotHookFn = (
+  context: SnapshotCaptureContext | null | undefined,
+  payload?: unknown,
+) => unknown | Promise<unknown>;
+
+const __plugins: SnapshotPlugin[] = [];
+
+export const normalizePlugin = (spec: unknown): SnapshotPlugin | null => {
+  if (!spec) return null;
+  if (Array.isArray(spec)) {
+    const [factory, options] = spec as [SnapshotPluginFactory | SnapshotPlugin, unknown];
+    return typeof factory === "function" ? factory(options) : factory;
+  }
+  if (typeof spec === "object" && "plugin" in spec) {
+    const { plugin, options } = spec as {
+      plugin: SnapshotPluginFactory | SnapshotPlugin;
+      options?: unknown;
+    };
+    return typeof plugin === "function" ? plugin(options) : plugin;
+  }
+  if (typeof spec === "function") return (spec as SnapshotPluginFactory)();
+  return spec as SnapshotPlugin;
+};
+
+export const registerPlugins = (...defs: unknown[]): void => {
+  const flat = defs.flat();
+  for (const d of flat) {
+    const inst = normalizePlugin(d);
+    if (!inst) continue;
+    if (!__plugins.some((p) => p && p.name && inst.name && p.name === inst.name)) {
+      __plugins.push(inst);
+    }
+  }
+};
+
+const getContextPlugins = (
+  context: SnapshotCaptureContext | null | undefined,
+): readonly SnapshotPlugin[] => {
+  return context && Array.isArray(context.plugins)
+    ? (context.plugins as SnapshotPlugin[])
+    : __plugins;
+};
+
+export const runHook = async (
+  name: string,
+  context: SnapshotCaptureContext | null | undefined,
+  payload?: unknown,
+): Promise<unknown> => {
+  let acc = payload;
+  const list = getContextPlugins(context);
+  for (const p of list) {
+    const candidate = p as unknown as Record<string, unknown>;
+    const fn =
+      p && typeof candidate[name] === "function" ? (candidate[name] as SnapshotHookFn) : null;
+    if (!fn) continue;
+    const out = await fn(context, acc);
+    if (typeof out !== "undefined") acc = out;
+  }
+  return acc;
+};
+
+export const runAll = async (
+  name: string,
+  context: SnapshotCaptureContext | null | undefined,
+  payload?: unknown,
+): Promise<unknown[]> => {
+  const outs: unknown[] = [];
+  const list = getContextPlugins(context);
+  for (const p of list) {
+    const candidate = p as unknown as Record<string, unknown>;
+    const fn =
+      p && typeof candidate[name] === "function" ? (candidate[name] as SnapshotHookFn) : null;
+    if (!fn) continue;
+    const out = await fn(context, payload);
+    if (typeof out !== "undefined") outs.push(out);
+  }
+  return outs;
+};
+
+const mergePlugins = (localDefs: unknown[] | undefined): ReadonlyArray<SnapshotPlugin> => {
+  const out: SnapshotPlugin[] = [];
+
+  if (Array.isArray(localDefs)) {
+    for (const d of localDefs) {
+      const inst = normalizePlugin(d);
+      if (!inst || !inst.name) continue;
+      const i = out.findIndex((x) => x && x.name === inst.name);
+      if (i >= 0) out.splice(i, 1);
+      out.push(inst);
+    }
+  }
+
+  for (const g of __plugins) {
+    if (g && g.name && !out.some((x) => x.name === g.name)) {
+      out.push(g);
+    }
+  }
+
+  return Object.freeze(out);
+};
+
+export const attachSessionPlugins = (
+  context: SnapshotCaptureContext,
+  localDefs: unknown[] | undefined,
+  force: boolean = false,
+): SnapshotCaptureContext => {
+  if (!context || (context.plugins && !force)) return context;
+  context.plugins = mergePlugins(localDefs) as SnapshotPluginUse[];
+  return context;
+};
+
+export const getGlobalPlugins = (): SnapshotPlugin[] => {
+  return __plugins.slice();
+};

--- a/packages/react-grab/src/snapshot/core/prepare.ts
+++ b/packages/react-grab/src/snapshot/core/prepare.ts
@@ -1,0 +1,166 @@
+import { generateCSSClasses, stripTranslate, debugWarn, getStyle } from "../utils/index.js";
+import { deepClone } from "./clone.js";
+import { inlinePseudoElements } from "../modules/pseudo.js";
+import { inlineExternalDefsAndSymbols } from "../modules/svg-defs.js";
+import { cache } from "../core/cache.js";
+import { freezeSticky } from "../modules/change-css.js";
+import { resolveBlobUrlsInTree } from "../utils/clone-helpers.js";
+import { stabilizeLayout, forceContentVisibility } from "../utils/prepare-helpers.js";
+import type { SnapshotCaptureContext } from "../types.js";
+
+interface SnapshotPrepareResult {
+  clone: HTMLElement;
+  classCSS: string;
+  styleCache: WeakMap<Element, CSSStyleDeclaration>;
+}
+
+export const prepareClone = async (
+  element: Element,
+  options: SnapshotCaptureContext = {},
+): Promise<SnapshotPrepareResult> => {
+  const sessionCache = {
+    styleMap: cache.session.styleMap,
+    styleCache: cache.session.styleCache,
+    nodeMap: cache.session.nodeMap,
+    options,
+  };
+
+  let clone!: HTMLElement;
+  let classCSS = "";
+  let shadowScopedCSS = "";
+
+  stabilizeLayout(element);
+
+  const undoContentVisibility = forceContentVisibility(element);
+
+  try {
+    clone = (await deepClone(element, sessionCache, options)) as HTMLElement;
+  } catch (e) {
+    console.warn("deepClone failed:", e);
+    throw e;
+  } finally {
+    undoContentVisibility();
+  }
+
+  try {
+    inlineExternalDefsAndSymbols(clone);
+  } catch (e) {
+    console.warn("inlineExternal defs or symbol failed:", e);
+  }
+  try {
+    await inlinePseudoElements(element, clone, sessionCache, options);
+  } catch (e) {
+    console.warn("inlinePseudoElements failed:", e);
+  }
+  await resolveBlobUrlsInTree(clone, sessionCache);
+  try {
+    const styleNodes = clone.querySelectorAll("style[data-sd]");
+    for (const s of styleNodes) {
+      shadowScopedCSS += s.textContent || "";
+      s.remove();
+    }
+  } catch (e) {
+    debugWarn(sessionCache, "Failed to extract shadow CSS from style[data-sd]", e);
+  }
+
+  const keyToClass = generateCSSClasses(sessionCache.styleMap);
+  classCSS = Array.from(keyToClass.entries())
+    .map(([key, className]) => `.${className}{${key}}`)
+    .join("");
+
+  const PSEUDO_SUPPRESS =
+    "[data-snapshot-has-after]::after,[data-snapshot-has-before]::before{content:none!important;display:none!important}";
+  classCSS = shadowScopedCSS + PSEUDO_SUPPRESS + classCSS;
+
+  for (const [node, key] of sessionCache.styleMap.entries()) {
+    if (node.tagName === "STYLE") continue;
+    /* c8 ignore next 4 */
+    if (node.getRootNode && node.getRootNode() instanceof ShadowRoot) {
+      node.setAttribute("style", key.replace(/;/g, "; "));
+      continue;
+    }
+
+    const className = keyToClass.get(key);
+    if (className) node.classList.add(className);
+
+    const styledNode = node as HTMLElement;
+    const bgImage = styledNode.style?.backgroundImage;
+    const hasIcon = styledNode.dataset?.snapshotHasIcon;
+    if (bgImage && bgImage !== "none") styledNode.style.backgroundImage = bgImage;
+    /* c8 ignore next 4 */
+    if (hasIcon) {
+      styledNode.style.verticalAlign = "middle";
+      styledNode.style.display = "inline";
+    }
+  }
+
+  for (const [cloneNode, originalNode] of sessionCache.nodeMap.entries()) {
+    const scrollX = originalNode.scrollLeft;
+    const scrollY = originalNode.scrollTop;
+    const hasScroll = scrollX || scrollY;
+    if (hasScroll && cloneNode instanceof HTMLElement) {
+      cloneNode.style.overflow = "hidden";
+      cloneNode.style.scrollbarWidth = "none";
+      (cloneNode.style as CSSStyleDeclaration & { msOverflowStyle?: string }).msOverflowStyle =
+        "none";
+
+      try {
+        const positioned = cloneNode.querySelectorAll("*");
+        for (const child of positioned) {
+          if (!(child instanceof HTMLElement)) continue;
+          const pos = child.style.position;
+          if (pos === "fixed" || pos === "absolute") {
+            const curTop = parseFloat(child.style.top) || 0;
+            const curLeft = parseFloat(child.style.left) || 0;
+            child.style.top = `${curTop + scrollY}px`;
+            child.style.left = `${curLeft + scrollX}px`;
+            if (pos === "fixed") child.style.position = "absolute";
+          }
+        }
+      } catch {}
+
+      const inner = document.createElement("div");
+      inner.style.all = "unset";
+      inner.style.transform = `translate(${-scrollX}px, ${-scrollY}px)`;
+      inner.style.willChange = "transform";
+      inner.style.display = "inline-block";
+      inner.style.width = "100%";
+      while (cloneNode.firstChild) {
+        inner.appendChild(cloneNode.firstChild);
+      }
+      cloneNode.appendChild(inner);
+    }
+  }
+  const contentRoot =
+    clone instanceof HTMLElement && clone.firstElementChild instanceof HTMLElement
+      ? clone.firstElementChild
+      : clone;
+
+  freezeSticky(element as HTMLElement, contentRoot);
+
+  if (element === sessionCache.nodeMap.get(clone)) {
+    const computed = sessionCache.styleCache.get(element) || getStyle(element);
+    sessionCache.styleCache.set(element, computed);
+    const transform = stripTranslate(computed.transform);
+    clone.style.margin = "0";
+    clone.style.top = "auto";
+    clone.style.left = "auto";
+    clone.style.right = "auto";
+    clone.style.bottom = "auto";
+    clone.style.animation = "none";
+    clone.style.transition = "none";
+    clone.style.willChange = "auto";
+    clone.style.float = "none";
+    clone.style.clear = "none";
+    clone.style.transform = transform || "";
+  }
+
+  for (const [cloneNode, originalNode] of sessionCache.nodeMap.entries()) {
+    if (originalNode.tagName === "PRE") {
+      const preClone = cloneNode as HTMLElement;
+      preClone.style.marginTop = "0";
+      preClone.style.marginBlockStart = "0";
+    }
+  }
+  return { clone, classCSS, styleCache: sessionCache.styleCache };
+};

--- a/packages/react-grab/src/snapshot/exporters/download.ts
+++ b/packages/react-grab/src/snapshot/exporters/download.ts
@@ -1,0 +1,63 @@
+import { toBlob } from "./to-blob.js";
+import { toCanvas } from "./to-canvas.js";
+import { isIOS } from "../utils/browser.js";
+import type { SnapshotBlobType, SnapshotCaptureContext } from "../types.js";
+
+const shareFile = async (blob: Blob, filename: string): Promise<boolean> => {
+  const file = new File([blob], filename, { type: blob.type });
+  if (!navigator.canShare?.({ files: [file] })) return false;
+  try {
+    await navigator.share({ files: [file], title: filename });
+  } catch (error) {
+    if (!(error instanceof Error) || error.name !== "AbortError") return false;
+  }
+  return true;
+};
+
+export const download = async (url: string, options: SnapshotCaptureContext): Promise<void> => {
+  const IMAGE_FORMATS = new Set(["png", "jpeg", "jpg", "webp", "svg"]);
+  const rawType = (options?.type || "").toLowerCase();
+  const typeAsFormat = IMAGE_FORMATS.has(rawType) ? rawType : "";
+  const format = (options?.format || typeAsFormat || "").toLowerCase();
+  const normalizedFormat = (format === "jpg" ? "jpeg" : format || "png") as SnapshotBlobType;
+  const filenameRaw = typeof options?.filename === "string" ? options.filename : "";
+  const filename = filenameRaw || `snapshot.${normalizedFormat}`;
+  const nextOptions: SnapshotCaptureContext = {
+    ...(options || {}),
+    format: normalizedFormat,
+    type: normalizedFormat,
+  };
+  nextOptions.dpr = 1;
+  const foundIOS = isIOS();
+
+  if (normalizedFormat === "svg") {
+    const blob = await toBlob(url, { ...nextOptions, type: "svg" });
+    if (foundIOS && (await shareFile(blob, filename))) return;
+    const objectURL = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = objectURL;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    URL.revokeObjectURL(objectURL);
+    a.remove();
+    return;
+  }
+
+  const canvas = await toCanvas(url, nextOptions);
+
+  if (foundIOS) {
+    const mimeType = `image/${normalizedFormat}`;
+    const blob = await new Promise<Blob | null>((resolve) =>
+      canvas.toBlob(resolve, mimeType, options?.quality),
+    );
+    if (blob && (await shareFile(blob, filename))) return;
+  }
+
+  const a = document.createElement("a");
+  a.href = canvas.toDataURL(`image/${normalizedFormat}`, options?.quality);
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+};

--- a/packages/react-grab/src/snapshot/exporters/to-blob.ts
+++ b/packages/react-grab/src/snapshot/exporters/to-blob.ts
@@ -1,0 +1,19 @@
+import { toCanvas } from "./to-canvas.js";
+import type { SnapshotCaptureContext } from "../types.js";
+
+export const toBlob = async (url: string, options: SnapshotCaptureContext): Promise<Blob> => {
+  const type = options.type;
+  if (type === "svg") {
+    const svgText = decodeURIComponent(url.split(",")[1] ?? "");
+    return new Blob([svgText], { type: "image/svg+xml" });
+  }
+
+  const canvas = await toCanvas(url, options);
+  return new Promise<Blob>((resolve) =>
+    canvas.toBlob(
+      (blob) => resolve(blob ?? new Blob([], { type: `image/${type}` })),
+      `image/${type}`,
+      options.quality,
+    ),
+  );
+};

--- a/packages/react-grab/src/snapshot/exporters/to-canvas.ts
+++ b/packages/react-grab/src/snapshot/exporters/to-canvas.ts
@@ -1,0 +1,256 @@
+import { isSafari } from "../utils/browser.js";
+import type { SnapshotCaptureContext, SnapshotImageMeta } from "../types.js";
+
+const MAX_RASTER_SIDE = 16384;
+const MAX_RASTER_AREA = 16384 * 16384;
+
+const clampSvgRasterSize = (url: string): string => {
+  if (!isSvgDataURL(url)) return url;
+  try {
+    const svg = decodeSvgFromDataURL(url);
+    const head = svg.match(/<svg\b[^>]*>/i);
+    if (!head) return url;
+    const tag = head[0];
+    const w = parseFloat((tag.match(/\bwidth="([\d.]+)/i) || [])[1]);
+    const h = parseFloat((tag.match(/\bheight="([\d.]+)/i) || [])[1]);
+    if (!Number.isFinite(w) || !Number.isFinite(h) || w <= 0 || h <= 0) return url;
+    const scaleFactor = Math.min(
+      1,
+      MAX_RASTER_SIDE / w,
+      MAX_RASTER_SIDE / h,
+      Math.sqrt(MAX_RASTER_AREA / (w * h)),
+    );
+    if (scaleFactor >= 1) return url;
+    const cappedWidth = Math.max(1, Math.floor(w * scaleFactor));
+    const cappedHeight = Math.max(1, Math.floor(h * scaleFactor));
+    console.warn(
+      `[snapshot] Capture ${Math.round(w)}×${Math.round(h)}px exceeds the browser image-decode ` +
+        `limit (${MAX_RASTER_SIDE}px/side); downscaling to ${cappedWidth}×${cappedHeight}px. Lower \`scale\` or set ` +
+        "`width`/`height` to control output size.",
+    );
+    const fixed = svg.replace(
+      tag,
+      tag
+        .replace(/(\bwidth=")[\d.]+/i, `$1${cappedWidth}`)
+        .replace(/(\bheight=")[\d.]+/i, `$1${cappedHeight}`),
+    );
+    return encodeSvgToDataURL(fixed);
+  } catch {
+    return url;
+  }
+};
+
+const isSvgDataURL = (u: string): boolean =>
+  typeof u === "string" && /^data:image\/svg\+xml/i.test(u);
+
+const decodeSvgFromDataURL = (u: string): string => {
+  const i = u.indexOf(",");
+  return i >= 0 ? decodeURIComponent(u.slice(i + 1)) : "";
+};
+
+const encodeSvgToDataURL = (svgText: string): string =>
+  `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgText)}`;
+
+const splitDecls = (s: string): string[] => {
+  const parts: string[] = [];
+  let buf = "";
+  let depth = 0;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (ch === "(") depth++;
+    if (ch === ")") depth = Math.max(0, depth - 1);
+    if (ch === ";" && depth === 0) {
+      parts.push(buf);
+      buf = "";
+    } else buf += ch;
+  }
+  if (buf.trim()) parts.push(buf);
+  return parts.map((x) => x.trim()).filter(Boolean);
+};
+
+const boxShadowToDropShadow = (value: string): string => {
+  const layers: string[] = [];
+  let buf = "";
+  let depth = 0;
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i];
+    if (ch === "(") depth++;
+    if (ch === ")") depth = Math.max(0, depth - 1);
+    if (ch === "," && depth === 0) {
+      layers.push(buf.trim());
+      buf = "";
+    } else buf += ch;
+  }
+  if (buf.trim()) layers.push(buf.trim());
+
+  const fns: string[] = [];
+  for (const layer of layers) {
+    if (/\binset\b/i.test(layer)) continue;
+    const nums = layer.match(/-?\d+(?:\.\d+)?px/gi) || [];
+    const [ox = "0px", oy = "0px", blur = "0px"] = nums;
+    const color = layer
+      .replace(/-?\d+(?:\.\d+)?px/gi, "")
+      .replace(/\binset\b/gi, "")
+      .trim()
+      .replace(/\s{2,}/g, " ");
+    const hasColor = Boolean(color) && color !== ",";
+    fns.push(`drop-shadow(${ox} ${oy} ${blur}${hasColor ? ` ${color}` : ""})`);
+  }
+  return fns.join(" ");
+};
+
+const rewriteDeclList = (list: string): string => {
+  const decls = splitDecls(list);
+  let filter: string | null = null;
+  let wfilter: string | null = null;
+  let box: string | null = null;
+  const rest: Array<[string, string]> = [];
+  for (const declaration of decls) {
+    const idx = declaration.indexOf(":");
+    if (idx < 0) continue;
+    const prop = declaration.slice(0, idx).trim().toLowerCase();
+    const val = declaration.slice(idx + 1).trim();
+    if (prop === "box-shadow") box = val;
+    else if (prop === "filter") filter = val;
+    else if (prop === "-webkit-filter") wfilter = val;
+    else rest.push([prop, val]);
+  }
+  if (box) {
+    const ds = boxShadowToDropShadow(box);
+    if (ds) {
+      filter = filter ? `${filter} ${ds}` : ds;
+      wfilter = wfilter ? `${wfilter} ${ds}` : ds;
+    }
+  }
+  const out: Array<[string, string]> = [...rest];
+  if (filter) out.push(["filter", filter]);
+  if (wfilter) out.push(["-webkit-filter", wfilter]);
+  return out.map(([key, value]) => `${key}:${value}`).join(";");
+};
+
+const rewriteCssBlock = (css: string): string =>
+  css.replace(
+    /([^{}]+)\{([^}]*)\}/g,
+    (_m: string, sel: string, body: string) => `${sel}{${rewriteDeclList(body)}}`,
+  );
+
+const rewriteSvgBoxShadowToDropShadow = (svgText: string): string => {
+  let result = svgText.replace(
+    /<style[^>]*>([\s\S]*?)<\/style>/gi,
+    (matched: string, css: string) => matched.replace(css, rewriteCssBlock(css)),
+  );
+  result = result.replace(
+    /style=(['"])([\s\S]*?)\1/gi,
+    (_matched: string, quote: string, body: string) =>
+      `style=${quote}${rewriteDeclList(body)}${quote}`,
+  );
+  return result;
+};
+
+const maybeConvertBoxShadowForSafari = (url: string): string => {
+  if (!isSafari() || !isSvgDataURL(url)) return url;
+  try {
+    const svg = decodeSvgFromDataURL(url);
+    const fixed = rewriteSvgBoxShadowToDropShadow(svg);
+    return encodeSvgToDataURL(fixed);
+  } catch {
+    return url;
+  }
+};
+
+export const toCanvas = async (
+  url: string,
+  options: SnapshotCaptureContext,
+): Promise<HTMLCanvasElement> => {
+  const { width: optW, height: optH, scale = 1, dpr = 1, backgroundColor } = options;
+  const meta = (options.meta ?? {}) as SnapshotImageMeta;
+  url = maybeConvertBoxShadowForSafari(url);
+  url = clampSvgRasterSize(url);
+
+  const img = new Image();
+  img.loading = "eager";
+  img.decoding = "sync";
+  img.crossOrigin = "anonymous";
+  img.src = url;
+  await img.decode();
+
+  if (isSafari()) {
+    img.style.cssText = "position:fixed;left:-99999px;top:-99999px;pointer-events:none";
+    document.body.appendChild(img);
+    try {
+      await new Promise<void>((resolve) =>
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+      );
+    } finally {
+      try {
+        img.remove();
+      } catch {}
+    }
+  }
+
+  const natW = img.naturalWidth;
+  const natH = img.naturalHeight;
+
+  const refW = Number.isFinite(meta.w0) ? meta.w0! : natW;
+  const refH = Number.isFinite(meta.h0) ? meta.h0! : natH;
+
+  let outW: number;
+  let outH: number;
+  const hasW = Number.isFinite(optW);
+  const hasH = Number.isFinite(optH);
+
+  if (hasW && hasH) {
+    outW = Math.max(1, optW!);
+    outH = Math.max(1, optH!);
+  } else if (hasW) {
+    const k = optW! / Math.max(1, refW);
+    outW = optW!;
+    outH = refH * k;
+  } else if (hasH) {
+    const k = optH! / Math.max(1, refH);
+    outH = optH!;
+    outW = refW * k;
+  } else {
+    outW = natW;
+    outH = natH;
+  }
+
+  outW = outW * scale;
+  outH = outH * scale;
+
+  const devW = outW * dpr;
+  const devH = outH * dpr;
+  const over = Math.max(
+    devW / MAX_RASTER_SIDE,
+    devH / MAX_RASTER_SIDE,
+    Math.sqrt((devW * devH) / MAX_RASTER_AREA),
+  );
+  if (over > 1) {
+    console.warn(
+      `[snapshot] Output ${Math.round(devW)}×${Math.round(devH)}px exceeds the browser canvas ` +
+        `limit (${MAX_RASTER_SIDE}px/side); downscaling. Lower \`scale\`/\`dpr\` or set \`width\`/\`height\`.`,
+    );
+    outW /= over;
+    outH /= over;
+  }
+
+  const canvas = document.createElement("canvas");
+  canvas.width = outW * dpr;
+  canvas.height = outH * dpr;
+  canvas.style.width = `${outW}px`;
+  canvas.style.height = `${outH}px`;
+
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("[snapshot] Could not acquire a 2D canvas context");
+  if (dpr !== 1) ctx.scale(dpr, dpr);
+
+  if (backgroundColor) {
+    ctx.save();
+    ctx.fillStyle = backgroundColor;
+    ctx.fillRect(0, 0, outW, outH);
+    ctx.restore();
+  }
+
+  ctx.drawImage(img, 0, 0, outW, outH);
+  return canvas;
+};

--- a/packages/react-grab/src/snapshot/exporters/to-img.ts
+++ b/packages/react-grab/src/snapshot/exporters/to-img.ts
@@ -1,0 +1,60 @@
+import { isSafari, debugWarn } from "../utils/index.js";
+import { rasterize } from "../modules/rasterize.js";
+import type { SnapshotCaptureContext, SnapshotImageMeta } from "../types.js";
+
+export const toImg = async (
+  url: string,
+  options: SnapshotCaptureContext,
+): Promise<HTMLImageElement> => {
+  const { scale = 1, width, height } = options;
+  const meta = (options.meta ?? {}) as SnapshotImageMeta;
+  const hasW = Number.isFinite(width);
+  const hasH = Number.isFinite(height);
+  const wantsScale = (Number.isFinite(scale) && scale !== 1) || hasW || hasH;
+  if (isSafari() && wantsScale) {
+    const pngUrl = await rasterize(url, { ...options, format: "png", quality: 1, meta });
+
+    return pngUrl;
+  }
+  const img = new Image();
+  img.decoding = "sync";
+  img.loading = "eager";
+  img.src = url;
+  await img.decode();
+  if (hasW && hasH) {
+    img.style.width = `${width}px`;
+    img.style.height = `${height}px`;
+  } else if (hasW) {
+    const refW = Number.isFinite(meta.w0) ? meta.w0! : img.naturalWidth;
+    const refH = Number.isFinite(meta.h0) ? meta.h0! : img.naturalHeight;
+    const k = width! / Math.max(1, refW);
+    img.style.width = `${width}px`;
+    img.style.height = `${Math.round(refH * k)}px`;
+  } else if (hasH) {
+    const refW = Number.isFinite(meta.w0) ? meta.w0! : img.naturalWidth;
+    const refH = Number.isFinite(meta.h0) ? meta.h0! : img.naturalHeight;
+    const k = height! / Math.max(1, refH);
+    img.style.height = `${height}px`;
+    img.style.width = `${Math.round(refW * k)}px`;
+  } else {
+    const cssW = Math.round(img.naturalWidth * scale);
+    const cssH = Math.round(img.naturalHeight * scale);
+    img.style.width = `${cssW}px`;
+    img.style.height = `${cssH}px`;
+    if (typeof url === "string" && url.startsWith("data:image/svg+xml")) {
+      try {
+        const decoded = decodeURIComponent(url.split(",")[1] ?? "");
+        const patched = decoded
+          .replace(/width="[^"]*"/, `width="${cssW}"`)
+          .replace(/height="[^"]*"/, `height="${cssH}"`);
+        url = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(patched)}`;
+        img.src = url;
+      } catch (error) {
+        debugWarn(options, "SVG width/height patch in toImg failed", error);
+      }
+    }
+  }
+  return img;
+};
+
+export { toImg as toSvg };

--- a/packages/react-grab/src/snapshot/index.ts
+++ b/packages/react-grab/src/snapshot/index.ts
@@ -1,0 +1,3 @@
+export { snapshot } from "./api/snapshot.js";
+export { preCache } from "./api/pre-cache.js";
+export type * from "./types.js";

--- a/packages/react-grab/src/snapshot/modules/background.ts
+++ b/packages/react-grab/src/snapshot/modules/background.ts
@@ -1,0 +1,139 @@
+import { getStyle, inlineSingleBackgroundEntry, splitBackgroundImage } from "../utils/index.js";
+import type { SnapshotCaptureContext } from "../types.js";
+
+export const inlineBackgroundImages = async (
+  source: HTMLElement,
+  clone: HTMLElement | undefined,
+  styleCache: WeakMap<Element, CSSStyleDeclaration>,
+  options: SnapshotCaptureContext = {},
+): Promise<void> => {
+  const queue: Array<[Element, HTMLElement | undefined]> = [[source, clone]];
+
+  const URL_PROPS = [
+    "background-image",
+
+    "mask",
+    "mask-image",
+    "-webkit-mask",
+    "-webkit-mask-image",
+
+    "mask-source",
+    "mask-box-image-source",
+    "mask-border-source",
+    "-webkit-mask-box-image-source",
+
+    "border-image",
+    "border-image-source",
+  ];
+
+  const MASK_LAYOUT_PROPS = [
+    "mask-position",
+    "mask-size",
+    "mask-repeat",
+    "mask-mode",
+    "mask-composite",
+    "-webkit-mask-position",
+    "-webkit-mask-size",
+    "-webkit-mask-repeat",
+    "-webkit-mask-composite",
+    "mask-origin",
+    "mask-clip",
+    "-webkit-mask-origin",
+    "-webkit-mask-clip",
+    "-webkit-mask-position-x",
+    "-webkit-mask-position-y",
+  ];
+  const BG_LAYOUT_PROPS = [
+    "background-position",
+    "background-position-x",
+    "background-position-y",
+    "background-size",
+    "background-repeat",
+    "background-origin",
+    "background-clip",
+    "background-attachment",
+    "background-blend-mode",
+  ];
+  const BORDER_AUX_PROPS = [
+    "border-image-slice",
+    "border-image-width",
+    "border-image-outset",
+    "border-image-repeat",
+  ];
+
+  while (queue.length) {
+    const entry = queue.shift();
+    if (!entry) continue;
+    const [srcNode, cloneNode] = entry;
+
+    if (!cloneNode) continue;
+
+    const style = styleCache.get(srcNode) || getStyle(srcNode);
+    if (!styleCache.has(srcNode)) styleCache.set(srcNode, style);
+    const hasBorderImage = (() => {
+      const bi = style.getPropertyValue("border-image");
+      const bis = style.getPropertyValue("border-image-source");
+      return (bi && bi !== "none") || (bis && bis !== "none");
+    })();
+    const bgImage = style.getPropertyValue("background-image");
+    const bgColor = style.getPropertyValue("background-color");
+    const hasBg =
+      (bgImage && bgImage !== "none") ||
+      (bgColor && bgColor !== "rgba(0, 0, 0, 0)" && bgColor !== "transparent") ||
+      /url\s*\(|gradient\s*\(/i.test(style.getPropertyValue("background") || "");
+    if (hasBg) {
+      for (const prop of BG_LAYOUT_PROPS) {
+        const v = style.getPropertyValue(prop);
+        if (!v) continue;
+        cloneNode.style.setProperty(prop, v);
+      }
+    }
+    for (const prop of URL_PROPS) {
+      let val = style.getPropertyValue(prop);
+      if (prop === "background-image" && (!val || val === "none")) {
+        const bgShorthand = style.getPropertyValue("background");
+        if (bgShorthand && /url\s*\(/.test(bgShorthand)) {
+          val =
+            splitBackgroundImage(bgShorthand)
+              .filter((p) => /url\s*\(/.test(p))
+              .join(", ") || val;
+        }
+      }
+      if (!val || val === "none") continue;
+
+      const splits = splitBackgroundImage(val);
+
+      const inlined = await Promise.all(
+        splits.map((entry) => inlineSingleBackgroundEntry(entry, options)),
+      );
+
+      if (inlined.some((p) => p && p !== "none" && !/^url\(undefined/.test(p))) {
+        cloneNode.style.setProperty(prop, inlined.join(", "));
+      }
+    }
+    for (const prop of MASK_LAYOUT_PROPS) {
+      const val = style.getPropertyValue(prop);
+      if (!val || val === "initial") continue;
+      cloneNode.style.setProperty(prop, val);
+    }
+    if (hasBorderImage) {
+      for (const prop of BORDER_AUX_PROPS) {
+        const val = style.getPropertyValue(prop);
+        if (!val || val === "initial") continue;
+        cloneNode.style.setProperty(prop, val);
+      }
+    }
+    const sChildren = srcNode.shadowRoot
+      ? Array.from(srcNode.shadowRoot.children).filter((el) => el.tagName !== "STYLE")
+      : Array.from(srcNode.children);
+    const cChildren = (Array.from(cloneNode.children) as HTMLElement[]).filter((el) => {
+      if (el.dataset?.snapshotPseudo) return false;
+      if (el.tagName === "STYLE" && el.dataset?.sd) return false;
+      return true;
+    });
+
+    for (let i = 0; i < Math.min(sChildren.length, cChildren.length); i++) {
+      queue.push([sChildren[i], cChildren[i]]);
+    }
+  }
+};

--- a/packages/react-grab/src/snapshot/modules/change-css.ts
+++ b/packages/react-grab/src/snapshot/modules/change-css.ts
@@ -1,0 +1,116 @@
+export const freezeSticky = (
+  originalRoot: HTMLElement | null | undefined,
+  cloneRoot: HTMLElement | null | undefined,
+): void => {
+  if (!originalRoot || !cloneRoot) return;
+
+  const scrollTop = originalRoot.scrollTop || 0;
+  if (!scrollTop) return;
+
+  if (getComputedStyle(cloneRoot).position === "static") {
+    cloneRoot.style.position = "relative";
+  }
+
+  const rootRect = originalRoot.getBoundingClientRect();
+  const viewportH = originalRoot.clientHeight;
+  const PH_ATTR = "data-snap-ph";
+
+  const walker = document.createTreeWalker(originalRoot, NodeFilter.SHOW_ELEMENT);
+  while (walker.nextNode()) {
+    const el = walker.currentNode as HTMLElement;
+    const cs = getComputedStyle(el);
+
+    const pos = cs.position;
+    if (pos !== "sticky" && pos !== "-webkit-sticky") continue;
+
+    const topInit = _toPx(cs.top);
+    const bottomInit = _toPx(cs.bottom);
+    if (topInit == null && bottomInit == null) continue;
+
+    const path = _pathOf(el, originalRoot);
+    const cloneEl = _findByPathIgnoringPlaceholders(cloneRoot, path, PH_ATTR);
+    if (!cloneEl) continue;
+
+    const elRect = el.getBoundingClientRect();
+    const widthPx = elRect.width;
+    const heightPx = elRect.height;
+    const leftPx = elRect.left - rootRect.left;
+    if (!(widthPx > 0 && heightPx > 0)) continue;
+    if (!Number.isFinite(leftPx)) continue;
+
+    const topAbsPx =
+      topInit != null
+        ? topInit + scrollTop
+        : scrollTop + (viewportH - heightPx - (bottomInit as number));
+    if (!Number.isFinite(topAbsPx)) continue;
+
+    const zParsed = Number.parseInt(cs.zIndex, 10);
+    const hasZ = Number.isFinite(zParsed);
+    const overlayZ = hasZ ? Math.max(zParsed, 1) + 1 : 2;
+    const placeholderZ = hasZ ? zParsed - 1 : 0;
+
+    const ph = cloneEl.cloneNode(false) as HTMLElement;
+    ph.setAttribute(PH_ATTR, "1");
+    ph.style.position = "sticky";
+    ph.style.left = `${leftPx}px`;
+    ph.style.top = `${topAbsPx}px`;
+    ph.style.width = `${widthPx}px`;
+    ph.style.height = `${heightPx}px`;
+    ph.style.visibility = "hidden";
+    ph.style.zIndex = String(placeholderZ);
+    ph.style.overflow = "hidden";
+    ph.style.background = "transparent";
+    ph.style.boxShadow = "none";
+    ph.style.filter = "none";
+
+    cloneEl.parentElement?.insertBefore(ph, cloneEl);
+
+    cloneEl.style.position = "absolute";
+    cloneEl.style.left = `${leftPx}px`;
+    cloneEl.style.top = `${topAbsPx}px`;
+    cloneEl.style.bottom = "auto";
+    cloneEl.style.zIndex = String(overlayZ);
+    cloneEl.style.pointerEvents = "none";
+  }
+};
+
+const _toPx = (v: string | null | undefined): number | null => {
+  if (!v || v === "auto") return null;
+  const n = Number.parseFloat(v);
+  return Number.isFinite(n) ? n : null;
+};
+
+const _pathOf = (el: Element, root: Element): number[] => {
+  const path: number[] = [];
+  for (let cur: Element | null = el; cur && cur !== root; ) {
+    const p: HTMLElement | null = cur.parentElement;
+    if (!p) break;
+    path.push(Array.from(p.children).indexOf(cur));
+    cur = p;
+  }
+  return path.reverse();
+};
+
+const _findByPathIgnoringPlaceholders = (
+  root: HTMLElement,
+  path: number[],
+  phAttr: string,
+): HTMLElement | null => {
+  let cur: Element = root;
+  for (let i = 0; i < path.length; i++) {
+    const kids = _childrenWithoutPlaceholders(cur, phAttr);
+    cur = kids[path[i]];
+    if (!cur) return null;
+  }
+  return cur instanceof HTMLElement ? cur : null;
+};
+
+const _childrenWithoutPlaceholders = (el: Element, phAttr: string): Element[] => {
+  const out: Element[] = [];
+  const ch = el.children;
+  for (let i = 0; i < ch.length; i++) {
+    const c = ch[i];
+    if (!c.hasAttribute(phAttr)) out.push(c);
+  }
+  return out;
+};

--- a/packages/react-grab/src/snapshot/modules/counter.ts
+++ b/packages/react-grab/src/snapshot/modules/counter.ts
@@ -1,0 +1,265 @@
+import { cache } from "../core/cache.js";
+import type { SnapshotCounterContext } from "../types.js";
+
+export type CounterContext = SnapshotCounterContext;
+
+export const hasCounters = (input: string | null | undefined): boolean => {
+  return /\bcounter\s*\(|\bcounters\s*\(/.test(input || "");
+};
+
+const alpha = (n: number, upper = false): string => {
+  let s = "",
+    x = Math.max(1, n);
+  while (x > 0) {
+    x--;
+    s = String.fromCharCode(97 + (x % 26)) + s;
+    x = Math.floor(x / 26);
+  }
+  return upper ? s.toUpperCase() : s;
+};
+
+const roman = (n: number, upper = true): string => {
+  const map: Array<[number, string]> = [
+    [1000, "M"],
+    [900, "CM"],
+    [500, "D"],
+    [400, "CD"],
+    [100, "C"],
+    [90, "XC"],
+    [50, "L"],
+    [40, "XL"],
+    [10, "X"],
+    [9, "IX"],
+    [5, "V"],
+    [4, "IV"],
+    [1, "I"],
+  ];
+  let num = Math.max(1, Math.min(3999, n)),
+    out = "";
+  for (const [v, sym] of map)
+    while (num >= v) {
+      out += sym;
+      num -= v;
+    }
+  return upper ? out : out.toLowerCase();
+};
+
+const formatCounter = (value: number, style: string): string => {
+  switch ((style || "decimal").toLowerCase()) {
+    case "decimal":
+      return String(value);
+    case "decimal-leading-zero": {
+      const abs = Math.abs(value);
+      return (value < 0 ? "-" : "") + (abs < 10 ? "0" : "") + String(abs);
+    }
+    case "lower-alpha":
+      return alpha(value, false);
+    case "upper-alpha":
+      return alpha(value, true);
+    case "lower-roman":
+      return roman(value, false);
+    case "upper-roman":
+      return roman(value, true);
+    default:
+      return String(value);
+  }
+};
+
+export const buildCounterContext = (root: Document | Element): CounterContext => {
+  const getEpoch = (): number => cache?.session?.__counterEpoch ?? 0;
+  let run = getEpoch();
+  const nodeCounters = new WeakMap<Element, Map<string, number[]>>();
+  const rootEl = root instanceof Document ? root.documentElement : root;
+
+  const isLi = (el: Element | null | undefined): boolean => el != null && el.tagName === "LI";
+  const countPrevLi = (li: Element | null | undefined): number => {
+    let c = 0,
+      p = li?.parentElement;
+    if (!p) return 0;
+    for (const sib of p.children) {
+      if (sib === li) break;
+      if (sib.tagName === "LI") c++;
+    }
+    return c;
+  };
+  const cloneMap = (m: Map<string, number[]>): Map<string, number[]> => {
+    const out = new Map<string, number[]>();
+    for (const [k, arr] of m) out.set(k, arr.slice());
+    return out;
+  };
+
+  const applyTo = (
+    baseMap: Map<string, number[]>,
+    parentMap: Map<string, number[]>,
+    el: Element,
+  ): Map<string, number[]> => {
+    const map = cloneMap(baseMap);
+
+    let reset: string | undefined;
+    try {
+      reset = (el as HTMLElement).style?.counterReset || getComputedStyle(el).counterReset;
+    } catch {}
+    if (reset && reset !== "none") {
+      for (const part of reset.split(",")) {
+        const toks = part.trim().split(/\s+/);
+        const name = toks[0];
+        const val = Number.isFinite(Number(toks[1])) ? Number(toks[1]) : 0;
+        if (!name) continue;
+
+        const parentStack = parentMap.get(name);
+        if (parentStack && parentStack.length) {
+          const s = parentStack.slice();
+          s.push(val);
+          map.set(name, s);
+        } else {
+          map.set(name, [val]);
+        }
+      }
+    }
+
+    let set: string | undefined;
+    try {
+      set = (el as HTMLElement).style?.counterSet || getComputedStyle(el).counterSet;
+    } catch {}
+    if (set && set !== "none") {
+      for (const part of set.split(",")) {
+        const toks = part.trim().split(/\s+/);
+        const name = toks[0];
+        const val = Number.isFinite(Number(toks[1])) ? Number(toks[1]) : 0;
+        if (!name) continue;
+        const stack = map.get(name) || [];
+        if (stack.length === 0) stack.push(0);
+        stack[stack.length - 1] = val;
+        map.set(name, stack);
+      }
+    }
+
+    let inc: string | undefined;
+    try {
+      inc = (el as HTMLElement).style?.counterIncrement || getComputedStyle(el).counterIncrement;
+    } catch {}
+    if (inc && inc !== "none") {
+      for (const part of inc.split(",")) {
+        const toks = part.trim().split(/\s+/);
+        const name = toks[0];
+        const by = Number.isFinite(Number(toks[1])) ? Number(toks[1]) : 1;
+        if (!name) continue;
+        const stack = map.get(name) || [];
+        if (stack.length === 0) stack.push(0);
+        stack[stack.length - 1] += by;
+        map.set(name, stack);
+      }
+    }
+
+    try {
+      const cs = getComputedStyle(el);
+      if (cs.display === "list-item" && isLi(el)) {
+        const p = el.parentElement;
+        let idx = 1;
+        if (p && p.tagName === "OL") {
+          const startAttr = p.getAttribute("start");
+          const start = Number.isFinite(Number(startAttr)) ? Number(startAttr) : 1;
+          const prev = countPrevLi(el);
+          const ownAttr = el.getAttribute("value");
+          idx = Number.isFinite(Number(ownAttr)) ? Number(ownAttr) : start + prev;
+        } else {
+          idx = 1 + countPrevLi(el);
+        }
+        const s = map.get("list-item") || [];
+        if (s.length === 0) s.push(0);
+        s[s.length - 1] = idx;
+        map.set("list-item", s);
+      }
+    } catch {}
+
+    return map;
+  };
+
+  const build = (
+    el: Element,
+    parentMap: Map<string, number[]>,
+    carryMap: Map<string, number[]>,
+  ): Map<string, number[]> => {
+    const curr = applyTo(carryMap, parentMap, el);
+    nodeCounters.set(el, curr);
+
+    let nextCarry = curr;
+    for (const child of el.children) {
+      const childCarry = build(child, curr, nextCarry);
+      nextCarry = childCarry;
+    }
+
+    const siblingCarry = new Map<string, number[]>();
+    for (const [name, inStack] of carryMap) {
+      const depth = inStack.length;
+      const finalStack = nextCarry.get(name);
+      siblingCarry.set(
+        name,
+        finalStack && finalStack.length ? finalStack.slice(0, depth) : inStack.slice(),
+      );
+    }
+    for (const [name, finalStack] of nextCarry) {
+      if (!siblingCarry.has(name) && finalStack.length && !parentMap.has(name)) {
+        siblingCarry.set(name, finalStack.slice(0, 1));
+      }
+    }
+    return siblingCarry;
+  };
+
+  const empty = new Map<string, number[]>();
+  build(rootEl, empty, empty);
+
+  const ensureFresh = (): void => {
+    const now = getEpoch();
+    if (now !== run) {
+      run = now;
+      const empty = new Map<string, number[]>();
+      build(rootEl, empty, empty);
+    }
+  };
+
+  return {
+    get(node: Element, name: string): number {
+      ensureFresh();
+      const s = nodeCounters.get(node)?.get(name);
+      return s && s.length ? s[s.length - 1] : 0;
+    },
+    getStack(node: Element, name: string): number[] {
+      ensureFresh();
+      const s = nodeCounters.get(node)?.get(name);
+      return s ? s.slice() : [];
+    },
+  };
+};
+
+export const resolveCountersInContent = (
+  raw: string,
+  node: Element,
+  ctx: CounterContext,
+): string => {
+  if (!raw || raw === "none") return raw;
+  try {
+    const RX = /\b(counter|counters)\s*\(([^)]+)\)/g;
+    return raw.replace(RX, (_, fn: string, args: string) => {
+      const parts = String(args)
+        .split(",")
+        .map((s) => s.trim());
+      if (fn === "counter") {
+        const name = parts[0]?.replace(/^["']|["']$/g, "");
+        const style = (parts[1] || "decimal").toLowerCase();
+        const v = ctx.get(node, name);
+        return formatCounter(v, style);
+      } else {
+        const name = parts[0]?.replace(/^["']|["']$/g, "");
+        const sep = parts[1]?.replace(/^["']|["']$/g, "") ?? "";
+        const style = (parts[2] || "decimal").toLowerCase();
+        const stack = ctx.getStack(node, name);
+        if (!stack.length) return "";
+        const pieces = stack.map((v) => formatCounter(v, style));
+        return pieces.join(sep);
+      }
+    });
+  } catch {
+    return "- ";
+  }
+};

--- a/packages/react-grab/src/snapshot/modules/css-var.ts
+++ b/packages/react-grab/src/snapshot/modules/css-var.ts
@@ -1,0 +1,148 @@
+const KEY_PROPS: string[] = ["fill", "stroke", "color", "background-color", "stop-color"];
+
+const SVG_TEMPLATE_TAGS = new Set<string>([
+  "symbol",
+  "defs",
+  "pattern",
+  "mask",
+  "clipPath",
+  "marker",
+  "linearGradient",
+  "radialGradient",
+  "filter",
+]);
+
+export const isInSvgTemplate = (el: Element): boolean => {
+  let current: Node | null = el;
+  while (current && current.nodeType === 1) {
+    const element = current as Element;
+    if (
+      element.namespaceURI === "http://www.w3.org/2000/svg" &&
+      SVG_TEMPLATE_TAGS.has(element.localName)
+    ) {
+      return true;
+    }
+    current = current.parentNode;
+  }
+  return false;
+};
+
+const __BASELINE_CACHE = new Map<string, Record<string, string>>();
+
+const getBaselineComputed = (tagName: string, ns: string): Record<string, string> => {
+  const key = ns + "::" + tagName.toLowerCase();
+  const entry = __BASELINE_CACHE.get(key);
+  if (entry) return entry;
+
+  const doc = document;
+  const el =
+    ns === "http://www.w3.org/2000/svg"
+      ? doc.createElementNS(ns, tagName)
+      : doc.createElement(tagName);
+
+  const holder = doc.createElement("div");
+  holder.style.cssText =
+    "position:absolute;left:-99999px;top:-99999px;contain:strict;display:block;";
+  holder.appendChild(el);
+  doc.documentElement.appendChild(holder);
+
+  const cs = getComputedStyle(el);
+  const base: Record<string, string> = {};
+  for (const p of KEY_PROPS) {
+    base[p] = cs.getPropertyValue(p) || "";
+  }
+
+  holder.remove();
+  __BASELINE_CACHE.set(key, base);
+  return base;
+};
+
+export const resolveCSSVars = (sourceEl: Element, cloneEl: Element): void => {
+  if (!(sourceEl instanceof Element) || !(cloneEl instanceof Element)) return;
+
+  if (isInSvgTemplate(sourceEl)) return;
+
+  const styleAttr = sourceEl.getAttribute?.("style");
+  let hasVar = Boolean(styleAttr && styleAttr.includes("var("));
+
+  if (!hasVar && sourceEl.attributes?.length) {
+    const attrs = sourceEl.attributes;
+    for (let i = 0; i < attrs.length; i++) {
+      const a = attrs[i];
+      if (a && typeof a.value === "string" && a.value.includes("var(")) {
+        hasVar = true;
+        break;
+      }
+    }
+  }
+
+  let cs: CSSStyleDeclaration | null = null;
+  if (hasVar) {
+    try {
+      cs = getComputedStyle(sourceEl);
+    } catch {}
+  }
+
+  if (hasVar) {
+    const author = (sourceEl as HTMLElement).style;
+    if (author && author.length) {
+      const visitedProps = new Set<string>();
+      for (let i = 0; i < author.length; i++) {
+        const prop = author[i];
+        if (visitedProps.has(prop)) continue;
+        visitedProps.add(prop);
+        const val = author.getPropertyValue(prop);
+        if (!val || !val.includes("var(")) continue;
+        const resolved = cs && cs.getPropertyValue(prop);
+        if (resolved) {
+          try {
+            (cloneEl as HTMLElement).style.setProperty(
+              prop,
+              resolved.trim(),
+              author.getPropertyPriority(prop),
+            );
+          } catch {}
+        }
+      }
+    }
+  }
+
+  if (hasVar && sourceEl.attributes?.length) {
+    const attrs = sourceEl.attributes;
+    for (let i = 0; i < attrs.length; i++) {
+      const a = attrs[i];
+      if (!a || typeof a.value !== "string" || !a.value.includes("var(")) continue;
+      const propName = a.name;
+      const resolved = cs && cs.getPropertyValue(propName);
+      if (resolved) {
+        try {
+          (cloneEl as HTMLElement).style.setProperty(propName, resolved.trim());
+        } catch {}
+      }
+    }
+  }
+
+  if (!hasVar) {
+    if (!cs) {
+      try {
+        cs = getComputedStyle(sourceEl);
+      } catch {
+        cs = null;
+      }
+    }
+    if (!cs) return;
+
+    const ns = sourceEl.namespaceURI || "html";
+    const base = getBaselineComputed(sourceEl.tagName, ns);
+
+    for (const prop of KEY_PROPS) {
+      const v = cs.getPropertyValue(prop) || "";
+      const b = base[prop] || "";
+      if (v && v !== b) {
+        try {
+          (cloneEl as HTMLElement).style.setProperty(prop, v.trim());
+        } catch {}
+      }
+    }
+  }
+};

--- a/packages/react-grab/src/snapshot/modules/fonts.ts
+++ b/packages/react-grab/src/snapshot/modules/fonts.ts
@@ -1,0 +1,494 @@
+import { cache } from "../core/cache.js";
+import { isIconFont } from "../modules/icon-fonts.js";
+import { snapFetch } from "./snap-fetch.js";
+import type { SnapshotExcludeFonts, SnapshotLocalFont } from "../types.js";
+import {
+  pickPrimaryFamily,
+  pickAllFamilies,
+  normWeight,
+  normStyle,
+  normStretchPct,
+  parseWeightSpec,
+  parseStyleSpec,
+  parseStretchSpec,
+  familiesFromRequired,
+} from "./fonts/normalize.js";
+import type { RequiredVariant } from "./fonts/normalize.js";
+import {
+  FACE_RE,
+  extractSrcUrls,
+  parseUnicodeRange,
+  unicodeIntersects,
+} from "./fonts/unicode-range.js";
+import {
+  buildSimpleExcluder,
+  buildFontsCacheKey,
+  dedupeFontFaces,
+  IMPORT_ANY_RE,
+  isLikelyFontStylesheet,
+  inlineImportsAndRewrite,
+  inlineUrlsInCssBlock,
+  collectFacesFromSheet,
+} from "./fonts/collect-faces.js";
+import type { FontFaceMeta, CollectFacesContext, SnapshotFontFace } from "./fonts/collect-faces.js";
+
+export { iconToImage } from "./fonts/icon.js";
+
+export interface SnapshotLocalFontSpec extends SnapshotLocalFont {
+  stretchPct?: number;
+}
+
+interface EmbedCustomFontsOptions {
+  required?: Set<string>;
+  usedCodepoints?: Set<number>;
+  exclude?: SnapshotExcludeFonts;
+  localFonts?: SnapshotLocalFontSpec[];
+  useProxy?: string;
+  fontStylesheetDomains?: string[];
+}
+
+export const embedCustomFonts = async ({
+  required,
+  usedCodepoints,
+  exclude = undefined,
+  localFonts = [],
+  useProxy = "",
+  fontStylesheetDomains = [],
+}: EmbedCustomFontsOptions = {}): Promise<string> => {
+  if (!(required instanceof Set)) required = new Set<string>();
+  if (!(usedCodepoints instanceof Set)) usedCodepoints = new Set<number>();
+
+  const requiredIndex = new Map<string, RequiredVariant[]>();
+  for (const key of required) {
+    const [fam, w, s, st] = String(key).split("__");
+    if (!fam) continue;
+    const famKey = fam.toLowerCase();
+    const arr = requiredIndex.get(famKey) || [];
+    arr.push({ w: parseInt(w, 10), s, st: parseInt(st, 10) });
+    requiredIndex.set(famKey, arr);
+  }
+
+  const faceMatchesRequired = (
+    fam: string,
+    styleSpec: string,
+    weightSpec: string,
+    stretchSpec: string,
+  ): boolean => {
+    const famKey = String(fam).toLowerCase();
+    if (!requiredIndex.has(famKey)) return false;
+
+    const need = requiredIndex.get(famKey);
+    if (!need) return false;
+    const ws = parseWeightSpec(weightSpec);
+    const ss = parseStyleSpec(styleSpec);
+    const ts = parseStretchSpec(stretchSpec);
+
+    const faceIsRange = ws.min !== ws.max;
+    const faceSingleW = ws.min;
+
+    const styleOK = (reqKind: string): boolean =>
+      (ss.kind === "normal" && reqKind === "normal") ||
+      (ss.kind !== "normal" && (reqKind === "italic" || reqKind === "oblique"));
+
+    let exactMatched = false;
+
+    for (const r of need) {
+      const wOk = faceIsRange ? r.w >= ws.min && r.w <= ws.max : r.w === faceSingleW;
+      const sOk = styleOK(normStyle(r.s));
+      const tOk = r.st >= ts.min && r.st <= ts.max;
+
+      if (wOk && sOk && tOk) {
+        exactMatched = true;
+        break;
+      }
+    }
+
+    if (exactMatched) return true;
+
+    if (!faceIsRange) {
+      for (const r of need) {
+        const sOk = styleOK(normStyle(r.s));
+        const tOk = r.st >= ts.min && r.st <= ts.max;
+        const nearWeight = Math.abs(faceSingleW - r.w) <= 300;
+        if (nearWeight && sOk && tOk) return true;
+      }
+    }
+
+    if (!faceIsRange && ss.kind === "normal") {
+      const hasItalicRequest = need.some((r) => normStyle(r.s) !== "normal");
+      if (hasItalicRequest) {
+        for (const r of need) {
+          const nearWeight = Math.abs(faceSingleW - r.w) <= 300;
+          const stretchOK = r.st >= ts.min && r.st <= ts.max;
+          if (nearWeight && stretchOK) {
+            return true;
+          }
+        }
+      }
+    }
+
+    return false;
+  };
+
+  const simpleExcluder = buildSimpleExcluder(exclude);
+
+  const cacheKey = buildFontsCacheKey(
+    required,
+    exclude,
+    localFonts,
+    useProxy,
+    fontStylesheetDomains,
+  );
+  if (cache.resource?.has(cacheKey)) {
+    return cache.resource.get(cacheKey) as string;
+  }
+
+  const requiredFamilies = familiesFromRequired(required);
+
+  const importUrls: string[] = [];
+  const IMPORT_ANY_RE_LOCAL = IMPORT_ANY_RE;
+
+  for (const styleTag of document.querySelectorAll("style")) {
+    const cssText = styleTag.textContent || "";
+    for (const m of cssText.matchAll(IMPORT_ANY_RE_LOCAL)) {
+      const u = (m[2] || m[4] || "").trim();
+      if (!u || isIconFont(u)) continue;
+      const hasLink = Boolean(document.querySelector(`link[rel="stylesheet"][href="${u}"]`));
+      if (!hasLink) importUrls.push(u);
+    }
+  }
+  const injectedLinks: HTMLLinkElement[] = [];
+  if (importUrls.length) {
+    await Promise.all(
+      importUrls.map(
+        (u) =>
+          new Promise<HTMLLinkElement | null>((resolve) => {
+            if (document.querySelector(`link[rel="stylesheet"][href="${u}"]`)) return resolve(null);
+            const link = document.createElement("link");
+            link.rel = "stylesheet";
+            link.href = u;
+            link.setAttribute("data-snapshot", "injected-import");
+            link.onload = () => resolve(link);
+            link.onerror = () => resolve(null);
+            document.head.appendChild(link);
+            injectedLinks.push(link);
+          }),
+      ),
+    );
+  }
+
+  let finalCSS = "";
+
+  const linkNodes = Array.from(
+    document.querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]'),
+  ).filter((l) => Boolean(l.href));
+  for (const l of injectedLinks) {
+    try {
+      l.remove();
+    } catch {}
+  }
+
+  for (const link of linkNodes) {
+    try {
+      if (isIconFont(link.href)) continue;
+
+      let cssText = "";
+      let sameOrigin = false;
+      try {
+        sameOrigin = new URL(link.href, location.href).origin === location.origin;
+      } catch {}
+
+      if (!sameOrigin) {
+        const allowedDomains = Array.isArray(fontStylesheetDomains) ? fontStylesheetDomains : [];
+        if (!isLikelyFontStylesheet(link.href, requiredFamilies, allowedDomains)) continue;
+      }
+
+      if (sameOrigin) {
+        const sheet = Array.from(document.styleSheets).find((s) => s.href === link.href);
+        if (sheet) {
+          try {
+            const rules = sheet.cssRules || [];
+            cssText = Array.from(rules)
+              .map((r) => r.cssText)
+              .join("");
+          } catch {}
+        }
+      }
+
+      if (!cssText) {
+        const res = await snapFetch(link.href, { as: "text", useProxy });
+        if (res?.ok && typeof res.data === "string") cssText = res.data;
+        if (isIconFont(link.href)) continue;
+      }
+
+      cssText = await inlineImportsAndRewrite(cssText, link.href, useProxy);
+
+      let facesOut = "";
+      for (const face of cssText.match(FACE_RE) || []) {
+        const famRaw = (face.match(/font-family:\s*([^;]+);/i)?.[1] || "").trim();
+        const family = pickPrimaryFamily(famRaw);
+        if (!family || isIconFont(family)) continue;
+
+        const weightSpec = (face.match(/font-weight:\s*([^;]+);/i)?.[1] || "400").trim();
+        const styleSpec = (face.match(/font-style:\s*([^;]+);/i)?.[1] || "normal").trim();
+        const stretchSpec = (face.match(/font-stretch:\s*([^;]+);/i)?.[1] || "100%").trim();
+        const urange = (face.match(/unicode-range:\s*([^;]+);/i)?.[1] || "").trim();
+        const srcRaw = (face.match(/src\s*:\s*([^;}]+)[;}]/i)?.[1] || "").trim();
+        const srcUrls = extractSrcUrls(srcRaw, link.href);
+
+        if (!faceMatchesRequired(family, styleSpec, weightSpec, stretchSpec)) continue;
+        const ranges = parseUnicodeRange(urange);
+        if (!unicodeIntersects(usedCodepoints, ranges)) continue;
+
+        const meta: FontFaceMeta = {
+          family,
+          weightSpec,
+          styleSpec,
+          stretchSpec,
+          unicodeRange: urange,
+          srcRaw,
+          srcUrls,
+          href: link.href,
+        };
+        if (exclude && simpleExcluder(meta, ranges)) continue;
+
+        const newFace = /url\(/i.test(srcRaw)
+          ? await inlineUrlsInCssBlock(face, link.href, useProxy)
+          : face;
+        facesOut += newFace;
+      }
+
+      if (facesOut.trim()) finalCSS += facesOut;
+    } catch {
+      console.warn("[snapshot] Failed to process stylesheet:", link.href);
+    }
+  }
+
+  const ctx: CollectFacesContext = {
+    requiredIndex,
+    usedCodepoints,
+    faceMatchesRequired,
+    simpleExcluder: exclude ? buildSimpleExcluder(exclude) : null,
+    useProxy,
+    visitedSheets: new Set<string>(),
+    depth: 0,
+  };
+
+  for (const sheet of document.styleSheets) {
+    if (sheet.href && linkNodes.some((l) => l.href === sheet.href)) continue;
+    try {
+      const rootHref = sheet.href || location.origin + "/";
+      if (rootHref) ctx.visitedSheets.add(rootHref);
+      await collectFacesFromSheet(
+        sheet,
+        rootHref,
+        async (faceCss: string) => {
+          finalCSS += faceCss;
+        },
+        ctx,
+      );
+    } catch {}
+  }
+
+  try {
+    for (const f of document.fonts || []) {
+      const face = f as SnapshotFontFace;
+      if (!face || !face.family || face.status !== "loaded" || !face._snapshotSrc) continue;
+      const snapshotSrc = face._snapshotSrc;
+      const fam = String(face.family).replace(/^['"]+|['"]+$/g, "");
+      if (isIconFont(fam)) continue;
+      if (!requiredIndex.has(fam.toLowerCase())) continue;
+
+      if (
+        exclude?.families &&
+        exclude.families.some((n) => String(n).toLowerCase() === fam.toLowerCase())
+      ) {
+        continue;
+      }
+
+      let b64 = snapshotSrc;
+      if (!String(b64).startsWith("data:")) {
+        if (cache.resource?.has(snapshotSrc)) {
+          b64 = cache.resource.get(snapshotSrc) as string;
+          cache.font?.add(snapshotSrc);
+        } else if (!cache.font?.has(snapshotSrc)) {
+          try {
+            const r = await snapFetch(snapshotSrc, { as: "dataURL", useProxy, silent: true });
+            if (r.ok && typeof r.data === "string") {
+              b64 = r.data;
+              cache.resource?.set(snapshotSrc, b64);
+              cache.font?.add(snapshotSrc);
+            } else {
+              continue;
+            }
+          } catch {
+            console.warn("[snapshot] Failed to fetch dynamic font src:", snapshotSrc);
+            continue;
+          }
+        }
+      }
+      finalCSS += `@font-face{font-family:'${fam}';src:url(${b64});font-style:${face.style || "normal"};font-weight:${face.weight || "normal"};}`;
+    }
+  } catch {}
+
+  for (const font of localFonts) {
+    if (!font || typeof font !== "object") continue;
+    const family = String(font.family || "").replace(/^['"]+|['"]+$/g, "");
+    if (!family || isIconFont(family)) continue;
+    if (!requiredIndex.has(family.toLowerCase())) continue;
+    if (
+      exclude?.families &&
+      exclude.families.some((n) => String(n).toLowerCase() === family.toLowerCase())
+    )
+      continue;
+
+    const weight = font.weight != null ? String(font.weight) : "normal";
+    const style = font.style != null ? String(font.style) : "normal";
+    const stretch = font.stretchPct != null ? `${font.stretchPct}%` : "100%";
+    const src = String(font.src || "");
+
+    let b64 = src;
+    if (!b64.startsWith("data:")) {
+      if (cache.resource?.has(src)) {
+        b64 = cache.resource.get(src) as string;
+        cache.font?.add(src);
+      } else if (!cache.font?.has(src)) {
+        try {
+          const r = await snapFetch(src, { as: "dataURL", useProxy, silent: true });
+          if (r.ok && typeof r.data === "string") {
+            b64 = r.data;
+            cache.resource?.set(src, b64);
+            cache.font?.add(src);
+          } else {
+            continue;
+          }
+        } catch {
+          console.warn("[snapshot] Failed to fetch localFonts src:", src);
+          continue;
+        }
+      }
+    }
+    finalCSS += `@font-face{font-family:'${family}';src:url(${b64});font-style:${style};font-weight:${weight};font-stretch:${stretch};}`;
+  }
+
+  if (finalCSS) {
+    finalCSS = dedupeFontFaces(finalCSS);
+    cache.resource?.set(cacheKey, finalCSS);
+  }
+  return finalCSS;
+};
+
+export const collectUsedFontVariants = (root: Element): Set<string> => {
+  const req = /* @__PURE__ */ new Set<string>();
+  if (!root) return req;
+  const tw = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT, null);
+  const addFromStyle = (cs: CSSStyleDeclaration): void => {
+    const families = pickAllFamilies(cs.fontFamily);
+    if (!families.length) return;
+    for (const family of families) {
+      const key = (w: string, s: string, st: string): string =>
+        `${family}__${normWeight(w)}__${normStyle(s)}__${normStretchPct(st)}`;
+      req.add(key(cs.fontWeight, cs.fontStyle, cs.fontStretch));
+    }
+  };
+  addFromStyle(getComputedStyle(root));
+  const csBeforeRoot = getComputedStyle(root, "::before");
+  if (csBeforeRoot && csBeforeRoot.content && csBeforeRoot.content !== "none")
+    addFromStyle(csBeforeRoot);
+  const csAfterRoot = getComputedStyle(root, "::after");
+  if (csAfterRoot && csAfterRoot.content && csAfterRoot.content !== "none")
+    addFromStyle(csAfterRoot);
+  while (tw.nextNode()) {
+    const el = tw.currentNode as Element;
+    const cs = getComputedStyle(el);
+    addFromStyle(cs);
+    const b = getComputedStyle(el, "::before");
+    if (b && b.content && b.content !== "none") addFromStyle(b);
+    const a = getComputedStyle(el, "::after");
+    if (a && a.content && a.content !== "none") addFromStyle(a);
+  }
+  return req;
+};
+
+export const collectUsedCodepoints = (root: Element): Set<number> => {
+  const used = /* @__PURE__ */ new Set<number>();
+  const pushText = (txt: string): void => {
+    if (!txt) return;
+    for (const ch of txt) {
+      const cp = ch.codePointAt(0);
+      if (cp !== undefined) used.add(cp);
+    }
+  };
+  const walker = document.createTreeWalker(
+    root,
+    NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT,
+    null,
+  );
+  while (walker.nextNode()) {
+    const n = walker.currentNode;
+    if (n.nodeType === Node.TEXT_NODE) {
+      pushText(n.nodeValue || "");
+    } else if (n.nodeType === Node.ELEMENT_NODE) {
+      const el = n as Element;
+      for (const pseudo of ["::before", "::after"]) {
+        const cs = getComputedStyle(el, pseudo);
+        const c = cs?.getPropertyValue("content");
+        if (!c || c === "none") continue;
+        if (/^"/.test(c) || /^'/.test(c)) {
+          pushText(c.slice(1, -1));
+        } else {
+          const matches = c.match(/\\[0-9A-Fa-f]{1,6}/g);
+          if (matches) {
+            for (const m of matches) {
+              try {
+                used.add(parseInt(m.slice(1), 16));
+              } catch {}
+            }
+          }
+        }
+      }
+    }
+  }
+  return used;
+};
+
+export const ensureFontsReady = async (
+  families: Set<string> | string[],
+  warmupRepetitions: number = 2,
+): Promise<void> => {
+  try {
+    await document.fonts.ready;
+  } catch {}
+
+  const fams = Array.from(families || []).filter(Boolean);
+  if (fams.length === 0) return;
+
+  const warmupOnce = (): void => {
+    const container = document.createElement("div");
+    container.style.cssText =
+      "position:absolute!important;left:-9999px!important;top:0!important;opacity:0!important;pointer-events:none!important;contain:layout size style;";
+
+    for (const fam of fams) {
+      const span = document.createElement("span");
+      span.textContent = "AaBbGg1234ÁÉÍÓÚçñ—∞";
+      span.style.fontFamily = `"${fam}"`;
+      span.style.fontWeight = "700";
+      span.style.fontStyle = "italic";
+      span.style.fontSize = "32px";
+      span.style.lineHeight = "1";
+      span.style.whiteSpace = "nowrap";
+      span.style.margin = "0";
+      span.style.padding = "0";
+      container.appendChild(span);
+    }
+
+    document.body.appendChild(container);
+    void container.offsetWidth;
+    document.body.removeChild(container);
+  };
+
+  for (let i = 0; i < Math.max(1, warmupRepetitions); i++) {
+    warmupOnce();
+    await new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())));
+  }
+};

--- a/packages/react-grab/src/snapshot/modules/fonts.ts
+++ b/packages/react-grab/src/snapshot/modules/fonts.ts
@@ -30,7 +30,7 @@ import {
   inlineUrlsInCssBlock,
   collectFacesFromSheet,
 } from "./fonts/collect-faces.js";
-import type { FontFaceMeta, CollectFacesContext, SnapshotFontFace } from "./fonts/collect-faces.js";
+import type { FontFaceMeta, CollectFacesContext } from "./fonts/collect-faces.js";
 
 export { iconToImage } from "./fonts/icon.js";
 
@@ -289,47 +289,6 @@ export const embedCustomFonts = async ({
       );
     } catch {}
   }
-
-  try {
-    for (const f of document.fonts || []) {
-      const face = f as SnapshotFontFace;
-      if (!face || !face.family || face.status !== "loaded" || !face._snapshotSrc) continue;
-      const snapshotSrc = face._snapshotSrc;
-      const fam = String(face.family).replace(/^['"]+|['"]+$/g, "");
-      if (isIconFont(fam)) continue;
-      if (!requiredIndex.has(fam.toLowerCase())) continue;
-
-      if (
-        exclude?.families &&
-        exclude.families.some((n) => String(n).toLowerCase() === fam.toLowerCase())
-      ) {
-        continue;
-      }
-
-      let b64 = snapshotSrc;
-      if (!String(b64).startsWith("data:")) {
-        if (cache.resource?.has(snapshotSrc)) {
-          b64 = cache.resource.get(snapshotSrc) as string;
-          cache.font?.add(snapshotSrc);
-        } else if (!cache.font?.has(snapshotSrc)) {
-          try {
-            const r = await snapFetch(snapshotSrc, { as: "dataURL", useProxy, silent: true });
-            if (r.ok && typeof r.data === "string") {
-              b64 = r.data;
-              cache.resource?.set(snapshotSrc, b64);
-              cache.font?.add(snapshotSrc);
-            } else {
-              continue;
-            }
-          } catch {
-            console.warn("[snapshot] Failed to fetch dynamic font src:", snapshotSrc);
-            continue;
-          }
-        }
-      }
-      finalCSS += `@font-face{font-family:'${fam}';src:url(${b64});font-style:${face.style || "normal"};font-weight:${face.weight || "normal"};}`;
-    }
-  } catch {}
 
   for (const font of localFonts) {
     if (!font || typeof font !== "object") continue;

--- a/packages/react-grab/src/snapshot/modules/fonts/collect-faces.ts
+++ b/packages/react-grab/src/snapshot/modules/fonts/collect-faces.ts
@@ -51,10 +51,6 @@ export interface CollectFacesContext {
   depth: number;
 }
 
-export interface SnapshotFontFace extends FontFace {
-  _snapshotSrc?: string;
-}
-
 export const isLikelyFontStylesheet = (
   href: string,
   requiredFamilies: Set<string>,
@@ -127,12 +123,15 @@ export const inlineImportsAndRewrite = async (
       return text;
     }
 
+    // Fresh regex per call: IMPORT_ANY_RE is global (/g) and resolveOnce recurses, so a
+    // shared lastIndex would make nested @import scans start mid-string and miss rules.
+    const importRe = new RegExp(IMPORT_ANY_RE.source, "g");
     let out = "";
     let last = 0;
     let m: RegExpExecArray | null;
-    while ((m = IMPORT_ANY_RE.exec(text))) {
+    while ((m = importRe.exec(text))) {
       out += text.slice(last, m.index);
-      last = IMPORT_ANY_RE.lastIndex;
+      last = importRe.lastIndex;
 
       const rawUrl = (m[2] || m[4] || "").trim();
       const absUrl = normalizeUrl(rawUrl, baseHref);

--- a/packages/react-grab/src/snapshot/modules/fonts/collect-faces.ts
+++ b/packages/react-grab/src/snapshot/modules/fonts/collect-faces.ts
@@ -1,0 +1,388 @@
+import { extractURL } from "../../utils/helpers.js";
+import { cache } from "../../core/cache.js";
+import { isIconFont } from "../icon-fonts.js";
+import { snapFetch } from "../snap-fetch.js";
+import type { SnapshotExcludeFonts } from "../../types.js";
+import type { SnapshotLocalFontSpec } from "../fonts.js";
+import {
+  normalizeUrl,
+  rewriteRelativeUrls,
+  pickPrimaryFamily,
+  baseFamilyToken,
+  FONT_LIBRARIES,
+} from "./normalize.js";
+import type { RequiredVariant } from "./normalize.js";
+import {
+  URL_RE,
+  parseUnicodeRange,
+  unicodeIntersects,
+  extractSrcUrls,
+  subsetFromRanges,
+} from "./unicode-range.js";
+
+export interface FontFaceMeta {
+  family: string;
+  weightSpec: string;
+  styleSpec: string;
+  stretchSpec: string;
+  unicodeRange: string;
+  srcRaw: string;
+  srcUrls: string[];
+  href: string;
+}
+
+export type FontFaceExcluder = (
+  meta: FontFaceMeta,
+  parsedRanges: Array<[number, number]>,
+) => boolean;
+
+export interface CollectFacesContext {
+  requiredIndex: Map<string, RequiredVariant[]>;
+  usedCodepoints: Set<number>;
+  faceMatchesRequired: (
+    fam: string,
+    styleSpec: string,
+    weightSpec: string,
+    stretchSpec: string,
+  ) => boolean;
+  simpleExcluder: FontFaceExcluder | null;
+  useProxy: string;
+  visitedSheets: Set<string>;
+  depth: number;
+}
+
+export interface SnapshotFontFace extends FontFace {
+  _snapshotSrc?: string;
+}
+
+export const isLikelyFontStylesheet = (
+  href: string,
+  requiredFamilies: Set<string>,
+  allowedDomains: string[] = [],
+): boolean => {
+  if (!href) return false;
+  try {
+    const u = new URL(href, location.href);
+    const sameOrigin = u.origin === location.origin;
+    if (sameOrigin) return true;
+
+    const host = u.host.toLowerCase();
+    const FONT_HOSTS = [
+      "fonts.googleapis.com",
+      "fonts.gstatic.com",
+      "use.typekit.net",
+      "p.typekit.net",
+      "kit.fontawesome.com",
+      "use.fontawesome.com",
+      "cdn.jsdelivr.net",
+      "unpkg.com",
+      "cdnjs.cloudflare.com",
+      "esm.sh",
+    ];
+    if (FONT_HOSTS.some((h) => host.endsWith(h))) return true;
+    if (
+      allowedDomains.some((d) => host === d.toLowerCase() || host.endsWith("." + d.toLowerCase()))
+    )
+      return true;
+
+    const path = (u.pathname + u.search).toLowerCase();
+    if (/\bfont(s)?\b/.test(path) || /\.woff2?(\b|$)/.test(path)) return true;
+
+    if (FONT_LIBRARIES.some((lib) => path.includes(lib))) return true;
+
+    for (const fam of requiredFamilies) {
+      const tokenA = fam.toLowerCase().replace(/\s+/g, "+");
+      const tokenB = fam.toLowerCase().replace(/\s+/g, "-");
+      const baseToken = baseFamilyToken(fam);
+      if (path.includes(tokenA) || path.includes(tokenB)) return true;
+      if (baseToken && path.includes(baseToken)) return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+};
+
+export const IMPORT_ANY_RE =
+  /@import\s+(?:url\(\s*(['"]?)([^)"']+)\1\s*\)|(['"])([^"']+)\3)([^;]*);/g;
+
+const MAX_IMPORT_DEPTH = 4;
+
+export const inlineImportsAndRewrite = async (
+  cssText: string,
+  ownerHref: string,
+  useProxy: string,
+): Promise<string> => {
+  if (!cssText) return cssText;
+
+  const visited = new Set<string>();
+
+  const resolveOnce = async (
+    text: string,
+    baseHref: string,
+    depth: number = 0,
+  ): Promise<string> => {
+    if (depth > MAX_IMPORT_DEPTH) {
+      console.warn(`[snapshot] @import depth exceeded (${MAX_IMPORT_DEPTH}) at ${baseHref}`);
+      return text;
+    }
+
+    let out = "";
+    let last = 0;
+    let m: RegExpExecArray | null;
+    while ((m = IMPORT_ANY_RE.exec(text))) {
+      out += text.slice(last, m.index);
+      last = IMPORT_ANY_RE.lastIndex;
+
+      const rawUrl = (m[2] || m[4] || "").trim();
+      const absUrl = normalizeUrl(rawUrl, baseHref);
+
+      if (visited.has(absUrl)) {
+        console.warn(`[snapshot] Skipping circular @import: ${absUrl}`);
+        continue;
+      }
+      visited.add(absUrl);
+
+      let imported = "";
+      try {
+        const r = await snapFetch(absUrl, { as: "text", useProxy, silent: true });
+        if (r.ok && typeof r.data === "string") imported = r.data;
+      } catch {}
+
+      if (imported) {
+        imported = rewriteRelativeUrls(imported, absUrl);
+        imported = await resolveOnce(imported, absUrl, depth + 1);
+        out += `\n/* inlined: ${absUrl} */\n${imported}\n`;
+      } else {
+        out += m[0];
+      }
+    }
+    out += text.slice(last);
+    return out;
+  };
+
+  let rewritten = rewriteRelativeUrls(cssText, ownerHref || location.href);
+  rewritten = await resolveOnce(rewritten, ownerHref || location.href, 0);
+  return rewritten;
+};
+
+export const inlineUrlsInCssBlock = async (
+  cssBlock: string,
+  baseHref: string,
+  useProxy: string = "",
+): Promise<string> => {
+  let out = cssBlock;
+  for (const m of cssBlock.matchAll(URL_RE)) {
+    const raw = extractURL(m[0]);
+    if (!raw) continue;
+    let abs = raw;
+    if (!abs.startsWith("http") && !abs.startsWith("data:")) {
+      try {
+        abs = new URL(abs, baseHref || location.href).href;
+      } catch {}
+    }
+    if (isIconFont(abs)) continue;
+
+    if (cache.resource?.has(abs)) {
+      cache.font?.add(abs);
+      out = out.replace(m[0], `url(${cache.resource.get(abs)})`);
+      continue;
+    }
+    if (cache.font?.has(abs)) continue;
+
+    try {
+      const r = await snapFetch(abs, { as: "dataURL", useProxy, silent: true });
+      if (r.ok && typeof r.data === "string") {
+        const b64 = r.data;
+        cache.resource?.set(abs, b64);
+        cache.font?.add(abs);
+        out = out.replace(m[0], `url(${b64})`);
+      }
+    } catch {
+      console.warn("[snapshot] Failed to fetch font resource:", abs);
+    }
+  }
+  return out;
+};
+
+export const buildSimpleExcluder = (ex: SnapshotExcludeFonts = {}): FontFaceExcluder => {
+  const famSet = new Set((ex.families || []).map((s) => String(s).toLowerCase()));
+  const domSet = new Set((ex.domains || []).map((s) => String(s).toLowerCase()));
+  const subSet = new Set((ex.subsets || []).map((s) => String(s).toLowerCase()));
+  return (meta: FontFaceMeta, parsedRanges: Array<[number, number]>): boolean => {
+    if (famSet.size && famSet.has(meta.family.toLowerCase())) return true;
+    if (domSet.size) {
+      for (const u of meta.srcUrls) {
+        try {
+          if (domSet.has(new URL(u).host.toLowerCase())) return true;
+        } catch {}
+      }
+    }
+    if (subSet.size) {
+      const label = subsetFromRanges(parsedRanges);
+      if (label && subSet.has(label)) return true;
+    }
+    return false;
+  };
+};
+
+export const dedupeFontFaces = (cssText: string): string => {
+  if (!cssText) return cssText;
+
+  const FACE_RE_G = /@font-face[^{}]*\{[^}]*\}/gi;
+
+  const seen = new Set<string>();
+  const out: string[] = [];
+
+  for (const block of cssText.match(FACE_RE_G) || []) {
+    const familyRaw = block.match(/font-family:\s*([^;]+);/i)?.[1] || "";
+    const family = pickPrimaryFamily(familyRaw);
+    const weightSpec = (block.match(/font-weight:\s*([^;]+);/i)?.[1] || "400").trim();
+    const styleSpec = (block.match(/font-style:\s*([^;]+);/i)?.[1] || "normal").trim();
+    const stretchSpec = (block.match(/font-stretch:\s*([^;]+);/i)?.[1] || "100%").trim();
+    const urange = (block.match(/unicode-range:\s*([^;]+);/i)?.[1] || "").trim();
+    const srcRaw = (block.match(/src\s*:\s*([^;}]+)[;}]/i)?.[1] || "").trim();
+
+    const urls = extractSrcUrls(srcRaw, location.href);
+    const srcPart = urls.length
+      ? urls
+          .map((u) => String(u).toLowerCase())
+          .sort()
+          .join("|")
+      : srcRaw.toLowerCase();
+
+    const key = [
+      String(family || "").toLowerCase(),
+      weightSpec,
+      styleSpec,
+      stretchSpec,
+      urange.toLowerCase(),
+      srcPart,
+    ].join("|");
+
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push(block);
+    }
+  }
+
+  if (out.length === 0) return cssText;
+
+  let i = 0;
+  return cssText.replace(FACE_RE_G, () => out[i++] || "");
+};
+
+export const buildFontsCacheKey = (
+  required: Set<string>,
+  exclude: SnapshotExcludeFonts | undefined,
+  localFonts: SnapshotLocalFontSpec[],
+  useProxy: string,
+  fontStylesheetDomains: string[],
+): string => {
+  const req = Array.from(required || [])
+    .sort()
+    .join("|");
+  const ex = exclude
+    ? JSON.stringify({
+        families: (exclude.families || []).map((s) => String(s).toLowerCase()).sort(),
+        domains: (exclude.domains || []).map((s) => String(s).toLowerCase()).sort(),
+        subsets: (exclude.subsets || []).map((s) => String(s).toLowerCase()).sort(),
+      })
+    : "";
+  const lf = (localFonts || [])
+    .map(
+      (f) =>
+        `${(f.family || "").toLowerCase()}::${f.weight || "normal"}::${f.style || "normal"}::${f.src || ""}`,
+    )
+    .sort()
+    .join("|");
+  const px = useProxy || "";
+  const fd = (fontStylesheetDomains || [])
+    .map((s) => String(s).toLowerCase())
+    .sort()
+    .join("|");
+  return `fonts-embed-css::req=${req}::ex=${ex}::lf=${lf}::px=${px}::fd=${fd}`;
+};
+
+export const collectFacesFromSheet = async (
+  sheet: CSSStyleSheet,
+  baseHref: string,
+  emitFace: (css: string) => Promise<void> | void,
+  ctx: CollectFacesContext,
+): Promise<void> => {
+  let rules: CSSRuleList | CSSRule[] = [];
+  try {
+    rules = sheet.cssRules || [];
+  } catch {
+    return;
+  }
+
+  for (const rule of rules) {
+    if (rule.type === CSSRule.IMPORT_RULE && (rule as CSSImportRule).styleSheet) {
+      const importRule = rule as CSSImportRule;
+      const childHref = importRule.href ? normalizeUrl(importRule.href, baseHref) : baseHref;
+
+      if (ctx.depth >= MAX_IMPORT_DEPTH) {
+        console.warn(
+          `[snapshot] CSSOM import depth exceeded (${MAX_IMPORT_DEPTH}) at ${childHref}`,
+        );
+        continue;
+      }
+      if (childHref && ctx.visitedSheets.has(childHref)) {
+        console.warn(`[snapshot] Skipping circular CSSOM import: ${childHref}`);
+        continue;
+      }
+      if (childHref) ctx.visitedSheets.add(childHref);
+
+      const nextCtx: CollectFacesContext = { ...ctx, depth: (ctx.depth || 0) + 1 };
+      if (importRule.styleSheet) {
+        await collectFacesFromSheet(importRule.styleSheet, childHref, emitFace, nextCtx);
+      }
+      continue;
+    }
+
+    if (rule.type === CSSRule.FONT_FACE_RULE) {
+      const fontFaceRule = rule as CSSFontFaceRule;
+      const famRaw = (fontFaceRule.style.getPropertyValue("font-family") || "").trim();
+      const family = pickPrimaryFamily(famRaw);
+      if (!family || isIconFont(family)) continue;
+
+      const weightSpec = (fontFaceRule.style.getPropertyValue("font-weight") || "400").trim();
+      const styleSpec = (fontFaceRule.style.getPropertyValue("font-style") || "normal").trim();
+      const stretchSpec = (fontFaceRule.style.getPropertyValue("font-stretch") || "100%").trim();
+      const srcRaw = (fontFaceRule.style.getPropertyValue("src") || "").trim();
+      const urange = (fontFaceRule.style.getPropertyValue("unicode-range") || "").trim();
+
+      if (!ctx.faceMatchesRequired(family, styleSpec, weightSpec, stretchSpec)) continue;
+      const ranges = parseUnicodeRange(urange);
+      if (!unicodeIntersects(ctx.usedCodepoints, ranges)) continue;
+
+      const meta: FontFaceMeta = {
+        family,
+        weightSpec,
+        styleSpec,
+        stretchSpec,
+        unicodeRange: urange,
+        srcRaw,
+        srcUrls: extractSrcUrls(srcRaw, baseHref || location.href),
+        href: baseHref || location.href,
+      };
+      if (ctx.simpleExcluder && ctx.simpleExcluder(meta, ranges)) continue;
+
+      if (/url\(/i.test(srcRaw)) {
+        const inlinedSrc = await inlineUrlsInCssBlock(
+          srcRaw,
+          baseHref || location.href,
+          ctx.useProxy,
+        );
+        await emitFace(
+          `@font-face{font-family:${family};src:${inlinedSrc};font-style:${styleSpec};font-weight:${weightSpec};font-stretch:${stretchSpec};${urange ? `unicode-range:${urange};` : ""}}`,
+        );
+      } else {
+        await emitFace(
+          `@font-face{font-family:${family};src:${srcRaw};font-style:${styleSpec};font-weight:${weightSpec};font-stretch:${stretchSpec};${urange ? `unicode-range:${urange};` : ""}}`,
+        );
+      }
+    }
+  }
+};

--- a/packages/react-grab/src/snapshot/modules/fonts/icon.ts
+++ b/packages/react-grab/src/snapshot/modules/fonts/icon.ts
@@ -1,0 +1,55 @@
+import type { SnapshotIconImageResult } from "../../types.js";
+
+export const iconToImage = async (
+  unicodeChar: string,
+  fontFamily: string,
+  fontWeight: string | number,
+  fontSize: number = 32,
+  color: string = "#000",
+): Promise<SnapshotIconImageResult> => {
+  fontFamily = fontFamily.replace(/^['"]+|['"]+$/g, "");
+  const dpr = window.devicePixelRatio || 1;
+
+  try {
+    await document.fonts.ready;
+  } catch {}
+
+  const span = document.createElement("span");
+  span.textContent = unicodeChar;
+  span.style.position = "absolute";
+  span.style.visibility = "hidden";
+  span.style.fontFamily = `"${fontFamily}"`;
+  span.style.fontWeight = String(fontWeight || "normal");
+  span.style.fontSize = `${fontSize}px`;
+  span.style.lineHeight = "1";
+  span.style.whiteSpace = "nowrap";
+  span.style.padding = "0";
+  span.style.margin = "0";
+  document.body.appendChild(span);
+
+  const rect = span.getBoundingClientRect();
+  const width = Math.ceil(rect.width);
+  const height = Math.ceil(rect.height);
+  document.body.removeChild(span);
+
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.max(1, width * dpr);
+  canvas.height = Math.max(1, height * dpr);
+
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("[snapshot] Failed to acquire 2D canvas context");
+  ctx.scale(dpr, dpr);
+  ctx.font = fontWeight
+    ? `${fontWeight} ${fontSize}px "${fontFamily}"`
+    : `${fontSize}px "${fontFamily}"`;
+  ctx.textAlign = "left";
+  ctx.textBaseline = "top";
+  ctx.fillStyle = color;
+  ctx.fillText(unicodeChar, 0, 0);
+
+  return {
+    dataUrl: canvas.toDataURL(),
+    width,
+    height,
+  };
+};

--- a/packages/react-grab/src/snapshot/modules/fonts/normalize.ts
+++ b/packages/react-grab/src/snapshot/modules/fonts/normalize.ts
@@ -1,0 +1,153 @@
+export interface RequiredVariant {
+  w: number;
+  s: string;
+  st: number;
+}
+
+export interface FontMinMax {
+  min: number;
+  max: number;
+}
+
+export interface StyleSpec {
+  kind: "normal" | "italic" | "oblique";
+}
+
+export const normalizeUrl = (url: string, base: string): string => {
+  try {
+    return new URL(url, base || location.href).href;
+  } catch {
+    return url;
+  }
+};
+
+const GENERIC_FAMILIES = new Set<string>([
+  "serif",
+  "sans-serif",
+  "monospace",
+  "cursive",
+  "fantasy",
+  "system-ui",
+  "emoji",
+  "math",
+  "fangsong",
+  "ui-serif",
+  "ui-sans-serif",
+  "ui-monospace",
+  "ui-rounded",
+]);
+
+export const FONT_LIBRARIES: string[] = ["katex", "mathjax", "mathml"];
+
+export const pickPrimaryFamily = (familyList: string): string => {
+  if (!familyList) return "";
+  for (const raw of familyList.split(",")) {
+    const f = raw.trim().replace(/^['"]+|['"]+$/g, "");
+    if (!f) continue;
+    if (!GENERIC_FAMILIES.has(f.toLowerCase())) return f;
+  }
+  return "";
+};
+
+export const pickAllFamilies = (familyList: string): string[] => {
+  if (!familyList) return [];
+  const out: string[] = [];
+  for (const raw of familyList.split(",")) {
+    const f = raw.trim().replace(/^['"]+|['"]+$/g, "");
+    if (!f) continue;
+    if (!GENERIC_FAMILIES.has(f.toLowerCase())) out.push(f);
+  }
+  return out;
+};
+
+export const normWeight = (w: string | number): number => {
+  const t = String(w ?? "400")
+    .trim()
+    .toLowerCase();
+  if (t === "normal") return 400;
+  if (t === "bold") return 700;
+  const n = parseInt(t, 10);
+  return Number.isFinite(n) ? Math.min(900, Math.max(100, n)) : 400;
+};
+
+export const normStyle = (s: string): "normal" | "italic" | "oblique" => {
+  const t = String(s ?? "normal")
+    .trim()
+    .toLowerCase();
+  if (t.startsWith("italic")) return "italic";
+  if (t.startsWith("oblique")) return "oblique";
+  return "normal";
+};
+
+export const normStretchPct = (st: string): number => {
+  const m = String(st ?? "100%").match(/(\d+(?:\.\d+)?)\s*%/);
+  return m ? Math.max(50, Math.min(200, parseFloat(m[1]))) : 100;
+};
+
+export const parseWeightSpec = (spec: string): FontMinMax => {
+  const s = String(spec || "400").trim();
+  const m = s.match(/^(\d{2,3})\s+(\d{2,3})$/);
+  if (m) {
+    const a = normWeight(m[1]),
+      b = normWeight(m[2]);
+    return { min: Math.min(a, b), max: Math.max(a, b) };
+  }
+  const v = normWeight(s);
+  return { min: v, max: v };
+};
+
+export const parseStyleSpec = (spec: string): StyleSpec => {
+  const t = String(spec || "normal")
+    .trim()
+    .toLowerCase();
+  if (t === "italic") return { kind: "italic" };
+  if (t.startsWith("oblique")) return { kind: "oblique" };
+  return { kind: "normal" };
+};
+
+export const parseStretchSpec = (spec: string): FontMinMax => {
+  const s = String(spec || "100%").trim();
+  const mm = s.match(/(\d+(?:\.\d+)?)\s*%\s+(\d+(?:\.\d+)?)\s*%/);
+  if (mm) {
+    const a = parseFloat(mm[1]),
+      b = parseFloat(mm[2]);
+    return { min: Math.min(a, b), max: Math.max(a, b) };
+  }
+  const m = s.match(/(\d+(?:\.\d+)?)\s*%/);
+  const v = m ? parseFloat(m[1]) : 100;
+  return { min: v, max: v };
+};
+
+export const baseFamilyToken = (family: string): string => {
+  if (!family || typeof family !== "string") return "";
+  const base = family
+    .replace(/\s+(variable|vf|v[0-9]+)$/i, "")
+    .trim()
+    .toLowerCase();
+  return base.replace(/\s+/g, "-");
+};
+
+export const familiesFromRequired = (required: Set<string>): Set<string> => {
+  const out = new Set<string>();
+  for (const k of required || []) {
+    const fam = String(k).split("__")[0]?.trim();
+    if (fam) out.add(fam);
+  }
+  return out;
+};
+
+export const rewriteRelativeUrls = (cssText: string, baseHref: string): string => {
+  if (!cssText) return cssText;
+  return cssText.replace(
+    /url\(\s*(['"]?)([^)'"]+)\1\s*\)/g,
+    (m: string, q: string, u: string): string => {
+      const src = (u || "").trim();
+      if (!src || /^data:|^blob:|^https?:|^file:|^about:/i.test(src)) return m;
+      let abs = src;
+      try {
+        abs = new URL(src, baseHref || location.href).href;
+      } catch {}
+      return `url("${abs}")`;
+    },
+  );
+};

--- a/packages/react-grab/src/snapshot/modules/fonts/unicode-range.ts
+++ b/packages/react-grab/src/snapshot/modules/fonts/unicode-range.ts
@@ -1,0 +1,77 @@
+export const URL_RE = /url\((["']?)([^"')]+)\1\)/g;
+export const FACE_RE = /@font-face[^{}]*\{[^}]*\}/g;
+
+export const parseUnicodeRange = (ur: string): Array<[number, number]> => {
+  if (!ur) return [];
+  const ranges: Array<[number, number]> = [];
+  const parts = ur
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  for (const p of parts) {
+    const m = p.match(/^U\+([0-9A-Fa-f?]+)(?:-([0-9A-Fa-f?]+))?$/);
+    if (!m) continue;
+    const a = m[1],
+      b = m[2];
+    const expand = (hex: string): number | [number, number] => {
+      if (!hex.includes("?")) return parseInt(hex, 16);
+      const min = parseInt(hex.replace(/\?/g, "0"), 16);
+      const max = parseInt(hex.replace(/\?/g, "F"), 16);
+      return [min, max];
+    };
+    if (b) {
+      const A = expand(a),
+        B = expand(b);
+      const min = Array.isArray(A) ? A[0] : A;
+      const max = Array.isArray(B) ? B[1] : B;
+      ranges.push([Math.min(min, max), Math.max(min, max)]);
+    } else {
+      const X = expand(a);
+      if (Array.isArray(X)) ranges.push([X[0], X[1]]);
+      else ranges.push([X, X]);
+    }
+  }
+  return ranges;
+};
+
+export const unicodeIntersects = (used: Set<number>, ranges: Array<[number, number]>): boolean => {
+  if (!ranges.length) return true;
+  if (!used || used.size === 0) return true;
+  for (const cp of used) {
+    for (const [a, b] of ranges) if (cp >= a && cp <= b) return true;
+  }
+  return false;
+};
+
+export const extractSrcUrls = (srcValue: string, baseHref: string): string[] => {
+  const urls: string[] = [];
+  if (!srcValue) return urls;
+  for (const m of srcValue.matchAll(URL_RE)) {
+    let u = (m[2] || "").trim();
+    if (!u || u.startsWith("data:")) continue;
+    if (!/^https?:/i.test(u)) {
+      try {
+        u = new URL(u, baseHref || location.href).href;
+      } catch {}
+    }
+    urls.push(u);
+  }
+  return urls;
+};
+
+export const subsetFromRanges = (ranges: Array<[number, number]>): string | null => {
+  if (!ranges.length) return null;
+  const hit = (a: number, b: number): boolean => ranges.some(([x, y]) => !(y < a || x > b));
+  const latin = hit(0x0000, 0x00ff) || hit(0x0131, 0x0131);
+  const latinExt = hit(0x0100, 0x024f) || hit(0x1e00, 0x1eff);
+  const greek = hit(0x0370, 0x03ff);
+  const cyr = hit(0x0400, 0x04ff);
+  const viet =
+    hit(0x1ea0, 0x1ef9) || hit(0x0102, 0x0103) || hit(0x01a0, 0x01a1) || hit(0x01af, 0x01b0);
+  if (viet) return "vietnamese";
+  if (cyr) return "cyrillic";
+  if (greek) return "greek";
+  if (latinExt) return "latin-ext";
+  if (latin) return "latin";
+  return null;
+};

--- a/packages/react-grab/src/snapshot/modules/icon-fonts.ts
+++ b/packages/react-grab/src/snapshot/modules/icon-fonts.ts
@@ -1,0 +1,316 @@
+import { cache } from "../core/cache.js";
+import type { SnapshotIconFontMatcher, SnapshotIconImageResult } from "../types.js";
+
+interface IconFontPick {
+  url: string;
+  alias: string;
+}
+
+interface LigatureCanvasFont {
+  familyForMeasure: string;
+  familyForCanvas: string;
+}
+
+interface MaterialIconToImageOptions {
+  family?: string;
+  weight?: string | number;
+  fontSize?: number;
+  color?: string;
+  variation?: string;
+  className?: string;
+}
+
+const defaultIconFonts: RegExp[] = [
+  /font\s*awesome/i,
+  /material\s*icons/i,
+  /ionicons/i,
+  /glyphicons/i,
+  /feather/i,
+  /bootstrap\s*icons/i,
+  /remix\s*icons/i,
+  /heroicons/i,
+  /layui/i,
+  /lucide/i,
+];
+
+export const ICON_FONT_URLS: Record<string, string> = Object.assign(
+  {
+    materialIconsFilled:
+      "https://fonts.gstatic.com/s/materialicons/v48/flUhRq6tzZclQEJ-Vdg-IuiaDsNcIhQ8tQ.woff2",
+    materialIconsOutlined:
+      "https://fonts.gstatic.com/s/materialiconsoutlined/v110/gok-H7zzDkdnRel8-DQ6KAXJ69wP1tGnf4ZGhUcel5euIg.woff2",
+    materialIconsRound:
+      "https://fonts.gstatic.com/s/materialiconsround/v109/LDItaoyNOAY6Uewc665JcIzCKsKc_M9flwmPq_HTTw.woff2",
+    materialIconsSharp:
+      "https://fonts.gstatic.com/s/materialiconssharp/v110/oPWQ_lt5nv4pWNJpghLP75WiFR4kLh3kvmvRImcycg.woff2",
+  },
+  (typeof window !== "undefined" &&
+    (window as Window & { __SNAPSHOT_ICON_FONTS__?: Record<string, string> })
+      .__SNAPSHOT_ICON_FONTS__) ||
+    {},
+);
+
+const userIconFonts: RegExp[] = [];
+
+const escapeRegExp = (string: string): string => {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+};
+
+export const extendIconFonts = (
+  fonts: SnapshotIconFontMatcher | SnapshotIconFontMatcher[],
+): void => {
+  const list = Array.isArray(fonts) ? fonts : [fonts];
+  for (const f of list) {
+    if (f instanceof RegExp) userIconFonts.push(f);
+    else if (typeof f === "string") userIconFonts.push(new RegExp(escapeRegExp(f), "i"));
+    else console.warn("[snapshot] Ignored invalid iconFont value:", f);
+  }
+};
+
+export const isIconFont = (input: unknown): boolean => {
+  const text = typeof input === "string" ? input : "";
+  const candidates = [...defaultIconFonts, ...userIconFonts];
+  for (const rx of candidates) {
+    if (rx instanceof RegExp && rx.test(text)) return true;
+  }
+  if (
+    /icon/i.test(text) ||
+    /glyph/i.test(text) ||
+    /symbols/i.test(text) ||
+    /feather/i.test(text) ||
+    /fontawesome/i.test(text)
+  )
+    return true;
+  return false;
+};
+
+const isMaterialFamily = (family: string = ""): boolean => {
+  const s = String(family).toLowerCase();
+  return /\bmaterial\s*icons\b/.test(s) || /\bmaterial\s*symbols\b/.test(s);
+};
+
+const loadedCanvasFamilies = new Map<string, boolean>();
+
+const parseAxes = (variation: string = ""): Record<string, number> => {
+  const out: Record<string, number> = Object.create(null);
+  const v = String(variation || "");
+  const rx = /['"]?\s*([A-Za-z]{3,4})\s*['"]?\s*([+-]?\d+(?:\.\d+)?)\s*/g;
+  let m: RegExpExecArray | null;
+  while ((m = rx.exec(v))) out[m[1].toUpperCase()] = Number(m[2]);
+  return out;
+};
+
+const ensureLigatureCanvasFont = async (
+  cssFamily: string,
+  className: string,
+  axes: Record<string, number>,
+): Promise<LigatureCanvasFont> => {
+  const fam = String(cssFamily || "");
+  const lowerFam = fam.toLowerCase();
+  const cls = String(className || "").toLowerCase();
+
+  if (/\bmaterial\s*icons\b/.test(lowerFam) && !/\bsymbols\b/.test(lowerFam)) {
+    return { familyForMeasure: fam, familyForCanvas: fam };
+  }
+
+  const isSymbols = /\bmaterial\s*symbols\b/.test(lowerFam);
+  if (!isSymbols) {
+    return { familyForMeasure: fam, familyForCanvas: fam };
+  }
+
+  const FILL = axes && (axes.FILL ?? axes.fill);
+  let style = "outlined";
+  if (/\brounded\b/.test(cls) || /\bround\b/.test(cls)) style = "rounded";
+  else if (/\bsharp\b/.test(cls)) style = "sharp";
+  else if (/\boutlined\b/.test(cls)) style = "outlined";
+
+  const filled = FILL === 1;
+
+  let pick: IconFontPick | null = null;
+  if (filled) {
+    if (style === "outlined" && ICON_FONT_URLS.materialIconsFilled) {
+      pick = { url: ICON_FONT_URLS.materialIconsFilled, alias: "snapshot-mi-filled" };
+    } else if (style === "rounded" && ICON_FONT_URLS.materialIconsRound) {
+      pick = { url: ICON_FONT_URLS.materialIconsRound, alias: "snapshot-mi-round" };
+    } else if (style === "sharp" && ICON_FONT_URLS.materialIconsSharp) {
+      pick = { url: ICON_FONT_URLS.materialIconsSharp, alias: "snapshot-mi-sharp" };
+    }
+  }
+
+  if (!pick) {
+    return { familyForMeasure: fam, familyForCanvas: fam };
+  }
+
+  if (!loadedCanvasFamilies.has(pick.alias)) {
+    try {
+      const ff = new FontFace(pick.alias, `url(${pick.url})`, { style: "normal", weight: "400" });
+      document.fonts.add(ff);
+      await ff.load();
+      loadedCanvasFamilies.set(pick.alias, true);
+    } catch {
+      return { familyForMeasure: fam, familyForCanvas: fam };
+    }
+  }
+
+  const quoted = `"${pick.alias}"`;
+  return { familyForMeasure: quoted, familyForCanvas: quoted };
+};
+
+const ensureMaterialFontsReady = async (
+  family: string = "Material Icons",
+  px: number = 24,
+): Promise<void> => {
+  try {
+    await Promise.all([
+      document.fonts.load(`400 ${px}px "${String(family).replace(/["']/g, "")}"`),
+      document.fonts.ready,
+    ]);
+  } catch {}
+};
+
+const resolvePaintColor = (cs: CSSStyleDeclaration): string => {
+  const fill = cs.getPropertyValue("-webkit-text-fill-color")?.trim() || "";
+  const isTransparent =
+    /^transparent$/i.test(fill) || /rgba?\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0\s*\)/i.test(fill);
+  if (fill && !isTransparent && fill.toLowerCase() !== "currentcolor") return fill;
+  const c = cs.color?.trim();
+  return c && c !== "inherit" ? c : "#000";
+};
+
+const materialIconToImage = async (
+  ligatureText: string,
+  {
+    family = "Material Icons",
+    weight = "normal",
+    fontSize = 32,
+    color = "#000",
+    variation = "",
+    className = "",
+  }: MaterialIconToImageOptions = {},
+): Promise<SnapshotIconImageResult> => {
+  const fam = String(family || "").replace(/^['"]+|['"]+$/g, "");
+  const dpr = window.devicePixelRatio || 1;
+  const axes = parseAxes(variation);
+
+  const { familyForMeasure, familyForCanvas } = await ensureLigatureCanvasFont(
+    fam,
+    className,
+    axes,
+  );
+
+  await ensureMaterialFontsReady(familyForCanvas.replace(/^["']+|["']+$/g, ""), fontSize);
+
+  const span = document.createElement("span");
+  span.textContent = ligatureText;
+  span.style.position = "absolute";
+  span.style.visibility = "hidden";
+  span.style.left = "-99999px";
+  span.style.whiteSpace = "nowrap";
+  span.style.fontFamily = familyForMeasure;
+  span.style.fontWeight = String(weight || "normal");
+  span.style.fontSize = `${fontSize}px`;
+  span.style.lineHeight = "1";
+  span.style.margin = "0";
+  span.style.padding = "0";
+  span.style.fontFeatureSettings = "'liga' 1";
+  span.style.fontVariantLigatures = "normal";
+  span.style.color = color;
+
+  document.body.appendChild(span);
+  const rect = span.getBoundingClientRect();
+  const width = Math.max(1, Math.ceil(rect.width));
+  const height = Math.max(1, Math.ceil(rect.height));
+  document.body.removeChild(span);
+
+  const canvas = document.createElement("canvas");
+  canvas.width = width * dpr;
+  canvas.height = height * dpr;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("[snapshot] Failed to acquire 2D canvas context");
+  ctx.scale(dpr, dpr);
+  ctx.font = `${weight ? `${weight} ` : ""}${fontSize}px ${familyForCanvas}`;
+  ctx.textAlign = "left";
+  ctx.textBaseline = "top";
+  ctx.fillStyle = color;
+  try {
+    ctx.fontKerning = "normal";
+  } catch {}
+  ctx.fillText(ligatureText, 0, 0);
+
+  return {
+    dataUrl: canvas.toDataURL(),
+    width,
+    height,
+  };
+};
+
+export const ligatureIconToImage = async (
+  cloneRoot: Element,
+  sourceRoot: Element,
+): Promise<number> => {
+  if (!(cloneRoot instanceof Element)) return 0;
+
+  const selector = '.material-icons, [class*="material-symbols"]';
+
+  const cloneNodes = Array.from(cloneRoot.querySelectorAll(selector)).filter(
+    (n) => n && n.textContent && n.textContent.trim(),
+  );
+
+  if (cloneNodes.length === 0) return 0;
+
+  const nodeMap = cache.session.nodeMap;
+  const sourceNodes =
+    sourceRoot instanceof Element
+      ? Array.from(sourceRoot.querySelectorAll(selector)).filter(
+          (n) => n && n.textContent && n.textContent.trim(),
+        )
+      : [];
+
+  let replaced = 0;
+
+  for (let i = 0; i < cloneNodes.length; i++) {
+    const el = cloneNodes[i];
+    const src = ((nodeMap && nodeMap.get(el)) || sourceNodes[i] || null) as Element | null;
+
+    try {
+      const cs = src ? getComputedStyle(src) : getComputedStyle(el);
+      const family = cs.fontFamily || "Material Icons";
+      if (!isMaterialFamily(family)) continue;
+
+      const text = (src || el).textContent?.trim();
+      if (!text) continue;
+
+      const size = parseInt(cs.fontSize, 10) || 24;
+      const weight = cs.fontWeight && cs.fontWeight !== "normal" ? cs.fontWeight : "normal";
+      const color = resolvePaintColor(cs);
+      const variation =
+        cs.fontVariationSettings && cs.fontVariationSettings !== "normal"
+          ? cs.fontVariationSettings
+          : "";
+      const className = ((src || el) as HTMLElement).className || "";
+
+      const { dataUrl, width, height } = await materialIconToImage(text, {
+        family,
+        weight,
+        fontSize: size,
+        color,
+        variation,
+        className,
+      });
+
+      el.textContent = "";
+      const img = el.ownerDocument.createElement("img");
+      img.src = dataUrl;
+      img.alt = text;
+      img.style.height = `${size}px`;
+      img.style.width = `${Math.max(1, Math.round((width / height) * size))}px`;
+      img.style.objectFit = "contain";
+      img.style.verticalAlign = getComputedStyle(el).verticalAlign || "baseline";
+      el.appendChild(img);
+
+      replaced++;
+    } catch {}
+  }
+
+  return replaced;
+};

--- a/packages/react-grab/src/snapshot/modules/images.ts
+++ b/packages/react-grab/src/snapshot/modules/images.ts
@@ -1,0 +1,119 @@
+import { snapFetch } from "./snap-fetch.js";
+import type { SnapshotCaptureContext } from "../types.js";
+
+const XLINK_NS = "http://www.w3.org/1999/xlink";
+
+const getSvgImageHref = (el: Element): string | null => {
+  return (
+    el.getAttribute("href") ||
+    el.getAttribute("xlink:href") ||
+    (typeof el.getAttributeNS === "function" ? el.getAttributeNS(XLINK_NS, "href") : null)
+  );
+};
+
+const extractImageDimensions = (img: HTMLImageElement): { width: number; height: number } => {
+  const dsW = parseInt(img.dataset?.snapshotWidth || "", 10) || 0;
+  const dsH = parseInt(img.dataset?.snapshotHeight || "", 10) || 0;
+  const attrW = parseInt(img.getAttribute("width") || "", 10) || 0;
+  const attrH = parseInt(img.getAttribute("height") || "", 10) || 0;
+  const styleW = parseFloat(img.style?.width || "") || 0;
+  const styleH = parseFloat(img.style?.height || "") || 0;
+
+  const w = dsW || styleW || attrW || img.width || img.naturalWidth || 100;
+  const h = dsH || styleH || attrH || img.height || img.naturalHeight || 100;
+
+  return { width: w, height: h };
+};
+
+export const inlineImages = async (
+  clone: Element,
+  options: SnapshotCaptureContext = {},
+): Promise<void> => {
+  const imgs = Array.from(clone.querySelectorAll("img"));
+  const processImg = async (img: HTMLImageElement): Promise<void> => {
+    if (!img.getAttribute("src")) {
+      const eff = img.currentSrc || img.src || "";
+      if (eff) img.setAttribute("src", eff);
+    }
+
+    img.removeAttribute("srcset");
+    img.removeAttribute("sizes");
+
+    const src = img.src || "";
+    if (!src) return;
+
+    const r = await snapFetch(src, { as: "dataURL", useProxy: options.useProxy });
+    if (r.ok && typeof r.data === "string" && r.data.startsWith("data:")) {
+      img.src = r.data;
+      if (!img.width) img.width = img.naturalWidth || 100;
+      if (!img.height) img.height = img.naturalHeight || 100;
+      return;
+    }
+    const { width: fbW, height: fbH } = extractImageDimensions(img);
+    const { fallbackURL } = options || {};
+    if (fallbackURL) {
+      try {
+        const dimensions = { width: fbW, height: fbH, src, element: img };
+        const fallbackUrl =
+          typeof fallbackURL === "function" ? await fallbackURL(dimensions) : fallbackURL;
+
+        if (fallbackUrl) {
+          const fallbackData = await snapFetch(fallbackUrl, {
+            as: "dataURL",
+            useProxy: options.useProxy,
+          });
+          if (fallbackData?.ok && typeof fallbackData.data === "string") {
+            img.src = fallbackData.data;
+            if (!img.width) img.width = fbW;
+            if (!img.height) img.height = fbH;
+            return;
+          }
+        }
+      } catch {}
+    }
+
+    if (options.placeholders !== false) {
+      const fallback = document.createElement("div");
+      fallback.style.cssText = [
+        `width:${fbW}px`,
+        `height:${fbH}px`,
+        "background:#ccc",
+        "display:inline-block",
+        "text-align:center",
+        `line-height:${fbH}px`,
+        "color:#666",
+        "font-size:12px",
+        "overflow:hidden",
+      ].join(";");
+      fallback.textContent = "img";
+      img.replaceWith(fallback);
+    } else {
+      const spacer = document.createElement("div");
+      spacer.style.cssText = `display:inline-block;width:${fbW}px;height:${fbH}px;visibility:hidden;`;
+      img.replaceWith(spacer);
+    }
+  };
+
+  const BATCH = 6;
+  for (let i = 0; i < imgs.length; i += BATCH) {
+    const group = imgs.slice(i, i + BATCH).map(processImg);
+    await Promise.allSettled(group);
+  }
+
+  const svgImages = Array.from(clone.querySelectorAll("image"));
+  const processSvgImage = async (el: SVGImageElement): Promise<void> => {
+    const href = getSvgImageHref(el);
+    if (!href || href.startsWith("data:") || href.startsWith("blob:")) return;
+
+    const r = await snapFetch(href, { as: "dataURL", useProxy: options.useProxy });
+    if (r.ok && typeof r.data === "string" && r.data.startsWith("data:")) {
+      el.setAttribute("href", r.data);
+      el.removeAttribute("xlink:href");
+      if (typeof el.removeAttributeNS === "function") el.removeAttributeNS(XLINK_NS, "href");
+    }
+  };
+  for (let i = 0; i < svgImages.length; i += BATCH) {
+    const group = svgImages.slice(i, i + BATCH).map(processSvgImage);
+    await Promise.allSettled(group);
+  }
+};

--- a/packages/react-grab/src/snapshot/modules/line-clamp.ts
+++ b/packages/react-grab/src/snapshot/modules/line-clamp.ts
@@ -1,0 +1,77 @@
+export const lineClampTree = (el: Element | null | undefined): (() => void) => {
+  if (!el) return () => {};
+  const undos: Array<() => void> = [];
+  const walk = (node: Element): void => {
+    const undo = lineClamp(node);
+    if (undo) undos.push(undo);
+    for (const child of node.children || []) walk(child);
+  };
+  walk(el);
+  return () => undos.forEach((u) => u());
+};
+
+const lineClamp = (el: Element | null | undefined): (() => void) => {
+  if (!el) return () => {};
+
+  const lines = getClamp(el);
+  if (lines <= 0) return () => {};
+
+  if (!isPlainTextContainer(el)) return () => {};
+
+  const cs = getComputedStyle(el);
+  const targetH = Math.round(usedLineHeightPx(cs) * lines + vpad(cs));
+
+  const original = el.textContent ?? "";
+  const prevText = original;
+
+  if (el.scrollHeight <= targetH + 0.5) {
+    return () => {};
+  }
+
+  let lo = 0,
+    hi = original.length,
+    best = -1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    el.textContent = original.slice(0, mid) + "…";
+    if (el.scrollHeight <= targetH + 0.5) {
+      best = mid;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+
+  el.textContent = (best >= 0 ? original.slice(0, best) : "") + "…";
+
+  return () => {
+    el.textContent = prevText;
+  };
+};
+
+const getClamp = (el: Element): number => {
+  const cs = getComputedStyle(el);
+  let v = cs.getPropertyValue("-webkit-line-clamp") || cs.getPropertyValue("line-clamp");
+  v = (v || "").trim();
+  const n = parseInt(v, 10);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+};
+
+const usedLineHeightPx = (cs: CSSStyleDeclaration): number => {
+  const lh = (cs.lineHeight || "").trim();
+  const fs = parseFloat(cs.fontSize) || 16;
+  if (!lh || lh === "normal") return Math.round(fs * 1.2);
+  if (lh.endsWith("px")) return parseFloat(lh);
+  if (/^\d+(\.\d+)?$/.test(lh)) return Math.round(parseFloat(lh) * fs);
+  if (lh.endsWith("%")) return Math.round((parseFloat(lh) / 100) * fs);
+  return Math.round(fs * 1.2);
+};
+
+const vpad = (cs: CSSStyleDeclaration): number => {
+  return (parseFloat(cs.paddingTop) || 0) + (parseFloat(cs.paddingBottom) || 0);
+};
+
+const isPlainTextContainer = (el: Element): boolean => {
+  if (el.childElementCount > 0) return false;
+  return Array.from(el.childNodes).some((n) => n.nodeType === Node.TEXT_NODE);
+};

--- a/packages/react-grab/src/snapshot/modules/picture-resolver.ts
+++ b/packages/react-grab/src/snapshot/modules/picture-resolver.ts
@@ -1,0 +1,230 @@
+import type { SnapshotCaptureContext, SnapshotPictureResolverOptions } from "../types.js";
+
+interface ResolvedPictureResolverOptions {
+  timeout: number;
+  concurrency: number;
+  resolveLazySrc: boolean;
+  silent: boolean;
+  useProxy: string;
+}
+
+interface RemovedSource {
+  el: HTMLSourceElement;
+  parent: HTMLElement | null;
+  next: ChildNode | null;
+}
+
+const isPlaceholderSrc = (src: string): boolean => {
+  if (!src) return true;
+  if (src.startsWith("data:")) return true;
+  if (src.startsWith("blob:")) return true;
+  if (/^data:image\/(gif|png|svg)/.test(src) && src.length < 200) return true;
+  return false;
+};
+
+const quickProbeMayNeedPictureResolver = (
+  root: Element | null | undefined,
+  resolveLazySrc: boolean,
+): boolean => {
+  if (!root || !(root instanceof Element)) return false;
+  if (root.querySelector("picture")) return true;
+  if (resolveLazySrc) {
+    return Boolean(
+      root.querySelector(
+        "img[data-src], img[data-lazy-src], img[data-original], img[data-hi-res-src], img[data-srcset], img[data-lazy-srcset]",
+      ),
+    );
+  }
+  return false;
+};
+
+const findRealUrlForPicture = (
+  img: HTMLImageElement,
+  picture: HTMLPictureElement,
+): string | null => {
+  const current = img.currentSrc || "";
+  if (current && !isPlaceholderSrc(current)) return current;
+
+  const sources = picture.querySelectorAll("source[srcset]");
+  let fallback: string | null = null;
+  for (const source of sources) {
+    const srcset = source.getAttribute("srcset");
+    if (!srcset || isPlaceholderSrc(srcset)) continue;
+
+    const media = source.getAttribute("media");
+    if (media) {
+      try {
+        if (window.matchMedia(media).matches) {
+          return srcset.split(",")[0].trim().split(/\s+/)[0];
+        }
+      } catch {}
+    }
+    if (!fallback) fallback = srcset.split(",")[0].trim().split(/\s+/)[0];
+  }
+  return fallback;
+};
+
+const findLazySrcAttr = (img: HTMLImageElement): string | null => {
+  const candidates = [
+    img.getAttribute("data-src"),
+    img.getAttribute("data-lazy-src"),
+    img.getAttribute("data-original"),
+    img.getAttribute("data-hi-res-src"),
+  ];
+  for (const c of candidates) {
+    if (c && !isPlaceholderSrc(c)) return c;
+  }
+  const dataSrcset = img.getAttribute("data-srcset") || img.getAttribute("data-lazy-srcset");
+  if (dataSrcset) {
+    const first = dataSrcset.split(",")[0].trim().split(/\s+/)[0];
+    if (first && !isPlaceholderSrc(first)) return first;
+  }
+  return null;
+};
+
+const mergePictureResolverOpts = (
+  options: SnapshotCaptureContext = {},
+): ResolvedPictureResolverOptions => {
+  const pr: SnapshotPictureResolverOptions =
+    options.pictureResolver && typeof options.pictureResolver === "object"
+      ? options.pictureResolver
+      : {};
+  return {
+    timeout: pr.timeout ?? 5000,
+    concurrency: pr.concurrency ?? 4,
+    resolveLazySrc: pr.resolveLazySrc !== false,
+    silent: pr.silent ?? false,
+    useProxy: typeof options.useProxy === "string" ? options.useProxy : "",
+  };
+};
+
+export const runPictureResolverBeforeClone = async (
+  root: Element | null | undefined,
+  options: SnapshotCaptureContext = {},
+): Promise<(() => Promise<void>) | null> => {
+  if (!root || !(root instanceof Element)) return null;
+  if (options.resolvePicturePlaceholders === false) return null;
+
+  const { timeout, concurrency, resolveLazySrc, silent, useProxy } =
+    mergePictureResolverOpts(options);
+
+  if (!quickProbeMayNeedPictureResolver(root, resolveLazySrc)) return null;
+
+  const undoStack: Array<() => void> = [];
+  const tasks: Array<() => Promise<void>> = [];
+
+  const fetchAsDataUrl = async (url: string): Promise<string | null> => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeout);
+    try {
+      let resp = await fetch(url, {
+        credentials: "include",
+        signal: controller.signal,
+      });
+      if (!resp.ok && useProxy) {
+        const proxyUrl = useProxy.includes("{url}")
+          ? useProxy.replace("{url}", encodeURIComponent(url))
+          : useProxy.endsWith("?")
+            ? `${useProxy}${encodeURIComponent(url)}`
+            : `${useProxy}${useProxy.includes("?") ? "&" : "?"}url=${encodeURIComponent(url)}`;
+        resp = await fetch(proxyUrl, { signal: controller.signal });
+      }
+      if (!resp.ok) return null;
+      const blob = await resp.blob();
+      return await new Promise<string>((resolve, reject) => {
+        const fr = new FileReader();
+        fr.onload = () => resolve(fr.result as string);
+        fr.onerror = reject;
+        fr.readAsDataURL(blob);
+      });
+    } catch {
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+
+  const runBatched = async (taskFns: Array<() => Promise<void>>): Promise<void> => {
+    for (let i = 0; i < taskFns.length; i += concurrency) {
+      const batch = taskFns.slice(i, i + concurrency);
+      await Promise.allSettled(batch.map((fn) => fn()));
+    }
+  };
+
+  const pictures = root.querySelectorAll("picture");
+  for (const picture of pictures) {
+    const img = picture.querySelector("img");
+    if (!img) continue;
+    const originalSrc = img.getAttribute("src") || "";
+    if (!isPlaceholderSrc(originalSrc)) continue;
+    const realUrl = findRealUrlForPicture(img, picture);
+    if (!realUrl) continue;
+
+    tasks.push(async () => {
+      const dataUrl = await fetchAsDataUrl(realUrl);
+      if (!dataUrl) {
+        if (!silent)
+          console.warn(`[snapshot:picture-resolver] Failed to fetch: ${realUrl.slice(0, 60)}`);
+        return;
+      }
+      const origAttr = img.getAttribute("src");
+      const origSrcset = img.getAttribute("srcset");
+      const origSizes = img.getAttribute("sizes");
+      const removedSources: RemovedSource[] = [];
+      img.src = dataUrl;
+      img.setAttribute("src", dataUrl);
+      img.removeAttribute("srcset");
+      img.removeAttribute("sizes");
+      const sources = picture.querySelectorAll("source");
+      for (const s of sources) {
+        removedSources.push({ el: s, parent: s.parentElement, next: s.nextSibling });
+        s.remove();
+      }
+      undoStack.push(() => {
+        if (origAttr !== null) img.setAttribute("src", origAttr);
+        else img.removeAttribute("src");
+        if (origSrcset !== null) img.setAttribute("srcset", origSrcset);
+        if (origSizes !== null) img.setAttribute("sizes", origSizes);
+        for (const { el, parent, next } of removedSources) {
+          if (parent) parent.insertBefore(el, next);
+        }
+      });
+    });
+  }
+
+  if (resolveLazySrc) {
+    const imgs = root.querySelectorAll("img");
+    for (const img of imgs) {
+      if (img.closest("picture") && isPlaceholderSrc(img.getAttribute("src") || "")) continue;
+      const currentSrc = img.getAttribute("src") || "";
+      const lazySrc = findLazySrcAttr(img);
+      if (lazySrc && isPlaceholderSrc(currentSrc)) {
+        tasks.push(async () => {
+          const dataUrl = await fetchAsDataUrl(lazySrc);
+          if (!dataUrl) return;
+          const origSrc = img.getAttribute("src");
+          img.src = dataUrl;
+          img.setAttribute("src", dataUrl);
+          img.removeAttribute("srcset");
+          img.removeAttribute("sizes");
+          undoStack.push(() => {
+            if (origSrc !== null) img.setAttribute("src", origSrc);
+            else img.removeAttribute("src");
+          });
+        });
+      }
+    }
+  }
+
+  if (tasks.length === 0) return null;
+
+  await runBatched(tasks);
+
+  return async function undoPictureResolverMutations(): Promise<void> {
+    for (const undo of undoStack) {
+      try {
+        undo();
+      } catch {}
+    }
+  };
+};

--- a/packages/react-grab/src/snapshot/modules/pseudo.ts
+++ b/packages/react-grab/src/snapshot/modules/pseudo.ts
@@ -1,0 +1,607 @@
+import {
+  getStyle,
+  snapshotComputedStyle,
+  extractURL,
+  safeEncodeURI,
+  inlineSingleBackgroundEntry,
+  splitBackgroundImage,
+  getStyleKey,
+  debugWarn,
+} from "../utils/index.js";
+import { iconToImage } from "../modules/fonts.js";
+import { isIconFont } from "../modules/icon-fonts.js";
+import { buildCounterContext, resolveCountersInContent, hasCounters } from "../modules/counter.js";
+import type { CounterContext } from "../modules/counter.js";
+import { snapFetch } from "./snap-fetch.js";
+import { cache } from "../core/cache.js";
+import type { SnapshotCaptureContext, SnapshotSessionCache } from "../types.js";
+
+interface PreflightMemo {
+  fingerprint: string;
+  result: boolean;
+}
+
+interface CounterDecl {
+  name: string;
+  num: number | undefined;
+}
+
+interface DerivedCounterContext extends CounterContext {
+  __incs: CounterDecl[];
+}
+
+const __preflightMemo = new WeakMap<Document, PreflightMemo>();
+
+const CSS_RULE_SCAN_BUDGET = 1000;
+
+const preflightWithFp = (
+  doc: Document,
+  sessionCache: SnapshotSessionCache | null | undefined,
+): boolean => {
+  const fp = styleFingerprint(doc);
+  if (!sessionCache) return shouldProcessPseudos(doc, fp);
+  if (sessionCache.__pseudoPreflightFp !== fp) {
+    sessionCache.__pseudoPreflight = shouldProcessPseudos(doc, fp);
+    sessionCache.__pseudoPreflightFp = fp;
+  }
+  return Boolean(sessionCache.__pseudoPreflight);
+};
+const safeRules = (sheet: CSSStyleSheet): CSSRuleList | null => {
+  try {
+    return sheet && sheet.cssRules ? sheet.cssRules : null;
+  } catch {
+    return null;
+  }
+};
+
+const styleFingerprint = (doc: Document): string => {
+  const nodes = doc.querySelectorAll('style,link[rel~="stylesheet"]');
+  let fp = `n:${nodes.length}|`;
+  let totalRules = 0;
+
+  for (let i = 0; i < nodes.length; i++) {
+    const n = nodes[i];
+    if (n.tagName === "STYLE") {
+      const len = n.textContent ? n.textContent.length : 0;
+      fp += `S${len}|`;
+      const sheet = (n as HTMLStyleElement).sheet;
+      const rules = sheet ? safeRules(sheet) : null;
+      if (rules) totalRules += rules.length;
+    } else {
+      const href = n.getAttribute("href") || "";
+      const media = n.getAttribute("media") || "all";
+      fp += `L${href}|m:${media}|`;
+      const sheet = (n as HTMLLinkElement).sheet;
+      const rules = sheet ? safeRules(sheet) : null;
+      if (rules) totalRules += rules.length;
+    }
+  }
+
+  const ass = doc.adoptedStyleSheets;
+  fp += `ass:${Array.isArray(ass) ? ass.length : 0}|tr:${totalRules}`;
+
+  return fp;
+};
+
+const sheetHasNeedles = (
+  sheet: CSSStyleSheet,
+  needles: string[],
+  state: { budget: number },
+): boolean => {
+  const rules = safeRules(sheet);
+  if (!rules) return false;
+
+  for (let i = 0; i < rules.length; i++) {
+    if (state.budget <= 0) return false;
+    const rule = rules[i];
+    const css = rule && rule.cssText ? rule.cssText : "";
+    state.budget--;
+    for (const k of needles) {
+      if (css.includes(k)) return true;
+    }
+    const grouping = rule as CSSGroupingRule;
+    if (rule && grouping.cssRules && grouping.cssRules.length) {
+      for (let j = 0; j < grouping.cssRules.length && state.budget > 0; j++) {
+        const inner = grouping.cssRules[j];
+        const innerCss = inner && inner.cssText ? inner.cssText : "";
+        state.budget--;
+        for (const k of needles) {
+          if (innerCss.includes(k)) return true;
+        }
+      }
+    }
+    if (state.budget <= 0) return false;
+  }
+  return false;
+};
+
+export const shouldProcessPseudos = (
+  doc: Document = document,
+  fp: string = styleFingerprint(doc),
+): boolean => {
+  const memo = __preflightMemo.get(doc);
+  if (memo && memo.fingerprint === fp) return memo.result;
+
+  const NEEDLES = [
+    "::before",
+    "::after",
+    "::first-letter",
+    ":before",
+    ":after",
+    ":first-letter",
+    "counter(",
+    "counters(",
+    "counter-increment",
+    "counter-reset",
+  ];
+
+  const styleEls = doc.querySelectorAll("style");
+  for (let i = 0; i < styleEls.length; i++) {
+    const t = styleEls[i].textContent || "";
+    for (const k of NEEDLES)
+      if (t.includes(k)) {
+        __preflightMemo.set(doc, { fingerprint: fp, result: true });
+        return true;
+      }
+  }
+
+  const ass = doc.adoptedStyleSheets;
+  if (Array.isArray(ass) && ass.length) {
+    const state = { budget: CSS_RULE_SCAN_BUDGET };
+    try {
+      for (const sheet of ass) {
+        if (sheetHasNeedles(sheet, NEEDLES, state)) {
+          __preflightMemo.set(doc, { fingerprint: fp, result: true });
+          return true;
+        }
+      }
+    } catch {}
+  }
+
+  {
+    const nodes = doc.querySelectorAll('style,link[rel~="stylesheet"]');
+    const state = { budget: CSS_RULE_SCAN_BUDGET };
+    for (let i = 0; i < nodes.length && state.budget > 0; i++) {
+      const n = nodes[i];
+      let sheet: CSSStyleSheet | null = null;
+      if (n.tagName === "STYLE") {
+        sheet = (n as HTMLStyleElement).sheet || null;
+      } else {
+        sheet = (n as HTMLLinkElement).sheet || null;
+      }
+      if (sheet && sheetHasNeedles(sheet, NEEDLES, state)) {
+        __preflightMemo.set(doc, { fingerprint: fp, result: true });
+        return true;
+      }
+    }
+  }
+
+  if (doc.querySelector('[style*="counter("], [style*="counters("]')) {
+    __preflightMemo.set(doc, { fingerprint: fp, result: true });
+    return true;
+  }
+
+  __preflightMemo.set(doc, { fingerprint: fp, result: false });
+  return false;
+};
+
+let __siblingCounters = new WeakMap<Element, Map<string, number>>();
+
+const hasPaintedBorder = (style: CSSStyleDeclaration): boolean => {
+  const sides = ["Top", "Right", "Bottom", "Left"] as const;
+  for (const side of sides) {
+    const w = parseFloat(style[`border${side}Width`]) || 0;
+    const s = style[`border${side}Style`];
+    if (w > 0 && s && s !== "none" && s !== "hidden") return true;
+  }
+  return false;
+};
+let __pseudoEpoch = -1;
+
+const collapseCssContent = (raw: string): string => {
+  if (!raw) return "";
+  const parts: string[] = [];
+  const rx = /"([^"]*)"/g;
+  let lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = rx.exec(raw))) {
+    const between = raw.slice(lastIndex, m.index).trim();
+    if (between) parts.push(between);
+    parts.push(m[1]);
+    lastIndex = rx.lastIndex;
+  }
+  const tail = raw.slice(lastIndex).trim();
+  if (tail) parts.push(tail);
+  return parts.join("");
+};
+
+const withSiblingOverrides = (node: Element, base: CounterContext): CounterContext => {
+  const parent = node.parentElement;
+  const map = parent ? __siblingCounters.get(parent) : null;
+  if (!map) return base;
+  return {
+    get(n: Element, name: string): number {
+      const v = base.get(n, name);
+      const ov = map.get(name);
+      return typeof ov === "number" ? Math.max(v, ov) : v;
+    },
+    getStack(n: Element, name: string): number[] {
+      const s = base.getStack(n, name);
+      if (!s.length) return s;
+      const ov = map.get(name);
+      if (typeof ov === "number") {
+        const out = s.slice();
+        out[out.length - 1] = Math.max(out[out.length - 1], ov);
+        return out;
+      }
+      return s;
+    },
+  };
+};
+
+const deriveCounterCtxForPseudo = (
+  node: Element,
+  pseudoStyle: CSSStyleDeclaration | null | undefined,
+  baseCtx: CounterContext,
+): DerivedCounterContext => {
+  const modStacks = new Map<string, number[]>();
+
+  const parseListDecl = (value: string | null | undefined): CounterDecl[] => {
+    const out: CounterDecl[] = [];
+    if (!value || value === "none") return out;
+    for (const part of String(value).split(",")) {
+      const toks = part.trim().split(/\s+/);
+      const name = toks[0];
+      const num = Number.isFinite(Number(toks[1])) ? Number(toks[1]) : undefined;
+      if (name) out.push({ name, num });
+    }
+    return out;
+  };
+
+  const resets = parseListDecl(pseudoStyle?.counterReset);
+  const sets = parseListDecl(pseudoStyle?.counterSet);
+  const incs = parseListDecl(pseudoStyle?.counterIncrement);
+
+  const getStackDerived = (name: string): number[] => {
+    if (modStacks.has(name)) return modStacks.get(name)!.slice();
+    let stack = baseCtx.getStack(node, name);
+    stack = stack.length ? stack.slice() : [];
+
+    const r = resets.find((x) => x.name === name);
+    if (r) {
+      const val = Number.isFinite(r.num) ? (r.num as number) : 0;
+      stack = stack.length ? [...stack, val] : [val];
+    }
+
+    const s = sets.find((x) => x.name === name);
+    if (s) {
+      const val = Number.isFinite(s.num) ? (s.num as number) : 0;
+      if (stack.length === 0) stack = [0];
+      stack[stack.length - 1] = val;
+    }
+
+    const inc = incs.find((x) => x.name === name);
+    if (inc) {
+      const by = Number.isFinite(inc.num) ? (inc.num as number) : 1;
+      if (stack.length === 0) stack = [0];
+      stack[stack.length - 1] += by;
+    }
+
+    modStacks.set(name, stack.slice());
+    return stack;
+  };
+
+  return {
+    get(_node: Element, name: string): number {
+      const s = getStackDerived(name);
+      return s.length ? s[s.length - 1] : 0;
+    },
+    getStack(_node: Element, name: string): number[] {
+      return getStackDerived(name);
+    },
+    __incs: incs,
+  };
+};
+
+const resolvePseudoContentAndIncs = (
+  node: Element,
+  pseudo: string,
+  baseCtx: CounterContext,
+): { text: string; incs: CounterDecl[] } => {
+  let ps: CSSStyleDeclaration | undefined;
+  try {
+    ps = getStyle(node, pseudo);
+  } catch {}
+  const raw = ps?.content;
+  if (!raw || raw === "none" || raw === "normal") return { text: "", incs: [] };
+
+  const baseWithSiblings = withSiblingOverrides(node, baseCtx);
+
+  const derived = deriveCounterCtxForPseudo(node, ps, baseWithSiblings);
+
+  const resolved = hasCounters(raw) ? resolveCountersInContent(raw, node, derived) : raw;
+
+  const text = collapseCssContent(resolved);
+  return { text, incs: derived.__incs || [] };
+};
+
+export const inlinePseudoElements = async (
+  source: Element,
+  clone: HTMLElement,
+  sessionCache: SnapshotSessionCache,
+  options: SnapshotCaptureContext,
+): Promise<void> => {
+  if (!(source instanceof Element) || !(clone instanceof Element)) return;
+  const doc = source.ownerDocument || document;
+  if (!preflightWithFp(doc, sessionCache)) {
+    return;
+  }
+
+  const epoch = cache?.session?.__counterEpoch ?? 0;
+  if (__pseudoEpoch !== epoch) {
+    __siblingCounters = new WeakMap();
+    if (sessionCache) sessionCache.__counterCtx = null;
+    __pseudoEpoch = epoch;
+  }
+
+  if (!sessionCache.__counterCtx) {
+    try {
+      sessionCache.__counterCtx = buildCounterContext(source.ownerDocument || document);
+    } catch (e) {
+      debugWarn(sessionCache, "buildCounterContext failed", e);
+    }
+  }
+  const counterCtx = sessionCache.__counterCtx!;
+
+  for (const pseudo of ["::before", "::after", "::first-letter"]) {
+    try {
+      const style = getStyle(source, pseudo);
+      if (!style) continue;
+      const isEmptyPseudo =
+        style.content === "none" &&
+        style.backgroundImage === "none" &&
+        style.backgroundColor === "transparent" &&
+        !hasPaintedBorder(style) &&
+        (!style.transform || style.transform === "none") &&
+        style.display === "inline";
+
+      if (isEmptyPseudo) continue;
+
+      if (pseudo === "::first-letter") {
+        const normal = getStyle(source);
+        const disp = (normal?.display || "").toLowerCase();
+        if (disp.includes("flex") || disp.includes("grid")) continue;
+        const isMeaningful =
+          style.color !== normal.color ||
+          style.fontSize !== normal.fontSize ||
+          style.fontWeight !== normal.fontWeight ||
+          style.fontFamily !== normal.fontFamily ||
+          style.fontStyle !== normal.fontStyle ||
+          style.textTransform !== normal.textTransform ||
+          style.float !== normal.float ||
+          style.paddingTop !== normal.paddingTop ||
+          style.paddingRight !== normal.paddingRight ||
+          style.paddingBottom !== normal.paddingBottom ||
+          style.paddingLeft !== normal.paddingLeft ||
+          style.marginTop !== normal.marginTop ||
+          style.marginRight !== normal.marginRight ||
+          style.marginBottom !== normal.marginBottom ||
+          style.marginLeft !== normal.marginLeft;
+        if (!isMeaningful) continue;
+
+        const textNode = Array.from(clone.childNodes).find(
+          (n) => n.nodeType === Node.TEXT_NODE && (n.textContent?.trim().length ?? 0) > 0,
+        );
+        if (!textNode) continue;
+
+        const text = textNode.textContent ?? "";
+        const match = text.match(/^([^\p{L}\p{N}\s]*[\p{L}\p{N}](?:['’])?)/u);
+        const first = match?.[0];
+        const rest = text.slice(first?.length || 0);
+        if (!first || /[\uD800-\uDFFF]/.test(first)) continue;
+
+        const span = document.createElement("span");
+        span.textContent = first;
+        span.dataset.snapshotPseudo = "::first-letter";
+        const snapshot = snapshotComputedStyle(style);
+        const key = getStyleKey(snapshot, "span");
+        sessionCache.styleMap.set(span, key);
+
+        const restNode = document.createTextNode(rest);
+        clone.replaceChild(restNode, textNode);
+        clone.insertBefore(span, restNode);
+        continue;
+      }
+
+      const rawContent = style.content ?? "";
+      const isNoExplicitContent =
+        rawContent === "" || rawContent === "none" || rawContent === "normal";
+      const { text: cleanContent, incs } = resolvePseudoContentAndIncs(source, pseudo, counterCtx);
+
+      const bg = style.backgroundImage;
+      const bgColor = style.backgroundColor;
+      const fontFamily = style.fontFamily;
+      const fontSize = parseInt(style.fontSize) || 32;
+      const fontWeight = parseInt(style.fontWeight) || false;
+      const color = style.color || "#000";
+      const transform = style.transform;
+
+      const isIconFont2 = isIconFont(fontFamily);
+
+      const hasExplicitContent = !isNoExplicitContent && cleanContent !== "";
+      const hasBg = bg && bg !== "none";
+      const hasBgColor = bgColor && bgColor !== "transparent" && bgColor !== "rgba(0, 0, 0, 0)";
+      const hasBorder = hasPaintedBorder(style);
+      const hasTransform = transform && transform !== "none";
+
+      const boxGenerating = rawContent !== "none" && rawContent !== "normal";
+      const hasLayoutBox =
+        boxGenerating &&
+        ((parseFloat(style.width) || 0) > 0 || (parseFloat(style.height) || 0) > 0);
+
+      const shouldRender =
+        hasExplicitContent || hasBg || hasBgColor || hasBorder || hasTransform || hasLayoutBox;
+
+      if (!shouldRender) {
+        if (incs && incs.length && source.parentElement) {
+          const map = __siblingCounters.get(source.parentElement) || new Map<string, number>();
+          for (const { name } of incs) {
+            if (!name) continue;
+            const baseWithSibs = withSiblingOverrides(source, counterCtx);
+            const derived = deriveCounterCtxForPseudo(
+              source,
+              getStyle(source, pseudo),
+              baseWithSibs,
+            );
+            const finalVal = derived.get(source, name);
+            map.set(name, finalVal);
+          }
+          __siblingCounters.set(source.parentElement, map);
+        }
+        continue;
+      }
+
+      let pinNowrap = false;
+      if (
+        hasExplicitContent &&
+        !isIconFont2 &&
+        cleanContent.length > 1 &&
+        !cleanContent.startsWith("url(")
+      ) {
+        const hostStyle = getStyle(source);
+        const fs = parseFloat(hostStyle.fontSize) || 16;
+        let lh = parseFloat(hostStyle.lineHeight);
+        if (!Number.isFinite(lh)) lh = fs * 1.5;
+        const rect = source.getBoundingClientRect();
+        if (rect.height < lh * 1.6) {
+          clone.style.whiteSpace = "nowrap";
+          pinNowrap = true;
+        }
+      }
+
+      const pseudoEl = document.createElement("span");
+      pseudoEl.dataset.snapshotPseudo = pseudo;
+      pseudoEl.style.pointerEvents = "none";
+      if (pinNowrap) pseudoEl.style.whiteSpace = "nowrap";
+      const snapshot = snapshotComputedStyle(style);
+      const key = getStyleKey(snapshot, "span");
+      sessionCache.styleMap.set(pseudoEl, key);
+
+      if (isIconFont2 && cleanContent && cleanContent.length === 1) {
+        const {
+          dataUrl,
+          width: w,
+          height: h,
+        } = await iconToImage(
+          cleanContent,
+          fontFamily,
+          fontWeight as string | number,
+          fontSize,
+          color,
+        );
+        const imgEl = document.createElement("img");
+        imgEl.src = dataUrl;
+        imgEl.style.cssText = `height:${fontSize}px;width:${(w / h) * fontSize}px;object-fit:contain;`;
+        pseudoEl.appendChild(imgEl);
+        clone.dataset.snapshotHasIcon = "true";
+      } else if (cleanContent && cleanContent.startsWith("url(")) {
+        const rawUrl = extractURL(cleanContent);
+        if (rawUrl?.trim()) {
+          try {
+            const dataUrl = await snapFetch(safeEncodeURI(rawUrl), {
+              as: "dataURL",
+              useProxy: options.useProxy,
+            });
+            if (dataUrl?.ok && typeof dataUrl.data === "string") {
+              const imgEl = document.createElement("img");
+              imgEl.src = dataUrl.data;
+              imgEl.style.cssText = `width:${fontSize}px;height:auto;object-fit:contain;`;
+              pseudoEl.appendChild(imgEl);
+            }
+          } catch (e) {
+            console.error(`[snapshot] Error in pseudo ${pseudo} for`, source, e);
+          }
+        }
+      } else if (!isIconFont2 && hasExplicitContent) {
+        pseudoEl.textContent = cleanContent;
+      }
+
+      pseudoEl.style.backgroundImage = "none";
+      if ("maskImage" in pseudoEl.style) pseudoEl.style.maskImage = "none";
+      if ("webkitMaskImage" in pseudoEl.style) pseudoEl.style.webkitMaskImage = "none";
+
+      try {
+        pseudoEl.style.backgroundRepeat = style.backgroundRepeat;
+        pseudoEl.style.backgroundSize = style.backgroundSize;
+        if (style.backgroundPositionX && style.backgroundPositionY) {
+          pseudoEl.style.backgroundPositionX = style.backgroundPositionX;
+          pseudoEl.style.backgroundPositionY = style.backgroundPositionY;
+        } else {
+          pseudoEl.style.backgroundPosition = style.backgroundPosition;
+        }
+        pseudoEl.style.backgroundOrigin = style.backgroundOrigin;
+        pseudoEl.style.backgroundClip = style.backgroundClip;
+        pseudoEl.style.backgroundAttachment = style.backgroundAttachment;
+        pseudoEl.style.backgroundBlendMode = style.backgroundBlendMode;
+      } catch {}
+
+      if (hasBg) {
+        try {
+          const bgSplits = splitBackgroundImage(bg);
+          const newBgParts = await Promise.all(
+            bgSplits.map((entry) => inlineSingleBackgroundEntry(entry)),
+          );
+          pseudoEl.style.backgroundImage = newBgParts.join(", ");
+        } catch (e) {
+          console.warn(`[snapshot] Failed to inline background-image for ${pseudo}`, e);
+        }
+      }
+      if (hasBgColor) pseudoEl.style.backgroundColor = bgColor;
+
+      const hasContent2 = pseudoEl.childNodes.length > 0 || pseudoEl.textContent?.trim() !== "";
+      const hasVisibleBox =
+        hasContent2 || hasBg || hasBgColor || hasBorder || hasTransform || hasLayoutBox;
+
+      if (incs && incs.length && source.parentElement) {
+        const map = __siblingCounters.get(source.parentElement) || new Map<string, number>();
+        const baseWithSibs = withSiblingOverrides(source, counterCtx);
+        const derived = deriveCounterCtxForPseudo(source, getStyle(source, pseudo), baseWithSibs);
+        for (const { name } of incs) {
+          if (!name) continue;
+          const finalVal = derived.get(source, name);
+          map.set(name, finalVal);
+        }
+        __siblingCounters.set(source.parentElement, map);
+      }
+
+      if (!hasVisibleBox) continue;
+
+      if (pseudo === "::before") {
+        clone.dataset.snapshotHasBefore = "1";
+        clone.insertBefore(pseudoEl, clone.firstChild);
+      } else {
+        clone.dataset.snapshotHasAfter = "1";
+        clone.appendChild(pseudoEl);
+      }
+    } catch (e) {
+      console.warn(`[snapshot] Failed to capture ${pseudo} for`, source, e);
+    }
+  }
+
+  const cChildren = (Array.from(clone.children) as HTMLElement[]).filter(
+    (child) => !child.dataset.snapshotPseudo,
+  );
+  if (sessionCache.nodeMap) {
+    for (const cChild of cChildren) {
+      const sChild = sessionCache.nodeMap.get(cChild);
+      if (sChild instanceof Element) {
+        await inlinePseudoElements(sChild, cChild, sessionCache, options);
+      }
+    }
+  } else {
+    const sChildren = Array.from(source.children);
+    for (let i = 0; i < Math.min(sChildren.length, cChildren.length); i++) {
+      await inlinePseudoElements(sChildren[i], cChildren[i], sessionCache, options);
+    }
+  }
+};

--- a/packages/react-grab/src/snapshot/modules/rasterize.ts
+++ b/packages/react-grab/src/snapshot/modules/rasterize.ts
@@ -1,0 +1,18 @@
+import { toCanvas } from "../exporters/to-canvas.js";
+import type { SnapshotCaptureContext } from "../types.js";
+
+export const rasterize = async (
+  url: string,
+  options: SnapshotCaptureContext,
+): Promise<HTMLImageElement> => {
+  const canvas = await toCanvas(url, options);
+
+  const img = new Image();
+  img.src = canvas.toDataURL(`image/${options.format}`, options.quality);
+  await img.decode();
+
+  const dpr = options.dpr ?? 1;
+  img.style.width = `${canvas.width / dpr}px`;
+  img.style.height = `${canvas.height / dpr}px`;
+  return img;
+};

--- a/packages/react-grab/src/snapshot/modules/snap-fetch.ts
+++ b/packages/react-grab/src/snapshot/modules/snap-fetch.ts
@@ -1,0 +1,368 @@
+import { safeEncodeURI } from "../utils/helpers.js";
+
+export type SnapFetchAs = "text" | "blob" | "dataURL";
+
+export interface SnapFetchOptions {
+  as?: SnapFetchAs;
+  timeout?: number;
+  useProxy?: string;
+  errorTTL?: number;
+  credentials?: RequestCredentials;
+  headers?: Record<string, string>;
+  silent?: boolean;
+  onError?: (result: SnapFetchResult) => void;
+}
+
+export interface SnapFetchResult {
+  ok: boolean;
+  data: string | Blob | null;
+  status: number;
+  url: string;
+  fromCache: boolean;
+  mime?: string;
+  reason?: string;
+}
+
+interface SnapLoggerOptions {
+  ttlMs?: number;
+  maxEntries?: number;
+}
+
+interface SnapLogger {
+  warnOnce: (key: string, msg: string) => void;
+  errorOnce: (key: string, msg: string) => void;
+  reset: () => void;
+}
+
+interface SnapFetchErrorCacheEntry {
+  until: number;
+  result: SnapFetchResult;
+}
+
+const createSnapLogger = (
+  prefix = "[snapshot]",
+  { ttlMs = 5 * 60_000, maxEntries = 12 }: SnapLoggerOptions = {},
+): SnapLogger => {
+  const seen = new Map<string, number>();
+  let emitted = 0;
+
+  const log = (level: "warn" | "error", key: string, msg: string): void => {
+    if (emitted >= maxEntries) return;
+    const now = Date.now();
+    const until = seen.get(key) || 0;
+    if (until > now) return;
+    seen.set(key, now + ttlMs);
+    emitted++;
+    if (level === "warn" && console && console.warn) console.warn(`${prefix} ${msg}`);
+    else if (console && console.error) console.error(`${prefix} ${msg}`);
+  };
+
+  return {
+    warnOnce: (key: string, msg: string): void => {
+      log("warn", key, msg);
+    },
+    errorOnce: (key: string, msg: string): void => {
+      log("error", key, msg);
+    },
+    reset: (): void => {
+      seen.clear();
+      emitted = 0;
+    },
+  };
+};
+
+const snapLogger = createSnapLogger("[snapshot]", { ttlMs: 3 * 60_000, maxEntries: 10 });
+
+const _inflight = new Map<string, Promise<SnapFetchResult>>();
+const _errorCache = new Map<string, SnapFetchErrorCacheEntry>();
+
+const isSpecialURL = (url: string): boolean => {
+  return /^data:|^blob:|^about:blank$/i.test(url);
+};
+
+const isAlreadyProxied = (url: string, useProxy: string): boolean => {
+  try {
+    const baseHref =
+      typeof location !== "undefined" && location.href ? location.href : "http://localhost/";
+    const proxyBaseRaw = useProxy.includes("{url}") ? useProxy.split("{url}")[0] : useProxy;
+    const proxyBase = new URL(proxyBaseRaw || ".", baseHref);
+    const u = new URL(url, baseHref);
+
+    if (u.origin === proxyBase.origin) return true;
+
+    const sp = u.searchParams;
+    if (sp && (sp.has("url") || sp.has("target"))) return true;
+  } catch {}
+  return false;
+};
+
+const shouldProxy = (url: string, useProxy: string): boolean => {
+  if (!useProxy) return false;
+  if (isSpecialURL(url)) return false;
+  if (isAlreadyProxied(url, useProxy)) return false;
+  try {
+    const base =
+      typeof location !== "undefined" && location.href ? location.href : "http://localhost/";
+    const u = new URL(url, base);
+    return typeof location !== "undefined" ? u.origin !== location.origin : true;
+  } catch {
+    return Boolean(useProxy);
+  }
+};
+
+const applyProxy = (url: string, useProxy: string): string => {
+  if (!useProxy) return url;
+
+  if (useProxy.includes("{url}")) {
+    return useProxy
+      .replace("{urlRaw}", safeEncodeURI(url))
+      .replace("{url}", encodeURIComponent(url));
+  }
+
+  if (/[?&]url=?$/.test(useProxy)) {
+    return `${useProxy}${encodeURIComponent(url)}`;
+  }
+  if (useProxy.endsWith("?")) {
+    return `${useProxy}url=${encodeURIComponent(url)}`;
+  }
+
+  if (useProxy.endsWith("/")) {
+    return `${useProxy}${safeEncodeURI(url)}`;
+  }
+
+  const sep = useProxy.includes("?") ? "&" : "?";
+  return `${useProxy}${sep}url=${encodeURIComponent(url)}`;
+};
+
+const blobToDataURL = (blob: Blob): Promise<string> => {
+  return new Promise((res, rej) => {
+    const fr = new FileReader();
+    fr.onload = () => res(String(fr.result || ""));
+    fr.onerror = () => rej(new Error("read_failed"));
+    fr.readAsDataURL(blob);
+  });
+};
+
+const makeKey = (
+  url: string,
+  o: Pick<SnapFetchOptions, "as" | "timeout" | "useProxy" | "errorTTL">,
+): string => {
+  return [o.as || "blob", o.timeout ?? 3000, o.useProxy || "", o.errorTTL ?? 8000, url].join("|");
+};
+
+export const snapFetch = async (
+  url: string,
+  options: SnapFetchOptions = {},
+): Promise<SnapFetchResult> => {
+  const as = options.as ?? "blob";
+  const timeout = options.timeout ?? 3000;
+  const useProxy = options.useProxy || "";
+  const errorTTL = options.errorTTL ?? 8000;
+  const headers = options.headers || {};
+  const silent = Boolean(options.silent);
+
+  if (/^data:/i.test(url)) {
+    try {
+      if (as === "text") {
+        return { ok: true, data: String(url), status: 200, url, fromCache: false };
+      }
+      if (as === "dataURL") {
+        return {
+          ok: true,
+          data: String(url),
+          status: 200,
+          url,
+          fromCache: false,
+          mime: String(url).slice(5).split(";")[0] || "",
+        };
+      }
+      const [, meta = "", data = ""] = String(url).match(/^data:([^,]*),(.*)$/) || [];
+      const isBase64 = /;base64/i.test(meta);
+      const bin = isBase64 ? atob(data) : decodeURIComponent(data);
+      const bytes = new Uint8Array([...bin].map((c) => c.charCodeAt(0)));
+      const b = new Blob([bytes], { type: (meta || "").split(";")[0] || "" });
+      return { ok: true, data: b, status: 200, url, fromCache: false, mime: b.type || "" };
+    } catch {
+      return {
+        ok: false,
+        data: null,
+        status: 0,
+        url,
+        fromCache: false,
+        reason: "special_url_error",
+      };
+    }
+  }
+
+  if (/^blob:/i.test(url)) {
+    try {
+      const resp = await fetch(url);
+      if (!resp.ok) {
+        return {
+          ok: false,
+          data: null,
+          status: resp.status,
+          url,
+          fromCache: false,
+          reason: "http_error",
+        };
+      }
+      const blob = await resp.blob();
+      const mime = blob.type || resp.headers.get("content-type") || "";
+      if (as === "dataURL") {
+        const dataURL = await blobToDataURL(blob);
+        return { ok: true, data: dataURL, status: resp.status, url, fromCache: false, mime };
+      }
+      if (as === "text") {
+        const text = await blob.text();
+        return { ok: true, data: text, status: resp.status, url, fromCache: false, mime };
+      }
+      return { ok: true, data: blob, status: resp.status, url, fromCache: false, mime };
+    } catch {
+      return { ok: false, data: null, status: 0, url, fromCache: false, reason: "network" };
+    }
+  }
+
+  if (/^about:blank$/i.test(url)) {
+    if (as === "dataURL") {
+      return {
+        ok: true,
+        data: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
+        status: 200,
+        url,
+        fromCache: false,
+        mime: "image/png",
+      };
+    }
+    return {
+      ok: true,
+      data: as === "text" ? "" : new Blob([]),
+      status: 200,
+      url,
+      fromCache: false,
+    };
+  }
+
+  const key = makeKey(url, { as, timeout, useProxy, errorTTL });
+
+  const e = _errorCache.get(key);
+  if (e && e.until > Date.now()) {
+    return { ...e.result, fromCache: true };
+  } else if (e) {
+    _errorCache.delete(key);
+  }
+
+  const inflight = _inflight.get(key);
+  if (inflight) return inflight;
+
+  const finalURL = shouldProxy(url, useProxy) ? applyProxy(url, useProxy) : url;
+
+  let cred = options.credentials;
+  if (!cred) {
+    try {
+      const base =
+        typeof location !== "undefined" && location.href ? location.href : "http://localhost/";
+      const u = new URL(url, base);
+      const sameOrigin = typeof location !== "undefined" && u.origin === location.origin;
+      cred = sameOrigin ? "include" : "omit";
+    } catch {
+      cred = "omit";
+    }
+  }
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort("timeout"), timeout);
+
+  const p = (async (): Promise<SnapFetchResult> => {
+    try {
+      const resp = await fetch(finalURL, { signal: ctrl.signal, credentials: cred, headers });
+
+      if (!resp.ok) {
+        const result: SnapFetchResult = {
+          ok: false,
+          data: null,
+          status: resp.status,
+          url: finalURL,
+          fromCache: false,
+          reason: "http_error",
+        };
+        if (errorTTL > 0) _errorCache.set(key, { until: Date.now() + errorTTL, result });
+        if (!silent) {
+          const short = `${resp.status} ${resp.statusText || ""}`.trim();
+          snapLogger.warnOnce(
+            `http:${resp.status}:${as}:${new URL(url, location?.href ?? "http://localhost/").origin}`,
+            `HTTP error ${short} while fetching ${as} ${url}`,
+          );
+        }
+        if (options.onError) options.onError(result);
+        return result;
+      }
+
+      if (as === "text") {
+        const text = await resp.text();
+        return { ok: true, data: text, status: resp.status, url: finalURL, fromCache: false };
+      }
+
+      const blob = await resp.blob();
+      const mime = blob.type || resp.headers.get("content-type") || "";
+
+      if (as === "dataURL") {
+        const dataURL = await blobToDataURL(blob);
+        return {
+          ok: true,
+          data: dataURL,
+          status: resp.status,
+          url: finalURL,
+          fromCache: false,
+          mime,
+        };
+      }
+
+      return { ok: true, data: blob, status: resp.status, url: finalURL, fromCache: false, mime };
+    } catch (err) {
+      const candidate = err as { name?: unknown; message?: unknown } | null;
+      const reason =
+        candidate &&
+        typeof candidate === "object" &&
+        "name" in candidate &&
+        candidate.name === "AbortError"
+          ? String(candidate.message || "").includes("timeout")
+            ? "timeout"
+            : "abort"
+          : "network";
+
+      const result: SnapFetchResult = {
+        ok: false,
+        data: null,
+        status: 0,
+        url: finalURL,
+        fromCache: false,
+        reason,
+      };
+
+      if (!/^blob:/i.test(url) && errorTTL > 0) {
+        _errorCache.set(key, { until: Date.now() + errorTTL, result });
+      }
+
+      if (!silent) {
+        const k = `${reason}:${as}:${new URL(url, location?.href ?? "http://localhost/").origin}`;
+        const tips =
+          reason === "timeout"
+            ? `Timeout after ${timeout}ms. Consider increasing timeout or using a proxy for ${url}`
+            : reason === "abort"
+              ? `Request aborted while fetching ${as} ${url}`
+              : `Network/CORS issue while fetching ${as} ${url}. A proxy may be required`;
+        snapLogger.errorOnce(k, tips);
+      }
+
+      if (options.onError) options.onError(result);
+      return result;
+    } finally {
+      clearTimeout(timer);
+      _inflight.delete(key);
+    }
+  })();
+
+  _inflight.set(key, p);
+  return p;
+};

--- a/packages/react-grab/src/snapshot/modules/styles.ts
+++ b/packages/react-grab/src/snapshot/modules/styles.ts
@@ -1,0 +1,412 @@
+import { getStyleKey, shouldIgnoreProp, getStyle } from "../utils/index.js";
+import { cache } from "../core/cache.js";
+import type { SnapshotCaptureContext, SnapshotCachePolicy } from "../types.js";
+
+interface SnapshotCacheEntry {
+  epoch: number;
+  snapshot: Record<string, string>;
+  embedFonts: boolean;
+  excludeStyleProps: unknown;
+}
+
+interface SnapshotStylePersist {
+  snapshotKeyCache: Map<string, string>;
+  defaultStyle: typeof cache.defaultStyle;
+  baseStyle: typeof cache.baseStyle;
+  image: typeof cache.image;
+  resource: typeof cache.resource;
+  background: typeof cache.background;
+  font: typeof cache.font;
+}
+
+interface SnapshotStyleContext {
+  session: typeof cache.session;
+  persist: SnapshotStylePersist;
+  options: SnapshotCaptureContext;
+}
+
+const snapshotCache = new WeakMap<Element, SnapshotCacheEntry>();
+const snapshotKeyCache = new Map<string, string>();
+const MAX_SNAPSHOT_KEY_CACHE = 2000;
+let __epoch = 0;
+const bumpEpoch = (): void => {
+  __epoch++;
+  if (snapshotKeyCache.size > MAX_SNAPSHOT_KEY_CACHE) snapshotKeyCache.clear();
+};
+
+let __wired = false;
+const setupInvalidationOnce = (root: Element = document.documentElement): void => {
+  if (__wired) return;
+  __wired = true;
+  try {
+    const domObs = new MutationObserver(() => bumpEpoch());
+    domObs.observe(root, { subtree: true, childList: true, characterData: true, attributes: true });
+  } catch {}
+  try {
+    const headObs = new MutationObserver(() => bumpEpoch());
+    headObs.observe(document.head, {
+      subtree: true,
+      childList: true,
+      characterData: true,
+      attributes: true,
+    });
+  } catch {}
+  try {
+    const f = document.fonts;
+    if (f) {
+      f.addEventListener?.("loadingdone", bumpEpoch);
+      f.ready?.then(() => bumpEpoch()).catch(() => {});
+    }
+  } catch {}
+};
+
+const snapshotComputedStyleFull = (
+  style: CSSStyleDeclaration,
+  options: SnapshotCaptureContext = {},
+): Record<string, string> => {
+  const out: Record<string, string> = {};
+  const vis = style.getPropertyValue("visibility");
+  const excludeStyleProps = options.excludeStyleProps;
+  for (let i = 0; i < style.length; i++) {
+    const prop = style[i];
+    if (shouldIgnoreProp(prop)) continue;
+    if (excludeStyleProps) {
+      if (excludeStyleProps instanceof RegExp && excludeStyleProps.test(prop)) continue;
+      if (typeof excludeStyleProps === "function" && excludeStyleProps(prop)) continue;
+    }
+    let val = style.getPropertyValue(prop);
+    if (
+      (prop === "background-image" || prop === "content") &&
+      val.includes("url(") &&
+      !val.includes("data:")
+    ) {
+      val = "none";
+    }
+    out[prop] = val;
+  }
+  const EXTRA_TEXT_DECORATION_PROPS = [
+    "text-decoration-line",
+    "text-decoration-color",
+    "text-decoration-style",
+    "text-decoration-thickness",
+    "text-underline-offset",
+    "text-decoration-skip-ink",
+  ];
+  for (const prop of EXTRA_TEXT_DECORATION_PROPS) {
+    if (out[prop]) continue;
+    try {
+      const v = style.getPropertyValue(prop);
+      if (v) out[prop] = v;
+    } catch {}
+  }
+  const TEXT_STROKE_PROPS = [
+    "-webkit-text-stroke",
+    "-webkit-text-stroke-width",
+    "-webkit-text-stroke-color",
+    "paint-order",
+  ];
+  for (const prop of TEXT_STROKE_PROPS) {
+    if (out[prop]) continue;
+    try {
+      const v = style.getPropertyValue(prop);
+      if (v) out[prop] = v;
+    } catch {}
+  }
+  if (options.embedFonts) {
+    const EXTRA_FONT_PROPS = [
+      "font-feature-settings",
+      "font-variation-settings",
+      "font-kerning",
+      "font-variant",
+      "font-variant-ligatures",
+      "font-optical-sizing",
+    ];
+    for (const prop of EXTRA_FONT_PROPS) {
+      if (out[prop]) continue;
+      try {
+        const v = style.getPropertyValue(prop);
+        if (v) out[prop] = v;
+      } catch {}
+    }
+  }
+  if (vis === "hidden") out.opacity = "0";
+  try {
+    const cv = out["content-visibility"] || style.getPropertyValue("content-visibility");
+    if (cv === "hidden") out["visibility"] = "hidden";
+  } catch {}
+
+  const bt = parseFloat(style.getPropertyValue("border-top-width") || "0") || 0;
+  const br = parseFloat(style.getPropertyValue("border-right-width") || "0") || 0;
+  const bb = parseFloat(style.getPropertyValue("border-bottom-width") || "0") || 0;
+  const bl = parseFloat(style.getPropertyValue("border-left-width") || "0") || 0;
+  if (bt === 0 && br === 0 && bb === 0 && bl === 0) {
+    const bis = (style.getPropertyValue("border-image-source") || "").trim();
+    const hasBorderImage = bis && bis !== "none";
+    const BORDER_PROPS = [
+      "border",
+      "border-top",
+      "border-right",
+      "border-bottom",
+      "border-left",
+      "border-width",
+      "border-style",
+      "border-color",
+      "border-top-width",
+      "border-top-style",
+      "border-top-color",
+      "border-right-width",
+      "border-right-style",
+      "border-right-color",
+      "border-bottom-width",
+      "border-bottom-style",
+      "border-bottom-color",
+      "border-left-width",
+      "border-left-style",
+      "border-left-color",
+      "border-block",
+      "border-block-width",
+      "border-block-style",
+      "border-block-color",
+      "border-inline",
+      "border-inline-width",
+      "border-inline-style",
+      "border-inline-color",
+    ];
+    for (const p of BORDER_PROPS) delete out[p];
+    if (!hasBorderImage) out["border"] = "none";
+  }
+
+  return out;
+};
+const __snapshotSig = new WeakMap<Record<string, string>, string>();
+const styleSignature = (snap: Record<string, string>): string => {
+  let sig = __snapshotSig.get(snap);
+  if (sig) return sig;
+  const entries = Object.entries(snap).sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
+  sig = entries.map(([k, v]) => `${k}:${v}`).join(";");
+  __snapshotSig.set(snap, sig);
+  return sig;
+};
+const getSnapshot = (
+  el: Element,
+  preStyle: CSSStyleDeclaration | null = null,
+  options: SnapshotCaptureContext = {},
+): Record<string, string> => {
+  const rec = snapshotCache.get(el);
+  const ef = Boolean(options && options.embedFonts);
+  const ex = (options && options.excludeStyleProps) || null;
+  if (rec && rec.epoch === __epoch && rec.embedFonts === ef && rec.excludeStyleProps === ex)
+    return rec.snapshot;
+  const style = preStyle || getComputedStyle(el);
+  const snap = snapshotComputedStyleFull(style, options);
+  stripHeightForWrappers(el, style, snap);
+  snapshotCache.set(el, { epoch: __epoch, snapshot: snap, embedFonts: ef, excludeStyleProps: ex });
+  return snap;
+};
+
+const _resolveCtx = (
+  sessionOrCtx: unknown,
+  opts?: SnapshotCaptureContext,
+): SnapshotStyleContext => {
+  const probe = sessionOrCtx as
+    | {
+        session?: unknown;
+        persist?: unknown;
+        styleMap?: unknown;
+        styleCache?: unknown;
+        nodeMap?: unknown;
+      }
+    | null
+    | undefined;
+
+  if (probe && probe.session && probe.persist) return sessionOrCtx as SnapshotStyleContext;
+  if (probe && (probe.styleMap || probe.styleCache || probe.nodeMap)) {
+    return {
+      session: sessionOrCtx as typeof cache.session,
+      persist: {
+        snapshotKeyCache,
+        defaultStyle: cache.defaultStyle,
+        baseStyle: cache.baseStyle,
+        image: cache.image,
+        resource: cache.resource,
+        background: cache.background,
+        font: cache.font,
+      },
+      options: opts || {},
+    };
+  }
+
+  return {
+    session: cache.session,
+    persist: {
+      snapshotKeyCache,
+      defaultStyle: cache.defaultStyle,
+      baseStyle: cache.baseStyle,
+      image: cache.image,
+      resource: cache.resource,
+      background: cache.background,
+      font: cache.font,
+    },
+    options: (sessionOrCtx as SnapshotCaptureContext) || opts || {},
+  };
+};
+
+const normalizeInlineStyleToComputed = (
+  source: Element,
+  clone: Element,
+  computed: CSSStyleDeclaration,
+): void => {
+  const sourceStyle = (source as HTMLElement).style;
+  if (!sourceStyle || sourceStyle.length === 0) return;
+  for (let i = 0; i < sourceStyle.length; i++) {
+    const prop = sourceStyle[i];
+    const val = computed.getPropertyValue(prop);
+    if (val) (clone as HTMLElement).style.setProperty(prop, val);
+  }
+};
+
+export const inlineAllStyles = async (
+  source: Element,
+  clone: Element,
+  sessionOrCtx: unknown,
+  opts?: SnapshotCaptureContext,
+): Promise<void> => {
+  if (source.tagName === "STYLE") return;
+
+  const ctx = _resolveCtx(sessionOrCtx, opts);
+  const resetMode: SnapshotCachePolicy | "auto" = (ctx.options && ctx.options.cache) || "auto";
+
+  if (resetMode !== "disabled") setupInvalidationOnce(document.documentElement);
+
+  if (resetMode === "disabled" && !ctx.session.__bumpedForDisabled) {
+    bumpEpoch();
+    snapshotKeyCache.clear();
+    ctx.session.__bumpedForDisabled = true;
+  }
+
+  const { session, persist } = ctx;
+
+  if (!session.styleCache.has(source)) {
+    let computed: CSSStyleDeclaration | null = null;
+    try {
+      computed = getComputedStyle(source);
+    } catch {}
+    session.styleCache.set(source, computed || getComputedStyle(document.documentElement));
+  }
+  const pre = session.styleCache.get(source) as CSSStyleDeclaration;
+
+  if (source.getAttribute?.("style")) {
+    normalizeInlineStyleToComputed(source, clone, pre);
+  }
+
+  const snap = getSnapshot(source, pre, ctx.options);
+
+  if (isFlexOrGridItem(source)) {
+    const mw = pre.getPropertyValue("min-width");
+    if (!mw || mw === "auto" || mw === "0px") {
+      snap["min-width"] = "0px";
+    }
+  }
+
+  const sig = styleSignature(snap);
+  let key = persist.snapshotKeyCache.get(sig);
+  if (!key) {
+    const tag = source.tagName?.toLowerCase() || "div";
+    key = getStyleKey(snap, tag);
+    persist.snapshotKeyCache.set(sig, key);
+  }
+  session.styleMap.set(clone, key);
+};
+
+const isReplaced = (el: Element): boolean => {
+  return (
+    el instanceof HTMLImageElement ||
+    el instanceof HTMLCanvasElement ||
+    el instanceof HTMLVideoElement ||
+    el instanceof HTMLIFrameElement ||
+    el instanceof SVGElement ||
+    el instanceof HTMLObjectElement ||
+    el instanceof HTMLEmbedElement
+  );
+};
+
+const hasBox = (cs: CSSStyleDeclaration): boolean => {
+  if (cs.backgroundImage && cs.backgroundImage !== "none") return true;
+  if (
+    cs.backgroundColor &&
+    cs.backgroundColor !== "rgba(0, 0, 0, 0)" &&
+    cs.backgroundColor !== "transparent"
+  )
+    return true;
+  if ((parseFloat(cs.borderTopWidth) || 0) > 0) return true;
+  if ((parseFloat(cs.borderBottomWidth) || 0) > 0) return true;
+  if ((parseFloat(cs.paddingTop) || 0) > 0) return true;
+  if ((parseFloat(cs.paddingBottom) || 0) > 0) return true;
+  const overflowBlock = (cs as CSSStyleDeclaration & { overflowBlock?: string }).overflowBlock;
+  const ob = overflowBlock || cs.overflowY || "visible";
+  return ob !== "visible";
+};
+
+const isFlexOrGridItem = (el: Element): boolean => {
+  const p = el.parentElement;
+  if (!p) return false;
+  const pd = getStyle(p).display || "";
+  return pd.includes("flex") || pd.includes("grid");
+};
+
+const hasFlowFast = (el: Element, cs: CSSStyleDeclaration): boolean => {
+  if (el.textContent && /\S/.test(el.textContent)) return true;
+  const f = el.firstElementChild,
+    l = el.lastElementChild;
+  if ((f && f.tagName === "BR") || (l && l.tagName === "BR")) return true;
+
+  const sh = el.scrollHeight;
+  if (sh === 0) return false;
+  const pt = parseFloat(cs.paddingTop) || 0;
+  const pb = parseFloat(cs.paddingBottom) || 0;
+  return sh > pt + pb;
+};
+
+const stripHeightForWrappers = (
+  el: Element,
+  cs: CSSStyleDeclaration,
+  snap: Record<string, string>,
+): void => {
+  if (el instanceof HTMLElement && el.style && el.style.height) return;
+
+  const tag = el.tagName && el.tagName.toLowerCase();
+  const ALLOWED_TAGS = ["div", "section", "article", "main", "aside", "header", "footer", "nav"];
+  if (!tag || !ALLOWED_TAGS.includes(tag)) return;
+
+  const usedH = parseFloat(cs.height);
+  const TOL = 2;
+  if (Number.isFinite(usedH) && el.scrollHeight > 0 && Math.abs(usedH - el.scrollHeight) > TOL)
+    return;
+
+  if (cs.aspectRatio && cs.aspectRatio !== "none" && cs.aspectRatio !== "auto") return;
+
+  const disp = cs.display || "";
+  if (disp.includes("flex") || disp.includes("grid")) return;
+
+  if (isReplaced(el)) return;
+
+  const pos = cs.position;
+  if (pos === "absolute" || pos === "fixed" || pos === "sticky") return;
+  if (cs.transform !== "none") return;
+  if (hasBox(cs)) return;
+  if (isFlexOrGridItem(el)) return;
+
+  const overflowX = cs.overflowX || cs.overflow || "visible";
+  const overflowY = cs.overflowY || cs.overflow || "visible";
+  if (overflowX !== "visible" || overflowY !== "visible") return;
+
+  const clip = cs.clip;
+  if (clip && clip !== "auto" && clip !== "rect(auto, auto, auto, auto)") return;
+
+  if (cs.visibility === "hidden" || cs.opacity === "0") return;
+
+  if (!hasFlowFast(el, cs)) return;
+
+  delete snap.height;
+  delete snap["block-size"];
+};

--- a/packages/react-grab/src/snapshot/modules/svg-defs.ts
+++ b/packages/react-grab/src/snapshot/modules/svg-defs.ts
@@ -1,0 +1,181 @@
+export const inlineExternalDefsAndSymbols = (
+  element: Element | null | undefined,
+  lookupRoot?: Document | ParentNode,
+): void => {
+  if (!element || !(element instanceof Element)) return;
+
+  const doc = element.ownerDocument || document;
+  const searchRoot = lookupRoot || doc;
+
+  const svgRoots: SVGSVGElement[] =
+    element instanceof SVGSVGElement ? [element] : Array.from(element.querySelectorAll("svg"));
+
+  if (svgRoots.length === 0) return;
+
+  const URL_ID_RE = /url\(\s*#([^)]+)\)/g;
+  const URL_ATTRS = [
+    "fill",
+    "stroke",
+    "filter",
+    "clip-path",
+    "mask",
+    "marker",
+    "marker-start",
+    "marker-mid",
+    "marker-end",
+  ];
+
+  const cssEscape = (s: string): string =>
+    window.CSS && CSS.escape ? CSS.escape(s) : s.replace(/[^a-zA-Z0-9_-]/g, "\\$&");
+
+  const XLINK_NS = "http://www.w3.org/1999/xlink";
+
+  const getHrefAttr = (el: Element | null | undefined): string | null => {
+    if (!el || !el.getAttribute) return null;
+
+    const href =
+      el.getAttribute("href") ||
+      el.getAttribute("xlink:href") ||
+      (typeof el.getAttributeNS === "function" ? el.getAttributeNS(XLINK_NS, "href") : null);
+
+    if (href) return href;
+
+    const attrs = el.attributes;
+    if (!attrs) return null;
+    for (let i = 0; i < attrs.length; i++) {
+      const a = attrs[i];
+      if (!a || !a.name) continue;
+      if (a.name === "href") return a.value;
+      const idx = a.name.indexOf(":");
+      if (idx !== -1 && a.name.slice(idx + 1) === "href") {
+        return a.value;
+      }
+    }
+    return null;
+  };
+
+  const globalExistingIds = new Set(Array.from(element.querySelectorAll("[id]")).map((n) => n.id));
+
+  const neededIds = new Set<string>();
+
+  let sawAnyReference = false;
+
+  const addUrlIdsFromValue = (
+    val: string | null | undefined,
+    queueForResolve: Set<string> | null = null,
+  ): void => {
+    if (!val) return;
+    URL_ID_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = URL_ID_RE.exec(val))) {
+      sawAnyReference = true;
+      const id = (m[1] || "").trim();
+      if (!id) continue;
+
+      if (!globalExistingIds.has(id)) {
+        neededIds.add(id);
+        if (queueForResolve && !queueForResolve.has(id)) {
+          queueForResolve.add(id);
+        }
+      }
+    }
+  };
+
+  const collectReferencesInSvg = (rootSvg: SVGSVGElement): void => {
+    const uses = rootSvg.querySelectorAll("use");
+    for (const u of uses) {
+      const href = getHrefAttr(u);
+      if (!href || !href.startsWith("#")) continue;
+      sawAnyReference = true;
+      const id = href.slice(1).trim();
+      if (id && !globalExistingIds.has(id)) neededIds.add(id);
+    }
+
+    const query =
+      '*[style*="url("],' +
+      '*[fill^="url("], *[stroke^="url("],*[filter^="url("],' +
+      '*[clip-path^="url("],*[mask^="url("],*[marker^="url("],' +
+      '*[marker-start^="url("],*[marker-mid^="url("],*[marker-end^="url("]';
+
+    const candidates = rootSvg.querySelectorAll(query);
+    for (const el of candidates) {
+      addUrlIdsFromValue(el.getAttribute("style") || "");
+      for (const a of URL_ATTRS) addUrlIdsFromValue(el.getAttribute(a));
+    }
+  };
+
+  for (const svg of svgRoots) collectReferencesInSvg(svg);
+
+  if (!sawAnyReference) return;
+
+  let defsHost: Element | null = element.querySelector("svg.inline-defs-container");
+  if (!defsHost) {
+    defsHost = doc.createElementNS("http://www.w3.org/2000/svg", "svg");
+    defsHost.classList.add("inline-defs-container");
+    defsHost.setAttribute("aria-hidden", "true");
+    defsHost.setAttribute("style", "position:absolute;width:0;height:0;overflow:hidden");
+    element.insertBefore(defsHost, element.firstChild || null);
+  }
+  let localDefs: Element | null = defsHost.querySelector("defs") || null;
+
+  const findGlobalById = (id: string): Element | null => {
+    if (!id) return null;
+    if (globalExistingIds.has(id)) return null;
+    const esc = cssEscape(id);
+
+    const tryFind = (sel: string): Element | null => {
+      const el = searchRoot.querySelector(sel);
+      return el && !element.contains(el) ? el : null;
+    };
+
+    return tryFind(`svg defs > *#${esc}`) || tryFind(`svg > symbol#${esc}`) || tryFind(`*#${esc}`);
+  };
+
+  if (!neededIds.size) return;
+
+  const queued = new Set(neededIds);
+  const inlined = new Set<string>();
+
+  while (queued.size) {
+    const id = queued.values().next().value!;
+    queued.delete(id);
+
+    if (!id || globalExistingIds.has(id) || inlined.has(id)) continue;
+
+    const source = findGlobalById(id);
+    if (!source) {
+      inlined.add(id);
+      continue;
+    }
+
+    if (!localDefs) {
+      localDefs = doc.createElementNS("http://www.w3.org/2000/svg", "defs");
+      defsHost.appendChild(localDefs);
+    }
+
+    const clone = source.cloneNode(true) as Element;
+    if (!clone.id) clone.setAttribute("id", id);
+    localDefs.appendChild(clone);
+    inlined.add(id);
+    globalExistingIds.add(id);
+
+    const walk = [clone, ...clone.querySelectorAll("*")];
+    for (const node of walk) {
+      const href = getHrefAttr(node);
+      if (href && href.startsWith("#")) {
+        const ref = href.slice(1).trim();
+        if (ref && !globalExistingIds.has(ref) && !inlined.has(ref)) {
+          queued.add(ref);
+        }
+      }
+
+      const style = node.getAttribute?.("style") || "";
+      if (style) addUrlIdsFromValue(style, queued);
+
+      for (const a of URL_ATTRS) {
+        const v = node.getAttribute?.(a);
+        if (v) addUrlIdsFromValue(v, queued);
+      }
+    }
+  }
+};

--- a/packages/react-grab/src/snapshot/types.ts
+++ b/packages/react-grab/src/snapshot/types.ts
@@ -1,0 +1,182 @@
+export type SnapshotRasterMime = "png" | "jpg" | "jpeg" | "webp";
+export type SnapshotBlobType = "svg" | SnapshotRasterMime;
+export type SnapshotIconFontMatcher = string | RegExp;
+export type SnapshotCachePolicy = "disabled" | "full" | "auto" | "soft";
+
+export interface SnapshotLocalFont {
+  family: string;
+  src: string;
+  weight?: string | number;
+  style?: string;
+}
+
+export interface SnapshotExcludeFonts {
+  families?: string[];
+  domains?: string[];
+  subsets?: string[];
+}
+
+export interface SnapshotPictureResolverOptions {
+  timeout?: number;
+  concurrency?: number;
+  resolveLazySrc?: boolean;
+  silent?: boolean;
+}
+
+export interface SnapshotOptions {
+  debug?: boolean;
+  fast?: boolean;
+  scale?: number;
+  dpr?: number;
+  width?: number;
+  height?: number;
+  backgroundColor?: string;
+  quality?: number;
+  format?: SnapshotBlobType;
+  useProxy?: string;
+  type?: SnapshotBlobType;
+  exclude?: string[];
+  excludeMode?: "hide" | "remove";
+  filter?: (element: Element) => boolean;
+  filterMode?: "hide" | "remove";
+  outerTransforms?: boolean;
+  outerShadows?: boolean;
+  embedFonts?: boolean;
+  localFonts?: SnapshotLocalFont[];
+  iconFonts?: SnapshotIconFontMatcher | SnapshotIconFontMatcher[];
+  excludeFonts?: SnapshotExcludeFonts;
+  fallbackURL?: string | ((dimensions: { width?: number; height?: number }) => string);
+  cache?: SnapshotCachePolicy;
+  placeholders?: boolean;
+  resolvePicturePlaceholders?: boolean;
+  pictureResolver?: SnapshotPictureResolverOptions;
+  safariWarmupAttempts?: number;
+  plugins?: SnapshotPluginUse[];
+}
+
+export interface SnapshotExportInfo {
+  type?: string;
+  options?: SnapshotCaptureContext;
+  url: string;
+  exports?: Record<string, (options?: SnapshotCaptureContext) => Promise<unknown>>;
+}
+
+export interface SnapshotCaptureContext extends SnapshotOptions {
+  element?: Element;
+  clone?: HTMLElement | SVGElement | null;
+  classCSS?: string;
+  styleCache?: unknown;
+  fontsCSS?: string;
+  baseCSS?: string;
+  svgString?: string;
+  dataURL?: string;
+  snap?: {
+    toPng: (element: Element, options?: SnapshotOptions) => Promise<HTMLImageElement>;
+    toSvg: (element: Element, options?: SnapshotOptions) => Promise<HTMLImageElement>;
+  };
+  export?: SnapshotExportInfo;
+  [key: string]: unknown;
+}
+
+export type SnapshotExporter = (
+  context: SnapshotCaptureContext,
+  options?: SnapshotCaptureContext,
+) => Promise<unknown>;
+
+export type SnapshotExportMap = Record<string, SnapshotExporter>;
+
+export interface SnapshotPlugin {
+  name: string;
+  beforeSnap?: (context: SnapshotCaptureContext) => void | Promise<void>;
+  beforeClone?: (context: SnapshotCaptureContext) => void | Promise<void>;
+  afterClone?: (context: SnapshotCaptureContext) => void | Promise<void>;
+  beforeRender?: (context: SnapshotCaptureContext) => void | Promise<void>;
+  afterRender?: (context: SnapshotCaptureContext) => void | Promise<void>;
+  beforeExport?: (context: SnapshotCaptureContext) => void | Promise<void>;
+  afterExport?: (context: SnapshotCaptureContext, result: unknown) => unknown | Promise<unknown>;
+  defineExports?: (
+    context: SnapshotCaptureContext,
+  ) => SnapshotExportMap | Promise<SnapshotExportMap>;
+  afterSnap?: (context: SnapshotCaptureContext) => void | Promise<void>;
+}
+
+export type SnapshotPluginFactory = (options?: unknown) => SnapshotPlugin;
+
+export type SnapshotPluginUse =
+  | SnapshotPlugin
+  | SnapshotPluginFactory
+  | [SnapshotPluginFactory, unknown]
+  | { plugin: SnapshotPluginFactory; options?: unknown };
+
+export interface SnapshotDownloadOptions {
+  filename?: string;
+  format?: SnapshotBlobType;
+  type?: SnapshotBlobType;
+  quality?: number;
+  width?: number;
+  height?: number;
+}
+
+export interface SnapshotBlobOptions {
+  type?: SnapshotBlobType;
+  quality?: number;
+  width?: number;
+  height?: number;
+}
+
+export interface SnapshotCaptureResult {
+  url: string;
+  toRaw: () => string;
+  to: (type: string, options?: SnapshotCaptureContext) => Promise<unknown>;
+  toImg: (options?: Partial<SnapshotOptions>) => Promise<HTMLImageElement>;
+  toSvg: (options?: Partial<SnapshotOptions>) => Promise<HTMLImageElement>;
+  toCanvas: (options?: Partial<SnapshotOptions>) => Promise<HTMLCanvasElement>;
+  toBlob: (options?: SnapshotBlobOptions & Partial<SnapshotOptions>) => Promise<Blob>;
+  toPng: (options?: Partial<SnapshotOptions>) => Promise<HTMLImageElement>;
+  toJpg: (options?: Partial<SnapshotOptions>) => Promise<HTMLImageElement>;
+  toWebp: (options?: Partial<SnapshotOptions>) => Promise<HTMLImageElement>;
+  download: (options?: SnapshotDownloadOptions & Partial<SnapshotOptions>) => Promise<void>;
+  [key: string]: unknown;
+}
+
+export interface SnapshotIconImageResult {
+  dataUrl: string;
+  width: number;
+  height: number;
+}
+
+export interface SnapshotCounterContext {
+  get: (node: Element, name: string) => number;
+  getStack: (node: Element, name: string) => number[];
+}
+
+export interface SnapshotSessionCache {
+  styleMap: Map<Element, string>;
+  styleCache: WeakMap<Element, CSSStyleDeclaration>;
+  nodeMap: Map<Element, Element>;
+  options?: SnapshotCaptureContext;
+  shadowScopeSeq?: number;
+  __counterEpoch?: number;
+  __counterCtx?: SnapshotCounterContext | null;
+  __pseudoPreflight?: boolean;
+  __pseudoPreflightFp?: string;
+  __bumpedForDisabled?: boolean;
+}
+
+export interface SnapshotImageMeta {
+  w0?: number;
+  h0?: number;
+}
+
+export interface SnapshotPreCacheOptions {
+  root?: Element | Document;
+  embedFonts?: boolean;
+  localFonts?: SnapshotLocalFont[];
+  iconFonts?: SnapshotIconFontMatcher | SnapshotIconFontMatcher[];
+  useProxy?: string;
+  cache?: SnapshotCachePolicy;
+  cacheOpt?: SnapshotCachePolicy;
+  excludeFonts?: SnapshotExcludeFonts;
+  fontStylesheetDomains?: string[];
+  reset?: boolean;
+}

--- a/packages/react-grab/src/snapshot/utils/browser.ts
+++ b/packages/react-grab/src/snapshot/utils/browser.ts
@@ -1,0 +1,61 @@
+interface NavigatorUAData {
+  platform: string;
+}
+
+export const idle = (
+  fn: (deadline?: IdleDeadline) => void,
+  { fast = false }: { fast?: boolean } = {},
+): void => {
+  if (fast) return fn();
+  if ("requestIdleCallback" in window) {
+    requestIdleCallback(fn, { timeout: 50 });
+  } else {
+    setTimeout(fn, 1);
+  }
+};
+
+export const isIOS = (): boolean => {
+  if (typeof navigator === "undefined") return false;
+  const uaData = (navigator as Navigator & { userAgentData?: NavigatorUAData }).userAgentData;
+  if (uaData) {
+    return uaData.platform === "iOS";
+  }
+
+  const ua = navigator.userAgent || "";
+  const isAppleMobile = /iPhone|iPad|iPod/.test(ua);
+  const isIPadOS = navigator.maxTouchPoints > 2 && /Macintosh/.test(ua);
+  return isAppleMobile || isIPadOS;
+};
+
+export const isSafari = (): boolean => {
+  if (typeof navigator === "undefined") return false;
+  const ua = navigator.userAgent || "";
+  const uaLower = ua.toLowerCase();
+
+  const isSafariUA =
+    uaLower.includes("safari") &&
+    !uaLower.includes("chrome") &&
+    !uaLower.includes("crios") &&
+    !uaLower.includes("fxios") &&
+    !uaLower.includes("android");
+
+  const isWebKit = /applewebkit/i.test(ua);
+  const isMobile = /mobile/i.test(ua);
+  const missingSafariToken = !/safari/i.test(ua);
+
+  const isUIWebView = isWebKit && isMobile && missingSafariToken;
+
+  const isWeChatUA = /(micromessenger|wxwork|wecom|windowswechat|macwechat)/i.test(ua);
+
+  const isBaiduUA = /(baiduboxapp|baidubrowser|baidusearch|baiduboxlite)/i.test(uaLower);
+
+  const isIOSWebKit = /ipad|iphone|ipod/.test(uaLower) && isWebKit;
+
+  return isSafariUA || isUIWebView || isWeChatUA || isBaiduUA || isIOSWebKit;
+};
+
+export const isFirefox = (): boolean => {
+  if (typeof navigator === "undefined") return false;
+  const ua = (navigator.userAgent || "").toLowerCase();
+  return ua.includes("firefox") || ua.includes("fxios");
+};

--- a/packages/react-grab/src/snapshot/utils/capture-helpers.ts
+++ b/packages/react-grab/src/snapshot/utils/capture-helpers.ts
@@ -1,0 +1,396 @@
+import { debugWarn } from "./index.js";
+import type { SnapshotCaptureContext } from "../types.js";
+
+export const stripRootShadows = (
+  originalEl: Element,
+  cloneRoot: HTMLElement,
+  opts: SnapshotCaptureContext = {},
+): void => {
+  if (!originalEl || !cloneRoot || !cloneRoot.style) return;
+  const cs = getComputedStyle(originalEl);
+  try {
+    cloneRoot.style.boxShadow = "none";
+  } catch (e) {
+    debugWarn(opts, "stripRootShadows boxShadow", e);
+  }
+  try {
+    cloneRoot.style.textShadow = "none";
+  } catch (e) {
+    debugWarn(opts, "stripRootShadows textShadow", e);
+  }
+  try {
+    cloneRoot.style.outline = "none";
+  } catch (e) {
+    debugWarn(opts, "stripRootShadows outline", e);
+  }
+  const f = cs.filter || "";
+  const cleaned = f
+    .replace(/\bblur\([^()]*\)\s*/gi, "")
+    .replace(/\bdrop-shadow\([^()]*\)\s*/gi, "")
+    .trim()
+    .replace(/\s+/g, " ");
+  try {
+    cloneRoot.style.filter = cleaned.length ? cleaned : "none";
+  } catch (e) {
+    debugWarn(opts, "stripRootShadows filter", e);
+  }
+};
+
+const establishesBFC = (cs: CSSStyleDeclaration): boolean => {
+  const disp = cs.display || "";
+  if (
+    disp.includes("flex") ||
+    disp.includes("grid") ||
+    disp.startsWith("table") ||
+    disp === "inline-block" ||
+    disp === "flow-root"
+  )
+    return true;
+  if (cs.position === "absolute" || cs.position === "fixed") return true;
+  if (cs.float && cs.float !== "none") return true;
+  const ox = cs.overflowX || cs.overflow || "visible";
+  const oy = cs.overflowY || cs.overflow || "visible";
+  if (ox !== "visible" || oy !== "visible") return true;
+  if (cs.contain && /\b(layout|content|paint|strict)\b/.test(cs.contain)) return true;
+  return false;
+};
+
+const firstInFlowBlockChild = (el: Element, side: "top" | "bottom"): Element | null => {
+  const kids = Array.from(el.childNodes);
+  const ordered = side === "top" ? kids : kids.reverse();
+  for (const n of ordered) {
+    if (n.nodeType === Node.TEXT_NODE) {
+      if (/\S/.test(n.textContent || "")) return null;
+      continue;
+    }
+    if (n.nodeType !== Node.ELEMENT_NODE) continue;
+    const element = n as Element;
+    const cs = getComputedStyle(element);
+    const disp = String(cs.display || "");
+    if (disp === "none" || disp === "contents") continue;
+    if (cs.position === "absolute" || cs.position === "fixed") continue;
+    if (cs.float && cs.float !== "none") return null;
+    if (disp.startsWith("inline")) return null;
+    return element;
+  }
+  return null;
+};
+
+export const neutralizeRootMarginCollapse = (originalEl: Element, cloneRoot: HTMLElement): void => {
+  if (!originalEl || !cloneRoot || !cloneRoot.style) return;
+  const rootCS = getComputedStyle(originalEl);
+  if (establishesBFC(rootCS)) return;
+
+  for (const side of ["top", "bottom"] as const) {
+    const Side = side === "top" ? "Top" : "Bottom";
+    const rootStyle = rootCS as unknown as Record<string, string>;
+    if ((parseFloat(rootStyle[`border${Side}Width`]) || 0) > 0) continue;
+    if ((parseFloat(rootStyle[`padding${Side}`]) || 0) > 0) continue;
+
+    let src: Element | null = originalEl;
+    let cln: HTMLElement | null | undefined = cloneRoot;
+    while (src && cln) {
+      const childSrc = firstInFlowBlockChild(src, side);
+      if (!childSrc) break;
+      const idx = Array.from(src.children).indexOf(childSrc);
+      const childCln: HTMLElement | null | undefined =
+        idx >= 0 ? (cln.children[idx] as HTMLElement | undefined) : null;
+      const childCS = getComputedStyle(childSrc);
+      const childStyle = childCS as unknown as Record<string, string>;
+      const m = parseFloat(childStyle[`margin${Side}`]) || 0;
+      if (childCln && childCln.style && m > 0) {
+        (childCln.style as unknown as Record<string, string>)[`margin${Side}`] = "0px";
+      }
+      if (establishesBFC(childCS)) break;
+      if ((parseFloat(childStyle[`border${Side}Width`]) || 0) > 0) break;
+      if ((parseFloat(childStyle[`padding${Side}`]) || 0) > 0) break;
+      src = childSrc;
+      cln = childCln;
+    }
+  }
+};
+
+const removeAllComments = (root: Node): void => {
+  const it = document.createTreeWalker(root, NodeFilter.SHOW_COMMENT);
+  const toRemove: ChildNode[] = [];
+  while (it.nextNode()) toRemove.push(it.currentNode as ChildNode);
+  for (const n of toRemove) n.remove();
+};
+
+const sanitizeAttributesForXHTML = (
+  root: Node,
+  opts: { stripFrameworkDirectives?: boolean } = {},
+): void => {
+  const { stripFrameworkDirectives = true } = opts;
+  const ALLOWED_PREFIXES = new Set(["xml", "xlink"]);
+
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
+  while (walker.nextNode()) {
+    const el = walker.currentNode as Element;
+    for (const attr of Array.from(el.attributes)) {
+      const name = attr.name;
+
+      if (name.includes("@")) {
+        el.removeAttribute(name);
+        continue;
+      }
+
+      if (name.includes(":")) {
+        const prefix = name.split(":", 1)[0];
+        if (!ALLOWED_PREFIXES.has(prefix)) {
+          el.removeAttribute(name);
+          continue;
+        }
+      }
+
+      if (!stripFrameworkDirectives) continue;
+
+      if (
+        name.startsWith("x-") ||
+        name.startsWith("v-") ||
+        name.startsWith(":") ||
+        name.startsWith("on:") ||
+        name.startsWith("bind:") ||
+        name.startsWith("let:") ||
+        name.startsWith("class:")
+      ) {
+        el.removeAttribute(name);
+        continue;
+      }
+    }
+  }
+};
+
+/* eslint-disable no-control-regex */
+const INVALID_XML_CHARS = /[\x00-\x08\x0B\x0C\x0E-\x1F￾￿]/g;
+/* eslint-enable no-control-regex */
+
+const stripInvalidXMLChars = (root: Element): void => {
+  if (!root) return;
+  const clean = (node: Node): void => {
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      const element = node as Element;
+      if (element.attributes) {
+        for (const attr of Array.from(element.attributes)) {
+          const cv = attr.value.replace(INVALID_XML_CHARS, "");
+          if (cv !== attr.value) {
+            try {
+              element.setAttribute(attr.name, cv);
+            } catch {}
+          }
+        }
+      }
+    } else if (node.nodeType === Node.TEXT_NODE || node.nodeType === Node.CDATA_SECTION_NODE) {
+      const charData = node as CharacterData;
+      const cv = charData.data.replace(INVALID_XML_CHARS, "");
+      if (cv !== charData.data) charData.data = cv;
+    }
+  };
+  clean(root);
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT);
+  let n: Node | null;
+  while ((n = walker.nextNode())) clean(n);
+};
+
+export const sanitizeCloneForXHTML = (
+  root: Element,
+  opts: { stripFrameworkDirectives?: boolean } = {},
+): void => {
+  if (!root) return;
+  sanitizeAttributesForXHTML(root, opts);
+  removeAllComments(root);
+  stripInvalidXMLChars(root);
+};
+
+const authorHasExplicitSize = (el: Element): boolean => {
+  try {
+    const s = el.getAttribute?.("style") || "";
+    return /\b(height|width|block-size|inline-size)\s*:/.test(s);
+  } catch {
+    return false;
+  }
+};
+
+const isReplacedElement = (el: Element): boolean => {
+  return (
+    el instanceof HTMLImageElement ||
+    el instanceof HTMLCanvasElement ||
+    el instanceof HTMLVideoElement ||
+    el instanceof HTMLIFrameElement ||
+    el instanceof SVGElement ||
+    el instanceof HTMLObjectElement ||
+    el instanceof HTMLEmbedElement
+  );
+};
+
+const shouldShrinkBox = (srcEl: Element, cs: CSSStyleDeclaration): boolean => {
+  if (!(srcEl instanceof Element)) return false;
+  if (authorHasExplicitSize(srcEl)) return false;
+  if (isReplacedElement(srcEl)) return false;
+
+  const pos = cs.position;
+  if (pos === "absolute" || pos === "fixed" || pos === "sticky") return false;
+
+  const disp = cs.display || "";
+  if (disp.includes("flex") || disp.includes("grid") || disp.startsWith("table")) return false;
+
+  if (cs.transform && cs.transform !== "none") return false;
+
+  return true;
+};
+
+interface ElementStyleCache {
+  get: (key: Element) => CSSStyleDeclaration | undefined;
+  has: (key: Element) => boolean;
+  set: (key: Element, value: CSSStyleDeclaration) => unknown;
+}
+
+export const shrinkAutoSizeBoxes = (
+  sourceRoot: Element,
+  cloneRoot: HTMLElement,
+  styleCache: ElementStyleCache = new Map(),
+): void => {
+  const walk = (src: Element, cln: Element): void => {
+    if (!(src instanceof Element) || !(cln instanceof Element)) return;
+
+    const lostKids = src.childElementCount > cln.childElementCount;
+
+    const cs = styleCache.get(src) || getComputedStyle(src);
+    if (!styleCache.has(src)) styleCache.set(src, cs);
+
+    if (lostKids && shouldShrinkBox(src, cs)) {
+      const cloneStyle = (cln as HTMLElement).style;
+      if (!cloneStyle.height) cloneStyle.height = "auto";
+      if (!cloneStyle.width) cloneStyle.width = "auto";
+
+      cloneStyle.removeProperty("block-size");
+      cloneStyle.removeProperty("inline-size");
+
+      if (!cloneStyle.minHeight) cloneStyle.minHeight = "0";
+      if (!cloneStyle.minWidth) cloneStyle.minWidth = "0";
+      if (!cloneStyle.maxHeight) cloneStyle.maxHeight = "none";
+      if (!cloneStyle.maxWidth) cloneStyle.maxWidth = "none";
+
+      const oy = cs.overflowY || cs.overflowBlock || "visible";
+      const ox = cs.overflowX || cs.overflowInline || "visible";
+      if (oy !== "visible" || ox !== "visible") {
+        cloneStyle.overflow = "visible";
+      }
+    }
+
+    const sKids = Array.from(src.children);
+    const cKids = Array.from(cln.children);
+    for (let i = 0; i < Math.min(sKids.length, cKids.length); i++) {
+      walk(sKids[i], cKids[i]);
+    }
+  };
+
+  walk(sourceRoot, cloneRoot);
+};
+
+const contributesToParentHeight = (el: Element): boolean => {
+  const cs = getComputedStyle(el);
+  if (cs.display === "none") return false;
+  if (cs.position === "absolute" || cs.position === "fixed") return false;
+  return true;
+};
+
+const willBeExcluded = (el: Element, options: SnapshotCaptureContext): boolean => {
+  if (!(el instanceof Element)) return false;
+  if (el.getAttribute("data-capture") === "exclude" && options?.excludeMode === "remove")
+    return true;
+  if (Array.isArray(options?.exclude)) {
+    for (const sel of options.exclude) {
+      try {
+        if (el.matches(sel)) return options.excludeMode === "remove";
+      } catch (e) {
+        debugWarn(options, "exclude selector match failed", e);
+      }
+    }
+  }
+  return false;
+};
+
+export const estimateKeptHeight = (container: Element, options: SnapshotCaptureContext): number => {
+  const csC = getComputedStyle(container);
+  const rC = container.getBoundingClientRect();
+
+  let minTop = Infinity;
+  let maxBottom = -Infinity;
+  let found = false;
+
+  const kids = Array.from(container.children);
+  for (const k of kids) {
+    if (willBeExcluded(k, options)) continue;
+    if (!contributesToParentHeight(k)) continue;
+    const rk = k.getBoundingClientRect();
+    const top = rk.top - rC.top;
+    const bottom = rk.bottom - rC.top;
+    if (bottom <= top) continue;
+    if (top < minTop) minTop = top;
+    if (bottom > maxBottom) maxBottom = bottom;
+    found = true;
+  }
+
+  const contentSpan = found ? Math.max(0, maxBottom - minTop) : 0;
+
+  const bt = parseFloat(csC.borderTopWidth) || 0;
+  const bb = parseFloat(csC.borderBottomWidth) || 0;
+  const pt = parseFloat(csC.paddingTop) || 0;
+  const pb = parseFloat(csC.paddingBottom) || 0;
+
+  return bt + bb + pt + pb + contentSpan;
+};
+
+export const limitDecimals = (v: number, n = 3): number =>
+  Number.isFinite(v) ? Math.round(v * 10 ** n) / 10 ** n : v;
+
+const SCROLLBAR_PSEUDO = /::-webkit-scrollbar(-[a-z]+)?\b/i;
+
+const collectScrollbarRulesFromRules = (
+  rules: CSSRuleList,
+  seen: Set<string> = new Set(),
+): string => {
+  let out = "";
+  if (!rules) return out;
+  for (let i = 0; i < rules.length; i++) {
+    const rule = rules[i];
+    try {
+      const importRule = rule as CSSImportRule;
+      if (rule.type === CSSRule.IMPORT_RULE && importRule.styleSheet) {
+        out += collectScrollbarRulesFromRules(importRule.styleSheet.cssRules, seen);
+        continue;
+      }
+      const mediaRule = rule as CSSMediaRule;
+      if (rule.type === CSSRule.MEDIA_RULE && mediaRule.cssRules) {
+        const inner = collectScrollbarRulesFromRules(mediaRule.cssRules, seen);
+        if (inner) out += `@media ${mediaRule.conditionText}{${inner}}`;
+        continue;
+      }
+      if (rule.type === CSSRule.STYLE_RULE) {
+        const sel = (rule as CSSStyleRule).selectorText || "";
+        if (SCROLLBAR_PSEUDO.test(sel)) {
+          const text = rule.cssText;
+          if (text && !seen.has(text)) {
+            seen.add(text);
+            out += text;
+          }
+        }
+      }
+    } catch {}
+  }
+  return out;
+};
+
+export const collectScrollbarCSS = (doc: Document): string => {
+  if (!doc || !doc.styleSheets) return "";
+  const seen = new Set<string>();
+  let out = "";
+  for (const sheet of Array.from(doc.styleSheets)) {
+    try {
+      const rules = sheet.cssRules;
+      if (rules) out += collectScrollbarRulesFromRules(rules, seen);
+    } catch {}
+  }
+  return out;
+};

--- a/packages/react-grab/src/snapshot/utils/clone-helpers.ts
+++ b/packages/react-grab/src/snapshot/utils/clone-helpers.ts
@@ -1,0 +1,617 @@
+import { idle, debugWarn } from "./index.js";
+import { cache, EvictingMap } from "../core/cache.js";
+import { snapFetch } from "../modules/snap-fetch.js";
+import { inlineAllStyles } from "../modules/styles.js";
+import type { SnapshotCaptureContext, SnapshotSessionCache } from "../types.js";
+
+interface SrcsetPart {
+  url: string;
+  desc: string;
+}
+
+export const idleCallback = (
+  childList: Node[],
+  callback: (child: Node, done: (value: Node | null) => void) => void,
+  fast: boolean,
+): Promise<(Node | null)[]> => {
+  return Promise.all(
+    childList.map((child) => {
+      return new Promise<Node | null>((resolve) => {
+        const deal = (): void => {
+          idle(
+            (deadline?: IdleDeadline) => {
+              const hasIdleBudget =
+                deadline && typeof deadline.timeRemaining === "function"
+                  ? deadline.timeRemaining() > 0
+                  : true;
+
+              if (hasIdleBudget) {
+                callback(child, resolve);
+              } else {
+                deal();
+              }
+            },
+            { fast },
+          );
+        };
+        deal();
+      });
+    }),
+  );
+};
+
+const addNotSlottedRightmost = (sel: string): string => {
+  sel = sel.trim();
+  if (!sel) return sel;
+  if (/:not\(\s*\[data-sd-slotted\]\s*\)\s*$/.test(sel)) return sel;
+  return `${sel}:not([data-sd-slotted])`;
+};
+
+const wrapWithScope = (
+  selectorList: string,
+  scopeSelector: string,
+  excludeSlotted = true,
+): string => {
+  return selectorList
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => {
+      if (s.startsWith(":where(")) return s;
+
+      if (s.startsWith("@")) return s;
+
+      const body = excludeSlotted ? addNotSlottedRightmost(s) : s;
+      return `:where(${scopeSelector} ${body})`;
+    })
+    .join(", ");
+};
+
+export const rewriteShadowCSS = (cssText: string, scopeSelector: string): string => {
+  if (!cssText) return "";
+
+  cssText = cssText.replace(/:host\(([^)]+)\)/g, (_: string, sel: string) => {
+    return `:where(${scopeSelector}:is(${sel.trim()}))`;
+  });
+  cssText = cssText.replace(/:host\b/g, `:where(${scopeSelector})`);
+
+  cssText = cssText.replace(/:host-context\(([^)]+)\)/g, (_: string, sel: string) => {
+    return `:where(:where(${sel.trim()}) ${scopeSelector})`;
+  });
+
+  cssText = cssText.replace(/::slotted\(([^)]+)\)/g, (_: string, sel: string) => {
+    return `:where(${scopeSelector} ${sel.trim()})`;
+  });
+
+  cssText = cssText.replace(
+    /(^|})(\s*)([^@}{]+){/g,
+    (_: string, brace: string, ws: string, selectorList: string) => {
+      const wrapped = wrapWithScope(selectorList, scopeSelector, true);
+      return `${brace}${ws}${wrapped}{`;
+    },
+  );
+
+  return cssText;
+};
+
+export const nextShadowScopeId = (sessionCache: { shadowScopeSeq?: number }): string => {
+  sessionCache.shadowScopeSeq = (sessionCache.shadowScopeSeq || 0) + 1;
+  return `s${sessionCache.shadowScopeSeq}`;
+};
+
+export const extractShadowCSS = (sr: ShadowRoot): string => {
+  let css = "";
+  try {
+    sr.querySelectorAll("style").forEach((s) => {
+      css += (s.textContent || "") + "\n";
+    });
+    const sheets = sr.adoptedStyleSheets || [];
+    for (const sh of sheets) {
+      try {
+        if (sh && sh.cssRules) {
+          for (const rule of sh.cssRules) css += rule.cssText + "\n";
+        }
+      } catch {}
+    }
+  } catch {}
+  return css;
+};
+
+export const injectScopedStyle = (hostClone: Element, cssText: string, scopeId: string): void => {
+  if (!cssText) return;
+  const style = document.createElement("style");
+  style.setAttribute("data-sd", scopeId);
+  style.textContent = cssText;
+  hostClone.insertBefore(style, hostClone.firstChild || null);
+};
+
+export const freezeImgSrcset = (original: HTMLImageElement, cloned: HTMLImageElement): void => {
+  try {
+    const chosen = original.currentSrc || original.src || "";
+    if (!chosen) return;
+    cloned.setAttribute("src", chosen);
+    cloned.removeAttribute("srcset");
+    cloned.removeAttribute("sizes");
+    cloned.loading = "eager";
+    cloned.decoding = "sync";
+  } catch {}
+};
+
+export const collectCustomPropsFromCSS = (cssText: string): Set<string> => {
+  const out = new Set<string>();
+  if (!cssText) return out;
+  const re = /var\(\s*(--[A-Za-z0-9_-]+)\b/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(cssText))) out.add(m[1]);
+  return out;
+};
+
+const resolveCustomProp = (el: Element, name: string): string => {
+  try {
+    const cs = getComputedStyle(el);
+    const v = cs.getPropertyValue(name).trim();
+    if (v) return v;
+  } catch {}
+  try {
+    const rootCS = getComputedStyle(document.documentElement);
+    const v = rootCS.getPropertyValue(name).trim();
+    if (v) return v;
+  } catch {}
+  return "";
+};
+
+export const buildSeedCustomPropsRule = (
+  hostEl: Element,
+  names: Iterable<string>,
+  scopeSelector: string,
+): string => {
+  const decls: string[] = [];
+  for (const name of names) {
+    const val = resolveCustomProp(hostEl, name);
+    if (val) decls.push(`${name}: ${val};`);
+  }
+  if (!decls.length) return "";
+  return `${scopeSelector}{${decls.join("")}}\n`;
+};
+
+export const markSlottedSubtree = (root: Element | null): void => {
+  if (!root) return;
+  if (root.nodeType === Node.ELEMENT_NODE) {
+    root.setAttribute("data-sd-slotted", "");
+  }
+  if (root.querySelectorAll) {
+    root.querySelectorAll("*").forEach((el) => el.setAttribute("data-sd-slotted", ""));
+  }
+};
+
+const getAccessibleIframeDocument = async (
+  iframe: HTMLIFrameElement,
+  attempts = 3,
+): Promise<Document | null> => {
+  const probe = (): Document | null => {
+    try {
+      return iframe.contentDocument || iframe.contentWindow?.document || null;
+    } catch {
+      return null;
+    }
+  };
+  let doc = probe();
+  let i = 0;
+  while (i < attempts && (!doc || (!doc.body && !doc.documentElement))) {
+    await new Promise((r) => setTimeout(r, 0));
+    doc = probe();
+    i++;
+  }
+  return doc && (doc.body || doc.documentElement) ? doc : null;
+};
+
+const measureContentBox = (
+  el: Element,
+): { contentWidth: number; contentHeight: number; rect: DOMRect } => {
+  const rect = el.getBoundingClientRect();
+  let bl = 0,
+    br = 0,
+    bt = 0,
+    bb = 0;
+  try {
+    const cs = getComputedStyle(el);
+    bl = parseFloat(cs.borderLeftWidth) || 0;
+    br = parseFloat(cs.borderRightWidth) || 0;
+    bt = parseFloat(cs.borderTopWidth) || 0;
+    bb = parseFloat(cs.borderBottomWidth) || 0;
+  } catch {}
+  const contentWidth = Math.max(0, Math.round(rect.width - (bl + br)));
+  const contentHeight = Math.max(0, Math.round(rect.height - (bt + bb)));
+  return { contentWidth, contentHeight, rect };
+};
+
+export const getUnscaledDimensions = (el: Element): { width: number; height: number } => {
+  let width = 0;
+  let height = 0;
+
+  const sized = el as HTMLImageElement;
+
+  if (sized.offsetWidth > 0) width = sized.offsetWidth;
+  if (sized.offsetHeight > 0) height = sized.offsetHeight;
+
+  if (width === 0 || height === 0) {
+    try {
+      const cs = getComputedStyle(el);
+      if (width === 0) {
+        const w = parseFloat(cs.width);
+        if (!isNaN(w) && w > 0) width = w;
+      }
+      if (height === 0) {
+        const h = parseFloat(cs.height);
+        if (!isNaN(h) && h > 0) height = h;
+      }
+    } catch {}
+  }
+
+  if (width === 0 || height === 0) {
+    try {
+      if (width === 0) {
+        const w = parseFloat(el.getAttribute("width") ?? "");
+        if (!isNaN(w) && w > 0) width = w;
+      }
+      if (height === 0) {
+        const h = parseFloat(el.getAttribute("height") ?? "");
+        if (!isNaN(h) && h > 0) height = h;
+      }
+    } catch {}
+  }
+
+  if ((width === 0 || height === 0) && (sized.naturalWidth || sized.naturalHeight)) {
+    try {
+      if (width === 0 && sized.naturalWidth > 0) width = sized.naturalWidth;
+      if (height === 0 && sized.naturalHeight > 0) height = sized.naturalHeight;
+    } catch {}
+  }
+
+  return { width, height };
+};
+
+const pinIframeViewport = (doc: Document, w: number, h: number): (() => void) => {
+  const win = doc.defaultView;
+  const sx = win ? win.scrollX : 0;
+  const sy = win ? win.scrollY : 0;
+  const bsl = doc.body ? doc.body.scrollLeft : 0;
+  const bst = doc.body ? doc.body.scrollTop : 0;
+  const hsl = doc.documentElement ? doc.documentElement.scrollLeft : 0;
+  const hst = doc.documentElement ? doc.documentElement.scrollTop : 0;
+
+  const style = doc.createElement("style");
+  style.setAttribute("data-sd-iframe-pin", "");
+  style.textContent = `html, body {margin: 0 !important;padding: 0 !important;width: ${w}px !important;height: ${h}px !important;min-width: ${w}px !important;min-height: ${h}px !important;box-sizing: border-box !important;overflow: hidden !important;background-clip: border-box !important;}`;
+  (doc.head || doc.documentElement).appendChild(style);
+
+  return () => {
+    try {
+      style.remove();
+    } catch {}
+    try {
+      if (win && typeof win.scrollTo === "function") win.scrollTo(sx, sy);
+      if (doc.body) {
+        doc.body.scrollLeft = bsl;
+        doc.body.scrollTop = bst;
+      }
+      if (doc.documentElement) {
+        doc.documentElement.scrollLeft = hsl;
+        doc.documentElement.scrollTop = hst;
+      }
+    } catch {}
+  };
+};
+
+export const rasterizeIframe = async (
+  iframe: HTMLIFrameElement,
+  sessionCache: SnapshotSessionCache,
+  options: SnapshotCaptureContext,
+): Promise<HTMLElement> => {
+  const doc = await getAccessibleIframeDocument(iframe, 3);
+  if (!doc) throw new Error("iframe document not accessible/ready");
+
+  const { contentWidth, contentHeight, rect } = measureContentBox(iframe);
+
+  let snap = options?.snap;
+  const globalWithSnapshot = window as unknown as { snapshot?: SnapshotCaptureContext["snap"] };
+  if (!snap && typeof window !== "undefined" && globalWithSnapshot.snapshot) {
+    snap = globalWithSnapshot.snapshot;
+  }
+  if (!snap || typeof snap.toPng !== "function") {
+    throw new Error(
+      "[snapshot] iframe capture requires snapshot.toPng. Use snapshot(el) or pass options.snap. " +
+        "With ESM, assign window.snapshot = snapshot after import if using iframes.",
+    );
+  }
+
+  const nested = { ...options, scale: 1 };
+
+  const unpin = pinIframeViewport(doc, contentWidth, contentHeight);
+  let imgEl: HTMLImageElement;
+  try {
+    imgEl = await snap.toPng(doc.documentElement, nested);
+  } finally {
+    unpin();
+  }
+
+  imgEl.style.display = "block";
+  imgEl.style.width = `${contentWidth}px`;
+  imgEl.style.height = `${contentHeight}px`;
+
+  const wrapper = document.createElement("div");
+  sessionCache.nodeMap.set(wrapper, iframe);
+  inlineAllStyles(iframe, wrapper, sessionCache, options);
+  wrapper.style.overflow = "hidden";
+  wrapper.style.display = "block";
+  if (!wrapper.style.width) wrapper.style.width = `${Math.round(rect.width)}px`;
+  if (!wrapper.style.height) wrapper.style.height = `${Math.round(rect.height)}px`;
+
+  wrapper.appendChild(imgEl);
+  return wrapper;
+};
+
+export const createCheckboxRadioReplacement = (
+  node: HTMLInputElement,
+): { el: HTMLDivElement; applyVisual: () => void } => {
+  const { width: unscaledW, height: unscaledH } = getUnscaledDimensions(node);
+  const rect = node.getBoundingClientRect();
+  let cs: CSSStyleDeclaration | undefined;
+  try {
+    cs = window.getComputedStyle(node);
+  } catch {}
+  const parsedW = cs ? parseFloat(cs.width) : NaN;
+  const parsedH = cs ? parseFloat(cs.height) : NaN;
+  const rw = Math.round(unscaledW || rect.width || 0);
+  const rh = Math.round(unscaledH || rect.height || 0);
+  const w = Number.isFinite(parsedW) && parsedW > 0 ? Math.round(parsedW) : Math.max(12, rw || 16);
+  const h = Number.isFinite(parsedH) && parsedH > 0 ? Math.round(parsedH) : Math.max(12, rh || 16);
+  const isCheckbox = (node.type || "text").toLowerCase() === "checkbox";
+  const checked = Boolean(node.checked);
+  const indeterminate = Boolean(node.indeterminate);
+
+  const size = Math.max(Math.min(w, h), 12);
+  const s = size;
+
+  let vAlign = "middle";
+  try {
+    if (cs && cs.verticalAlign) vAlign = cs.verticalAlign;
+  } catch {}
+
+  const box = document.createElement("div");
+  box.setAttribute("data-snapshot-input-replacement", node.type || "checkbox");
+  box.style.cssText = `display:inline-block;width:${s}px;height:${s}px;vertical-align:${vAlign};flex-shrink:0;line-height:0;`;
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("width", String(s));
+  svg.setAttribute("height", String(s));
+  svg.setAttribute("viewBox", `0 0 ${s} ${s}`);
+  box.appendChild(svg);
+
+  const applyVisual = (): void => {
+    let color = "#0a6ed1";
+    try {
+      if (cs) color = cs.accentColor || cs.color || color;
+    } catch {}
+    const stroke = 2;
+    const pad = stroke / 2;
+    const inner = s - stroke;
+    svg.innerHTML = "";
+    if (isCheckbox) {
+      const rectEl = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+      rectEl.setAttribute("x", String(pad));
+      rectEl.setAttribute("y", String(pad));
+      rectEl.setAttribute("width", String(inner));
+      rectEl.setAttribute("height", String(inner));
+      rectEl.setAttribute("rx", "2");
+      rectEl.setAttribute("ry", "2");
+      rectEl.setAttribute("fill", checked ? color : "none");
+      rectEl.setAttribute("stroke", color);
+      rectEl.setAttribute("stroke-width", String(stroke));
+      svg.appendChild(rectEl);
+      if (checked) {
+        const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+        path.setAttribute(
+          "d",
+          `M ${pad + 2} ${s / 2} L ${s / 2 - 1} ${s - pad - 2} L ${s - pad - 2} ${pad + 2}`,
+        );
+        path.setAttribute("stroke", "white");
+        path.setAttribute("stroke-width", String(Math.max(1.5, stroke)));
+        path.setAttribute("fill", "none");
+        path.setAttribute("stroke-linecap", "round");
+        path.setAttribute("stroke-linejoin", "round");
+        svg.appendChild(path);
+      } else if (indeterminate) {
+        const dash = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+        const dw = Math.max(6, inner - 4);
+        dash.setAttribute("x", String((s - dw) / 2));
+        dash.setAttribute("y", String((s - stroke) / 2));
+        dash.setAttribute("width", String(dw));
+        dash.setAttribute("height", String(stroke));
+        dash.setAttribute("fill", color);
+        dash.setAttribute("rx", "1");
+        svg.appendChild(dash);
+      }
+    } else {
+      const circle = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+      circle.setAttribute("cx", String(s / 2));
+      circle.setAttribute("cy", String(s / 2));
+      circle.setAttribute("r", String((s - stroke) / 2));
+      circle.setAttribute("fill", checked ? color : "none");
+      circle.setAttribute("stroke", color);
+      circle.setAttribute("stroke-width", String(stroke));
+      svg.appendChild(circle);
+      if (checked) {
+        const dot = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+        const r = Math.max(2, (s - stroke * 2) * 0.35);
+        dot.setAttribute("cx", String(s / 2));
+        dot.setAttribute("cy", String(s / 2));
+        dot.setAttribute("r", String(r));
+        dot.setAttribute("fill", "white");
+        svg.appendChild(dot);
+      }
+    }
+    box.style.setProperty("width", `${s}px`, "important");
+    box.style.setProperty("height", `${s}px`, "important");
+    box.style.setProperty("min-width", `${s}px`, "important");
+    box.style.setProperty("min-height", `${s}px`, "important");
+  };
+  applyVisual();
+  return { el: box, applyVisual };
+};
+
+const _blobToDataUrlCache = new EvictingMap(80);
+
+export const blobUrlToDataUrl = async (blobUrl: string): Promise<string> => {
+  if (cache.resource?.has(blobUrl)) return cache.resource.get(blobUrl) as string;
+
+  if (_blobToDataUrlCache.has(blobUrl))
+    return _blobToDataUrlCache.get(blobUrl) as string | Promise<string>;
+
+  const p = (async (): Promise<string> => {
+    const r = await snapFetch(blobUrl, { as: "dataURL", silent: true });
+    if (!r.ok || typeof r.data !== "string") {
+      throw new Error(`[snapshot] Failed to read blob URL: ${blobUrl}`);
+    }
+    cache.resource?.set(blobUrl, r.data);
+    return r.data;
+  })();
+
+  _blobToDataUrlCache.set(blobUrl, p);
+  try {
+    const data = await p;
+    _blobToDataUrlCache.set(blobUrl, data);
+    return data;
+  } catch (e) {
+    _blobToDataUrlCache.delete(blobUrl);
+    throw e;
+  }
+};
+
+const BLOB_URL_RE = /\bblob:[^)"'\s]+/g;
+
+const replaceBlobUrlsInCssText = async (cssText: string): Promise<string> => {
+  if (!cssText || cssText.indexOf("blob:") === -1) return cssText;
+  const uniques = Array.from(new Set(cssText.match(BLOB_URL_RE) || []));
+  if (uniques.length === 0) return cssText;
+  let out = cssText;
+  for (const u of uniques) {
+    try {
+      const d = await blobUrlToDataUrl(u);
+      out = out.split(u).join(d);
+    } catch {}
+  }
+  return out;
+};
+
+const isBlobUrl = (u: unknown): u is string => {
+  return typeof u === "string" && u.startsWith("blob:");
+};
+
+const parseSrcset = (srcset: string): SrcsetPart[] => {
+  return (srcset || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((item) => {
+      const m = item.match(/^(\S+)(\s+.+)?$/);
+      return m ? { url: m[1], desc: m[2] || "" } : null;
+    })
+    .filter((part): part is SrcsetPart => Boolean(part));
+};
+
+const stringifySrcset = (parts: SrcsetPart[]): string => {
+  return parts.map((p) => (p.desc ? `${p.url} ${p.desc.trim()}` : p.url)).join(", ");
+};
+
+export const resolveBlobUrlsInTree = async (
+  root: ParentNode | null,
+  sessionCache: SnapshotCaptureContext | null = null,
+): Promise<void> => {
+  if (!root) return;
+  const ctx = sessionCache;
+
+  const imgs = root.querySelectorAll ? root.querySelectorAll("img") : [];
+  for (const img of imgs) {
+    try {
+      const srcAttr = img.getAttribute("src");
+      const effective = srcAttr || img.currentSrc || "";
+      if (isBlobUrl(effective)) {
+        const data = await blobUrlToDataUrl(effective);
+        img.setAttribute("src", data);
+      }
+      const srcset = img.getAttribute("srcset");
+      if (srcset && srcset.includes("blob:")) {
+        const parts = parseSrcset(srcset);
+        let changed = false;
+        for (const p of parts) {
+          if (isBlobUrl(p.url)) {
+            try {
+              p.url = await blobUrlToDataUrl(p.url);
+              changed = true;
+            } catch (e) {
+              debugWarn(ctx, "blobUrlToDataUrl for srcset item failed", e);
+            }
+          }
+        }
+        if (changed) img.setAttribute("srcset", stringifySrcset(parts));
+      }
+    } catch (e) {
+      debugWarn(ctx, "resolveBlobUrls for img failed", e);
+    }
+  }
+
+  const svgImages = root.querySelectorAll ? root.querySelectorAll("image") : [];
+  for (const node of svgImages) {
+    try {
+      const XLINK_NS = "http://www.w3.org/1999/xlink";
+      const href = node.getAttribute("href") || node.getAttributeNS?.(XLINK_NS, "href");
+      if (isBlobUrl(href)) {
+        const d = await blobUrlToDataUrl(href);
+        node.setAttribute("href", d);
+        node.removeAttributeNS?.(XLINK_NS, "href");
+      }
+    } catch (e) {
+      debugWarn(ctx, "resolveBlobUrls for SVG image href failed", e);
+    }
+  }
+
+  const styled = root.querySelectorAll ? root.querySelectorAll("[style*='blob:']") : [];
+  for (const el of styled) {
+    try {
+      const styleText = el.getAttribute("style");
+      if (styleText && styleText.includes("blob:")) {
+        const replaced = await replaceBlobUrlsInCssText(styleText);
+        el.setAttribute("style", replaced);
+      }
+    } catch (e) {
+      debugWarn(ctx, "replaceBlobUrls in inline style failed", e);
+    }
+  }
+
+  const styleTags = root.querySelectorAll ? root.querySelectorAll("style") : [];
+  for (const s of styleTags) {
+    try {
+      const css = s.textContent || "";
+      if (css.includes("blob:")) {
+        s.textContent = await replaceBlobUrlsInCssText(css);
+      }
+    } catch (e) {
+      debugWarn(ctx, "replaceBlobUrls in style tag failed", e);
+    }
+  }
+
+  const urlAttrs = ["poster"];
+  for (const attr of urlAttrs) {
+    const nodes = root.querySelectorAll ? root.querySelectorAll(`[${attr}^='blob:']`) : [];
+    for (const n of nodes) {
+      try {
+        const u = n.getAttribute(attr);
+        if (isBlobUrl(u)) {
+          n.setAttribute(attr, await blobUrlToDataUrl(u));
+        }
+      } catch (e) {
+        debugWarn(ctx, `resolveBlobUrls for ${attr} failed`, e);
+      }
+    }
+  }
+};

--- a/packages/react-grab/src/snapshot/utils/css.ts
+++ b/packages/react-grab/src/snapshot/utils/css.ts
@@ -1,0 +1,355 @@
+import { cache } from "../core/cache.js";
+
+export const NO_CAPTURE_TAGS = new Set(["meta", "script", "noscript", "title", "link", "template"]);
+
+const NO_DEFAULTS_TAGS = new Set([
+  "meta",
+  "link",
+  "style",
+  "title",
+  "noscript",
+  "script",
+  "template",
+  "g",
+  "defs",
+  "use",
+  "marker",
+  "mask",
+  "clipPath",
+  "pattern",
+  "path",
+  "polygon",
+  "polyline",
+  "line",
+  "circle",
+  "ellipse",
+  "rect",
+  "filter",
+  "lineargradient",
+  "radialgradient",
+  "stop",
+]);
+
+const commonTags = [
+  "div",
+  "span",
+  "p",
+  "a",
+  "img",
+  "ul",
+  "li",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  "label",
+  "section",
+  "article",
+  "header",
+  "footer",
+  "nav",
+  "main",
+  "aside",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "table",
+  "thead",
+  "tbody",
+  "tr",
+  "td",
+  "th",
+];
+
+export const precacheCommonTags = (): void => {
+  for (const tag of commonTags) {
+    const t = String(tag).toLowerCase();
+    if (NO_CAPTURE_TAGS.has(t)) continue;
+    if (NO_DEFAULTS_TAGS.has(t)) continue;
+    getDefaultStyleForTag(t);
+  }
+};
+
+const getDefaultStyleForTag = (tagName: string): Record<string, string> => {
+  tagName = String(tagName).toLowerCase();
+
+  if (NO_DEFAULTS_TAGS.has(tagName)) {
+    const empty: Record<string, string> = {};
+    cache.defaultStyle.set(tagName, empty);
+    return empty;
+  }
+
+  if (cache.defaultStyle.has(tagName)) {
+    return cache.defaultStyle.get(tagName)!;
+  }
+
+  let sandbox = document.getElementById("snapshot-sandbox");
+  if (!sandbox) {
+    sandbox = document.createElement("div");
+    sandbox.id = "snapshot-sandbox";
+    sandbox.setAttribute("data-snapshot-sandbox", "true");
+    sandbox.setAttribute("aria-hidden", "true");
+    sandbox.style.position = "absolute";
+    sandbox.style.left = "-9999px";
+    sandbox.style.top = "-9999px";
+    sandbox.style.width = "0px";
+    sandbox.style.height = "0px";
+    sandbox.style.overflow = "hidden";
+    document.body.appendChild(sandbox);
+  }
+
+  const el = document.createElement(tagName);
+  el.style.all = "initial";
+  sandbox.appendChild(el);
+
+  const styles = getComputedStyle(el);
+  const defaults: Record<string, string> = {};
+  for (const prop of styles) {
+    if (shouldIgnoreProp(prop)) continue;
+    const value = styles.getPropertyValue(prop);
+    defaults[prop] = value;
+  }
+
+  sandbox.removeChild(el);
+  cache.defaultStyle.set(tagName, defaults);
+  return defaults;
+};
+
+const NO_PAINT_TOKEN = /(?:^|-)(animation|transition)(?:-|$)/i;
+
+const NO_PAINT_PREFIX =
+  /^(--.+|view-timeline|scroll-timeline|animation-trigger|offset-|position-try|app-region|interactivity|overlay|view-transition|-webkit-locale|-webkit-user-(?:drag|modify)|-webkit-tap-highlight-color|-webkit-text-security)$/i;
+
+const NO_PAINT_EXACT = new Set([
+  "cursor",
+  "pointer-events",
+  "touch-action",
+  "user-select",
+  "print-color-adjust",
+  "speak",
+  "reading-flow",
+  "reading-order",
+  "anchor-name",
+  "anchor-scope",
+  "container-name",
+  "container-type",
+  "timeline-scope",
+  "zoom",
+]);
+
+export const shouldIgnoreProp = (prop: string): boolean => {
+  const p = String(prop).toLowerCase();
+  if (NO_PAINT_EXACT.has(p)) return true;
+  if (NO_PAINT_PREFIX.test(p)) return true;
+  if (NO_PAINT_TOKEN.test(p)) return true;
+  return false;
+};
+
+export const getStyleKey = (snapshot: Record<string, string>, tagName: string): string => {
+  tagName = String(tagName || "").toLowerCase();
+  if (NO_DEFAULTS_TAGS.has(tagName)) {
+    return "";
+  }
+
+  const entries: string[] = [];
+  const defaults = getDefaultStyleForTag(tagName);
+  const display = (snapshot.display || "").toLowerCase();
+  const isInline = display === "inline";
+  const INLINE_SIZED_TAGS = new Set([
+    "span",
+    "small",
+    "em",
+    "strong",
+    "b",
+    "i",
+    "u",
+    "s",
+    "code",
+    "cite",
+    "mark",
+    "sub",
+    "sup",
+  ]);
+  const TABLE_TAGS = new Set(["table", "thead", "tbody", "tfoot", "tr", "td", "th"]);
+  const skipWidth = isInline || INLINE_SIZED_TAGS.has(tagName) || TABLE_TAGS.has(tagName);
+  const isWidthProp = (p: string): boolean =>
+    p === "width" ||
+    p === "min-width" ||
+    p === "max-width" ||
+    p === "inline-size" ||
+    p === "min-inline-size" ||
+    p === "max-inline-size";
+  for (const [prop, value] of Object.entries(snapshot)) {
+    if (shouldIgnoreProp(prop)) continue;
+    if (skipWidth && isWidthProp(prop)) continue;
+    const def = defaults[prop];
+    if (value && value !== def) entries.push(`${prop}:${value}`);
+  }
+  entries.sort();
+  return entries.join(";");
+};
+
+export const collectUsedTagNames = (root: Node): string[] => {
+  const tagSet = new Set<string>();
+  if (root.nodeType !== Node.ELEMENT_NODE && root.nodeType !== Node.DOCUMENT_FRAGMENT_NODE) {
+    return [];
+  }
+  const elementLike = root as Element;
+  if (elementLike.tagName) {
+    tagSet.add(elementLike.tagName.toLowerCase());
+  }
+  if (typeof elementLike.querySelectorAll === "function") {
+    elementLike.querySelectorAll("*").forEach((el) => tagSet.add(el.tagName.toLowerCase()));
+  }
+  return Array.from(tagSet);
+};
+
+export const generateDedupedBaseCSS = (usedTagNames: string[]): string => {
+  const groups = new Map<string, string[]>();
+
+  for (const tagName of usedTagNames) {
+    const styles = cache.defaultStyle.get(tagName);
+    if (!styles) continue;
+
+    const key = Object.entries(styles)
+      .map(([k, v]) => `${k}:${v};`)
+      .sort()
+      .join("");
+
+    if (!key) continue;
+
+    if (!groups.has(key)) {
+      groups.set(key, []);
+    }
+    groups.get(key)!.push(tagName);
+  }
+
+  let css = "";
+  for (const [styleBlock, tagList] of groups.entries()) {
+    css += `${tagList.join(",")} { ${styleBlock} }\n`;
+  }
+
+  return css;
+};
+
+export const generateCSSClasses = (styleMap: Map<unknown, string>): Map<string, string> => {
+  const keys = Array.from(new Set(styleMap.values())).filter(Boolean).sort();
+  const classMap = new Map<string, string>();
+  let i = 1;
+  for (const k of keys) classMap.set(k, `c${i++}`);
+  return classMap;
+};
+
+const getWindowForElement = (el: Element): Window | null => {
+  try {
+    const doc = el?.ownerDocument;
+    if (!doc) return typeof window !== "undefined" ? window : null;
+    const win = doc.defaultView;
+    if (win && typeof win.getComputedStyle === "function") return win;
+    if (typeof window !== "undefined" && window.frames) {
+      for (let i = 0; i < window.frames.length; i++) {
+        try {
+          if (window.frames[i]?.document === doc) return window.frames[i];
+        } catch {}
+      }
+    }
+  } catch {}
+  return typeof window !== "undefined" ? window : null;
+};
+
+export const getStyle = (el: Element, pseudo: string | null = null): CSSStyleDeclaration => {
+  const emptyStyle = (): CSSStyleDeclaration => {
+    const base: {
+      length: number;
+      getPropertyValue: () => string;
+      item: () => string;
+      [Symbol.iterator]?: () => Generator<string>;
+    } = {
+      length: 0,
+      getPropertyValue: () => "",
+      item: () => "",
+    };
+    base[Symbol.iterator] = function* (): Generator<string> {};
+    return base as unknown as CSSStyleDeclaration;
+  };
+
+  if (!(el instanceof Element)) {
+    const win = typeof window !== "undefined" ? window : null;
+    if (win && typeof win.getComputedStyle === "function") {
+      try {
+        return win.getComputedStyle(el as Element, pseudo) || emptyStyle();
+      } catch {
+        return emptyStyle();
+      }
+    }
+    return emptyStyle();
+  }
+  let map = cache.computedStyle.get(el);
+  if (!map) {
+    map = new Map();
+    cache.computedStyle.set(el, map);
+  }
+
+  let style = map.get(pseudo);
+
+  if (!style) {
+    const win = getWindowForElement(el);
+    let st: CSSStyleDeclaration | null = null;
+    try {
+      st =
+        win && typeof win.getComputedStyle === "function" ? win.getComputedStyle(el, pseudo) : null;
+    } catch {}
+
+    if (!st && typeof window !== "undefined" && typeof window.getComputedStyle === "function") {
+      try {
+        if (el.ownerDocument === document) {
+          st = window.getComputedStyle(el, pseudo);
+        }
+      } catch {}
+    }
+
+    style = st || emptyStyle();
+    map.set(pseudo, style);
+  }
+
+  return style;
+};
+
+const BORDER_SIDES = ["top", "right", "bottom", "left"];
+
+export const snapshotComputedStyle = (style: CSSStyleDeclaration): Record<string, string> => {
+  const snap: Record<string, string> = {};
+  for (const prop of style) {
+    snap[prop] = style.getPropertyValue(prop);
+  }
+  for (const side of BORDER_SIDES) {
+    const sty = snap[`border-${side}-style`];
+    const wid = snap[`border-${side}-width`];
+    if (sty === "none" || sty === "hidden" || wid === "0px") {
+      delete snap[`border-${side}-style`];
+      delete snap[`border-${side}-width`];
+      delete snap[`border-${side}-color`];
+    }
+  }
+  return snap;
+};
+
+export const splitBackgroundImage = (bg: string): string[] => {
+  const parts: string[] = [];
+  let depth = 0;
+  let lastIndex = 0;
+  for (let i = 0; i < bg.length; i++) {
+    const char = bg[i];
+    if (char === "(") depth++;
+    if (char === ")") depth--;
+    if (char === "," && depth === 0) {
+      parts.push(bg.slice(lastIndex, i).trim());
+      lastIndex = i + 1;
+    }
+  }
+  parts.push(bg.slice(lastIndex).trim());
+  return parts;
+};

--- a/packages/react-grab/src/snapshot/utils/debug.ts
+++ b/packages/react-grab/src/snapshot/utils/debug.ts
@@ -1,0 +1,16 @@
+interface DebugContext {
+  debug?: boolean;
+  options?: { debug?: boolean };
+}
+
+export const debugWarn = (ctx: unknown, msg: string, err?: unknown): void => {
+  const ctxObject = ctx && typeof ctx === "object" ? (ctx as DebugContext) : null;
+  const opts = ctxObject ? (ctxObject.options ?? ctxObject) : null;
+  if (opts && opts.debug) {
+    if (err !== undefined) {
+      console.warn("[snapshot]", msg, err);
+    } else {
+      console.warn("[snapshot]", msg);
+    }
+  }
+};

--- a/packages/react-grab/src/snapshot/utils/helpers.ts
+++ b/packages/react-grab/src/snapshot/utils/helpers.ts
@@ -1,0 +1,54 @@
+export const extractURL = (value: string): string | null => {
+  const match = value.match(/url\((['"]?)(.*?)(\1)\)/);
+  if (!match) return null;
+
+  const url = match[2].trim();
+  if (url.startsWith("#")) return null;
+  return url;
+};
+
+export const stripTranslate = (transform: string): string => {
+  if (!transform || transform === "none") return "";
+
+  let cleaned = transform.replace(/translate[XY]?\([^)]*\)/g, "");
+
+  cleaned = cleaned.replace(/matrix\(([^)]+)\)/g, (_: string, values: string) => {
+    const parts = values.split(",").map((s) => s.trim());
+    if (parts.length !== 6) return `matrix(${values})`;
+    parts[4] = "0";
+    parts[5] = "0";
+    return `matrix(${parts.join(", ")})`;
+  });
+
+  cleaned = cleaned.replace(/matrix3d\(([^)]+)\)/g, (_: string, values: string) => {
+    const parts = values.split(",").map((s) => s.trim());
+    if (parts.length !== 16) return `matrix3d(${values})`;
+    parts[12] = "0";
+    parts[13] = "0";
+    return `matrix3d(${parts.join(", ")})`;
+  });
+
+  return cleaned.trim().replace(/\s{2,}/g, " ");
+};
+
+export const safeEncodeURI = (uri: string): string => {
+  if (/%[0-9A-Fa-f]{2}/.test(uri)) return uri;
+  try {
+    return encodeURI(uri);
+  } catch {
+    return uri;
+  }
+};
+
+export const resolveURL = (url: string, base?: string): string => {
+  if (!url || /^(data|blob|about|#)/i.test(url.trim())) return url;
+  try {
+    const b =
+      base ||
+      (typeof document !== "undefined" && (document.baseURI || document.location?.href)) ||
+      "http://localhost/";
+    return new URL(url, b).href;
+  } catch {
+    return url;
+  }
+};

--- a/packages/react-grab/src/snapshot/utils/image.ts
+++ b/packages/react-grab/src/snapshot/utils/image.ts
@@ -1,0 +1,36 @@
+import { cache } from "../core/cache.js";
+import { extractURL, safeEncodeURI, resolveURL } from "./helpers.js";
+import { snapFetch } from "../modules/snap-fetch.js";
+
+export const inlineSingleBackgroundEntry = async (
+  entry: string,
+  options: { useProxy?: string } = {},
+): Promise<string> => {
+  const isGradient = /^((repeating-)?(linear|radial|conic)-gradient)\(/i.test(entry);
+  if (isGradient || entry.trim() === "none") {
+    return entry;
+  }
+  const rawUrl = extractURL(entry);
+  if (!rawUrl) {
+    return entry;
+  }
+  const absoluteUrl = resolveURL(rawUrl);
+  const encodedUrl = safeEncodeURI(absoluteUrl);
+  const cacheKey = (options.useProxy || "") + "|" + encodedUrl;
+  if (cache.background.has(cacheKey)) {
+    const dataUrl = cache.background.get(cacheKey);
+    return dataUrl ? `url("${dataUrl}")` : "none";
+  }
+  try {
+    const dataUrl = await snapFetch(encodedUrl, { as: "dataURL", useProxy: options.useProxy });
+    if (dataUrl.ok && typeof dataUrl.data === "string") {
+      cache.background.set(cacheKey, dataUrl.data);
+      return `url("${dataUrl.data}")`;
+    }
+    cache.background.set(cacheKey, null);
+    return "none";
+  } catch {
+    cache.background.set(cacheKey, null);
+    return "none";
+  }
+};

--- a/packages/react-grab/src/snapshot/utils/index.ts
+++ b/packages/react-grab/src/snapshot/utils/index.ts
@@ -1,0 +1,16 @@
+export { inlineSingleBackgroundEntry } from "./image.js";
+export {
+  precacheCommonTags,
+  getStyleKey,
+  collectUsedTagNames,
+  generateDedupedBaseCSS,
+  generateCSSClasses,
+  getStyle,
+  snapshotComputedStyle,
+  splitBackgroundImage,
+  NO_CAPTURE_TAGS,
+  shouldIgnoreProp,
+} from "./css.js";
+export { idle, isIOS, isSafari } from "./browser.js";
+export { safeEncodeURI, stripTranslate, extractURL, resolveURL } from "./helpers.js";
+export { debugWarn } from "./debug.js";

--- a/packages/react-grab/src/snapshot/utils/prepare-helpers.ts
+++ b/packages/react-grab/src/snapshot/utils/prepare-helpers.ts
@@ -1,0 +1,46 @@
+export const stabilizeLayout = (element: Element): void => {
+  const style = getComputedStyle(element);
+  const outlineStyle = style.outlineStyle;
+  const outlineWidth = style.outlineWidth;
+  const borderStyle = style.borderStyle;
+  const borderWidth = style.borderWidth;
+
+  const outlineVisible = outlineStyle !== "none" && parseFloat(outlineWidth) > 0;
+  const borderAbsent = borderStyle === "none" || parseFloat(borderWidth) === 0;
+
+  if (outlineVisible && borderAbsent && element instanceof HTMLElement) {
+    element.style.border = `${outlineWidth} solid transparent`;
+  }
+};
+
+export const forceContentVisibility = (root: Element): (() => void) => {
+  const saved: { el: HTMLElement; original: string }[] = [];
+  try {
+    const all = root.querySelectorAll("*");
+    for (const el of all) {
+      if (!(el instanceof HTMLElement)) continue;
+      const cv = el.style.contentVisibility || "";
+      const cs = getComputedStyle(el);
+      const computed = cs.contentVisibility || cs.getPropertyValue("content-visibility") || "";
+      if (computed === "auto" || computed === "hidden") {
+        saved.push({ el, original: cv });
+        el.style.contentVisibility = "visible";
+      }
+    }
+    if (root instanceof HTMLElement) {
+      const cs = getComputedStyle(root);
+      const computed = cs.contentVisibility || cs.getPropertyValue("content-visibility") || "";
+      if (computed === "auto" || computed === "hidden") {
+        saved.push({ el: root, original: root.style.contentVisibility || "" });
+        root.style.contentVisibility = "visible";
+      }
+    }
+  } catch {}
+  return () => {
+    for (const { el, original } of saved) {
+      try {
+        el.style.contentVisibility = original;
+      } catch {}
+    }
+  };
+};

--- a/packages/react-grab/src/snapshot/utils/transforms-helpers.ts
+++ b/packages/react-grab/src/snapshot/utils/transforms-helpers.ts
@@ -1,0 +1,426 @@
+import { limitDecimals } from "./capture-helpers.js";
+import { getStyle } from "./css.js";
+
+interface BleedBox {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}
+
+interface Matrix2D {
+  a: number;
+  b: number;
+  c: number;
+  d: number;
+}
+
+interface IndividualTransforms {
+  rotate: string;
+  scale: string | null;
+  translate: string | null;
+}
+
+interface TransformInput {
+  baseTransform?: string;
+  rotate?: string | null;
+  scale?: string | null;
+  translate?: string | null;
+}
+
+interface CSSNumericLike {
+  value?: number;
+  unit?: string;
+}
+
+interface CSSTypedValue {
+  angle?: CSSNumericLike;
+  unit?: string;
+  value?: number;
+  x?: CSSNumericLike;
+  y?: CSSNumericLike;
+}
+
+export const parseBoxShadow = (cs: CSSStyleDeclaration): BleedBox => {
+  const v = cs.boxShadow || "";
+  if (!v || v === "none") return { top: 0, right: 0, bottom: 0, left: 0 };
+  const parts: string[] = [];
+  let buf = "",
+    depth = 0;
+  for (let i = 0; i < v.length; i++) {
+    const ch = v[i];
+    if (ch === "(") depth++;
+    else if (ch === ")") depth = Math.max(0, depth - 1);
+    if (ch === "," && depth === 0) {
+      parts.push(buf);
+      buf = "";
+    } else buf += ch;
+  }
+  if (buf.trim()) parts.push(buf);
+  let t = 0,
+    r = 0,
+    b2 = 0,
+    l = 0;
+  for (const part of parts) {
+    if (/\binset\b/i.test(part)) continue;
+    const nums = part.match(/-?\d+(\.\d+)?px/g)?.map((n) => parseFloat(n)) || [];
+    if (nums.length < 2) continue;
+    const [ox2, oy2, blur = 0, spread = 0] = nums;
+    const extX = Math.abs(ox2) + blur + spread;
+    const extY = Math.abs(oy2) + blur + spread;
+    r = Math.max(r, extX + Math.max(ox2, 0));
+    l = Math.max(l, extX + Math.max(-ox2, 0));
+    b2 = Math.max(b2, extY + Math.max(oy2, 0));
+    t = Math.max(t, extY + Math.max(-oy2, 0));
+  }
+  return { top: Math.ceil(t), right: Math.ceil(r), bottom: Math.ceil(b2), left: Math.ceil(l) };
+};
+
+export const parseFilterBlur = (cs: CSSStyleDeclaration): BleedBox => {
+  const raw = cs.filter && cs.filter !== "none" ? cs.filter : cs.webkitFilter || "";
+  const re = /blur\(\s*([0-9.]+)px\s*\)/gi;
+  let total = 0,
+    m: RegExpExecArray | null;
+  while ((m = re.exec(raw))) total += parseFloat(m[1]) || 0;
+  const b2 = Math.ceil(total);
+  return { top: b2, right: b2, bottom: b2, left: b2 };
+};
+
+export const parseOutline = (cs: CSSStyleDeclaration): BleedBox => {
+  if ((cs.outlineStyle || "none") === "none") return { top: 0, right: 0, bottom: 0, left: 0 };
+  const w = Math.ceil(parseFloat(cs.outlineWidth || "0") || 0);
+  const offset = parseFloat(cs.outlineOffset || "0") || 0;
+  const total = w + Math.max(0, Math.ceil(offset));
+  return { top: total, right: total, bottom: total, left: total };
+};
+
+export const parseFilterDropShadows = (
+  cs: CSSStyleDeclaration,
+): { bleed: BleedBox; has: boolean } => {
+  const raw = `${cs.filter || ""} ${cs.webkitFilter || ""}`.trim();
+  if (!raw || raw === "none") {
+    return { bleed: { top: 0, right: 0, bottom: 0, left: 0 }, has: false };
+  }
+  const tokens = raw.match(/drop-shadow\((?:[^()]|\([^()]*\))*\)/gi) || [];
+  let t = 0,
+    r = 0,
+    b = 0,
+    l = 0;
+  let found = false;
+  for (const tok of tokens) {
+    found = true;
+    const nums = tok.match(/-?\d+(?:\.\d+)?px/gi)?.map((v) => parseFloat(v)) || [];
+    const [ox = 0, oy = 0, blur = 0] = nums;
+    const extX = Math.abs(ox) + blur;
+    const extY = Math.abs(oy) + blur;
+    r = Math.max(r, extX + Math.max(ox, 0));
+    l = Math.max(l, extX + Math.max(-ox, 0));
+    b = Math.max(b, extY + Math.max(oy, 0));
+    t = Math.max(t, extY + Math.max(-oy, 0));
+  }
+  return {
+    bleed: {
+      top: limitDecimals(t),
+      right: limitDecimals(r),
+      bottom: limitDecimals(b),
+      left: limitDecimals(l),
+    },
+    has: found,
+  };
+};
+
+export const normalizeRootTransforms = (
+  originalEl: Element,
+  cloneRoot: HTMLElement,
+): Matrix2D | null => {
+  if (!originalEl || !cloneRoot || !cloneRoot.style) return null;
+  const cs = getComputedStyle(originalEl);
+
+  try {
+    cloneRoot.style.transformOrigin = "0 0";
+  } catch {}
+
+  try {
+    if ("translate" in cloneRoot.style) cloneRoot.style.translate = "none";
+    if ("rotate" in cloneRoot.style) cloneRoot.style.rotate = "none";
+  } catch {}
+
+  const decomposeScaleShear = (a: number, b: number, c: number, d: number): Matrix2D => {
+    const scaleX = Math.sqrt(a * a + b * b) || 0;
+    let shear = 0,
+      scaleY = 0;
+    if (scaleX > 0) {
+      const a1 = a / scaleX;
+      const b1 = b / scaleX;
+      shear = a1 * c + b1 * d;
+      const c2 = c - a1 * shear;
+      const d2 = d - b1 * shear;
+      scaleY = Math.sqrt(c2 * c2 + d2 * d2) || 0;
+      if (scaleY > 0) shear = shear / scaleY;
+      else shear = 0;
+    }
+    return {
+      a: scaleX,
+      b: 0,
+      c: shear * scaleY,
+      d: scaleY,
+    };
+  };
+
+  const tr = cs.transform || "none";
+  if (!tr || tr === "none") {
+    let scaleStr: string | null = null;
+    try {
+      scaleStr = readIndividualTransforms(originalEl).scale;
+    } catch {}
+    try {
+      cloneRoot.style.transform = "none";
+    } catch {}
+    if (!scaleStr) return { a: 1, b: 0, c: 0, d: 1 };
+    const sv = scaleStr.trim().split(/\s+/).map(parseFloat);
+    const sx = Number.isFinite(sv[0]) ? sv[0] : 1;
+    const sy = Number.isFinite(sv[1]) ? sv[1] : sx;
+    return { a: sx, b: 0, c: 0, d: sy };
+  }
+
+  const m2d = tr.match(/^matrix\(\s*([^)]+)\)$/i);
+  if (m2d) {
+    const nums = m2d[1].split(",").map((v) => parseFloat(v.trim()));
+    if (nums.length === 6 && nums.every(Number.isFinite)) {
+      const [a, b, c, d] = nums;
+      const dec = decomposeScaleShear(a, b, c, d);
+      try {
+        cloneRoot.style.transform = `matrix(${dec.a}, ${dec.b}, ${dec.c}, ${dec.d}, 0, 0)`;
+      } catch {}
+      return dec;
+    }
+  }
+
+  const m3d = tr.match(/^matrix3d\(\s*([^)]+)\)$/i);
+  if (m3d) {
+    const nums = m3d[1].split(",").map((v) => parseFloat(v.trim()));
+    if (nums.length === 16 && nums.every(Number.isFinite)) {
+      const a = nums[0],
+        b = nums[1],
+        c = nums[4],
+        d = nums[5];
+      const dec = decomposeScaleShear(a, b, c, d);
+      try {
+        cloneRoot.style.transform = `matrix(${dec.a}, ${dec.b}, ${dec.c}, ${dec.d}, 0, 0)`;
+      } catch {}
+      return dec;
+    }
+  }
+
+  try {
+    const M = new DOMMatrix(tr);
+    const dec = decomposeScaleShear(M.a, M.b, M.c, M.d);
+    try {
+      cloneRoot.style.transform = `matrix(${dec.a}, ${dec.b}, ${dec.c}, ${dec.d}, 0, 0)`;
+    } catch {}
+    return dec;
+  } catch {
+    return null;
+  }
+};
+
+export const bboxWithOriginFull = (
+  w2: number,
+  h2: number,
+  M: DOMMatrix,
+  ox2: number,
+  oy2: number,
+): { minX: number; minY: number; maxX: number; maxY: number; width: number; height: number } => {
+  const a2 = M.a,
+    b2 = M.b,
+    c2 = M.c,
+    d2 = M.d,
+    e2 = M.e || 0,
+    f2 = M.f || 0;
+  const pt = (x: number, y: number): [number, number] => {
+    const X = x - ox2,
+      Y = y - oy2;
+    let X2 = a2 * X + c2 * Y,
+      Y2 = b2 * X + d2 * Y;
+    X2 += ox2 + e2;
+    Y2 += oy2 + f2;
+    return [X2, Y2];
+  };
+  const P = [pt(0, 0), pt(w2, 0), pt(0, h2), pt(w2, h2)];
+  let minX2 = Infinity,
+    minY2 = Infinity,
+    maxX2 = -Infinity,
+    maxY2 = -Infinity;
+  for (const [X, Y] of P) {
+    if (X < minX2) minX2 = X;
+    if (Y < minY2) minY2 = Y;
+    if (X > maxX2) maxX2 = X;
+    if (Y > maxY2) maxY2 = Y;
+  }
+  return {
+    minX: minX2,
+    minY: minY2,
+    maxX: maxX2,
+    maxY: maxY2,
+    width: maxX2 - minX2,
+    height: maxY2 - minY2,
+  };
+};
+
+export const parseTransformOriginPx = (
+  cs: CSSStyleDeclaration,
+  w: number,
+  h: number,
+): { ox: number; oy: number } => {
+  const raw = (cs.transformOrigin || "0 0").trim().split(/\s+/);
+  const [oxRaw, oyRaw] = [raw[0] || "0", raw[1] || "0"];
+
+  const toPx = (token: string, size: number): number => {
+    const t = token.toLowerCase();
+    if (t === "left" || t === "top") return 0;
+    if (t === "center") return size / 2;
+    if (t === "right") return size;
+    if (t === "bottom") return size;
+    if (t.endsWith("px")) return parseFloat(t) || 0;
+    if (t.endsWith("%")) return ((parseFloat(t) || 0) * size) / 100;
+    if (/^-?\d+(\.\d+)?$/.test(t)) return parseFloat(t) || 0;
+    return 0;
+  };
+
+  return {
+    ox: toPx(oxRaw, w),
+    oy: toPx(oyRaw, h),
+  };
+};
+
+export const readIndividualTransforms = (el: Element): IndividualTransforms => {
+  const out: IndividualTransforms = { rotate: "0deg", scale: null, translate: null };
+
+  const map = typeof el.computedStyleMap === "function" ? el.computedStyleMap() : null;
+  if (map) {
+    const safeGet = (prop: string): CSSTypedValue | null => {
+      try {
+        if (typeof map.has === "function" && !map.has(prop)) return null;
+        if (typeof map.get !== "function") return null;
+        return map.get(prop) as unknown as CSSTypedValue;
+      } catch {
+        return null;
+      }
+    };
+
+    const rot = safeGet("rotate");
+    if (rot) {
+      if (rot.angle) {
+        const ang = rot.angle;
+        out.rotate =
+          ang.unit === "rad" ? (ang.value! * 180) / Math.PI + "deg" : ang.value! + ang.unit!;
+      } else if (rot.unit) {
+        out.rotate =
+          rot.unit === "rad" ? (rot.value! * 180) / Math.PI + "deg" : rot.value! + rot.unit;
+      } else {
+        out.rotate = String(rot);
+      }
+    } else {
+      const cs = getComputedStyle(el);
+      out.rotate = cs.rotate && cs.rotate !== "none" ? cs.rotate : "0deg";
+    }
+
+    const sc = safeGet("scale");
+    if (sc) {
+      const sx =
+        "x" in sc && sc.x?.value != null
+          ? sc.x!.value
+          : Array.isArray(sc)
+            ? sc[0]?.value
+            : Number(sc) || 1;
+      const sy =
+        "y" in sc && sc.y?.value != null ? sc.y!.value : Array.isArray(sc) ? sc[1]?.value : sx;
+      out.scale = `${sx} ${sy}`;
+    } else {
+      const cs = getComputedStyle(el);
+      out.scale = cs.scale && cs.scale !== "none" ? cs.scale : null;
+    }
+
+    const tr = safeGet("translate");
+    if (tr) {
+      const tx = "x" in tr && "value" in tr.x! ? tr.x!.value : Array.isArray(tr) ? tr[0]?.value : 0;
+      const ty = "y" in tr && "value" in tr.y! ? tr.y!.value : Array.isArray(tr) ? tr[1]?.value : 0;
+      const ux = "x" in tr && tr.x?.unit ? tr.x!.unit : "px";
+      const uy = "y" in tr && tr.y?.unit ? tr.y!.unit : "px";
+      out.translate = `${tx}${ux} ${ty}${uy}`;
+    } else {
+      const cs = getComputedStyle(el);
+      out.translate = cs.translate && cs.translate !== "none" ? cs.translate : null;
+    }
+    return out;
+  }
+
+  const cs = getComputedStyle(el);
+  out.rotate = cs.rotate && cs.rotate !== "none" ? cs.rotate : "0deg";
+  out.scale = cs.scale && cs.scale !== "none" ? cs.scale : null;
+  out.translate = cs.translate && cs.translate !== "none" ? cs.translate : null;
+  return out;
+};
+
+let __measureHost: HTMLElement | null = null;
+
+const getMeasureHost = (): HTMLElement => {
+  if (__measureHost) return __measureHost;
+  const n = document.createElement("div");
+  n.id = "snapshot-measure-slot";
+  n.setAttribute("aria-hidden", "true");
+  Object.assign(n.style, {
+    position: "absolute",
+    left: "-99999px",
+    top: "0px",
+    width: "0px",
+    height: "0px",
+    overflow: "hidden",
+    opacity: "0",
+    pointerEvents: "none",
+    contain: "size layout style",
+  });
+  document.documentElement.appendChild(n);
+  __measureHost = n;
+  return n;
+};
+
+export const readTotalTransformMatrix = (t: TransformInput): DOMMatrix => {
+  const host = getMeasureHost();
+  const tmp = document.createElement("div");
+  tmp.style.transformOrigin = "0 0";
+  if (t.baseTransform) tmp.style.transform = t.baseTransform;
+  if (t.rotate) tmp.style.rotate = t.rotate;
+  if (t.scale) tmp.style.scale = t.scale;
+  if (t.translate) tmp.style.translate = t.translate;
+  host.appendChild(tmp);
+  const M = matrixFromComputed(tmp);
+  host.removeChild(tmp);
+  return M;
+};
+
+export const hasBBoxAffectingTransform = (el: Element): boolean => {
+  const cs = getStyle(el);
+  const t = cs.transform || "none";
+
+  const hasMatrix =
+    t !== "none" && !/^matrix\(\s*1\s*,\s*0\s*,\s*0\s*,\s*1\s*,\s*0\s*,\s*0\s*\)$/i.test(t);
+
+  if (hasMatrix) return true;
+
+  const r = cs.rotate && cs.rotate !== "none" && cs.rotate !== "0deg";
+  const s = cs.scale && cs.scale !== "none" && cs.scale !== "1";
+  const tr = cs.translate && cs.translate !== "none" && cs.translate !== "0px 0px";
+
+  return Boolean(r || s || tr);
+};
+
+const matrixFromComputed = (el: Element): DOMMatrix => {
+  const tr = getComputedStyle(el).transform;
+  if (!tr || tr === "none") return new DOMMatrix();
+  try {
+    return new DOMMatrix(tr);
+  } catch {
+    return new WebKitCSSMatrix(tr);
+  }
+};


### PR DESCRIPTION
## Summary
- Vendors a TypeScript port of [snapDOM](https://github.com/zumerlab/snapdom) (MIT) under `packages/react-grab/src/snapshot/` as a self-contained **snapshot** subsystem that captures DOM elements to SVG/PNG/Canvas/Blob.
- Public API: `import { snapshot, preCache } from "./snapshot/index.js"` plus all `Snapshot*` types.
- Converted to react-grab conventions: arrow functions, explicit strict TS types, NodeNext `.js` imports, kebab-case files, shared `types.ts`; dynamic `import()` made static; dead code/exports removed; session types consolidated into one `SnapshotSessionCache`; `fonts.ts` split into focused `modules/fonts/*`; comments stripped to the repo's "default to no comments" style. Upstream MIT `LICENSE` retained.
- **Self-contained and not yet wired into the capture/copy flow** — this PR only adds the engine.

## Test plan
- [x] `pnpm typecheck` (tsc strict + NodeNext) — 0 errors
- [x] `pnpm lint` — 0 warnings/errors
- [x] `pnpm format` — clean
- [x] `pnpm build` — succeeds (subsystem tree-shaken out since unused)
- [x] Browser smoke test (headless Chromium): `snapshot()` → valid `data:image/svg+xml`, `toPng()` → `HTMLImageElement`, `toBlob()` → `image/png`, exercising `embedFonts` + CSS counters
- [ ] Wire into the grab copy flow (follow-up)

🤖 Generated with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new client-side capture stack that fetches and inlines cross-origin assets and fonts when enabled; risk is contained while unused but grows once wired into user-facing copy flows.
> 
> **Overview**
> Introduces a **self-contained DOM-to-image engine** under `packages/react-grab/src/snapshot/` (TypeScript port of snapDOM, MIT `LICENSE` included). The public surface is **`snapshot(element, options)`** → SVG data URL plus chained exports (**PNG/JPEG/WebP**, canvas, blob, download), and optional **`preCache(root)`** to warm image, background, and font caches ahead of capture.
> 
> The implementation **clones and inlines** the live DOM for faithful static output: computed styles, shadow roots, pseudo-elements, CSS variables/counters, SVG defs, canvas/video/iframe handling, responsive `<picture>` / lazy `src` resolution, and optional **font subsetting** with proxy-aware **`snapFetch`**. Session caches, plugin hooks, and Safari/iOS-specific raster paths are built in.
> 
> **Nothing in the existing grab/copy flow imports this yet** — the package only adds the module; consumers opt in via `./snapshot/index.js` in a follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8da9c79f4707fc44b535850d4d541822bed40d88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a self‑contained DOM‑to‑image snapshot engine to `packages/react-grab/src/snapshot/` that captures elements to SVG and exports to PNG/JPEG/WebP/canvas/blob. It’s vendored from snapDOM (MIT), not yet wired into the grab/copy flow, and now includes fixes for nested font @imports and export queue reliability.

- **New Features**
  - Public API: `import { snapshot, preCache } from "./snapshot/index.js"` plus `Snapshot*` types.
  - SVG‑first capture with exporters (`toImg`, `toCanvas`, `toBlob`, `download`); supports `format`, `scale`, `quality`.
  - Asset handling: inlines images/backgrounds, resolves `<picture>`/lazy `src`, embeds/subsets fonts (incl. icon fonts), CSS vars, pseudo‑elements, counters, and SVG defs.
  - Caching and performance: session/persistent caches with policies (`full`/`soft`/`auto`/`disabled`), idle scheduling, Safari/iOS quirks handled.
  - Extensibility via plugin hooks and a typed capture context.

- **Bug Fixes**
  - Fixed nested `@import` parsing in font stylesheets, preventing missed faces during embedding.
  - One failed export no longer cancels later exports queued on the same capture.
  - Removed a dead font path and unused types from `fonts`.

<sup>Written for commit 8da9c79f4707fc44b535850d4d541822bed40d88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

