### PR TITLE
chore: add changeset for the grab lag / Grabbing-forever fixes

### DIFF
--- a/.changeset/grab-source-fetch-lag-fixes.md
+++ b/.changeset/grab-source-fetch-lag-fixes.md
@@ -1,0 +1,13 @@
+---
+"react-grab": patch
+---
+
+Fix the grab hanging on "Grabbing…" when the app saturates the dev server's connection pool. Source resolution (bundle and source-map fetches via bippy, plus Next.js server-frame symbolication) now runs through a concurrency-capped, abortable queue with a timeout, so it no longer queues indefinitely behind the app's own requests. Requires bippy ≥0.5.42 so an aborted source-map fetch no longer poisons bippy's cache and later grabs recover.
+
+Also fixes:
+
+- A click immediately after keyboard navigation selecting a stale element instead of the one under the pointer.
+- The page jumping when focus is restored after a grab (focus now restores with `preventScroll`).
+- Being unable to select page content while a modal sets `body { pointer-events: none }` (e.g. Radix), via a hit-test override.
+
+Plus activation and drag performance: animations freeze via the Web Animations API instead of a universal-selector recalc, activation batches its layout reads before writes, the React-update freeze walks fibers iteratively, and drag de-duplication is O(n·d) instead of O(n²).


### PR DESCRIPTION
#482 merged without a changeset, so the next `version packages` release wouldn't bump `react-grab` for that work. This adds a patch changeset covering it:

- "Grabbing…" hang fix (concurrency-capped, abortable source-fetch queue; requires bippy ≥0.5.42 for non-poisoning source-map cache)
- click-after-keyboard-nav selecting a stale element
- page jump on focus restore (`preventScroll`)
- selecting through a modal's `body { pointer-events: none }` (Radix)
- activation/drag perf (WAAPI freeze, batched reads, iterative fiber walk, O(n·d) drag de-dup)

Changeset only — no code changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only release metadata; no runtime or build code changes in this PR.
> 
> **Overview**
> Adds a **patch** changeset for `react-grab` so the next `version packages` / release flow bumps the package after #482 landed without one.
> 
> The changeset text is the release note for that work: **“Grabbing…”** no longer hangs when the dev server connection pool is saturated (concurrency-limited, abortable source-fetch queue; **bippy ≥0.5.42**), plus keyboard-then-click selection, **`preventScroll`** on focus restore, selection through modals with **`body { pointer-events: none }`**, and activation/drag performance improvements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1333176b83ba5027c5786ed72f54771c05f65478. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a patch changeset for `react-grab` so the next release includes the grab-lag fix and related UX/perf improvements. Changeset only; no code changes.

- **Bug Fixes**
  - Fix "Grabbing…" hang by routing bundle/source-map work through a concurrency-limited, abortable queue with a timeout.
  - Fix clicks after keyboard navigation selecting a stale element.
  - Prevent page jump when focus is restored (uses preventScroll).
  - Allow selection while a modal sets body pointer-events: none (e.g., Radix).

- **Migration**
  - Requires `bippy` ≥ 0.5.42 to avoid cache poisoning after aborted source-map fetches.

<sup>Written for commit 1333176b83ba5027c5786ed72f54771c05f65478. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

