### PR TITLE
Switch styled element by clicking while the Style panel is open

### DIFF
--- a/packages/react-grab/e2e/edit-panel-helpers.ts
+++ b/packages/react-grab/e2e/edit-panel-helpers.ts
@@ -12,6 +12,7 @@ export const IDLE_BUFFER_MS = 700;
 export const DISCARD_PROMPT_IDLE_MS = 2000;
 export const BUTTON_SELECTOR = "[data-testid='nested-button']";
 export const CARD_SELECTOR = "[data-testid='nested-card']";
+export const MAIN_TITLE_SELECTOR = "[data-testid='main-title']";
 
 export const isEditPanelVisible = async (page: Page): Promise<boolean> =>
   page.evaluate(

--- a/packages/react-grab/e2e/edit-panel-helpers.ts
+++ b/packages/react-grab/e2e/edit-panel-helpers.ts
@@ -11,7 +11,6 @@ export const TAILWIND_LABEL_ATTR = "data-react-grab-tailwind-label";
 export const IDLE_BUFFER_MS = 700;
 export const DISCARD_PROMPT_IDLE_MS = 2000;
 export const BUTTON_SELECTOR = "[data-testid='nested-button']";
-export const CARD_SELECTOR = "[data-testid='nested-card']";
 export const MAIN_TITLE_SELECTOR = "[data-testid='main-title']";
 
 export const isEditPanelVisible = async (page: Page): Promise<boolean> =>

--- a/packages/react-grab/e2e/edit-panel.spec.ts
+++ b/packages/react-grab/e2e/edit-panel.spec.ts
@@ -1490,6 +1490,37 @@ test.describe("Style Panel", () => {
       );
     });
 
