### PR TITLE
fix(react-grab): don't surface list-item keys overridden by a JSX spread

### DIFF
--- a/.changeset/list-item-key-spread-override.md
+++ b/.changeset/list-item-key-spread-override.md
@@ -1,0 +1,5 @@
+---
+"react-grab": patch
+---
+
+Don't surface a list-item `key` when a JSX spread overrides it. `fiber.key` is the key React resolved at runtime, so `<li key={item.id} {...item}>` (where `item` carries a `key`) and `<li {...item}>` report a value that doesn't match the `key={…}` written at that JSX site, which misleads a consumer trying to locate the picked instance. The key is now confirmed against the element's source before it is surfaced: if a spread follows the `key` attribute (or the key comes entirely from a spread), the hint is dropped; an explicit `key` with no trailing spread is unaffected. When the element's source can't be read the key is still surfaced, so the common spread-free case is unchanged.

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -21,6 +21,10 @@ export const INPUT_TEXT_SELECTION_ACTIVATION_DELAY_MS = 600;
 export const DEFAULT_KEY_HOLD_DURATION_MS = 100;
 export const DEFAULT_MAX_CONTEXT_LINES = 3;
 export const MAX_TRACE_CONTEXT_LINES = 20;
+// How many original-source lines to read from a keyed element's JSX call site
+// when checking whether a spread overrides its `key` - enough to span a
+// multi-line opening tag without scanning the whole file.
+export const SOURCE_SNIPPET_MAX_LINES = 12;
 // Path segments marking app-owned reusable UI directories (shadcn's
 // components/ui, a monorepo packages/ui, headless primitives). A bare `/ui/`
 // is deliberately excluded: Next's App Router convention places feature code

--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -19,6 +19,8 @@ import { isSharedUiSourcePath } from "../utils/is-shared-ui-source-path.js";
 import { isNextProjectRuntime } from "../utils/is-next-project-runtime.js";
 import { enrichServerFrameLocations, symbolicateServerFrames } from "./next-server-frames.js";
 import { runQueuedSourceFetch } from "../utils/source-fetch-queue.js";
