### PR TITLE
Remove Copy button from edit panel discard prompt

### DIFF
--- a/packages/react-grab/e2e/edit-panel-helpers.ts
+++ b/packages/react-grab/e2e/edit-panel-helpers.ts
@@ -454,7 +454,7 @@ export const clickHeaderCopyButton = async (page: Page): Promise<void> => {
 
 export const clickDiscardButton = async (
   page: Page,
-  action: "cancel" | "confirm" | "copy",
+  action: "cancel" | "confirm",
 ): Promise<void> => {
   await page.evaluate(
     ({ attrName, actionName }) => {

--- a/packages/react-grab/e2e/edit-panel.spec.ts
+++ b/packages/react-grab/e2e/edit-panel.spec.ts
@@ -285,28 +285,6 @@ test.describe("Style Panel", () => {
       expect(await isDiscardPromptVisible(reactGrab.page)).toBe(true);
     });
 
-    test("mouse movement after keyboard tweak opens discard prompt with Copy", async ({
-      reactGrab,
-    }) => {
-      await openEditPanel(reactGrab, BUTTON_SELECTOR);
-      await reactGrab.page.keyboard.press("ArrowRight");
-      await reactGrab.page.waitForTimeout(80);
-      const inlineStyleAfterTweak = await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR);
-      expect(inlineStyleAfterTweak.length).toBeGreaterThan(0);
-
-      await reactGrab.page.mouse.move(10, 10);
-      await reactGrab.page.waitForTimeout(80);
-      expect(await isEditPanelVisible(reactGrab.page)).toBe(true);
-      expect(await isEditPanelCompact(reactGrab.page)).toBe(false);
-      expect(await isDiscardPromptVisible(reactGrab.page)).toBe(true);
-
-      await clickDiscardButton(reactGrab.page, "copy");
-      await expect.poll(() => isEditPanelVisible(reactGrab.page)).toBe(false);
-      expect(await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR)).toBe(
-        inlineStyleAfterTweak,
-      );
-    });
-
     test("canceling mouse-move discard prompt consumes the pointer handoff", async ({
       reactGrab,
     }) => {

--- a/packages/react-grab/src/components/edit-panel/copy-button.tsx
+++ b/packages/react-grab/src/components/edit-panel/copy-button.tsx
@@ -1,7 +1,6 @@
 import type { Component } from "solid-js";
 
 interface EditPanelCopyButtonProps {
-  discardAction?: "copy";
   onCopy: () => void;
 }
 
@@ -9,7 +8,6 @@ export const EditPanelCopyButton: Component<EditPanelCopyButtonProps> = (props) 
   <button
     data-react-grab-ignore-events
     data-react-grab-copy-button
-    data-react-grab-discard-button={props.discardAction}
     type="button"
     class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[var(--rg-surface-hover)] [border-width:0.5px] border-solid border-[var(--rg-border-button)] cursor-pointer transition-all hover:bg-[var(--rg-surface-active)] press-scale h-[17px]"
     onClick={(event) => {

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -635,7 +635,6 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
                     No
                   </span>
                 </button>
-                <EditPanelCopyButton discardAction="copy" onCopy={handleSubmit} />
                 <button
                   data-react-grab-ignore-events
                   data-react-grab-discard-button="confirm"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The edit panel's "Discard edits?" prompt previously showed three actions: `No`, `Copy`, and `Yes`. This removes the `Copy` action so the prompt offers just `No` / `Yes`.

## Changes

- `edit-panel/index.tsx`: removed the `EditPanelCopyButton` rendered between `No` and `Yes` in the discard prompt.
- `edit-panel/copy-button.tsx`: dropped the now-unused `discardAction` prop (and its `data-react-grab-discard-button` binding), since the discard prompt was its only consumer. The header copy button (`hasSubmittableEdits`) still uses this component unchanged.
- `e2e/edit-panel.spec.ts`: removed the test that specifically exercised the discard prompt's Copy button.
- `e2e/edit-panel-helpers.ts`: narrowed `clickDiscardButton`'s action union from `"cancel" | "confirm" | "copy"` to `"cancel" | "confirm"`.

The separate selection-label discard prompt ("Discard selection?") is unchanged.

## Verification

- `pnpm build` passes
- `pnpm typecheck` passes
- `pnpm lint` passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7de92fe-e93c-4594-b177-f06740315668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7de92fe-e93c-4594-b177-f06740315668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Copy button from the edit panel’s “Discard edits?” prompt, leaving only No and Yes to simplify the decision.
Cleaned up the unused `discardAction` prop in `EditPanelCopyButton`, updated helpers to remove the "copy" action, and removed the related e2e test; the selection-label discard prompt is unchanged.

<sup>Written for commit 9193853aca4886c3830f79b3973cfb48cd9b5b49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