+    test("copy reverts a switched-away element whose tweak was undone", async ({ reactGrab }) => {
+      await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      const buttonStyleBeforeTweak = await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR);
+      await reactGrab.page.keyboard.press("ArrowRight");
+      await reactGrab.page.waitForTimeout(80);
+      await reactGrab.page.keyboard.press("ArrowLeft");
+      await reactGrab.page.waitForTimeout(80);
+
+      await reactGrab.page.locator(MAIN_TITLE_SELECTOR).click({ force: true });
+      await reactGrab.page.waitForTimeout(150);
+      await reactGrab.page.keyboard.press("ArrowRight");
+      await reactGrab.page.waitForTimeout(80);
+      const titleStyleBeforeCopy = await getInlineStyleAttribute(
+        reactGrab.page,
+        MAIN_TITLE_SELECTOR,
+      );
+
+      await reactGrab.page.keyboard.press("Enter");
+      await expect.poll(() => isEditPanelVisible(reactGrab.page)).toBe(false);
+      const clipboardContent = await reactGrab.getClipboardContent();
+      expect(clipboardContent.match(/```css/g)?.length).toBe(1);
+
+      // The button netted no edits, so copy must not leave it styled.
+      expect(await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR)).toBe(
+        buttonStyleBeforeTweak,
+      );
+      expect(await getInlineStyleAttribute(reactGrab.page, MAIN_TITLE_SELECTOR)).toBe(
+        titleStyleBeforeCopy,
+      );
+    });
+
     test("session edits from a previous element keep the discard prompt armed", async ({
       reactGrab,
     }) => {

--- a/packages/react-grab/e2e/edit-panel.spec.ts
+++ b/packages/react-grab/e2e/edit-panel.spec.ts
@@ -2,7 +2,6 @@ import { expect, test } from "./fixtures.js";
 import {
   ATTRIBUTE_NAME,
   BUTTON_SELECTOR,
-  CARD_SELECTOR,
   COPY_BUTTON_ATTR,
   DISCARD_PROMPT_IDLE_MS,
   EDIT_PANEL_ATTR,
@@ -33,6 +32,7 @@ import {
   isEditPanelCompact,
   isEditPanelVisible,
   isHeaderCopyButtonVisible,
+  MAIN_TITLE_SELECTOR,
   openDiscardPromptViaEscape,
   openEditPanel,
   readSessionStorageEntries,
@@ -226,9 +226,11 @@ test.describe("Style Panel", () => {
       expect(await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR)).toBe(beforeTweak);
     });
 
-    test("click outside dismisses the panel", async ({ reactGrab }) => {
+    test("outside mousedown without a grabbable target dismisses the panel", async ({
+      reactGrab,
+    }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
-      await reactGrab.page.mouse.click(5, 5);
+      await dispatchOutsideDismiss(reactGrab.page);
       await expect.poll(() => isEditPanelVisible(reactGrab.page)).toBe(false);
     });
 
@@ -1389,7 +1391,7 @@ test.describe("Style Panel", () => {
     });
   });
 
-  test.describe("Selection lock", () => {
+  test.describe("Element switching", () => {
     test("panel stays open while pointer moves over other elements", async ({ reactGrab }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
       await reactGrab.page.mouse.move(10, 10);
@@ -1399,36 +1401,116 @@ test.describe("Style Panel", () => {
       expect(await isEditPanelVisible(reactGrab.page)).toBe(true);
     });
 
-    test("clicking another element does not change selection", async ({ reactGrab }) => {
+    test("clicking another element switches the style target and keeps applied styles", async ({
+      reactGrab,
+    }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
-      const panelStateBeforeClick = await reactGrab.page.evaluate(
-        ({ attrName }) => {
-          const host = document.querySelector(`[${attrName}]`);
-          const shadowRoot = host?.shadowRoot;
-          const panel = shadowRoot?.querySelector("[data-react-grab-edit-panel]");
-          return panel ? "panel-open" : "panel-gone";
-        },
-        { attrName: ATTRIBUTE_NAME },
-      );
-      expect(panelStateBeforeClick).toBe("panel-open");
+      await reactGrab.page.keyboard.press("ArrowRight");
+      await reactGrab.page.waitForTimeout(80);
+      const buttonStyleAfterTweak = await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR);
+      expect(buttonStyleAfterTweak.length).toBeGreaterThan(0);
 
-      await reactGrab.page.locator(CARD_SELECTOR).first().click({ force: true });
+      await reactGrab.page.locator(MAIN_TITLE_SELECTOR).click({ force: true });
       await reactGrab.page.waitForTimeout(150);
 
-      const stateAfter = await reactGrab.page.evaluate(
-        ({ attrName, buttonSelector }) => {
-          const host = document.querySelector(`[${attrName}]`);
-          const shadowRoot = host?.shadowRoot;
-          const panel = shadowRoot?.querySelector("[data-react-grab-edit-panel]");
-          const buttonElement = document.querySelector(buttonSelector);
-          return {
-            panelStillOpen: panel !== null,
-            buttonStillExists: buttonElement !== null,
-          };
-        },
-        { attrName: ATTRIBUTE_NAME, buttonSelector: BUTTON_SELECTOR },
+      expect(await isEditPanelVisible(reactGrab.page)).toBe(true);
+      expect(await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR)).toBe(
+        buttonStyleAfterTweak,
       );
-      expect(stateAfter.buttonStillExists).toBe(true);
+
+      await reactGrab.page.keyboard.press("ArrowRight");
+      await reactGrab.page.waitForTimeout(80);
+      const titleStyleAfterTweak = await getInlineStyleAttribute(
+        reactGrab.page,
+        MAIN_TITLE_SELECTOR,
+      );
+      expect(titleStyleAfterTweak.length).toBeGreaterThan(0);
+    });
+
+    test("edits compound across switched elements on copy", async ({ reactGrab }) => {
+      await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      await reactGrab.page.keyboard.press("ArrowRight");
+      await reactGrab.page.waitForTimeout(80);
+
+      await reactGrab.page.locator(MAIN_TITLE_SELECTOR).click({ force: true });
+      await reactGrab.page.waitForTimeout(150);
+      await reactGrab.page.keyboard.press("ArrowRight");
+      await reactGrab.page.waitForTimeout(80);
+
+      const buttonStyleBeforeCopy = await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR);
+      const titleStyleBeforeCopy = await getInlineStyleAttribute(
+        reactGrab.page,
+        MAIN_TITLE_SELECTOR,
+      );
+
+      await reactGrab.page.keyboard.press("Enter");
+      await expect.poll(() => isEditPanelVisible(reactGrab.page)).toBe(false);
+      await expect
+        .poll(() => reactGrab.getClipboardContent())
+        .toContain("best expresses the underlying layout intent");
+      const clipboardContent = await reactGrab.getClipboardContent();
+      expect(clipboardContent.match(/```css/g)?.length).toBe(2);
+
+      expect(await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR)).toBe(
+        buttonStyleBeforeCopy,
+      );
+      expect(await getInlineStyleAttribute(reactGrab.page, MAIN_TITLE_SELECTOR)).toBe(
+        titleStyleBeforeCopy,
+      );
+    });
+
+    test("discarding after switching restores every styled element", async ({ reactGrab }) => {
+      await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      const buttonStyleBeforeTweak = await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR);
+      await reactGrab.page.keyboard.press("ArrowRight");
+      await reactGrab.page.waitForTimeout(80);
+
+      await reactGrab.page.locator(MAIN_TITLE_SELECTOR).click({ force: true });
+      await reactGrab.page.waitForTimeout(150);
+      const titleStyleBeforeTweak = await getInlineStyleAttribute(
+        reactGrab.page,
+        MAIN_TITLE_SELECTOR,
+      );
+      await reactGrab.page.keyboard.press("ArrowRight");
+      await reactGrab.page.waitForTimeout(80);
+      expect(await getInlineStyleAttribute(reactGrab.page, MAIN_TITLE_SELECTOR)).not.toBe(
+        titleStyleBeforeTweak,
+      );
+
+      await openDiscardPromptViaEscape(reactGrab.page);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(true);
+      await reactGrab.page.keyboard.press("Escape");
+      await expect.poll(() => isEditPanelVisible(reactGrab.page)).toBe(false);
+
+      expect(await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR)).toBe(
+        buttonStyleBeforeTweak,
+      );
+      expect(await getInlineStyleAttribute(reactGrab.page, MAIN_TITLE_SELECTOR)).toBe(
+        titleStyleBeforeTweak,
+      );
+    });
+
+    test("session edits from a previous element keep the discard prompt armed", async ({
+      reactGrab,
+    }) => {
+      await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      const buttonStyleBeforeTweak = await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR);
+      await reactGrab.page.keyboard.press("ArrowRight");
+      await reactGrab.page.waitForTimeout(80);
+
+      await reactGrab.page.locator(MAIN_TITLE_SELECTOR).click({ force: true });
+      await reactGrab.page.waitForTimeout(150);
+
+      await reactGrab.page.keyboard.press("Escape");
+      await reactGrab.page.waitForTimeout(80);
+      expect(await isEditPanelVisible(reactGrab.page)).toBe(true);
+      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(true);
+
+      await reactGrab.page.keyboard.press("Escape");
+      await expect.poll(() => isEditPanelVisible(reactGrab.page)).toBe(false);
+      expect(await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR)).toBe(
+        buttonStyleBeforeTweak,
+      );
     });
   });
 

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -26,13 +26,13 @@ import type {
   EditableProperty,
   EditPanelState,
   OverlayDismissSource,
+  PendingEdits,
 } from "../../types.js";
 import { clampToRange } from "../../utils/clamp-to-range.js";
 import { cn } from "../../utils/cn.js";
 import { createAnchoredDropdown } from "../../utils/create-anchored-dropdown.js";
 import { findTailwindClass } from "../../utils/find-tailwind-class.js";
 import { formatEditableValue, roundEditableNumericValue } from "../../utils/format-css-value.js";