+import { getFiberSourceSnippet } from "../utils/get-fiber-source-snippet.js";
+import { isKeyOverriddenBySpread } from "../utils/is-key-overridden-by-spread.js";
 import { getHTMLPreview, getInlineHTMLPreview } from "./html-preview.js";
 import {
   isInternalComponentName,
@@ -54,12 +56,12 @@ const findNearestFiberElement = (element: Element): Element => {
 // on the list item's host element, on the list-item component itself, or on a
 // host wrapper around a list-item component, without wandering up to unrelated
 // ancestor keys (e.g. a route or transition `key` many components above).
-const getNearestListItemKey = (element: Element): string | null => {
+const getNearestListItemKeyFiber = (element: Element): Fiber | null => {
   if (!isInstrumentationActive()) return null;
   let fiber: Fiber | null = getFiberFromHostInstance(findNearestFiberElement(element));
   let componentBoundariesCrossed = 0;
   while (fiber) {
-    if (fiber.key) return fiber.key;
+    if (fiber.key) return fiber;
     if (isCompositeFiber(fiber)) {
       componentBoundariesCrossed += 1;
       if (componentBoundariesCrossed === 2) break;
@@ -67,6 +69,27 @@ const getNearestListItemKey = (element: Element): string | null => {
     fiber = fiber.return;
   }
   return null;
+};
+
+// `fiber.key` is React's resolved key, with no trace of how it was written, so a
+// spread that overrode it (`<li key={id} {...item}>`, or a key sourced entirely
+// from `<li {...item}>`) reports a value that won't match the `key={…}` an agent
+// reads at that JSX site. We confirm the key against the element's source before
+// surfacing it; if the source can't be read we keep surfacing it (the common,
+// spread-free case is unaffected).
+const isListItemKeyTrustworthy = (fiber: Fiber): Promise<boolean> =>
+  runQueuedSourceFetch(async (signal) => {
+    const snippet = await getFiberSourceSnippet(fiber, createSourceFetch(signal));
+    if (snippet === null) return true;
+    return !isKeyOverriddenBySpread(snippet);
+  }, true);
+
+const resolveListItemKeyHint = async (element: Element): Promise<string> => {
+  const keyedFiber = getNearestListItemKeyFiber(element);
+  const listItemKey = keyedFiber?.key;
+  if (!listItemKey) return "";
+  if (!(await isListItemKeyTrustworthy(keyedFiber))) return "";
+  return `\n  key: "${listItemKey}"`;
 };
 
 const stackCache = new WeakMap<Element, Promise<StackFrame[] | null>>();
@@ -474,9 +497,11 @@ export const getStackContext = async (
   return traceContext.text;
 };
 
-const composeElementContext = (element: Element, traceContext: TraceContextResult): string => {
-  const listItemKey = getNearestListItemKey(element);
-  const keyHint = listItemKey !== null ? `\n  key: "${listItemKey}"` : "";
+const composeElementContext = async (
+  element: Element,
+  traceContext: TraceContextResult,
+): Promise<string> => {
+  const keyHint = await resolveListItemKeyHint(element);
   const selectorHint = traceContext.shouldAppendSelectorHint
     ? `\n  selector: ${createElementSelector(element)}`
     : "";
@@ -488,7 +513,8 @@ export const getElementReferenceContext = async (
   options: StackContextOptions = {},
 ): Promise<string> => {
   const traceContext = await getTraceContext(element, options);
-  return `${getInlineHTMLPreview(element)}${composeElementContext(element, traceContext).replace(/\n\s+/g, " ")}`;
+  const elementContext = await composeElementContext(element, traceContext);
+  return `${getInlineHTMLPreview(element)}${elementContext.replace(/\n\s+/g, " ")}`;
 };
 
 export const formatElementInfo = async (
@@ -498,5 +524,6 @@ export const formatElementInfo = async (
   const nearestFiberElement = findNearestFiberElement(element);
   const htmlPreview = getHTMLPreview(nearestFiberElement);
   const traceContext = await getTraceContext(nearestFiberElement, options);
-  return `${htmlPreview}${composeElementContext(nearestFiberElement, traceContext)}`;
+  const elementContext = await composeElementContext(nearestFiberElement, traceContext);
+  return `${htmlPreview}${elementContext}`;
 };

--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -71,18 +71,26 @@ const getNearestListItemKeyFiber = (element: Element): Fiber | null => {
   return null;
 };
 
+// Surfacing the list-item key is a hint, never worth a network round-trip - it
+// must not add latency to a grab or block it from completing (e.g. when the
+// dev-server connection pool is saturated). So the key check reuses only the
+// source maps the leading-source resolution already warmed: this fetch rejects,
+// turning bippy's resolution into a cache-only lookup. A cache miss yields a null
+// snippet and the key is surfaced as before.
+const rejectUncachedSourceFetch = (): Promise<Response> =>
+  Promise.reject(new Error("react-grab: list-item key check is cache-only"));
+
 // `fiber.key` is React's resolved key, with no trace of how it was written, so a
 // spread that overrode it (`<li key={id} {...item}>`, or a key sourced entirely
 // from `<li {...item}>`) reports a value that won't match the `key={…}` an agent
 // reads at that JSX site. We confirm the key against the element's source before
-// surfacing it; if the source can't be read we keep surfacing it (the common,
+// surfacing it; if the source isn't cached we keep surfacing it (the common,
 // spread-free case is unaffected).
-const isListItemKeyTrustworthy = (fiber: Fiber): Promise<boolean> =>
-  runQueuedSourceFetch(async (signal) => {
-    const snippet = await getFiberSourceSnippet(fiber, createSourceFetch(signal));
-    if (snippet === null) return true;
-    return !isKeyOverriddenBySpread(snippet);
-  }, true);
+const isListItemKeyTrustworthy = async (fiber: Fiber): Promise<boolean> => {
+  const snippet = await getFiberSourceSnippet(fiber, rejectUncachedSourceFetch);
+  if (snippet === null) return true;
+  return !isKeyOverriddenBySpread(snippet);
+};
 
 const resolveListItemKeyHint = async (element: Element): Promise<string> => {
   const keyedFiber = getNearestListItemKeyFiber(element);

--- a/packages/react-grab/src/utils/get-fiber-source-snippet.ts
+++ b/packages/react-grab/src/utils/get-fiber-source-snippet.ts
@@ -1,0 +1,67 @@
+import { getOwnerStack, getSourceFromSourceMap, getSourceMap, type SourceMap } from "bippy/source";
+import type { Fiber } from "bippy";
+import { SOURCE_SNIPPET_MAX_LINES } from "../constants.js";
+
+const getSourcesContentFor = (sourceMap: SourceMap, fileName: string): string | null => {
+  const directIndex = sourceMap.sources.indexOf(fileName);
+  if (directIndex !== -1 && sourceMap.sourcesContent?.[directIndex]) {
+    return sourceMap.sourcesContent[directIndex];
+  }
+  if (sourceMap.sections) {
+    for (const section of sourceMap.sections) {
+      const sectionIndex = section.map.sources.indexOf(fileName);
+      if (sectionIndex !== -1 && section.map.sourcesContent?.[sectionIndex]) {
+        return section.map.sourcesContent[sectionIndex];
+      }
+    }
+  }
+  return null;
+};
+
+// Resolves the original JSX text around where `fiber` is created, starting at its
+// owner-stack call site. Returns the opening-tag region (a handful of lines, so a
+// multi-line tag is captured) or null when the location can't be mapped back to
+// original source - which is common: bundlers that ship inline source maps, or
+// owner stacks that only carry component names, leave nothing to read, and the
+// caller treats a null snippet as "can't verify" and keeps surfacing the key.
+// Source-map fetches go through bippy's cache, which the leading source
+// resolution has usually already warmed, so this rarely adds a request.
+export const getFiberSourceSnippet = async (
+  fiber: Fiber,
+  fetchFn: (url: string) => Promise<Response>,
+): Promise<string | null> => {
+  try {
+    const frames = await getOwnerStack(fiber, true, fetchFn);
+    const callSite = frames.find(
+      (frame) =>
+        frame.fileName &&
+        typeof frame.lineNumber === "number" &&
+        typeof frame.columnNumber === "number",
+    );
+    if (!callSite?.fileName) return null;
+
+    const sourceMap = await getSourceMap(callSite.fileName, true, fetchFn);
+    if (!sourceMap) return null;
+
+    const original = getSourceFromSourceMap(
+      sourceMap,
+      callSite.lineNumber as number,
+      callSite.columnNumber as number,
+    );
+    if (!original?.fileName || !original.lineNumber) return null;
+
+    const content = getSourcesContentFor(sourceMap, original.fileName);
+    if (!content) return null;
+
+    const lines = content.split("\n");
+    const startLineIndex = original.lineNumber - 1;
+    if (startLineIndex < 0 || startLineIndex >= lines.length) return null;
+
+    const snippetLines = lines.slice(startLineIndex, startLineIndex + SOURCE_SNIPPET_MAX_LINES);
+    const startColumn = Math.max(0, (original.columnNumber ?? 1) - 1);
+    snippetLines[0] = snippetLines[0].slice(startColumn);
+    return snippetLines.join("\n");
+  } catch {
+    return null;
+  }
+};

--- a/packages/react-grab/src/utils/is-key-overridden-by-spread.ts
+++ b/packages/react-grab/src/utils/is-key-overridden-by-spread.ts
@@ -1,0 +1,129 @@
+// React resolves a list item's `key` from JSX at runtime, so `fiber.key` is the
+// final value regardless of how it was written - there is no runtime signal for
+// whether a spread overrode it. To know if a surfaced key is trustworthy we
+// have to look at the source: `<li key={id} {...props}>` lets `props.key`
+// silently override `id` (and `<li {...props}>` sources the key entirely from
+// the spread), so the value React reports won't match the `key={…}` an agent
+// reads at that JSX site. A spread that sits *before* the key (`<li {...props}
+// key={id}>`) can't override it, so that key stays reliable.
+//
+// This walks only the opening tag, tracking brace depth and string state so a
+// `key`/`{...}` nested inside an attribute expression (e.g. `data-x={{ key: 1
+// }}` or `title={spread(a)}`) never counts as a top-level attribute.
+
+const isIdentifierChar = (character: string): boolean => /[A-Za-z0-9_$]/.test(character);
+
+interface OpeningTagScan {
+  hasExplicitKey: boolean;
+  hasAnySpread: boolean;
+  hasSpreadAfterKey: boolean;
+}
+
+const scanOpeningTag = (openingTag: string): OpeningTagScan => {
+  let braceDepth = 0;
+  let stringQuote: string | null = null;
+  let keyIndex = -1;
+  let hasAnySpread = false;
+  let hasSpreadAfterKey = false;
+
+  for (let index = 0; index < openingTag.length; index++) {
+    const character = openingTag[index];
+
+    if (stringQuote !== null) {
+      if (character === stringQuote) stringQuote = null;
+      continue;
+    }
+
+    if (character === '"' || character === "'" || character === "`") {
+      stringQuote = character;
+      continue;
+    }
+
+    if (character === "{") {
+      if (braceDepth === 0 && openingTag.slice(index + 1, index + 4) === "...") {
+        hasAnySpread = true;
+        if (keyIndex !== -1) hasSpreadAfterKey = true;
+      }
+      braceDepth++;
+      continue;
+    }
+
+    if (character === "}") {
+      if (braceDepth > 0) braceDepth--;
+      continue;
+    }
+
+    if (braceDepth !== 0) continue;
+
+    // A top-level `key` attribute name: `key` bounded by a non-identifier on the
+    // left and an `=` (optionally spaced) on the right.
+    if (
+      keyIndex === -1 &&
+      character === "k" &&
+      openingTag.slice(index, index + 3) === "key" &&
+      !isIdentifierChar(openingTag[index - 1] ?? " ") &&
+      !isIdentifierChar(openingTag[index + 3] ?? " ")
+    ) {
+      const afterKey = openingTag.slice(index + 3).match(/^\s*=/);
+      if (afterKey) keyIndex = index;
+    }
+  }
+
+  return { hasExplicitKey: keyIndex !== -1, hasAnySpread, hasSpreadAfterKey };
+};
+
+// Returns the substring from the element's opening `<` to the `>` that closes
+// the opening tag, or null when the tag can't be delimited (so callers keep the
+// current behavior rather than acting on a half-parsed tag).
+const extractOpeningTag = (source: string): string | null => {
+  const tagStart = source.indexOf("<");
+  if (tagStart === -1) return null;
+
+  let braceDepth = 0;
+  let stringQuote: string | null = null;
+
+  for (let index = tagStart + 1; index < source.length; index++) {
+    const character = source[index];
+
+    if (stringQuote !== null) {
+      if (character === stringQuote) stringQuote = null;
+      continue;
+    }
+
+    if (character === '"' || character === "'" || character === "`") {
+      stringQuote = character;
+      continue;
+    }
+
+    if (character === "{") {
+      braceDepth++;
+      continue;
+    }
+
+    if (character === "}") {
+      if (braceDepth > 0) braceDepth--;
+      continue;
+    }
+
+    if (braceDepth === 0 && character === ">") {
+      return source.slice(tagStart, index + 1);
+    }
+  }
+
+  return null;
+};
+
+// True when the `key` React resolved cannot be trusted to match the JSX `key={…}`
+// at this site: a spread follows the key (so it may override it), or the key was
+// sourced entirely from a spread (no explicit `key={…}`). A tag with no spread
+// is always trusted, and an unparseable tag returns false, so an imperfect
+// source read never suppresses a key that might be perfectly fine.
+export const isKeyOverriddenBySpread = (elementSource: string): boolean => {
+  const openingTag = extractOpeningTag(elementSource);
+  if (openingTag === null) return false;
+
+  const { hasExplicitKey, hasAnySpread, hasSpreadAfterKey } = scanOpeningTag(openingTag);
+  if (!hasAnySpread) return false;
+  if (!hasExplicitKey) return true;
+  return hasSpreadAfterKey;
+};

--- a/packages/react-grab/tests/is-key-overridden-by-spread.test.ts
+++ b/packages/react-grab/tests/is-key-overridden-by-spread.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vite-plus/test";
+import { isKeyOverriddenBySpread } from "../src/utils/is-key-overridden-by-spread.js";
+
+describe("isKeyOverriddenBySpread", () => {
+  it("trusts an explicit key with no spread", () => {
+    expect(isKeyOverriddenBySpread('<div key={item.id} className="card">')).toBe(false);
+  });
+
+  it("trusts an explicit key when the spread comes before it", () => {
+    expect(isKeyOverriddenBySpread("<div {...props} key={item.id}>")).toBe(false);
+  });
+
+  it("flags a spread that follows the key (the spread can override it)", () => {
+    expect(isKeyOverriddenBySpread("<div key={item.id} {...item}>")).toBe(true);
+  });
+
+  it("flags a key sourced entirely from a spread", () => {
+    expect(isKeyOverriddenBySpread("<Item {...item} />")).toBe(true);
+  });
+
+  it("trusts a key followed only by ordinary attributes", () => {
+    expect(isKeyOverriddenBySpread('<li key={i} className="row" data-testid="x">')).toBe(false);
+  });
+
+  it("flags a key with a trailing spread even when other attributes sit between", () => {
+    expect(isKeyOverriddenBySpread('<li key={i} className="row" {...rest} />')).toBe(true);
+  });
+
+  it("ignores a `key` that only appears inside an attribute expression", () => {
+    expect(isKeyOverriddenBySpread("<div data-meta={{ key: 1 }} {...props}>")).toBe(true);
+    expect(isKeyOverriddenBySpread("<div data-meta={{ key: 1 }}>")).toBe(false);
+  });
+
+  it("ignores a spread nested inside an attribute expression", () => {
+    expect(isKeyOverriddenBySpread("<div key={i} style={merge({ ...base })}>")).toBe(false);
+  });
+
+  it("ignores braces and tag characters inside string attribute values", () => {
+    expect(isKeyOverriddenBySpread('<div title="a > b {...c}" key={i}>')).toBe(false);
+  });
+
+  it("handles a key attribute that spans multiple lines before the spread", () => {
+    const source = `<div\n  key={item.id}\n  className="card"\n  {...item}\n>`;
+    expect(isKeyOverriddenBySpread(source)).toBe(true);
+  });
+
+  it("returns false when the tag cannot be delimited", () => {
+    expect(isKeyOverriddenBySpread("not jsx at all")).toBe(false);
+    expect(isKeyOverriddenBySpread("<div key={i}")).toBe(false);
+  });
+
+  it("does not treat an identifier ending in `key` as the key attribute", () => {
+    expect(isKeyOverriddenBySpread("<div datakey={i} {...props}>")).toBe(true);
+    expect(isKeyOverriddenBySpread("<div keyboard={i}>")).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`getNearestListItemKey` surfaces `fiber.key` to disambiguate mapped list items (added in #474). But `fiber.key` is the key React *resolved* at runtime, with no trace of how it was written. When a spread overrides the key, the surfaced value no longer matches the `key={…}` an agent reads at that JSX site:

- `<li key={item.id} {...item}>` where `item` carries a `key` → React uses `item.key`, not `item.id`. We'd report e.g. `key: "spread-bravo"` while the source says `key={item.id}` (`"bravo"`).
- `<li {...item}>` → the key is sourced entirely from the spread, so there's no `key={…}` to find at all.

In both cases the surfaced key points the consumer at the wrong identity. A spread that sits *before* the key (`<li {...item} key={item.id}>`) can't override it, so that key stays reliable.

## Fix

Confirm the key against the element's source before surfacing it. A new pure helper, `isKeyOverriddenBySpread`, scans the JSX opening tag (tracking brace depth and string state so a `key`/`{...}` nested inside an attribute expression doesn't count) and reports whether a top-level spread follows the `key` attribute, or whether the key is sourced entirely from a spread. `getFiberSourceSnippet` resolves the keyed element's original JSX text via bippy's owner stack + source map. The key hint is dropped only when the source positively shows it's overridden.

Crucially this is conservative: when the source can't be read, or there's no spread, the key is surfaced exactly as before — so the common spread-free path (and the existing #474 behavior) is unchanged.

### Cache-only — no added grab latency

Surfacing the key is a hint, never worth a network round-trip. The check is **cache-only**: it reuses the source maps the leading-source resolution already warmed (the resolver's fetch rejects, turning bippy's lookup into a cache hit or a fast miss). It never issues a new fetch, never takes a source-fetch-queue slot, and never blocks a grab from completing — including when the dev-server connection pool is saturated. On a cache miss the key is surfaced as before.

## Changes

- `packages/react-grab/src/utils/is-key-overridden-by-spread.ts`: pure JSX opening-tag scanner (depth/string-aware). Fully unit-tested.
- `packages/react-grab/src/utils/get-fiber-source-snippet.ts`: resolves a keyed fiber's original source snippet via `getOwnerStack` + `getSourceMap`/`getSourceFromSourceMap`, returning `null` (→ keep surfacing) whenever the location can't be mapped.
- `packages/react-grab/src/core/context.ts`: `getNearestListItemKey` → `getNearestListItemKeyFiber`; the key hint is now resolved asynchronously and suppressed when the (cache-only) source read shows a spread override. `composeElementContext` and its two callers are now async.
- `packages/react-grab/src/constants.ts`: `SOURCE_SNIPPET_MAX_LINES`.
- Changeset (patch).

## Testing

- `pnpm typecheck`, `pnpm lint` pass.
- Unit tests pass (`vp test run tests`), including 12 new cases for `isKeyOverriddenBySpread` (explicit key, spread-before, spread-after, spread-only, nested expressions, strings, multi-line tags, `datakey`/`keyboard` non-matches).
- Existing `element-context` e2e (mapped host key, mapped component key, wrapper key) still pass — reliable keys are unaffected.
- `next-symbolication-blocking` e2e (incl. the saturated-connection-pool case) pass — the cache-only design adds no latency to the grab path.

## Note on runtime source availability

The suppression depends on the keyed element's own JSX source already being resolved/cached at pick time. That resolution is best-effort and bounded by what the runtime exposes (bippy owner-stack locations + source maps); where it can't be resolved, the key is surfaced as before, so there is no regression. The detection logic itself is exercised directly by the unit tests.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50583f20-d65b-48ec-b2b9-5f0231ac2163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50583f20-d65b-48ec-b2b9-5f0231ac2163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops showing list-item key hints in `react-grab` when a JSX spread can override them, preventing misleading keys in the picker. Keys are now confirmed against the element’s JSX source using cache-only lookups; unreliable keys are hidden, reliable keys are unchanged.

- **Bug Fixes**
  - Verify `fiber.key` against original JSX using `getFiberSourceSnippet` (bippy owner stack + source maps, cache-only) and `isKeyOverriddenBySpread`.
  - Suppress the key hint when a spread follows `key={…}` or when the key comes only from a spread; fall back to surfacing the key when no spread is present or when source can’t be read.
  - Made context composition async to resolve key trustworthiness (`getNearestListItemKey` → `getNearestListItemKeyFiber`, `composeElementContext` and callers now async).
  - Added `SOURCE_SNIPPET_MAX_LINES` and unit tests for the scanner; existing e2e tests remain green.

<sup>Written for commit 3ca54b54dd27dfda11cfcdbb1743f10d9e73ad04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

