### PR TITLE
Surface React key to disambiguate mapped list items

### DIFF
--- a/.changeset/surface-list-item-key.md
+++ b/.changeset/surface-list-item-key.md
@@ -1,0 +1,5 @@
+---
+"react-grab": patch
+---
+
+Surface the React `key` of the picked element in its copied context. Elements rendered through `.map()` share the same JSX source location, so the source line alone couldn't tell list instances apart. The context now walks the fiber tree to the nearest list-item key (the host element's own key, or the enclosing keyed list-item component's key) and includes it, letting agents disambiguate which mapped instance was selected.

--- a/apps/e2e-app/src/App.tsx
+++ b/apps/e2e-app/src/App.tsx
@@ -202,6 +202,34 @@ const DynamicElements = () => {
   );
 };
 
+const MappedCardBody = ({ label }: { label: string }) => {
+  return <p className="font-medium">{label}</p>;
+};
+
+const MappedCards = () => {
+  const cards = [
+    { id: "alpha", label: "Alpha card" },
+    { id: "bravo", label: "Bravo card" },
+  ];
+
+  return (
+    <section className="border rounded-lg p-4" data-testid="mapped-cards-section">
+      <h2 className="text-lg font-bold mb-4">Mapped Cards</h2>
+      <div className="space-y-2">
+        {cards.map((card) => (
+          <div
+            key={card.id}
+            className="p-2 bg-gray-100 rounded"
+            data-testid={`mapped-card-${card.id}`}
+          >
+            <MappedCardBody label={card.label} />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};
+
 const EdgeElements = () => {
   return (
     <>
@@ -651,6 +679,8 @@ export default function App() {
       </header>
 
       <TodoList />
+
+      <MappedCards />
 
       <DeeplyNested />
 

--- a/packages/react-grab/e2e/element-context.spec.ts
+++ b/packages/react-grab/e2e/element-context.spec.ts
@@ -50,7 +50,7 @@ test.describe("Element Context Fallback", () => {
       await reactGrab.clickElement(mappedItem);
 
       const clipboard = await reactGrab.getClipboardContent();
-      expect(clipboard).toContain("key: 2");
+      expect(clipboard).toContain('key: "2"');
     });
 
     test("should surface the list-item key for mapped component instances", async ({
@@ -64,7 +64,21 @@ test.describe("Element Context Fallback", () => {
       await reactGrab.clickElement(todoItem);
 
       const clipboard = await reactGrab.getClipboardContent();
-      expect(clipboard).toContain("key: 3");
+      expect(clipboard).toContain('key: "3"');
+    });
+
+    test("should surface the wrapper key when picking inside a mapped child component", async ({
+      reactGrab,
+    }) => {
+      await reactGrab.activate();
+
+      const cardBody = "[data-testid='mapped-card-bravo'] p";
+      await reactGrab.hoverElement(cardBody);
+      await reactGrab.waitForSelectionBox();
+      await reactGrab.clickElement(cardBody);
+
+      const clipboard = await reactGrab.getClipboardContent();
+      expect(clipboard).toContain('key: "bravo"');
     });
   });
 

--- a/packages/react-grab/e2e/element-context.spec.ts
+++ b/packages/react-grab/e2e/element-context.spec.ts
@@ -40,6 +40,32 @@ test.describe("Element Context Fallback", () => {
       expect(clipboard).toMatch(/^\[<\w+[\s>]/);
       expect(clipboard).toContain("TodoItem");
     });
+
+    test("should surface the list-item key for mapped host elements", async ({ reactGrab }) => {
+      await reactGrab.activate();
+
+      const mappedItem = "[data-testid='dynamic-element-2']";
+      await reactGrab.hoverElement(mappedItem);
+      await reactGrab.waitForSelectionBox();
+      await reactGrab.clickElement(mappedItem);
+
+      const clipboard = await reactGrab.getClipboardContent();
+      expect(clipboard).toContain("key: 2");
+    });
+
+    test("should surface the list-item key for mapped component instances", async ({
+      reactGrab,
+    }) => {
+      await reactGrab.activate();
+
+      const todoItem = "[data-testid='todo-list'] ul li:nth-child(3) span";
+      await reactGrab.hoverElement(todoItem);
+      await reactGrab.waitForSelectionBox();
+      await reactGrab.clickElement(todoItem);
+
+      const clipboard = await reactGrab.getClipboardContent();
+      expect(clipboard).toContain("key: 3");
+    });
   });
 
   test.describe("Non-React Elements Fallback", () => {

--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -44,6 +44,24 @@ const findNearestFiberElement = (element: Element): Element => {
   return element;
 };
 
+// Elements rendered inside a `.map()` all share the same JSX source location, so
+// the source line alone can't tell list instances apart. React already
+// disambiguates siblings via their `key`, so we surface the nearest list-item
+// key. The walk stops at the first component boundary: a keyed host element
+// directly under its rendering component (or a keyed list-item component itself)
+// is the identity we want; keys further up belong to unrelated ancestor lists.
+const getNearestListItemKey = (element: Element): string | null => {
+  if (!isInstrumentationActive()) return null;
+  let fiber: Fiber | null = getFiberFromHostInstance(findNearestFiberElement(element));
+  while (fiber) {
+    const fiberKey = fiber.key;
+    if (fiberKey != null && String(fiberKey).length > 0) return String(fiberKey);
+    if (isCompositeFiber(fiber)) break;
+    fiber = fiber.return;
+  }
+  return null;
+};
+
 const stackCache = new WeakMap<Element, Promise<StackFrame[] | null>>();
 const fiberSourceCache = new WeakMap<Element, Promise<ResolvedSource | null>>();
 
@@ -405,10 +423,12 @@ export const getStackContext = async (
 };
 
 const composeElementContext = (element: Element, traceContext: TraceContextResult): string => {
+  const listItemKey = getNearestListItemKey(element);
+  const keyHint = listItemKey !== null ? `\n  key: ${listItemKey}` : "";
   const selectorHint = traceContext.shouldAppendSelectorHint
     ? `\n  selector: ${createElementSelector(element)}`
     : "";
-  return `${traceContext.text}${selectorHint}`;
+  return `${traceContext.text}${keyHint}${selectorHint}`;
 };
 
 export const getElementReferenceContext = async (

--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -44,19 +44,15 @@ const findNearestFiberElement = (element: Element): Element => {
   return element;
 };
 
-// Elements rendered inside a `.map()` all share the same JSX source location, so
-// the source line alone can't tell list instances apart. React already
-// disambiguates siblings via their `key`, so we surface the nearest list-item
-// key. The walk stops at the first component boundary: a keyed host element
-// directly under its rendering component (or a keyed list-item component itself)
-// is the identity we want; keys further up belong to unrelated ancestor lists.
+// Elements rendered through `.map()` share one JSX source location, so the
+// source line alone can't tell list instances apart. React assigns a `key` only
+// to siblings in a list, so the nearest keyed fiber above the picked node is its
+// list-item identity.
 const getNearestListItemKey = (element: Element): string | null => {
   if (!isInstrumentationActive()) return null;
   let fiber: Fiber | null = getFiberFromHostInstance(findNearestFiberElement(element));
   while (fiber) {
-    const fiberKey = fiber.key;
-    if (fiberKey != null && String(fiberKey).length > 0) return String(fiberKey);
-    if (isCompositeFiber(fiber)) break;
+    if (fiber.key) return fiber.key;
     fiber = fiber.return;
   }
   return null;

--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -46,13 +46,21 @@ const findNearestFiberElement = (element: Element): Element => {
 
 // Elements rendered through `.map()` share one JSX source location, so the
 // source line alone can't tell list instances apart. React assigns a `key` only
-// to siblings in a list, so the nearest keyed fiber above the picked node is its
-// list-item identity.
+// to siblings in a list, so we surface the nearest keyed fiber above the picked
+// node. The walk crosses at most one component boundary: enough to reach a key
+// on the list item's host element, on the list-item component itself, or on a
+// host wrapper around a list-item component, without wandering up to unrelated
+// ancestor keys (e.g. a route or transition `key` many components above).
 const getNearestListItemKey = (element: Element): string | null => {
   if (!isInstrumentationActive()) return null;
   let fiber: Fiber | null = getFiberFromHostInstance(findNearestFiberElement(element));
+  let componentBoundariesCrossed = 0;
   while (fiber) {
     if (fiber.key) return fiber.key;
+    if (isCompositeFiber(fiber)) {
+      componentBoundariesCrossed += 1;
+      if (componentBoundariesCrossed === 2) break;
+    }
     fiber = fiber.return;
   }
   return null;
@@ -420,7 +428,7 @@ export const getStackContext = async (
 
 const composeElementContext = (element: Element, traceContext: TraceContextResult): string => {
   const listItemKey = getNearestListItemKey(element);
-  const keyHint = listItemKey !== null ? `\n  key: ${listItemKey}` : "";
+  const keyHint = listItemKey !== null ? `\n  key: "${listItemKey}"` : "";
   const selectorHint = traceContext.shouldAppendSelectorHint
     ? `\n  selector: ${createElementSelector(element)}`
     : "";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Fixes [#469](https://github.com/aidenybai/react-grab/issues/469).

When a component renders a list via `.map()`, every rendered element shares the same JSX source location (the template line inside the callback). The context returned by React Grab points at that line for every iteration, so from the consumer side (e.g. an LLM agent acting on the picked element) there's no way to tell which instance was selected.

## Fix

React assigns a `key` only to siblings in a list, so the nearest keyed fiber above the picked node is its list-item identity. The element context now walks the fiber tree from the picked element up the `return` chain to the nearest non-empty `key` and appends it as `key: "<value>"`.

The walk crosses at most one component boundary, which keeps it scoped to the picked element's list item while covering every mapped-list shape:

- Host-element items (`{items.map((item, i) => <div key={i}>…</div>)}`) — the key lives on the picked element's own host fiber.
- Component items (`{todos.map((todo) => <TodoItem key={todo.id} />)}`) — the key lives on the enclosing keyed component.
- Keyed host wrapping a child component (`{items.map((item) => <div key={item.id}><ItemContent /></div>)}`) — picking inside `ItemContent` still resolves the wrapper's key.

Bounding the walk avoids surfacing unrelated ancestor keys (e.g. a route or transition `key={pathname}` many components above) on elements that aren't list items. The value is quoted so keys containing spaces or punctuation stay unambiguous after the reference string is collapsed to one line.

When the user provides a meaningful key (`key={item.slug}`) this gives exact identity; when keys are array indices it at least gives the index. This implements suggestion (1) from the issue and composes with the existing inner-text HTML preview (suggestion 3), which together cover the real-world list/grid/gallery cases.

## Changes

- `packages/react-grab/src/core/context.ts`: add `getNearestListItemKey` (bounded fiber walk) and include the quoted key in `composeElementContext` (flows into both the copied reference and `formatElementInfo`).
- `apps/e2e-app/src/App.tsx`: add a `MappedCards` fixture (keyed host wrapping a child component) for the cross-boundary case.
- `packages/react-grab/e2e/element-context.spec.ts`: tests for keyed host elements, keyed component instances, and the keyed-wrapper-around-component case.
- Changeset (patch).

## Testing

- `pnpm build`, `pnpm typecheck`, `pnpm lint` pass.
- Unit tests (`vp test run tests`) pass.
- New e2e tests pass (keyed host element → `key: "2"`, keyed component instance → `key: "3"`, wrapper around child component → `key: "bravo"`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d17c905b-10b2-4e44-8a78-2f089c46c525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d17c905b-10b2-4e44-8a78-2f089c46c525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface the nearest React list-item key in the element context so mapped items can be told apart. Picked elements from `.map()` are now uniquely identifiable in `react-grab`.

- **Bug Fixes**
  - Walk the fiber return chain, bounded to avoid unrelated ancestors, and use the nearest keyed fiber as the list-item identity.
  - Append the key hint to the composed context (e.g., key: "3") for keyed host elements, keyed list-item components, and when picking inside a child of a keyed wrapper.
  - Add e2e tests for mapped host elements, mapped component instances, and wrapper-key cases.

<sup>Written for commit 885aa1ef55952dc29a4282e2860047ebf0ac71cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