-import { formatSessionEditsPrompt } from "../../utils/format-edit-prompt.js";
 import { getShadowActiveElement } from "../../utils/get-shadow-active-element.js";
 import { getTagDisplay } from "../../utils/get-tag-display.js";
 import { isEventFromOverlay } from "../../utils/is-event-from-overlay.js";
@@ -54,7 +54,8 @@ interface EditPanelProps {
   state: EditPanelState | null;
   position: DropdownAnchor | null;
   onDismiss: () => void;
-  onSubmit: (prompt: string) => void;
+  onSubmit: (pendingEdits: PendingEdits) => void;
+  onPendingEditsChange?: (pendingEdits: PendingEdits) => void;
   onInteractingChange?: (interacting: boolean) => void;
 }
 
@@ -68,6 +69,7 @@ export const EditPanel: Component<EditPanelProps> = (props) => (
             position={() => props.position}
             onDismiss={props.onDismiss}
             onSubmit={props.onSubmit}
+            onPendingEditsChange={props.onPendingEditsChange}
             onInteractingChange={props.onInteractingChange}
           />
         )}
@@ -80,7 +82,8 @@ interface EditPanelBodyProps {
   state: EditPanelState;
   position: () => DropdownAnchor | null;
   onDismiss: () => void;
-  onSubmit: (prompt: string) => void;
+  onSubmit: (pendingEdits: PendingEdits) => void;
+  onPendingEditsChange?: (pendingEdits: PendingEdits) => void;
   onInteractingChange?: (interacting: boolean) => void;
 }
 
@@ -107,6 +110,9 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
   };
   const [activeIndex, setActiveIndex] = createSignal(firstNumericActiveIndex());
   const hasPendingStyles = createMemo(() => styleStore.hasPendingStyles());
+  const hasSubmittableEdits = createMemo(
+    () => hasPendingStyles() || Boolean(props.state.hasSessionEdits),
+  );
   const [isCompact, setIsCompact] = createSignal(false);
 
   let activeKeyTimerId: ReturnType<typeof setTimeout> | undefined;
