### PR TITLE
feat(cli): expose programmatic Node install API

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -116,7 +116,7 @@ import {
   installSkill,
 } from "@react-grab/cli/api";
 
-const project = await detectProject(cwd);
+const project = await detectProject(process.cwd());
 const transform = previewTransform(
   project.projectRoot,
   project.framework,

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -69,11 +69,11 @@ npx grab@latest configure
 
 ## Node API
 
-The same primitives that power the CLI are exposed under `@react-grab/cli/api`, so you can build your own installer or wrap React Grab setup inside another tool. The API has no side effects on import (unlike the CLI entry, which parses `argv` immediately).
+`@react-grab/cli/api` exposes the same primitives that power the CLI, so you can build your own installer or wrap React Grab setup inside another tool. Importing it runs no code, unlike the CLI entry (`.`), which parses `argv` on import.
 
 ### `installReactGrab(options?)`
 
-High-level, non-interactive orchestrator. Detects the project, installs the `react-grab` package with the detected package manager, and applies the framework-specific dev-only setup. Returns a structured result instead of printing or exiting.
+A high-level, non-interactive orchestrator. It detects the project, installs `react-grab` with the detected package manager, and applies the framework-specific development-only setup. It returns a structured result instead of printing or exiting.
 
 ```ts
 import { installReactGrab } from "@react-grab/cli/api";
@@ -98,9 +98,17 @@ console.log(result.transform.filePath); // the file that was (or would be) edite
 | `dryRun`                | `boolean`                                                | Compute the changes without installing or writing                                                                       |
 | `installPackageOptions` | `Omit<InstallPackageOptions, "cwd" \| "packageManager">` | Passed through to `installPackages` (e.g. `silent`, `isDev`); `cwd`/`packageManager` are controlled by the orchestrator |
 
-Failures throw a `ReactGrabInstallError` with a `code` (`"unsupported-framework"`, `"unknown-framework"`, `"transform-failed"`, `"install-failed"`, `"write-failed"`) so callers can branch on the cause. The original error is preserved on `error.cause`.
+Failures throw a `ReactGrabInstallError` whose `code` identifies the cause, with the original error preserved on `error.cause`:
 
-`installReactGrab` operates on a single project at `cwd` (it does not walk a monorepo). Point `cwd` at the app you want to configure; to discover apps in a monorepo first, use the exported `findReactProjects` helper. Calling it with default options mutates the project: it runs your package manager and edits a framework entry file. Use `dryRun: true` to compute the changes (returned on `result.transform`) without installing or writing.
+- `unsupported-framework`: framework has no automatic setup (Remix, Astro, SvelteKit, Gatsby)
+- `unknown-framework`: no supported framework detected
+- `transform-failed`: entry file could not be located or edited
+- `install-failed`: package manager failed to install `react-grab`
+- `write-failed`: edited file could not be written
+
+`installReactGrab` configures a single project at `cwd` and does not walk a monorepo. Point `cwd` at the app you want to set up, or call `findReactProjects` first to locate the apps in a workspace.
+
+By default the call mutates your project: it runs the package manager and edits a framework entry file. Pass `dryRun: true` to compute the change set (returned on `result.transform`) without installing or writing.
 
 ### Low-level building blocks
 
@@ -123,7 +131,11 @@ const transform = previewTransform(
   project.nextRouterType,
   project.isReactGrabConfigured,
 );
+```
 
+Install the package only when it's missing, then write the previewed edit. `previewTransform` sets `noChanges` when React Grab is already wired up, so guard on it before calling `applyTransform`, which writes `transform.newContent` to `transform.filePath`:
+
+```ts
 if (!project.hasReactGrab) {
   await installPackages(getPackagesToInstall(), {
     cwd: project.projectRoot,
@@ -131,16 +143,18 @@ if (!project.hasReactGrab) {
   });
 }
 
-// `noChanges` is set when React Grab is already wired up, so guard on it too
 if (transform.success && transform.newContent && !transform.noChanges) {
-  applyTransform(transform); // writes transform.newContent to transform.filePath
+  applyTransform(transform);
 }
 
-// Optionally install the agent skill for all detected agents
 await installSkill({ cwd: project.projectRoot });
 ```
 
-Exposed helpers include `detectProject`, `detectFramework`, `detectPackageManager`, `detectNextRouterType`, `detectReactGrab`, `findReactProjects`, `previewTransform`, `previewOptionsTransform`, `previewCdnTransform`, `applyTransform`, `hasFrameworkEntryPoint`, `installPackages`, `getPackagesToInstall`, `installSkill`, and `removeSkill`, along with their TypeScript types.
+The full export surface, each with its TypeScript types:
+
+- Detection: `detectProject`, `detectFramework`, `detectPackageManager`, `detectNextRouterType`, `detectReactGrab`, `findReactProjects`
+- Transforms: `previewTransform`, `previewOptionsTransform`, `previewCdnTransform`, `applyTransform`, `hasFrameworkEntryPoint`
+- Installation: `installPackages`, `getPackagesToInstall`, `installSkill`, `removeSkill`
 
 ## Supported Frameworks
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -67,6 +67,77 @@ npx grab@latest configure --mode hold --hold-duration 500
 npx grab@latest configure
 ```
 
+## Node API
+
+The same primitives that power the CLI are exposed under `@react-grab/cli/api`, so you can build your own installer or wrap React Grab setup inside another tool. The API has no side effects on import (unlike the CLI entry, which parses `argv` immediately).
+
+### `installReactGrab(options?)`
+
+High-level, non-interactive orchestrator. Detects the project, installs the `react-grab` package with the detected package manager, and applies the framework-specific dev-only setup. Returns a structured result instead of printing or exiting.
+
+```ts
+import { installReactGrab } from "@react-grab/cli/api";
+
+const result = await installReactGrab({ cwd: process.cwd() });
+
+console.log(result.framework); // "next" | "vite" | "tanstack" | "webpack"
+console.log(result.didInstallPackage); // whether react-grab was added to deps
+console.log(result.didChangeFile); // whether an entry file was modified
+console.log(result.transform.filePath); // the file that was (or would be) edited
+```
+
+| Option                  | Type                    | Description                                                  |
+| ----------------------- | ----------------------- | ------------------------------------------------------------ |
+| `cwd`                   | `string`                | Project directory (default: `process.cwd()`)                 |
+| `framework`             | `Framework`             | Override framework detection                                 |
+| `nextRouterType`        | `NextRouterType`        | Override Next.js router detection (`app` / `pages`)          |
+| `packageManager`        | `PackageManager`        | Override package-manager detection                           |
+| `force`                 | `boolean`               | Re-apply setup even if React Grab is already configured      |
+| `skipPackageInstall`    | `boolean`               | Skip installing the `react-grab` npm package                 |
+| `skipTransform`         | `boolean`               | Skip editing the framework entry file                        |
+| `dryRun`                | `boolean`               | Compute the changes without installing or writing            |
+| `installPackageOptions` | `InstallPackageOptions` | Passed through to `installPackages` (e.g. `silent`, `isDev`) |
+
+Failures throw a `ReactGrabInstallError` with a `code` (`"unsupported-framework"`, `"unknown-framework"`, `"transform-failed"`, `"write-failed"`) so callers can branch on the cause.
+
+### Low-level building blocks
+
+If you want full control, compose the same functions the orchestrator uses:
+
+```ts
+import {
+  detectProject,
+  previewTransform,
+  applyTransform,
+  installPackages,
+  installSkill,
+} from "@react-grab/cli/api";
+
+const project = await detectProject(cwd);
+const transform = previewTransform(
+  project.projectRoot,
+  project.framework,
+  project.nextRouterType,
+  project.isReactGrabConfigured,
+);
+
+if (!project.hasReactGrab) {
+  await installPackages(["react-grab"], {
+    cwd: project.projectRoot,
+    packageManager: project.packageManager,
+  });
+}
+
+if (transform.success && transform.newContent) {
+  applyTransform(transform); // writes transform.newContent to transform.filePath
+}
+
+// Optionally install the agent skill for all detected agents
+await installSkill({ cwd: project.projectRoot });
+```
+
+Exposed helpers include `detectProject`, `detectFramework`, `detectPackageManager`, `detectNextRouterType`, `detectReactGrab`, `findReactProjects`, `previewTransform`, `previewOptionsTransform`, `previewCdnTransform`, `applyTransform`, `hasFrameworkEntryPoint`, `installPackages`, `getPackagesToInstall`, `installSkill`, and `removeSkill`, along with their TypeScript types.
+
 ## Supported Frameworks
 
 The CLI currently configures:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -86,17 +86,17 @@ console.log(result.didChangeFile); // whether an entry file was modified
 console.log(result.transform.filePath); // the file that was (or would be) edited
 ```
 
-| Option                  | Type                    | Description                                                                                    |
-| ----------------------- | ----------------------- | ---------------------------------------------------------------------------------------------- |
-| `cwd`                   | `string`                | Project directory (default: `process.cwd()`)                                                   |
-| `framework`             | `Framework`             | Override framework detection                                                                   |
-| `nextRouterType`        | `NextRouterType`        | Override Next.js router detection (`app` / `pages`)                                            |
-| `packageManager`        | `PackageManager`        | Override package-manager detection                                                             |
-| `force`                 | `boolean`               | Re-run setup even when React Grab is already configured (does not rewrite existing setup code) |
-| `skipPackageInstall`    | `boolean`               | Skip installing the `react-grab` npm package                                                   |
-| `skipTransform`         | `boolean`               | Skip editing the framework entry file                                                          |
-| `dryRun`                | `boolean`               | Compute the changes without installing or writing                                              |
-| `installPackageOptions` | `InstallPackageOptions` | Passed through to `installPackages` (e.g. `silent`, `isDev`)                                   |
+| Option                  | Type                                                     | Description                                                                                                             |
+| ----------------------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `cwd`                   | `string`                                                 | Project directory (default: `process.cwd()`)                                                                            |
+| `framework`             | `Framework`                                              | Override framework detection                                                                                            |
+| `nextRouterType`        | `NextRouterType`                                         | Override Next.js router detection (`app` / `pages`)                                                                     |
+| `packageManager`        | `PackageManager`                                         | Override package-manager detection                                                                                      |
+| `force`                 | `boolean`                                                | Re-run setup even when React Grab is already configured (does not rewrite existing setup code)                          |
+| `skipPackageInstall`    | `boolean`                                                | Skip installing the `react-grab` npm package                                                                            |
+| `skipTransform`         | `boolean`                                                | Skip editing the framework entry file                                                                                   |
+| `dryRun`                | `boolean`                                                | Compute the changes without installing or writing                                                                       |
+| `installPackageOptions` | `Omit<InstallPackageOptions, "cwd" \| "packageManager">` | Passed through to `installPackages` (e.g. `silent`, `isDev`); `cwd`/`packageManager` are controlled by the orchestrator |
 
 Failures throw a `ReactGrabInstallError` with a `code` (`"unsupported-framework"`, `"unknown-framework"`, `"transform-failed"`, `"install-failed"`, `"write-failed"`) so callers can branch on the cause. The original error is preserved on `error.cause`.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -112,6 +112,7 @@ import {
   previewTransform,
   applyTransform,
   installPackages,
+  getPackagesToInstall,
   installSkill,
 } from "@react-grab/cli/api";
 
@@ -124,13 +125,14 @@ const transform = previewTransform(
 );
 
 if (!project.hasReactGrab) {
-  await installPackages(["react-grab"], {
+  await installPackages(getPackagesToInstall(), {
     cwd: project.projectRoot,
     packageManager: project.packageManager,
   });
 }
 
-if (transform.success && transform.newContent) {
+// `noChanges` is set when React Grab is already wired up, so guard on it too
+if (transform.success && transform.newContent && !transform.noChanges) {
   applyTransform(transform); // writes transform.newContent to transform.filePath
 }
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -92,7 +92,6 @@ console.log(result.transform.filePath); // the file that was (or would be) edite
 | `framework`             | `Framework`                                              | Override framework detection                                                                                            |
 | `nextRouterType`        | `NextRouterType`                                         | Override Next.js router detection (`app` / `pages`)                                                                     |
 | `packageManager`        | `PackageManager`                                         | Override package-manager detection                                                                                      |
-| `force`                 | `boolean`                                                | Re-run setup even when React Grab is already configured (does not rewrite existing setup code)                          |
 | `skipPackageInstall`    | `boolean`                                                | Skip installing the `react-grab` npm package                                                                            |
 | `skipTransform`         | `boolean`                                                | Skip editing the framework entry file                                                                                   |
 | `dryRun`                | `boolean`                                                | Compute the changes without installing or writing                                                                       |
@@ -152,7 +151,7 @@ await installSkill({ cwd: project.projectRoot });
 
 The full export surface, each with its TypeScript types:
 
-- Detection: `detectProject`, `detectFramework`, `detectPackageManager`, `detectNextRouterType`, `detectReactGrab`, `findReactProjects`
+- Detection: `detectProject`, `detectFramework`, `detectPackageManager`, `detectNextRouterType`, `detectReactGrab`, `detectReactGrabConfigured`, `detectUnsupportedFramework`, `findReactProjects`
 - Transforms: `previewTransform`, `previewOptionsTransform`, `previewCdnTransform`, `applyTransform`, `hasFrameworkEntryPoint`
 - Installation: `installPackages`, `getPackagesToInstall`, `installSkill`, `removeSkill`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -86,19 +86,21 @@ console.log(result.didChangeFile); // whether an entry file was modified
 console.log(result.transform.filePath); // the file that was (or would be) edited
 ```
 
-| Option                  | Type                    | Description                                                  |
-| ----------------------- | ----------------------- | ------------------------------------------------------------ |
-| `cwd`                   | `string`                | Project directory (default: `process.cwd()`)                 |
-| `framework`             | `Framework`             | Override framework detection                                 |
-| `nextRouterType`        | `NextRouterType`        | Override Next.js router detection (`app` / `pages`)          |
-| `packageManager`        | `PackageManager`        | Override package-manager detection                           |
-| `force`                 | `boolean`               | Re-apply setup even if React Grab is already configured      |
-| `skipPackageInstall`    | `boolean`               | Skip installing the `react-grab` npm package                 |
-| `skipTransform`         | `boolean`               | Skip editing the framework entry file                        |
-| `dryRun`                | `boolean`               | Compute the changes without installing or writing            |
-| `installPackageOptions` | `InstallPackageOptions` | Passed through to `installPackages` (e.g. `silent`, `isDev`) |
+| Option                  | Type                    | Description                                                                                    |
+| ----------------------- | ----------------------- | ---------------------------------------------------------------------------------------------- |
+| `cwd`                   | `string`                | Project directory (default: `process.cwd()`)                                                   |
+| `framework`             | `Framework`             | Override framework detection                                                                   |
+| `nextRouterType`        | `NextRouterType`        | Override Next.js router detection (`app` / `pages`)                                            |
+| `packageManager`        | `PackageManager`        | Override package-manager detection                                                             |
+| `force`                 | `boolean`               | Re-run setup even when React Grab is already configured (does not rewrite existing setup code) |
+| `skipPackageInstall`    | `boolean`               | Skip installing the `react-grab` npm package                                                   |
+| `skipTransform`         | `boolean`               | Skip editing the framework entry file                                                          |
+| `dryRun`                | `boolean`               | Compute the changes without installing or writing                                              |
+| `installPackageOptions` | `InstallPackageOptions` | Passed through to `installPackages` (e.g. `silent`, `isDev`)                                   |
 
-Failures throw a `ReactGrabInstallError` with a `code` (`"unsupported-framework"`, `"unknown-framework"`, `"transform-failed"`, `"write-failed"`) so callers can branch on the cause.
+Failures throw a `ReactGrabInstallError` with a `code` (`"unsupported-framework"`, `"unknown-framework"`, `"transform-failed"`, `"install-failed"`, `"write-failed"`) so callers can branch on the cause. The original error is preserved on `error.cause`.
+
+`installReactGrab` operates on a single project at `cwd` (it does not walk a monorepo). Point `cwd` at the app you want to configure; to discover apps in a monorepo first, use the exported `findReactProjects` helper. Calling it with default options mutates the project: it runs your package manager and edits a framework entry file. Use `dryRun: true` to compute the changes (returned on `result.transform`) without installing or writing.
 
 ### Low-level building blocks
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,6 +19,11 @@
       "types": "./dist/cli.d.ts",
       "import": "./dist/cli.js",
       "require": "./dist/cli.cjs"
+    },
+    "./api": {
+      "types": "./dist/api.d.ts",
+      "import": "./dist/api.js",
+      "require": "./dist/api.cjs"
     }
   },
   "scripts": {

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -1,6 +1,5 @@
 export {
   detectFramework,
-  detectMonorepo,
   detectNextRouterType,
   detectPackageManager,
   detectProject,

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -1,0 +1,41 @@
+export {
+  detectFramework,
+  detectMonorepo,
+  detectNextRouterType,
+  detectPackageManager,
+  detectProject,
+  detectReactGrab,
+  detectReactGrabConfigured,
+  detectUnsupportedFramework,
+  findReactProjects,
+} from "./utils/detect.js";
+export type {
+  Framework,
+  NextRouterType,
+  PackageManager,
+  ProjectInfo,
+  UnsupportedFramework,
+  WorkspaceProject,
+} from "./utils/detect.js";
+
+export {
+  applyTransform,
+  hasFrameworkEntryPoint,
+  previewCdnTransform,
+  previewOptionsTransform,
+  previewTransform,
+} from "./utils/transform.js";
+export type { ReactGrabOptions, TransformResult } from "./utils/transform.js";
+
+export { getPackagesToInstall, installPackages } from "./utils/install.js";
+export type { InstallPackageOptions } from "./utils/install.js";
+
+export { installReactGrab, ReactGrabInstallError } from "./utils/install-react-grab.js";
+export type {
+  InstallReactGrabOptions,
+  InstallReactGrabResult,
+  ReactGrabInstallErrorCode,
+} from "./utils/install-react-grab.js";
+
+export { installSkill, removeSkill } from "./utils/install-skill.js";
+export type { InstallSkillOptions } from "./utils/install-skill.js";

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -5,7 +5,7 @@ import { detectNonInteractive } from "../utils/is-non-interactive.js";
 import { detectProject } from "../utils/detect.js";
 import { handleError } from "../utils/handle-error.js";
 import { highlighter } from "../utils/highlighter.js";
-import { promptSkillInstall } from "../utils/install-skill.js";
+import { promptSkillInstall } from "../utils/prompt-skill-install.js";
 import { logger } from "../utils/logger.js";
 import { spinner } from "../utils/spinner.js";
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -5,7 +5,7 @@ import pc from "picocolors";
 import { detectNonInteractive } from "../utils/is-non-interactive.js";
 import { prompts } from "../utils/prompts.js";
 import { applyTransformWithFeedback, installPackagesWithFeedback } from "../utils/cli-helpers.js";
-import { promptSkillInstall } from "../utils/install-skill.js";
+import { promptSkillInstall } from "../utils/prompt-skill-install.js";
 import {
   detectProject,
   findReactProjects,

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -3,7 +3,7 @@ import { Command } from "commander";
 import pc from "picocolors";
 import { handleError } from "../utils/handle-error.js";
 import { highlighter } from "../utils/highlighter.js";
-import { removeSkill } from "../utils/install-skill.js";
+import { agentLabel, removeSkill } from "../utils/install-skill.js";
 import { logger } from "../utils/logger.js";
 
 const VERSION = process.env.VERSION ?? "0.0.1";
@@ -19,14 +19,17 @@ export const remove = new Command()
 
     try {
       logger.break();
-      const removedCount = await removeSkill({ cwd: resolve(opts.cwd), global: opts.global });
+      const removedAgents = await removeSkill({ cwd: resolve(opts.cwd), global: opts.global });
+      for (const agent of removedAgents) {
+        logger.log(`  ${highlighter.success("\u2713")} ${agentLabel(agent)}`);
+      }
 
       logger.break();
-      if (removedCount === 0) {
+      if (removedAgents.length === 0) {
         logger.log("React Grab skill is not installed in any detected agent.");
       } else {
         logger.log(
-          `${highlighter.success("Removed")} the React Grab skill from ${removedCount} agent${removedCount === 1 ? "" : "s"}.`,
+          `${highlighter.success("Removed")} the React Grab skill from ${removedAgents.length} agent${removedAgents.length === 1 ? "" : "s"}.`,
         );
       }
       logger.break();

--- a/packages/cli/src/utils/detect.ts
+++ b/packages/cli/src/utils/detect.ts
@@ -10,7 +10,7 @@ export type Framework = "next" | "vite" | "tanstack" | "webpack" | "unknown";
 export type NextRouterType = "app" | "pages" | "unknown";
 export type UnsupportedFramework = "remix" | "astro" | "sveltekit" | "gatsby" | null;
 
-interface ProjectInfo {
+export interface ProjectInfo {
   packageManager: PackageManager;
   framework: Framework;
   nextRouterType: NextRouterType;

--- a/packages/cli/src/utils/install-react-grab.ts
+++ b/packages/cli/src/utils/install-react-grab.ts
@@ -112,8 +112,9 @@ export const installReactGrab = async (
     }
   }
 
-  const hasPendingFileChange =
-    !transform.noChanges && Boolean(transform.originalContent) && Boolean(transform.newContent);
+  // Mirrors applyTransform's own write guard (it does not require originalContent),
+  // so an empty source file still receives the injected setup.
+  const hasPendingFileChange = !transform.noChanges && Boolean(transform.newContent);
   const didChangeFile = hasPendingFileChange && !options.skipTransform && !options.dryRun;
 
   if (didChangeFile) {

--- a/packages/cli/src/utils/install-react-grab.ts
+++ b/packages/cli/src/utils/install-react-grab.ts
@@ -112,7 +112,8 @@ export const installReactGrab = async (
     }
   }
 
-  const hasPendingFileChange = Boolean(transform.newContent) && !transform.noChanges;
+  const hasPendingFileChange =
+    !transform.noChanges && Boolean(transform.originalContent) && Boolean(transform.newContent);
   const didChangeFile = hasPendingFileChange && !options.skipTransform && !options.dryRun;
 
   if (didChangeFile) {

--- a/packages/cli/src/utils/install-react-grab.ts
+++ b/packages/cli/src/utils/install-react-grab.ts
@@ -31,7 +31,6 @@ export interface InstallReactGrabOptions {
   framework?: Framework;
   nextRouterType?: NextRouterType;
   packageManager?: PackageManager;
-  force?: boolean;
   skipPackageInstall?: boolean;
   skipTransform?: boolean;
   dryRun?: boolean;
@@ -87,7 +86,7 @@ export const installReactGrab = async (
     project.projectRoot,
     framework,
     nextRouterType,
-    alreadyConfigured && !options.force,
+    alreadyConfigured,
   );
 
   if (!transform.success && !options.skipTransform) {

--- a/packages/cli/src/utils/install-react-grab.ts
+++ b/packages/cli/src/utils/install-react-grab.ts
@@ -1,23 +1,26 @@
+import { resolve } from "node:path";
 import {
+  detectNextRouterType,
   detectProject,
   type Framework,
   type NextRouterType,
   type PackageManager,
 } from "./detect.js";
-import { installPackages, type InstallPackageOptions } from "./install.js";
+import { getPackagesToInstall, installPackages, type InstallPackageOptions } from "./install.js";
 import { applyTransform, previewTransform, type TransformResult } from "./transform.js";
 
 export type ReactGrabInstallErrorCode =
   | "unsupported-framework"
   | "unknown-framework"
   | "transform-failed"
+  | "install-failed"
   | "write-failed";
 
 export class ReactGrabInstallError extends Error {
   readonly code: ReactGrabInstallErrorCode;
 
-  constructor(message: string, code: ReactGrabInstallErrorCode) {
-    super(message);
+  constructor(message: string, code: ReactGrabInstallErrorCode, options?: ErrorOptions) {
+    super(message, options);
     this.name = "ReactGrabInstallError";
     this.code = code;
   }
@@ -32,7 +35,7 @@ export interface InstallReactGrabOptions {
   skipPackageInstall?: boolean;
   skipTransform?: boolean;
   dryRun?: boolean;
-  installPackageOptions?: InstallPackageOptions;
+  installPackageOptions?: Omit<InstallPackageOptions, "cwd" | "packageManager">;
 }
 
 export interface InstallReactGrabResult {
@@ -50,11 +53,10 @@ export interface InstallReactGrabResult {
 export const installReactGrab = async (
   options: InstallReactGrabOptions = {},
 ): Promise<InstallReactGrabResult> => {
-  const cwd = options.cwd ?? process.cwd();
+  const cwd = resolve(options.cwd ?? process.cwd());
   const project = await detectProject(cwd);
 
   const framework = options.framework ?? project.framework;
-  const nextRouterType = options.nextRouterType ?? project.nextRouterType;
   const packageManager = options.packageManager ?? project.packageManager;
 
   if (project.unsupportedFramework && !options.framework) {
@@ -71,6 +73,14 @@ export const installReactGrab = async (
     );
   }
 
+  // Detection only resolves the router type when the *detected* framework is
+  // Next.js, so derive it ourselves when the caller overrides to Next.
+  const nextRouterType =
+    options.nextRouterType ??
+    (framework === "next" && project.nextRouterType === "unknown"
+      ? detectNextRouterType(project.projectRoot)
+      : project.nextRouterType);
+
   const alreadyConfigured = project.isReactGrabConfigured;
 
   const transform = previewTransform(
@@ -80,18 +90,26 @@ export const installReactGrab = async (
     alreadyConfigured && !options.force,
   );
 
-  if (!transform.success) {
+  if (!transform.success && !options.skipTransform) {
     throw new ReactGrabInstallError(transform.message, "transform-failed");
   }
 
   const didInstallPackage = !options.skipPackageInstall && !options.dryRun && !project.hasReactGrab;
 
   if (didInstallPackage) {
-    await installPackages(["react-grab"], {
-      cwd: project.projectRoot,
-      packageManager,
-      ...options.installPackageOptions,
-    });
+    try {
+      await installPackages(getPackagesToInstall(), {
+        ...options.installPackageOptions,
+        cwd: project.projectRoot,
+        packageManager,
+      });
+    } catch (error) {
+      throw new ReactGrabInstallError(
+        error instanceof Error ? error.message : "Failed to install the react-grab package.",
+        "install-failed",
+        { cause: error },
+      );
+    }
   }
 
   const hasPendingFileChange = Boolean(transform.newContent) && !transform.noChanges;

--- a/packages/cli/src/utils/install-react-grab.ts
+++ b/packages/cli/src/utils/install-react-grab.ts
@@ -1,0 +1,121 @@
+import {
+  detectProject,
+  type Framework,
+  type NextRouterType,
+  type PackageManager,
+} from "./detect.js";
+import { installPackages, type InstallPackageOptions } from "./install.js";
+import { applyTransform, previewTransform, type TransformResult } from "./transform.js";
+
+export type ReactGrabInstallErrorCode =
+  | "unsupported-framework"
+  | "unknown-framework"
+  | "transform-failed"
+  | "write-failed";
+
+export class ReactGrabInstallError extends Error {
+  readonly code: ReactGrabInstallErrorCode;
+
+  constructor(message: string, code: ReactGrabInstallErrorCode) {
+    super(message);
+    this.name = "ReactGrabInstallError";
+    this.code = code;
+  }
+}
+
+export interface InstallReactGrabOptions {
+  cwd?: string;
+  framework?: Framework;
+  nextRouterType?: NextRouterType;
+  packageManager?: PackageManager;
+  force?: boolean;
+  skipPackageInstall?: boolean;
+  skipTransform?: boolean;
+  dryRun?: boolean;
+  installPackageOptions?: InstallPackageOptions;
+}
+
+export interface InstallReactGrabResult {
+  projectRoot: string;
+  framework: Framework;
+  nextRouterType: NextRouterType;
+  packageManager: PackageManager;
+  alreadyConfigured: boolean;
+  didInstallPackage: boolean;
+  didChangeFile: boolean;
+  dryRun: boolean;
+  transform: TransformResult;
+}
+
+export const installReactGrab = async (
+  options: InstallReactGrabOptions = {},
+): Promise<InstallReactGrabResult> => {
+  const cwd = options.cwd ?? process.cwd();
+  const project = await detectProject(cwd);
+
+  const framework = options.framework ?? project.framework;
+  const nextRouterType = options.nextRouterType ?? project.nextRouterType;
+  const packageManager = options.packageManager ?? project.packageManager;
+
+  if (project.unsupportedFramework && !options.framework) {
+    throw new ReactGrabInstallError(
+      `${project.unsupportedFramework} is not supported by automatic setup.`,
+      "unsupported-framework",
+    );
+  }
+
+  if (framework === "unknown") {
+    throw new ReactGrabInstallError(
+      "Could not detect a supported framework. Pass `framework` explicitly to override detection.",
+      "unknown-framework",
+    );
+  }
+
+  const alreadyConfigured = project.isReactGrabConfigured;
+
+  const transform = previewTransform(
+    project.projectRoot,
+    framework,
+    nextRouterType,
+    alreadyConfigured && !options.force,
+  );
+
+  if (!transform.success) {
+    throw new ReactGrabInstallError(transform.message, "transform-failed");
+  }
+
+  const didInstallPackage = !options.skipPackageInstall && !options.dryRun && !project.hasReactGrab;
+
+  if (didInstallPackage) {
+    await installPackages(["react-grab"], {
+      cwd: project.projectRoot,
+      packageManager,
+      ...options.installPackageOptions,
+    });
+  }
+
+  const hasPendingFileChange = Boolean(transform.newContent) && !transform.noChanges;
+  const didChangeFile = hasPendingFileChange && !options.skipTransform && !options.dryRun;
+
+  if (didChangeFile) {
+    const writeResult = applyTransform(transform);
+    if (!writeResult.success) {
+      throw new ReactGrabInstallError(
+        writeResult.error ?? `Failed to write to ${transform.filePath}`,
+        "write-failed",
+      );
+    }
+  }
+
+  return {
+    projectRoot: project.projectRoot,
+    framework,
+    nextRouterType,
+    packageManager,
+    alreadyConfigured,
+    didInstallPackage,
+    didChangeFile,
+    dryRun: Boolean(options.dryRun),
+    transform,
+  };
+};

--- a/packages/cli/src/utils/install-skill.ts
+++ b/packages/cli/src/utils/install-skill.ts
@@ -33,6 +33,21 @@ const installedSkillDir = (agent: SkillAgentType, global: boolean, cwd: string):
     SKILL_NAME,
   );
 
+export interface InstallSkillOptions {
+  agents?: SkillAgentType[];
+  global?: boolean;
+  cwd?: string;
+}
+
+export const installSkill = async ({
+  agents,
+  global = false,
+  cwd = process.cwd(),
+}: InstallSkillOptions = {}): Promise<Awaited<ReturnType<typeof add>>> => {
+  const targetAgents = agents ?? (await detectAvailableAgents());
+  return add({ source: SKILL_SOURCE, agents: targetAgents, global, cwd, mode: "copy" });
+};
+
 interface PromptSkillInstallOptions {
   yes?: boolean;
   global?: boolean;
@@ -77,13 +92,7 @@ export const promptSkillInstall = async ({
   }
 
   const installSpinner = spinner("Installing React Grab skill.").start();
-  const { installed, failed } = await add({
-    source: SKILL_SOURCE,
-    agents: selectedAgents,
-    global,
-    cwd,
-    mode: "copy",
-  });
+  const { installed, failed } = await installSkill({ agents: selectedAgents, global, cwd });
 
   if (installed.length === 0) {
     installSpinner.fail("Failed to install React Grab skill.");

--- a/packages/cli/src/utils/install-skill.ts
+++ b/packages/cli/src/utils/install-skill.ts
@@ -10,8 +10,6 @@ import {
   isUniversalSkillAgent,
 } from "agent-install/skill";
 import { detectAvailableAgents } from "./detect-agents.js";
-import { highlighter } from "./highlighter.js";
-import { logger } from "./logger.js";
 
 const SKILL_NAME = "react-grab";
 
@@ -56,7 +54,7 @@ interface RemoveSkillOptions {
 export const removeSkill = async ({
   cwd = process.cwd(),
   global = false,
-}: RemoveSkillOptions = {}): Promise<number> => {
+}: RemoveSkillOptions = {}): Promise<SkillAgentType[]> => {
   const agents = await detectAvailableAgents();
   const removedAgents: SkillAgentType[] = [];
   const dirsToRemove = new Set<string>();
@@ -69,8 +67,5 @@ export const removeSkill = async ({
   for (const skillDir of dirsToRemove) {
     rmSync(skillDir, { recursive: true, force: true });
   }
-  for (const agent of removedAgents) {
-    logger.log(`  ${highlighter.success("\u2713")} ${agentLabel(agent)}`);
-  }
-  return removedAgents.length;
+  return removedAgents;
 };

--- a/packages/cli/src/utils/install-skill.ts
+++ b/packages/cli/src/utils/install-skill.ts
@@ -12,8 +12,6 @@ import {
 import { detectAvailableAgents } from "./detect-agents.js";
 import { highlighter } from "./highlighter.js";
 import { logger } from "./logger.js";
-import { prompts } from "./prompts.js";
-import { spinner } from "./spinner.js";
 
 const SKILL_NAME = "react-grab";
 
@@ -21,7 +19,7 @@ const SKILL_NAME = "react-grab";
 // so installs work offline and stay pinned to this CLI version.
 const SKILL_SOURCE = fileURLToPath(new URL("../skills/react-grab", import.meta.url));
 
-const agentLabel = (agent: SkillAgentType): string => getSkillAgentConfig(agent).displayName;
+export const agentLabel = (agent: SkillAgentType): string => getSkillAgentConfig(agent).displayName;
 
 // Universal agents share the canonical .agents/skills directory; others use
 // their own. Mirror where agent-install actually writes so removal lands.
@@ -46,65 +44,6 @@ export const installSkill = async ({
 }: InstallSkillOptions = {}): Promise<Awaited<ReturnType<typeof add>>> => {
   const targetAgents = agents ?? (await detectAvailableAgents());
   return add({ source: SKILL_SOURCE, agents: targetAgents, global, cwd, mode: "copy" });
-};
-
-interface PromptSkillInstallOptions {
-  yes?: boolean;
-  global?: boolean;
-  cwd?: string;
-}
-
-export const promptSkillInstall = async ({
-  yes = false,
-  global = false,
-  cwd = process.cwd(),
-}: PromptSkillInstallOptions = {}): Promise<boolean> => {
-  const detectedAgents = await detectAvailableAgents();
-  if (detectedAgents.length === 0) {
-    logger.warn("No supported agents detected.");
-    return false;
-  }
-
-  let selectedAgents = detectedAgents;
-  if (!yes) {
-    const { confirmed } = await prompts({
-      type: "confirm",
-      name: "confirmed",
-      message: `Install the React Grab skill (${global ? "global" : "this project"})?`,
-      initial: true,
-    });
-    if (!confirmed) return false;
-
-    const { agents } = await prompts({
-      type: "multiselect",
-      name: "agents",
-      message: `Install the React Grab skill (${global ? "global" : "this project"}) for:`,
-      choices: detectedAgents.map((agent) => ({
-        title: agentLabel(agent),
-        value: agent,
-        selected: true,
-      })),
-      instructions: false,
-      min: 1,
-    });
-    selectedAgents = agents ?? [];
-    if (selectedAgents.length === 0) return false;
-  }
-
-  const installSpinner = spinner("Installing React Grab skill.").start();
-  const { installed, failed } = await installSkill({ agents: selectedAgents, global, cwd });
-
-  if (installed.length === 0) {
-    installSpinner.fail("Failed to install React Grab skill.");
-    return false;
-  }
-  installSpinner.succeed(
-    `Installed React Grab skill for ${installed.map((record) => agentLabel(record.agent)).join(", ")}.`,
-  );
-  for (const record of failed) {
-    logger.log(`  ${highlighter.error("\u2717")} ${agentLabel(record.agent)} ${record.error}`);
-  }
-  return true;
 };
 
 interface RemoveSkillOptions {

--- a/packages/cli/src/utils/prompt-skill-install.ts
+++ b/packages/cli/src/utils/prompt-skill-install.ts
@@ -1,0 +1,65 @@
+import { detectAvailableAgents } from "./detect-agents.js";
+import { highlighter } from "./highlighter.js";
+import { agentLabel, installSkill } from "./install-skill.js";
+import { logger } from "./logger.js";
+import { prompts } from "./prompts.js";
+import { spinner } from "./spinner.js";
+
+interface PromptSkillInstallOptions {
+  yes?: boolean;
+  global?: boolean;
+  cwd?: string;
+}
+
+export const promptSkillInstall = async ({
+  yes = false,
+  global = false,
+  cwd = process.cwd(),
+}: PromptSkillInstallOptions = {}): Promise<boolean> => {
+  const detectedAgents = await detectAvailableAgents();
+  if (detectedAgents.length === 0) {
+    logger.warn("No supported agents detected.");
+    return false;
+  }
+
+  let selectedAgents = detectedAgents;
+  if (!yes) {
+    const { confirmed } = await prompts({
+      type: "confirm",
+      name: "confirmed",
+      message: `Install the React Grab skill (${global ? "global" : "this project"})?`,
+      initial: true,
+    });
+    if (!confirmed) return false;
+
+    const { agents } = await prompts({
+      type: "multiselect",
+      name: "agents",
+      message: `Install the React Grab skill (${global ? "global" : "this project"}) for:`,
+      choices: detectedAgents.map((agent) => ({
+        title: agentLabel(agent),
+        value: agent,
+        selected: true,
+      })),
+      instructions: false,
+      min: 1,
+    });
+    selectedAgents = agents ?? [];
+    if (selectedAgents.length === 0) return false;
+  }
+
+  const installSpinner = spinner("Installing React Grab skill.").start();
+  const { installed, failed } = await installSkill({ agents: selectedAgents, global, cwd });
+
+  if (installed.length === 0) {
+    installSpinner.fail("Failed to install React Grab skill.");
+    return false;
+  }
+  installSpinner.succeed(
+    `Installed React Grab skill for ${installed.map((record) => agentLabel(record.agent)).join(", ")}.`,
+  );
+  for (const record of failed) {
+    logger.log(`  ${highlighter.error("\u2717")} ${agentLabel(record.agent)} ${record.error}`);
+  }
+  return true;
+};

--- a/packages/cli/test/install-react-grab.test.ts
+++ b/packages/cli/test/install-react-grab.test.ts
@@ -1,0 +1,186 @@
+import { vi, describe, expect, it, beforeEach } from "vite-plus/test";
+
+vi.mock("../src/utils/detect.js", () => ({
+  detectProject: vi.fn(),
+}));
+
+vi.mock("../src/utils/install.js", () => ({
+  installPackages: vi.fn(),
+}));
+
+vi.mock("../src/utils/transform.js", () => ({
+  previewTransform: vi.fn(),
+  applyTransform: vi.fn(),
+}));
+
+import { detectProject } from "../src/utils/detect.js";
+import { installPackages } from "../src/utils/install.js";
+import { applyTransform, previewTransform } from "../src/utils/transform.js";
+import { installReactGrab, ReactGrabInstallError } from "../src/utils/install-react-grab.js";
+
+const mockDetectProject = vi.mocked(detectProject);
+const mockInstallPackages = vi.mocked(installPackages);
+const mockPreviewTransform = vi.mocked(previewTransform);
+const mockApplyTransform = vi.mocked(applyTransform);
+
+const baseProject = {
+  packageManager: "pnpm" as const,
+  framework: "vite" as const,
+  nextRouterType: "unknown" as const,
+  isMonorepo: false,
+  projectRoot: "/app",
+  hasReactGrab: false,
+  isReactGrabConfigured: false,
+  reactGrabVersion: null,
+  unsupportedFramework: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockApplyTransform.mockReturnValue({ success: true });
+});
+
+describe("installReactGrab", () => {
+  it("installs the package and writes the entry file for a fresh project", async () => {
+    mockDetectProject.mockResolvedValue({ ...baseProject });
+    mockPreviewTransform.mockReturnValue({
+      success: true,
+      filePath: "/app/src/main.tsx",
+      message: "Add React Grab",
+      originalContent: "render()",
+      newContent: 'import("react-grab");\n\nrender()',
+    });
+
+    const result = await installReactGrab({ cwd: "/app" });
+
+    expect(mockInstallPackages).toHaveBeenCalledWith(["react-grab"], {
+      cwd: "/app",
+      packageManager: "pnpm",
+    });
+    expect(mockApplyTransform).toHaveBeenCalledTimes(1);
+    expect(result.didInstallPackage).toBe(true);
+    expect(result.didChangeFile).toBe(true);
+    expect(result.framework).toBe("vite");
+  });
+
+  it("does not install the package when it is already present", async () => {
+    mockDetectProject.mockResolvedValue({ ...baseProject, hasReactGrab: true });
+    mockPreviewTransform.mockReturnValue({
+      success: true,
+      filePath: "/app/src/main.tsx",
+      message: "Add React Grab",
+      originalContent: "render()",
+      newContent: 'import("react-grab");\n\nrender()',
+    });
+
+    const result = await installReactGrab({ cwd: "/app" });
+
+    expect(mockInstallPackages).not.toHaveBeenCalled();
+    expect(result.didInstallPackage).toBe(false);
+    expect(result.didChangeFile).toBe(true);
+  });
+
+  it("never installs or writes during a dry run", async () => {
+    mockDetectProject.mockResolvedValue({ ...baseProject });
+    mockPreviewTransform.mockReturnValue({
+      success: true,
+      filePath: "/app/src/main.tsx",
+      message: "Add React Grab",
+      originalContent: "render()",
+      newContent: 'import("react-grab");\n\nrender()',
+    });
+
+    const result = await installReactGrab({ cwd: "/app", dryRun: true });
+
+    expect(mockInstallPackages).not.toHaveBeenCalled();
+    expect(mockApplyTransform).not.toHaveBeenCalled();
+    expect(result.dryRun).toBe(true);
+    expect(result.didInstallPackage).toBe(false);
+    expect(result.didChangeFile).toBe(false);
+  });
+
+  it("does not write when there are no pending changes", async () => {
+    mockDetectProject.mockResolvedValue({ ...baseProject, isReactGrabConfigured: true });
+    mockPreviewTransform.mockReturnValue({
+      success: true,
+      filePath: "/app/src/main.tsx",
+      message: "React Grab is already configured",
+      noChanges: true,
+    });
+
+    const result = await installReactGrab({ cwd: "/app" });
+
+    expect(mockApplyTransform).not.toHaveBeenCalled();
+    expect(result.alreadyConfigured).toBe(true);
+    expect(result.didChangeFile).toBe(false);
+  });
+
+  it("honors framework and package manager overrides", async () => {
+    mockDetectProject.mockResolvedValue({ ...baseProject, framework: "unknown" });
+    mockPreviewTransform.mockReturnValue({
+      success: true,
+      filePath: "/app/app/layout.tsx",
+      message: "Add React Grab",
+      originalContent: "x",
+      newContent: "y",
+    });
+
+    const result = await installReactGrab({
+      cwd: "/app",
+      framework: "next",
+      nextRouterType: "app",
+      packageManager: "npm",
+    });
+
+    expect(mockPreviewTransform).toHaveBeenCalledWith("/app", "next", "app", false);
+    expect(mockInstallPackages).toHaveBeenCalledWith(["react-grab"], {
+      cwd: "/app",
+      packageManager: "npm",
+    });
+    expect(result.framework).toBe("next");
+  });
+
+  it("throws for unsupported frameworks", async () => {
+    mockDetectProject.mockResolvedValue({ ...baseProject, unsupportedFramework: "remix" });
+
+    await expect(installReactGrab({ cwd: "/app" })).rejects.toMatchObject({
+      code: "unsupported-framework",
+    });
+    expect(mockInstallPackages).not.toHaveBeenCalled();
+  });
+
+  it("throws when no framework can be resolved", async () => {
+    mockDetectProject.mockResolvedValue({ ...baseProject, framework: "unknown" });
+
+    await expect(installReactGrab({ cwd: "/app" })).rejects.toBeInstanceOf(ReactGrabInstallError);
+  });
+
+  it("throws when the transform fails", async () => {
+    mockDetectProject.mockResolvedValue({ ...baseProject });
+    mockPreviewTransform.mockReturnValue({
+      success: false,
+      filePath: "",
+      message: "Could not find entry file",
+    });
+
+    await expect(installReactGrab({ cwd: "/app" })).rejects.toMatchObject({
+      code: "transform-failed",
+    });
+  });
+
+  it("throws when writing the entry file fails", async () => {
+    mockDetectProject.mockResolvedValue({ ...baseProject });
+    mockPreviewTransform.mockReturnValue({
+      success: true,
+      filePath: "/app/src/main.tsx",
+      message: "Add React Grab",
+      originalContent: "render()",
+      newContent: 'import("react-grab");\n\nrender()',
+    });
+    mockApplyTransform.mockReturnValue({ success: false, error: "permission denied" });
+
+    await expect(installReactGrab({ cwd: "/app" })).rejects.toMatchObject({
+      code: "write-failed",
+    });
+  });
+});

--- a/packages/cli/test/install-react-grab.test.ts
+++ b/packages/cli/test/install-react-grab.test.ts
@@ -1,11 +1,14 @@
 import { vi, describe, expect, it, beforeEach } from "vite-plus/test";
+import type { ProjectInfo } from "../src/utils/detect.js";
 
 vi.mock("../src/utils/detect.js", () => ({
   detectProject: vi.fn(),
+  detectNextRouterType: vi.fn(() => "app"),
 }));
 
 vi.mock("../src/utils/install.js", () => ({
   installPackages: vi.fn(),
+  getPackagesToInstall: vi.fn(() => ["react-grab"]),
 }));
 
 vi.mock("../src/utils/transform.js", () => ({
@@ -13,43 +16,47 @@ vi.mock("../src/utils/transform.js", () => ({
   applyTransform: vi.fn(),
 }));
 
-import { detectProject } from "../src/utils/detect.js";
+import { detectNextRouterType, detectProject } from "../src/utils/detect.js";
 import { installPackages } from "../src/utils/install.js";
 import { applyTransform, previewTransform } from "../src/utils/transform.js";
 import { installReactGrab, ReactGrabInstallError } from "../src/utils/install-react-grab.js";
 
 const mockDetectProject = vi.mocked(detectProject);
+const mockDetectNextRouterType = vi.mocked(detectNextRouterType);
 const mockInstallPackages = vi.mocked(installPackages);
 const mockPreviewTransform = vi.mocked(previewTransform);
 const mockApplyTransform = vi.mocked(applyTransform);
 
 const baseProject = {
-  packageManager: "pnpm" as const,
-  framework: "vite" as const,
-  nextRouterType: "unknown" as const,
+  packageManager: "pnpm",
+  framework: "vite",
+  nextRouterType: "unknown",
   isMonorepo: false,
   projectRoot: "/app",
   hasReactGrab: false,
   isReactGrabConfigured: false,
   reactGrabVersion: null,
   unsupportedFramework: null,
+} satisfies ProjectInfo;
+
+const pendingTransform = {
+  success: true,
+  filePath: "/app/src/main.tsx",
+  message: "Add React Grab",
+  originalContent: "render()",
+  newContent: 'import("react-grab");\n\nrender()',
 };
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockApplyTransform.mockReturnValue({ success: true });
+  mockDetectNextRouterType.mockReturnValue("app");
 });
 
 describe("installReactGrab", () => {
   it("installs the package and writes the entry file for a fresh project", async () => {
     mockDetectProject.mockResolvedValue({ ...baseProject });
-    mockPreviewTransform.mockReturnValue({
-      success: true,
-      filePath: "/app/src/main.tsx",
-      message: "Add React Grab",
-      originalContent: "render()",
-      newContent: 'import("react-grab");\n\nrender()',
-    });
+    mockPreviewTransform.mockReturnValue(pendingTransform);
 
     const result = await installReactGrab({ cwd: "/app" });
 
@@ -65,13 +72,7 @@ describe("installReactGrab", () => {
 
   it("does not install the package when it is already present", async () => {
     mockDetectProject.mockResolvedValue({ ...baseProject, hasReactGrab: true });
-    mockPreviewTransform.mockReturnValue({
-      success: true,
-      filePath: "/app/src/main.tsx",
-      message: "Add React Grab",
-      originalContent: "render()",
-      newContent: 'import("react-grab");\n\nrender()',
-    });
+    mockPreviewTransform.mockReturnValue(pendingTransform);
 
     const result = await installReactGrab({ cwd: "/app" });
 
@@ -82,13 +83,7 @@ describe("installReactGrab", () => {
 
   it("never installs or writes during a dry run", async () => {
     mockDetectProject.mockResolvedValue({ ...baseProject });
-    mockPreviewTransform.mockReturnValue({
-      success: true,
-      filePath: "/app/src/main.tsx",
-      message: "Add React Grab",
-      originalContent: "render()",
-      newContent: 'import("react-grab");\n\nrender()',
-    });
+    mockPreviewTransform.mockReturnValue(pendingTransform);
 
     const result = await installReactGrab({ cwd: "/app", dryRun: true });
 
@@ -149,10 +144,84 @@ describe("installReactGrab", () => {
     expect(mockInstallPackages).not.toHaveBeenCalled();
   });
 
-  it("throws when no framework can be resolved", async () => {
+  it("throws an unknown-framework error when no framework can be resolved", async () => {
     mockDetectProject.mockResolvedValue({ ...baseProject, framework: "unknown" });
 
+    await expect(installReactGrab({ cwd: "/app" })).rejects.toMatchObject({
+      code: "unknown-framework",
+    });
     await expect(installReactGrab({ cwd: "/app" })).rejects.toBeInstanceOf(ReactGrabInstallError);
+  });
+
+  it("derives the Next.js router type when only the framework is overridden", async () => {
+    mockDetectProject.mockResolvedValue({ ...baseProject, framework: "unknown" });
+    mockPreviewTransform.mockReturnValue({
+      success: true,
+      filePath: "/app/app/layout.tsx",
+      message: "Add React Grab",
+      originalContent: "x",
+      newContent: "y",
+    });
+
+    const result = await installReactGrab({ cwd: "/app", framework: "next" });
+
+    expect(mockDetectNextRouterType).toHaveBeenCalledWith("/app");
+    expect(mockPreviewTransform).toHaveBeenCalledWith("/app", "next", "app", false);
+    expect(result.nextRouterType).toBe("app");
+  });
+
+  it("skips package installation when skipPackageInstall is set", async () => {
+    mockDetectProject.mockResolvedValue({ ...baseProject });
+    mockPreviewTransform.mockReturnValue(pendingTransform);
+
+    const result = await installReactGrab({ cwd: "/app", skipPackageInstall: true });
+
+    expect(mockInstallPackages).not.toHaveBeenCalled();
+    expect(result.didInstallPackage).toBe(false);
+    expect(result.didChangeFile).toBe(true);
+  });
+
+  it("does not write or throw on a failed transform when skipTransform is set", async () => {
+    mockDetectProject.mockResolvedValue({ ...baseProject });
+    mockPreviewTransform.mockReturnValue({
+      success: false,
+      filePath: "",
+      message: "Could not find entry file",
+    });
+
+    const result = await installReactGrab({ cwd: "/app", skipTransform: true });
+
+    expect(mockInstallPackages).toHaveBeenCalledTimes(1);
+    expect(mockApplyTransform).not.toHaveBeenCalled();
+    expect(result.didChangeFile).toBe(false);
+  });
+
+  it("pins cwd and packageManager over installPackageOptions and passes through extras", async () => {
+    mockDetectProject.mockResolvedValue({ ...baseProject });
+    mockPreviewTransform.mockReturnValue(pendingTransform);
+
+    await installReactGrab({
+      cwd: "/app",
+      installPackageOptions: { silent: true },
+    });
+
+    expect(mockInstallPackages).toHaveBeenCalledWith(["react-grab"], {
+      silent: true,
+      cwd: "/app",
+      packageManager: "pnpm",
+    });
+  });
+
+  it("wraps package-manager failures in an install-failed error", async () => {
+    mockDetectProject.mockResolvedValue({ ...baseProject });
+    mockPreviewTransform.mockReturnValue(pendingTransform);
+    mockInstallPackages.mockRejectedValueOnce(new Error("network down"));
+
+    await expect(installReactGrab({ cwd: "/app" })).rejects.toMatchObject({
+      code: "install-failed",
+      message: "network down",
+    });
+    expect(mockApplyTransform).not.toHaveBeenCalled();
   });
 
   it("throws when the transform fails", async () => {
@@ -170,13 +239,7 @@ describe("installReactGrab", () => {
 
   it("throws when writing the entry file fails", async () => {
     mockDetectProject.mockResolvedValue({ ...baseProject });
-    mockPreviewTransform.mockReturnValue({
-      success: true,
-      filePath: "/app/src/main.tsx",
-      message: "Add React Grab",
-      originalContent: "render()",
-      newContent: 'import("react-grab");\n\nrender()',
-    });
+    mockPreviewTransform.mockReturnValue(pendingTransform);
     mockApplyTransform.mockReturnValue({ success: false, error: "permission denied" });
 
     await expect(installReactGrab({ cwd: "/app" })).rejects.toMatchObject({

--- a/packages/cli/vite.config.ts
+++ b/packages/cli/vite.config.ts
@@ -7,7 +7,7 @@ const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8")) as {
 
 export default defineConfig({
   pack: {
-    entry: ["src/cli.ts"],
+    entry: ["src/cli.ts", "src/api.ts"],
     format: ["cjs", "esm"],
     dts: true,
     clean: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Today, all of React Grab's install/setup logic is locked behind the CLI: importing `@react-grab/cli` immediately parses `argv` and runs the program, and there are no subpath exports. There's no way for an external tool to detect a project, install the package, and apply the framework setup programmatically.

This PR adds a side-effect-free **Node API** at `@react-grab/cli/api` so external consumers can build their own installers/CLIs around React Grab.

### Answer to "does it expose a Node API?"

It did not. Now it does — via `@react-grab/cli/api`.

## What's added

- **`installReactGrab(options?)`** — a high-level, non-interactive orchestrator that detects the project, installs the `react-grab` package with the detected package manager, and applies the framework-specific dev-only setup. Returns a structured `InstallReactGrabResult` instead of printing/exiting. Supports overrides (`framework`, `nextRouterType`, `packageManager`), and `force` / `skipPackageInstall` / `skipTransform` / `dryRun` flags.
- **`ReactGrabInstallError`** with a discriminated `code` (`unsupported-framework`, `unknown-framework`, `transform-failed`, `install-failed`, `write-failed`) so callers can branch on failure cause instead of parsing messages or hitting `process.exit`. The underlying error is preserved on `error.cause`.
- **Low-level building blocks re-exported** for full control: `detectProject`, `detectFramework`, `detectPackageManager`, `detectNextRouterType`, `detectReactGrab`, `detectReactGrabConfigured`, `detectUnsupportedFramework`, `findReactProjects`, `previewTransform`, `previewOptionsTransform`, `previewCdnTransform`, `applyTransform`, `hasFrameworkEntryPoint`, `installPackages`, `getPackagesToInstall`, `installSkill`, `removeSkill` — plus all relevant types.
- **`installSkill(options?)`** — a non-interactive agent-skill install extracted from `promptSkillInstall` (which now reuses it; no behavior change to the interactive flow).

## Implementation notes

- New programmatic entry `packages/cli/src/api.ts` (no side effects on import) — distinct from the existing CLI entry `.` which still parses `argv`.
- `packages/cli/src/utils/install-react-grab.ts` houses the orchestrator + error type.
- `ProjectInfo` is now exported from `detect.ts` for typed consumers.
- `package.json` gains an `./api` subpath export (`types`/`import`/`require`); `vite.config.ts` builds `src/api.ts` alongside `src/cli.ts`. The existing `.` export and bins are untouched.

## Usage

```ts
import { installReactGrab } from "@react-grab/cli/api";

const result = await installReactGrab({ cwd: process.cwd() });
// result.framework / result.didInstallPackage / result.didChangeFile / result.transform.filePath
```

Or compose the primitives directly (`detectProject` → `previewTransform` → `installPackages` → `applyTransform` → `installSkill`). See the updated `packages/cli/README.md` for the full table and examples. `installReactGrab` targets a single project at `cwd` (use `findReactProjects` to locate apps in a monorepo first), and mutates the project unless `dryRun: true`.

## Review hardening

A second pass (code-quality, performance, reuse, and security review) tightened the orchestrator:

- Derive the Next.js router type when `framework` is overridden to `next`, so the Pages-router path isn't wrongly selected.
- Pin `cwd`/`packageManager` over `installPackageOptions` (and `Omit` them from its type) so the install directory can't diverge from the edited file.
- Wrap package-manager failures as `install-failed` (preserving `error.cause`) so the structured error contract covers the most likely runtime failure.
- Don't throw `transform-failed` when `skipTransform` is set; resolve `cwd` to an absolute path; reuse `getPackagesToInstall()`; align the pending-change predicate with `init`'s invariant.
- **Keep interactive deps out of the API bundle**: `promptSkillInstall` (and its `prompts`/`ora` imports) moved to `utils/prompt-skill-install.ts`, so `import "@react-grab/cli/api"` no longer eagerly loads the interactive prompt/spinner stack. Verified the interactive code is absent from the built `api` graph.
- Documented accurate `force` semantics, the monorepo/`cwd` + mutation expectations, and corrected the low-level README example.

### Deferred (noted, out of scope)

- Refactoring the `init` command to delegate to `installReactGrab` — `init` interleaves an interactive diff/confirm between preview and apply and uses spinner-wrapped install/apply, so delegating would risk the CLI UX. The shared gating predicates (`getPackagesToInstall`, `!hasReactGrab`, the pending-change check) are now aligned to minimize drift.
- Built-in monorepo discovery inside the orchestrator (kept non-interactive; callers use `findReactProjects`).

## Testing

- `pnpm --filter @react-grab/cli build` — both `cli` and `api` entries build, `.d.ts` generated.
- Verified `import`/`require` of the built `api` expose the full surface and that the interactive prompt/spinner code is no longer in the `api` graph.
- `pnpm test` — 225 passing (`test/install-react-grab.test.ts` covers fresh install, already-installed, dry-run, no-op, framework/router + package-manager overrides, skip flags, `installPackageOptions` precedence, and every error code).
- `lint` + `format` clean (run under Node 22.18, since the repo's `vite.config.ts` config loader requires Node ≥22.18 for default TS stripping).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26d8c8c1-bda0-4f5e-bea1-3189d4b9f365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26d8c8c1-bda0-4f5e-bea1-3189d4b9f365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a side-effect-free Node API at `@react-grab/cli/api` to detect, install, and configure `react-grab` programmatically with structured results and errors. Keeps the API bundle lean by moving interactive prompts out and tightens the Node API README.

- **New Features**
  - `installReactGrab(options?)`: non-interactive detect/install/transform orchestrator with overrides and flags (`force`, `skipPackageInstall`, `skipTransform`, `dryRun`); returns a structured result. `installPackageOptions` excludes `cwd`/`packageManager` (set by the orchestrator).
  - `ReactGrabInstallError` with codes: `unsupported-framework`, `unknown-framework`, `transform-failed`, `install-failed`, `write-failed`.
  - Re-exports low-level helpers and types (`detectProject`, `previewTransform`, `applyTransform`, `installPackages`, `getPackagesToInstall`, `installSkill`, `removeSkill`, `ProjectInfo`, etc.). New `./api` subpath and build entry; `src/api.ts` has no import side effects. README docs and tests added.

- **Refactors**
  - Moved interactive `promptSkillInstall` to `utils/prompt-skill-install.ts`; API now exports lean `installSkill`/`removeSkill` (non-interactive). `init`/`add` updated; `remove` now logs per-agent and `removeSkill` returns the removed agents.
  - Write guard matches `applyTransform`: drop `originalContent` check so empty files still receive setup. README examples use `process.cwd()`, guard on `!noChanges`, reuse `getPackagesToInstall()`, and document precise `installPackageOptions` type.
  - Hardened install flow: derive Next.js router type when `framework: "next"` is overridden, pin `cwd`/`packageManager`, wrap package-manager failures as `install-failed`, skip throwing on failed preview when `skipTransform` is set, and resolve `cwd` to an absolute path.
  - Stop exporting internal `detectMonorepo` from the public API.

<sup>Written for commit fc377ce203b6b1259c1ea77fa7f0f19cdabc540d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

