### PR TITLE
Remove Windsurf from skill install targets

### DIFF
--- a/packages/cli/src/utils/install-skill.ts
+++ b/packages/cli/src/utils/install-skill.ts
@@ -16,12 +16,17 @@ import { prompts } from "./prompts.js";
 import { spinner } from "./spinner.js";
 
 const SKILL_NAME = "react-grab";
+const WINDSURF_AGENT_NAME = "windsurf";
 
 // The skill is bundled next to the compiled CLI (see scripts/bundle-skill.mjs)
 // so installs work offline and stay pinned to this CLI version.
 const SKILL_SOURCE = fileURLToPath(new URL("../skills/react-grab", import.meta.url));
 
 const agentLabel = (agent: SkillAgentType): string => getSkillAgentConfig(agent).displayName;
+
+export const getInstallableSkillAgents = <AgentName extends string>(
+  agents: readonly AgentName[],
+): AgentName[] => agents.filter((agent) => agent !== WINDSURF_AGENT_NAME);
 
 // Universal agents share the canonical .agents/skills directory; others use
 // their own. Mirror where agent-install actually writes so removal lands.
@@ -44,7 +49,7 @@ export const promptSkillInstall = async ({
   global = false,
   cwd = process.cwd(),
 }: PromptSkillInstallOptions = {}): Promise<boolean> => {
-  const detectedAgents = await detectAvailableAgents();
+  const detectedAgents = getInstallableSkillAgents(await detectAvailableAgents());
   if (detectedAgents.length === 0) {
     logger.warn("No supported agents detected.");
     return false;

--- a/packages/cli/test/install-skill.test.ts
+++ b/packages/cli/test/install-skill.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vite-plus/test";
+import { getInstallableSkillAgents } from "../src/utils/install-skill.js";
+
+describe("getInstallableSkillAgents", () => {
+  it("removes Windsurf from install targets", () => {
+    expect(getInstallableSkillAgents(["claude-code", "windsurf", "cursor"])).toEqual([
+      "claude-code",
+      "cursor",
+    ]);
+  });
+});

--- a/skills/react-grab/SKILL.md
+++ b/skills/react-grab/SKILL.md
@@ -52,9 +52,9 @@ While acting on a grab:
 npx react-grab@latest pull --max-age 0 --wait 0
 ```
 
-  Empty output means nothing new — keep going. If it prints a grab, the user has
-  moved on: stop the current task, cancel any background processes you started for
-  it, and act on the newest grab instead.
+Empty output means nothing new — keep going. If it prints a grab, the user has
+moved on: stop the current task, cancel any background processes you started for
+it, and act on the newest grab instead.
 
 ## Acting on a grab
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Filter Windsurf out of React Grab skill install targets before prompts and non-interactive installs
- Add unit coverage for the install-target filter
- Apply repository markdown formatting to the canonical React Grab skill

## Verification
- `pnpm dlx --package @antfu/ni nr build`
- `pnpm dlx --package @antfu/ni nr test` (passed after installing Playwright Chromium in the cloud image)
- `PATH="/home/ubuntu/.nvm/versions/node/v22.22.2/bin:$PATH" pnpm dlx --package @antfu/ni nr build`
- `PATH="/home/ubuntu/.nvm/versions/node/v22.22.2/bin:$PATH" pnpm dlx --package @antfu/ni nr lint`
- `PATH="/home/ubuntu/.nvm/versions/node/v22.22.2/bin:$PATH" pnpm dlx --package @antfu/ni nr typecheck`
- `PATH="/home/ubuntu/.nvm/versions/node/v22.22.2/bin:$PATH" pnpm dlx --package @antfu/ni nr format`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a48fcd9-5eab-4307-8037-bbdfc79fbe80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a48fcd9-5eab-4307-8037-bbdfc79fbe80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed Windsurf from `react-grab` skill install targets for both interactive prompts and non-interactive installs to avoid offering an unsupported agent. Added `getInstallableSkillAgents` with a unit test to enforce the filter, and cleaned up `skills/react-grab/SKILL.md` formatting.

<sup>Written for commit 8e3a9b294b8fe95beb228cd28c5760662e049b2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