@@ -246,6 +252,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
   ) => {
     styleStore.applyStyle(property, nextValue);
     preview.apply(property.cssProperties, formatEditableValue(property, nextValue));
+    props.onPendingEditsChange?.(styleStore.buildPendingEdits());
     markAsInteracting();
     if (!options.isFromKeyRepeat) discardConfirmation.hide();
     if (options.flashDirection) flashActiveKey(options.flashDirection === 1 ? "right" : "left");
@@ -314,13 +321,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
   );
 
   const handleSubmit = () => {
-    const pendingEdits = styleStore.buildPendingEdits();
-    const entry = {
-      filePath: props.state.filePath ?? "",
-      lineNumber: props.state.lineNumber ?? 0,
-      edits: pendingEdits,
-    };
-    props.onSubmit(formatSessionEditsPrompt(pendingEdits.length > 0 ? [entry] : []));
+    props.onSubmit(styleStore.buildPendingEdits());
   };
 
   const discardConfirmation = createDiscardConfirmation();
@@ -346,7 +347,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
       closePanel("discard");
       return;
     }
-    if (!hasPendingStyles()) {
+    if (!hasSubmittableEdits()) {
       closePanel(preview.hasAppliedStyles() ? "discard" : "preserve");
       return;
     }
@@ -413,7 +414,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
       // and the pending change is discarded instead of copied.
       const isUnchangedColor =
         property?.kind === "color" && !styleStore.hasChangedStyleFor(property.key);
-      if (isUnchangedColor && colorPickerTrigger && !hasPendingStyles()) {
+      if (isUnchangedColor && colorPickerTrigger && !hasSubmittableEdits()) {
         colorPickerTrigger();
         return;
       }
@@ -498,7 +499,6 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
       discardConfirmation.cleanup();
       dropdown.clearAnimationHandles();
       setIsTransientInteraction(false);
-      preview.forget();
     });
   });
 
@@ -555,7 +555,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
                 <div
                   class={cn(
                     "contain-layout shrink-0 flex items-center gap-1 pt-1.5 pb-1 h-fit px-2",
-                    hasPendingStyles() ? "w-full self-stretch justify-between" : "w-fit",
+                    hasSubmittableEdits() ? "w-full self-stretch justify-between" : "w-fit",
                   )}
                   onMouseEnter={() => setIsHeaderHovered(true)}
                   onMouseLeave={() => setIsHeaderHovered(false)}
@@ -567,7 +567,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
                     onClick={() => {}}
                     shrink
                   />
-                  <Show when={hasPendingStyles()}>
+                  <Show when={hasSubmittableEdits()}>
                     <button
                       data-react-grab-ignore-events
                       data-react-grab-copy-button

--- a/packages/react-grab/src/components/renderer.tsx
+++ b/packages/react-grab/src/components/renderer.tsx
@@ -179,6 +179,7 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
         position={props.editPanelPosition ?? null}
         onDismiss={props.onEditPanelDismiss ?? (() => {})}
         onSubmit={props.onEditPanelSubmit ?? (() => {})}
+        onPendingEditsChange={props.onEditPanelPendingEditsChange}
         onInteractingChange={props.onEditPanelInteractingChange}
       />
     </>

--- a/packages/react-grab/src/core/edit-mode.ts
+++ b/packages/react-grab/src/core/edit-mode.ts
@@ -1,10 +1,17 @@
 import { createSignal, type Accessor } from "solid-js";
-import type { EditPanelState, Position } from "../types.js";
+import type {
+  EditPanelState,
+  PendingEdits,
+  PendingEditsEntry,
+  Position,
+  PreviewStyles,
+} from "../types.js";
 import { buildEditableProperties } from "../utils/build-editable-properties.js";
 import { createElementBounds } from "../utils/create-element-bounds.js";
+import { formatSessionEditsPrompt } from "../utils/format-edit-prompt.js";
 import { getTagName } from "../utils/get-tag-name.js";
 import { createPreviewStyles } from "../utils/preview-styles.js";
-import { getNearestComponentName } from "./context.js";
+import { getNearestComponentName, resolveSource } from "./context.js";
 
 export interface EditModeOverrides {
   filePath?: string;
@@ -12,6 +19,14 @@ export interface EditModeOverrides {
   componentName?: string;
   tagName?: string;
   initialSearchQuery?: string;
+}
+
+interface EditSessionRecord {
+  element: Element;
+  preview: PreviewStyles;
+  filePath: string;
+  lineNumber: number;
+  edits: PendingEdits;
 }
 
 interface EditModeDependencies {
@@ -42,31 +57,65 @@ interface EditModeDependencies {
 export interface EditModeController {
   state: Accessor<EditPanelState | null>;
   trigger: (element: Element, position: Position, overrides?: EditModeOverrides) => boolean;
+  switchToElement: (element: Element, position: Position) => boolean;
+  setPendingEdits: (pendingEdits: PendingEdits) => void;
   dismiss: () => void;
   closePreservingRenderer: () => void;
-  submit: (prompt: string) => void;
+  submit: (pendingEdits: PendingEdits) => void;
   resetWithDiscard: () => void;
   isOpen: Accessor<boolean>;
   isInteracting: Accessor<boolean>;
   setInteracting: (interacting: boolean) => void;
 }
 
+const mergeEditsIntoEntry = (entry: PendingEditsEntry, edits: PendingEdits) => {
+  for (const edit of edits) {
+    const sameKeyIndex = entry.edits.findIndex((existingEdit) => existingEdit.key === edit.key);
+    if (sameKeyIndex >= 0) {
+      entry.edits[sameKeyIndex] = edit;
+    } else {
+      entry.edits.push(edit);
+    }
+  }
+};
+
 export const createEditModeController = (
   dependencies: EditModeDependencies,
 ): EditModeController => {
   const [state, setState] = createSignal<EditPanelState | null>(null);
   const [isInteracting, setIsInteracting] = createSignal(false);
+  let sessionRecords: EditSessionRecord[] = [];
+  let currentPendingEdits: PendingEdits = [];
+
+  const setPendingEdits = (pendingEdits: PendingEdits) => {
+    currentPendingEdits = pendingEdits;
+  };
 
   const clearAll = () => {
     const wasOpen = state() !== null;
     setState(null);
     setIsInteracting(false);
+    sessionRecords = [];
+    currentPendingEdits = [];
     if (wasOpen) dependencies.onClose?.();
   };
 
   const clearWithPreviewRestore = () => {
     state()?.preview.restore();
+    for (let recordIndex = sessionRecords.length - 1; recordIndex >= 0; recordIndex--) {
+      sessionRecords[recordIndex].preview.restore();
+    }
     clearAll();
+  };
+
+  const resolveComponentNameIntoState = (element: Element) => {
+    void getNearestComponentName(element).then((nearestComponentName) => {
+      if (!nearestComponentName) return;
+      setState((current) => {
+        if (!current || current.element !== element || current.componentName) return current;
+        return { ...current, componentName: nearestComponentName };
+      });
+    });
   };
 
   const trigger = (
@@ -97,13 +146,7 @@ export const createEditModeController = (
       initialSearchQuery: overrides.initialSearchQuery,
     });
 
-    void getNearestComponentName(element).then((nearestComponentName) => {
-      if (!nearestComponentName) return;
-      setState((current) => {
-        if (!current || current.element !== element || current.componentName) return current;
-        return { ...current, componentName: nearestComponentName };
-      });
-    });
+    resolveComponentNameIntoState(element);
 
     // Order matters: actions.freeze() is a no-op unless the state machine
     // is already "active", so the renderer must activate first.
@@ -117,10 +160,94 @@ export const createEditModeController = (
     return true;
   };
 
-  const submit = (prompt: string) => {
+  const switchToElement = (element: Element, position: Position): boolean => {
+    const currentState = state();
+    if (!currentState) return false;
+    if (currentState.element === element) return false;
+    const properties = buildEditableProperties(element);
+    if (properties.length === 0) return false;
+
+    if (currentPendingEdits.length > 0 || currentState.preview.hasAppliedStyles()) {
+      sessionRecords.push({
+        element: currentState.element,
+        preview: currentState.preview,
+        filePath: currentState.filePath ?? "",
+        lineNumber: currentState.lineNumber ?? 0,
+        edits: currentPendingEdits,
+      });
+    }
+    currentPendingEdits = [];
+
+    setState({
+      element,
+      position,
+      selectionBounds: createElementBounds(element),
+      properties,
+      preview: createPreviewStyles(element),
+      tagName: getTagName(element),
+      hasSessionEdits: sessionRecords.some((record) => record.edits.length > 0),
+    });
+
+    // The store's selection source still points at the previous element, so
+    // the new element's source is resolved directly instead.
+    void resolveSource(element)
+      .then((source) => {
+        if (!source) return;
+        setState((current) => {
+          if (!current || current.element !== element || current.filePath) return current;
+          return {
+            ...current,
+            filePath: source.filePath,
+            lineNumber: source.lineNumber ?? undefined,
+          };
+        });
+      })
+      .catch(() => undefined);
+
+    resolveComponentNameIntoState(element);
+
+    dependencies.actions.setPointer(position);
+    dependencies.actions.setFrozenElement(element);
+    return true;
+  };
+
+  const buildSessionEntries = (
+    currentState: EditPanelState,
+    pendingEdits: PendingEdits,
+  ): PendingEditsEntry[] => {
+    const records: EditSessionRecord[] = [
+      ...sessionRecords,
+      {
+        element: currentState.element,
+        preview: currentState.preview,
+        filePath: currentState.filePath ?? "",
+        lineNumber: currentState.lineNumber ?? 0,
+        edits: pendingEdits,
+      },
+    ];
+
+    const entryByElement = new Map<Element, PendingEditsEntry>();
+    for (const record of records) {
+      if (record.edits.length === 0) continue;
+      const existingEntry = entryByElement.get(record.element);
+      if (existingEntry) {
+        mergeEditsIntoEntry(existingEntry, record.edits);
+        continue;
+      }
+      entryByElement.set(record.element, {
+        filePath: record.filePath,
+        lineNumber: record.lineNumber,
+        edits: [...record.edits],
+      });
+    }
+    return Array.from(entryByElement.values());
+  };
+
+  const submit = (pendingEdits: PendingEdits) => {
     const currentState = state();
     if (!currentState) return;
     const element = currentState.element;
+    const prompt = formatSessionEditsPrompt(buildSessionEntries(currentState, pendingEdits));
     clearAll();
     if (!dependencies.store.wasActivatedByToggle) {
       dependencies.actions.unfreeze();
@@ -152,6 +279,8 @@ export const createEditModeController = (
   return {
     state,
     trigger,
+    switchToElement,
+    setPendingEdits,
     dismiss,
     closePreservingRenderer,
     submit,

--- a/packages/react-grab/src/core/edit-mode.ts
+++ b/packages/react-grab/src/core/edit-mode.ts
@@ -224,15 +224,12 @@ export const createEditModeController = (
     return true;
   };
 
-  const buildSessionEntries = (
+  const buildSessionRecords = (
     currentState: EditPanelState,
     pendingEdits: PendingEdits,
-  ): PendingEditsEntry[] => {
-    const records: EditSessionRecord[] = [
-      ...sessionRecords,
-      toSessionRecord(currentState, pendingEdits),
-    ];
+  ): EditSessionRecord[] => [...sessionRecords, toSessionRecord(currentState, pendingEdits)];
 
+  const buildSessionEntries = (records: EditSessionRecord[]): PendingEditsEntry[] => {
     const entryByElement = new Map<Element, PendingEditsEntry>();
     for (const record of records) {
       if (record.edits.length === 0) continue;
@@ -255,11 +252,31 @@ export const createEditModeController = (
     return Array.from(entryByElement.values());
   };
 
+  // Copy keeps the preview of every element whose edits made it into the
+  // prompt, but a banked visit can hold preview styles with no net edits
+  // (e.g. tweaked then stepped back to original). Those never reach the
+  // prompt, so revert them like a discard would, or the page keeps stray
+  // inline styles the copy never described.
+  const restoreUneditedPreviews = (records: EditSessionRecord[]) => {
+    const editedElements = new Set<Element>();
+    for (const record of records) {
+      if (record.edits.length > 0) editedElements.add(record.element);
+    }
+    for (let recordIndex = records.length - 1; recordIndex >= 0; recordIndex--) {
+      const record = records[recordIndex];
+      if (record.edits.length === 0 && !editedElements.has(record.element)) {
+        record.preview.restore();
+      }
+    }
+  };
+
   const submit = (pendingEdits: PendingEdits) => {
     const currentState = state();
     if (!currentState) return;
     const element = currentState.element;
-    const prompt = formatSessionEditsPrompt(buildSessionEntries(currentState, pendingEdits));
+    const records = buildSessionRecords(currentState, pendingEdits);
+    const prompt = formatSessionEditsPrompt(buildSessionEntries(records));
+    restoreUneditedPreviews(records);
     clearAll();
     if (!dependencies.store.wasActivatedByToggle) {
       dependencies.actions.unfreeze();

--- a/packages/react-grab/src/core/edit-mode.ts
+++ b/packages/react-grab/src/core/edit-mode.ts
@@ -79,6 +79,17 @@ const mergeEditsIntoEntry = (entry: PendingEditsEntry, edits: PendingEdits) => {
   }
 };
 
+const toSessionRecord = (
+  currentState: EditPanelState,
+  edits: PendingEdits,
+): EditSessionRecord => ({
+  element: currentState.element,
+  preview: currentState.preview,
+  filePath: currentState.filePath ?? "",
+  lineNumber: currentState.lineNumber ?? 0,
+  edits,
+});
+
 export const createEditModeController = (
   dependencies: EditModeDependencies,
 ): EditModeController => {
@@ -168,13 +179,7 @@ export const createEditModeController = (
     if (properties.length === 0) return false;
 
     if (currentPendingEdits.length > 0 || currentState.preview.hasAppliedStyles()) {
-      sessionRecords.push({
-        element: currentState.element,
-        preview: currentState.preview,
-        filePath: currentState.filePath ?? "",
-        lineNumber: currentState.lineNumber ?? 0,
-        edits: currentPendingEdits,
-      });
+      sessionRecords.push(toSessionRecord(currentState, currentPendingEdits));
     }
     currentPendingEdits = [];
 
@@ -189,10 +194,18 @@ export const createEditModeController = (
     });
 
     // The store's selection source still points at the previous element, so
-    // the new element's source is resolved directly instead.
+    // the new element's source is resolved directly instead. Resolution is
+    // async, so a fast switch can bank this element's record before it lands;
+    // patch any already-recorded visit of this element too, not just live state.
     void resolveSource(element)
       .then((source) => {
         if (!source) return;
+        for (const record of sessionRecords) {
+          if (record.element === element && !record.filePath) {
+            record.filePath = source.filePath;
+            record.lineNumber = source.lineNumber ?? 0;
+          }
+        }
         setState((current) => {
           if (!current || current.element !== element || current.filePath) return current;
           return {
@@ -217,13 +230,7 @@ export const createEditModeController = (
   ): PendingEditsEntry[] => {
     const records: EditSessionRecord[] = [
       ...sessionRecords,
-      {
-        element: currentState.element,
-        preview: currentState.preview,
-        filePath: currentState.filePath ?? "",
-        lineNumber: currentState.lineNumber ?? 0,
-        edits: pendingEdits,
-      },
+      toSessionRecord(currentState, pendingEdits),
     ];
 
     const entryByElement = new Map<Element, PendingEditsEntry>();
@@ -231,6 +238,11 @@ export const createEditModeController = (
       if (record.edits.length === 0) continue;
       const existingEntry = entryByElement.get(record.element);
       if (existingEntry) {
+        // A later visit may have resolved the source the first visit missed.
+        if (!existingEntry.filePath && record.filePath) {
+          existingEntry.filePath = record.filePath;
+          existingEntry.lineNumber = record.lineNumber;
+        }
         mergeEditsIntoEntry(existingEntry, record.edits);
         continue;
       }

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -325,6 +325,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     let toolbarElement: HTMLDivElement | undefined;
     let stopToolbarMenuTracking: (() => void) | null = null;
     let stopEditPanelTracking: (() => void) | null = null;
+    let didSwitchEditTargetOnPointerDown = false;
 
     let shiftSelectionLabelAnchorRatioByElement = new WeakMap<Element, number>();
 
@@ -1447,6 +1448,15 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       position: Position,
       overrides: EditModeOverrides = {},
     ): boolean => editMode.trigger(element, position, overrides);
+
+    const tryHandleEditModeElementSwitch = (clientX: number, clientY: number): boolean => {
+      if (!editMode.isOpen() || store.contextMenuPosition !== null) return false;
+      const element = getElementsAtPoint(clientX, clientY).find(isValidGrabbableElement);
+      if (!element) return false;
+      const didSwitch = editMode.switchToElement(element, { x: clientX, y: clientY });
+      if (didSwitch) freezeAllAnimations([element]);
+      return didSwitch;
+    };
 
     const currentSelectionEditOverrides = (element: Element): EditModeOverrides => ({
       filePath: store.selectionFilePath ?? undefined,
@@ -2598,8 +2608,16 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         if (event.button !== 0) return;
         if (!event.isPrimary) return;
         actions.setTouchMode(event.pointerType === "touch");
+        didSwitchEditTargetOnPointerDown = false;
         if (isEventFromOverlay(event, "data-react-grab-ignore-events")) return;
-        if (isModalPopoverOpen()) return;
+        if (isModalPopoverOpen()) {
+          if (tryHandleEditModeElementSwitch(event.clientX, event.clientY)) {
+            didSwitchEditTargetOnPointerDown = true;
+            event.preventDefault();
+            event.stopImmediatePropagation();
+          }
+          return;
+        }
 
         if (isPromptMode()) {
           const bounds = selectionBounds();
@@ -2710,6 +2728,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       "click",
       (event: MouseEvent) => {
         if (isEventFromOverlay(event, "data-react-grab-ignore-events")) return;
+        if (didSwitchEditTargetOnPointerDown) {
+          didSwitchEditTargetOnPointerDown = false;
+          event.preventDefault();
+          event.stopImmediatePropagation();
+          return;
+        }
         if (isModalPopoverOpen()) return;
 
         if (isRendererActive() || didJustDrag()) {
@@ -3585,6 +3609,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
                 editPanelPosition={editPanelPosition()}
                 onEditPanelDismiss={editMode.dismiss}
                 onEditPanelSubmit={editMode.submit}
+                onEditPanelPendingEditsChange={editMode.setPendingEdits}
                 onEditPanelInteractingChange={editMode.setInteracting}
               />
             );

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -243,7 +243,6 @@ export interface PendingEditsEntry {
 export interface PreviewStyles {
   apply: (cssProperties: readonly string[], cssValue: string) => void;
   restore: () => void;
-  forget: () => void;
   hasAppliedStyles: () => boolean;
 }
 
@@ -259,6 +258,7 @@ export interface EditPanelState {
   tagName?: string;
   htmlPreview?: string;
   initialSearchQuery?: string;
+  hasSessionEdits?: boolean;
 }
 
 export interface ContextMenuAction {
@@ -515,7 +515,8 @@ export interface ReactGrabRendererProps {
   editPanelState?: EditPanelState | null;
   editPanelPosition?: DropdownAnchor | null;
   onEditPanelDismiss?: () => void;
-  onEditPanelSubmit?: (prompt: string) => void;
+  onEditPanelSubmit?: (pendingEdits: PendingEdits) => void;
+  onEditPanelPendingEditsChange?: (pendingEdits: PendingEdits) => void;
   onEditPanelInteractingChange?: (interacting: boolean) => void;
 }
 

--- a/packages/react-grab/src/utils/preview-styles.ts
+++ b/packages/react-grab/src/utils/preview-styles.ts
@@ -40,11 +40,7 @@ export const createPreviewStyles = (element: Element): PreviewStyles => {
     baselineStyles.clear();
   };
 
-  const forget = (): void => {
-    baselineStyles.clear();
-  };
-
   const hasAppliedStyles = (): boolean => baselineStyles.size > 0;
 
-  return { apply, restore, forget, hasAppliedStyles };
+  return { apply, restore, hasAppliedStyles };
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

While the Style (edit) panel is open, clicking another element on the page now switches the editing session to that element instead of dismissing the panel. Edits compound across elements within a single session:

- **Switching keeps applied styles.** The previous element's inline style preview stays on the page, and its pending edits are accumulated into the session.
- **Copy emits all edits.** Submitting (Enter / Copy button) formats one prompt entry per styled element, merged by element identity (re-visiting an element merges its edits instead of duplicating the entry).
- **Discard reverts everything.** Confirming the discard prompt (or dismissing on a non-grabbable target) restores every element styled during the session, in reverse order so re-visited elements unwind correctly.
- The discard prompt and header Copy button stay armed after switching, even when the current element has no tweaks yet, as long as the session holds edits from previous elements.

## Implementation

- `core/edit-mode.ts`: the controller now tracks per-visit session records (element, preview, edits, source location) and exposes `switchToElement` plus `setPendingEdits`. Prompt formatting moved here from the panel so the compound prompt is built from the whole session. The new element's source path is resolved asynchronously since the store's selection source still points at the previous element.
- `core/index.tsx`: window `pointerdown` while the panel is open resolves a grabbable element under the cursor and switches to it (consuming the gesture); the follow-up `click` is suppressed so page buttons/links don't activate when picked.
- `components/edit-panel/index.tsx`: reports pending edits to the controller on every commit, gates dismiss/submit affordances on session edits, and no longer clears preview baselines on unmount (the controller owns restore-on-discard across switches).
- `utils/preview-styles.ts`: removed the now-unused `forget`.

## Testing

- New e2e tests in `edit-panel.spec.ts` ("Element switching"): switch keeps applied styles and retargets tweaks; compound copy produces two CSS blocks; discard restores all elements; discard prompt stays armed after switching with no new tweaks.
- Full suite: `pnpm test` (658 passed, 1 unrelated flaky that passes in isolation), `pnpm lint`, `pnpm typecheck`, `pnpm format` all green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f438972-5167-48dd-8d90-502da8b96b18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f438972-5167-48dd-8d90-502da8b96b18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the styled element by clicking another element while the Style panel is open. Edits persist across elements so you can copy or discard the whole session at once, and copy now reverts preview‑only elements to avoid stray inline styles.

- **New Features**
  - Click another element to switch the style target without closing the panel; follow-up clicks are suppressed so links/buttons don’t fire.
  - Applied inline style previews stay visible when switching.
  - Copy emits one prompt entry per styled element; re-visits merge edits; file:line headers resolve even after fast switches.
  - Copy reverts switched-away elements with no net edits, preventing leftover inline styles.
  - Discard restores every element touched in the session, in correct order.
  - Discard prompt and header Copy button stay enabled if the session has prior edits.

- **Migration**
  - `onEditPanelSubmit` now receives `PendingEdits` instead of a formatted prompt.
  - New: `onEditPanelPendingEditsChange` reports live `PendingEdits`.
  - `PreviewStyles.forget()` was removed.

<sup>Written for commit 739dfa4974ace022d3c1dbf39aaca5ed8148610c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

