### PR TITLE
Clean up unused react-grab style hooks

### DIFF
--- a/apps/openstory/stories/renderer.stories.tsx
+++ b/apps/openstory/stories/renderer.stories.tsx
@@ -321,9 +321,7 @@ const Scene = (props: SceneProps) => {
         mouseX={mouseX()}
         isPromptMode={props.isPromptMode}
         inputValue={props.inputValue}
-        discardPrompt={
-          props.isPendingDismiss ? { onConfirm: noop, onCancel: noop } : undefined
-        }
+        discardPrompt={props.isPendingDismiss ? { onConfirm: noop, onCancel: noop } : undefined}
         isFrozen={false}
         toolbarVisible={props.showToolbar}
         isActive={props.isActive}

--- a/packages/react-grab/CHANGELOG.md
+++ b/packages/react-grab/CHANGELOG.md
@@ -7,7 +7,6 @@
 - 5407d4e: Surface deeper copy context for wrapper-heavy elements. App-owned shared-UI / design-system frames (files under `components/ui/`, `packages/ui/`, `design-system(s)/`, or `primitives/`, e.g. shadcn's `components/ui` or a monorepo `packages/ui`) are now treated like `node_modules` frames: still shown, but exempt from the compact line budget, so a grabbed wrapper digs through its UI primitives to the meaningful feature source by default. Adds a `maxContextLines` option (also settable via the script `data-options` attribute) to raise the budget further for large apps and agent/edit prompts — restoring the option the CLI already writes.
 
   Also hardens the trace: a non-finite/negative `maxContextLines` no longer disables the hard line cap (it falls back to the default), and consecutive duplicate trace lines from shared-UI frames are collapsed so the output stays readable.
-
   - @react-grab/cli@0.1.47
 
 ## 0.1.46
@@ -15,7 +14,6 @@
 ### Patch Changes
 
 - b85b9b1: Make app theme detection (which drives the overlay's inverted theme) more robust:
-
   - Read background luminance through the existing `parseAnyColor` helper so pages whose background is authored with `oklch()` (e.g. Tailwind v4) are no longer mis-detected. Browsers serialize these computed colors in their own color space rather than `rgb()`, so the previous `rgb()`-only luminance heuristic silently failed and fell back to `prefers-color-scheme` — a forced-light page then looked dark to dark-OS visitors.
   - Treat a dual `color-scheme` (`light dark` / `dark light`) as "decided by the OS preference / actual paint" instead of blindly trusting the first listed token, which mis-detected dark-OS visitors on sites that opt into both schemes.
   - Inspect `<body>` in addition to `<html>` for theme markers (class, `data-theme`/`data-bs-theme`/etc., and presence attributes) so apps that theme the body are detected.

--- a/packages/react-grab/e2e/constants.ts
+++ b/packages/react-grab/e2e/constants.ts
@@ -1,3 +1,5 @@
+export { REACT_GRAB_ATTRIBUTE_NAME as ATTRIBUTE_NAME } from "../src/constants.js";
+
 export const SHIFT_LABEL_CLICK_ANCHOR_RATIO = 0.25;
 export const SHIFT_LABEL_SECOND_CLICK_ANCHOR_RATIO = 0.75;
 export const SHIFT_LABEL_ANCHORED_COUNT = 2;

--- a/packages/react-grab/e2e/constants.ts
+++ b/packages/react-grab/e2e/constants.ts
@@ -1,4 +1,4 @@
-export { REACT_GRAB_ATTRIBUTE_NAME as ATTRIBUTE_NAME } from "../src/constants.js";
+export { REACT_GRAB_ATTRIBUTE_NAME as ATTRIBUTE_NAME } from "../src/utils/react-grab-attribute-name.js";
 
 export const SHIFT_LABEL_CLICK_ANCHOR_RATIO = 0.25;
 export const SHIFT_LABEL_SECOND_CLICK_ANCHOR_RATIO = 0.75;

--- a/packages/react-grab/e2e/edit-panel-helpers.ts
+++ b/packages/react-grab/e2e/edit-panel-helpers.ts
@@ -1,8 +1,9 @@
 import type { Page } from "@playwright/test";
 import { expect } from "./fixtures.js";
 import type { ReactGrabPageObject } from "./fixtures.js";
+import { ATTRIBUTE_NAME } from "./constants.js";
 
-export const ATTRIBUTE_NAME = "data-react-grab";
+export { ATTRIBUTE_NAME };
 export const EDIT_PANEL_ATTR = "data-react-grab-edit-panel";
 export const EDIT_PROPERTY_ATTR = "data-react-grab-edit-property";
 export const SEARCH_INPUT_ATTR = "data-react-grab-input";

--- a/packages/react-grab/e2e/fixtures.ts
+++ b/packages/react-grab/e2e/fixtures.ts
@@ -1,6 +1,6 @@
 import { test as base, expect, Page, Locator } from "@playwright/test";
+import { ATTRIBUTE_NAME } from "./constants.js";
 
-const ATTRIBUTE_NAME = "data-react-grab";
 const DEFAULT_KEY_HOLD_DURATION_MS = 200;
 const ACTIVATION_BUFFER_MS = 200;
 const PAGE_SETUP_MAX_ATTEMPTS = 2;

--- a/packages/react-grab/e2e/freeze-animations.spec.ts
+++ b/packages/react-grab/e2e/freeze-animations.spec.ts
@@ -1,7 +1,6 @@
 import type { Page } from "@playwright/test";
 import { test, expect } from "./fixtures.js";
-
-const ATTRIBUTE_NAME = "data-react-grab";
+import { ATTRIBUTE_NAME } from "./constants.js";
 
 const simulateGsapPresence = (page: Page): Promise<void> =>
   page.evaluate(() => {

--- a/packages/react-grab/e2e/keyboard-navigation.spec.ts
+++ b/packages/react-grab/e2e/keyboard-navigation.spec.ts
@@ -1,7 +1,6 @@
 import { expect, test, type ReactGrabPageObject } from "./fixtures.js";
 import { isEditPanelVisible } from "./edit-panel-helpers.js";
-
-const ATTRIBUTE_NAME = "data-react-grab";
+import { ATTRIBUTE_NAME } from "./constants.js";
 
 const clickSelectionDiscardButton = async (
   reactGrab: ReactGrabPageObject,

--- a/packages/react-grab/e2e/next-symbolication-blocking.spec.ts
+++ b/packages/react-grab/e2e/next-symbolication-blocking.spec.ts
@@ -19,9 +19,11 @@ const formatWithinBudget = (page: Page, selector: string) =>
   Promise.race([
     page
       .evaluate((sel) => {
-        const format = (window as unknown as {
-          formatElementInfo: (element: Element) => Promise<string>;
-        }).formatElementInfo;
+        const format = (
+          window as unknown as {
+            formatElementInfo: (element: Element) => Promise<string>;
+          }
+        ).formatElementInfo;
         return format(document.querySelector(sel) as Element);
       }, selector)
       .then((trace) => ({ completed: true as const, trace })),

--- a/packages/react-grab/e2e/selection.spec.ts
+++ b/packages/react-grab/e2e/selection.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "./fixtures.js";
+import { ATTRIBUTE_NAME } from "./constants.js";
 
 test.describe("Element Selection", () => {
   test("should show selection box when hovering over element while active", async ({
@@ -8,13 +9,13 @@ test.describe("Element Selection", () => {
     await reactGrab.hoverElement("li");
     await reactGrab.waitForSelectionBox();
 
-    const hasSelectionContent = await reactGrab.page.evaluate(() => {
-      const host = document.querySelector("[data-react-grab]");
+    const hasSelectionContent = await reactGrab.page.evaluate((attrName) => {
+      const host = document.querySelector(`[${attrName}]`);
       const shadowRoot = host?.shadowRoot;
       if (!shadowRoot) return false;
-      const root = shadowRoot.querySelector("[data-react-grab]");
+      const root = shadowRoot.querySelector(`[${attrName}]`);
       return root !== null && root.innerHTML.length > 0;
-    });
+    }, ATTRIBUTE_NAME);
 
     expect(hasSelectionContent).toBe(true);
   });

--- a/packages/react-grab/e2e/selection.spec.ts
+++ b/packages/react-grab/e2e/selection.spec.ts
@@ -276,9 +276,7 @@ test.describe("Selection Bounds and Mutations", () => {
   }) => {
     // Open a Radix-style modal that sets `body { pointer-events: none }`.
     await page.locator("[data-testid='pe-modal-trigger']").click();
-    await expect
-      .poll(() => page.evaluate(() => document.body.style.pointerEvents))
-      .toBe("none");
+    await expect.poll(() => page.evaluate(() => document.body.style.pointerEvents)).toBe("none");
 
     await reactGrab.activate();
     // The hit-test override must see through the page's pointer-events:none so an

--- a/packages/react-grab/e2e/toolbar-selection-hover.spec.ts
+++ b/packages/react-grab/e2e/toolbar-selection-hover.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from "./fixtures.js";
-
-const ATTRIBUTE_NAME = "data-react-grab";
+import { ATTRIBUTE_NAME } from "./constants.js";
 
 const hoverToolbar = async (page: import("@playwright/test").Page) => {
   const toolbarRect = await page.evaluate((attrName) => {

--- a/packages/react-grab/playwright.config.ts
+++ b/packages/react-grab/playwright.config.ts
@@ -60,7 +60,7 @@ const nextWebServer = {
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
-  forbidOnly: !!process.env.CI,
+  forbidOnly: Boolean(process.env.CI),
   retries: process.env.CI ? 2 : 1,
   workers: process.env.CI ? 4 : undefined,
   timeout: 60_000,

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -130,8 +130,6 @@ export const MODIFIER_KEYS: readonly string[] = ["Meta", "Control", "Shift", "Al
 
 export const ARROW_KEYS = new Set(["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"]);
 
-export const REACT_GRAB_ATTRIBUTE_NAME = "data-react-grab";
-
 export const FROZEN_ELEMENT_ATTRIBUTE = "data-react-grab-frozen";
 
 export const USER_IGNORE_ATTRIBUTE = "data-react-grab-ignore";

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -130,6 +130,8 @@ export const MODIFIER_KEYS: readonly string[] = ["Meta", "Control", "Shift", "Al
 
 export const ARROW_KEYS = new Set(["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"]);
 
+export { REACT_GRAB_ATTRIBUTE_NAME } from "./utils/react-grab-attribute-name.js";
+
 export const FROZEN_ELEMENT_ATTRIBUTE = "data-react-grab-frozen";
 
 export const USER_IGNORE_ATTRIBUTE = "data-react-grab-ignore";

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -130,6 +130,8 @@ export const MODIFIER_KEYS: readonly string[] = ["Meta", "Control", "Shift", "Al
 
 export const ARROW_KEYS = new Set(["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"]);
 
+export const REACT_GRAB_ATTRIBUTE_NAME = "data-react-grab";
+
 export const FROZEN_ELEMENT_ATTRIBUTE = "data-react-grab-frozen";
 
 export const USER_IGNORE_ATTRIBUTE = "data-react-grab-ignore";

--- a/packages/react-grab/src/core/edit-mode.ts
+++ b/packages/react-grab/src/core/edit-mode.ts
@@ -79,10 +79,7 @@ const mergeEditsIntoEntry = (entry: PendingEditsEntry, edits: PendingEdits) => {
   }
 };
 
-const toSessionRecord = (
-  currentState: EditPanelState,
-  edits: PendingEdits,
-): EditSessionRecord => ({
+const toSessionRecord = (currentState: EditPanelState, edits: PendingEdits): EditSessionRecord => ({
   element: currentState.element,
   preview: currentState.preview,
   filePath: currentState.filePath ?? "",

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -81,6 +81,7 @@ import {
   DEFAULT_ACTION_ID,
   COMMENT_ACTION_ID,
   EDIT_ACTION_ID,
+  REACT_GRAB_ATTRIBUTE_NAME,
 } from "../constants.js";
 import { getBoundsCenter } from "../utils/get-bounds-center.js";
 import { hideFromThirdParties } from "../utils/hide-from-third-parties.js";
@@ -2895,7 +2896,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     eventListenerManager.addWindowListener(
       "focusin",
       (event: FocusEvent) => {
-        if (isEventFromOverlay(event, "data-react-grab")) {
+        if (isEventFromOverlay(event, REACT_GRAB_ATTRIBUTE_NAME)) {
           event.stopPropagation();
         }
       },

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -81,10 +81,10 @@ import {
   DEFAULT_ACTION_ID,
   COMMENT_ACTION_ID,
   EDIT_ACTION_ID,
-  REACT_GRAB_ATTRIBUTE_NAME,
 } from "../constants.js";
 import { getBoundsCenter } from "../utils/get-bounds-center.js";
 import { hideFromThirdParties } from "../utils/hide-from-third-parties.js";
+import { REACT_GRAB_ATTRIBUTE_NAME } from "../utils/react-grab-attribute-name.js";
 import { detectCspNonce } from "../utils/detect-csp-nonce.js";
 import { isCLikeKey } from "../utils/is-c-like-key.js";
 import { isTargetKeyCombination } from "../utils/is-target-key-combination.js";

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -81,10 +81,10 @@ import {
   DEFAULT_ACTION_ID,
   COMMENT_ACTION_ID,
   EDIT_ACTION_ID,
+  REACT_GRAB_ATTRIBUTE_NAME,
 } from "../constants.js";
 import { getBoundsCenter } from "../utils/get-bounds-center.js";
 import { hideFromThirdParties } from "../utils/hide-from-third-parties.js";
-import { REACT_GRAB_ATTRIBUTE_NAME } from "../utils/react-grab-attribute-name.js";
 import { detectCspNonce } from "../utils/detect-csp-nonce.js";
 import { isCLikeKey } from "../utils/is-c-like-key.js";
 import { isTargetKeyCombination } from "../utils/is-target-key-combination.js";

--- a/packages/react-grab/src/styles.css
+++ b/packages/react-grab/src/styles.css
@@ -4,10 +4,6 @@
   --font-sans: "Geist", ui-sans-serif, system-ui, sans-serif;
   --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
   --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
-  --ease-badge-pop: cubic-bezier(0.34, 1.36, 0.64, 1);
-  --ease-badge-close: cubic-bezier(0.4, 0, 0.2, 1);
-  --ease-text-swap: ease-out;
-  --animate-rg-badge-slide: rg-badge-slide 260ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 :host {
@@ -82,15 +78,6 @@
   --rg-shimmer-from: #71717a;
   --rg-shimmer-to: #a1a1aa;
   --rg-text-primary-85: rgba(23, 23, 23, 0.85);
-}
-
-@keyframes rg-badge-slide {
-  from {
-    transform: translate(-8.2px, 12.4px);
-  }
-  to {
-    transform: translate(0, 0);
-  }
 }
 
 /* Slot digit enter/exit. Direction-aware: incrementing rolls the
@@ -290,29 +277,6 @@
   background-clip: text;
   color: transparent;
   animation: shimmer 2.5s linear infinite;
-}
-
-@keyframes clock-flash {
-  0% {
-    transform: scale(1);
-  }
-  25% {
-    transform: scale(1.2);
-  }
-  50% {
-    transform: scale(0.92);
-  }
-  75% {
-    transform: scale(1.05);
-  }
-  100% {
-    transform: scale(1);
-  }
-}
-
-.animate-clock-flash {
-  animation: clock-flash 400ms ease-out;
-  will-change: transform;
 }
 
 .animate-shake,

--- a/packages/react-grab/src/utils/is-valid-grabbable-element.ts
+++ b/packages/react-grab/src/utils/is-valid-grabbable-element.ts
@@ -1,13 +1,13 @@
 import {
   DEV_TOOLS_OVERLAY_Z_INDEX_THRESHOLD,
   OVERLAY_Z_INDEX_THRESHOLD,
+  REACT_GRAB_ATTRIBUTE_NAME,
   USER_IGNORE_ATTRIBUTE,
   VIEWPORT_COVERAGE_THRESHOLD,
   VISIBILITY_CACHE_TTL_MS,
 } from "../constants.js";
 import { isElementVisible } from "./is-element-visible.js";
 import { isRootElement } from "./is-root-element.js";
-import { REACT_GRAB_ATTRIBUTE_NAME } from "./react-grab-attribute-name.js";
 
 const isReactGrabElement = (element: Element): boolean => {
   if (element.hasAttribute(REACT_GRAB_ATTRIBUTE_NAME)) return true;

--- a/packages/react-grab/src/utils/is-valid-grabbable-element.ts
+++ b/packages/react-grab/src/utils/is-valid-grabbable-element.ts
@@ -1,13 +1,13 @@
 import {
   DEV_TOOLS_OVERLAY_Z_INDEX_THRESHOLD,
   OVERLAY_Z_INDEX_THRESHOLD,
-  REACT_GRAB_ATTRIBUTE_NAME,
   USER_IGNORE_ATTRIBUTE,
   VIEWPORT_COVERAGE_THRESHOLD,
   VISIBILITY_CACHE_TTL_MS,
 } from "../constants.js";
 import { isElementVisible } from "./is-element-visible.js";
 import { isRootElement } from "./is-root-element.js";
+import { REACT_GRAB_ATTRIBUTE_NAME } from "./react-grab-attribute-name.js";
 
 const isReactGrabElement = (element: Element): boolean => {
   if (element.hasAttribute(REACT_GRAB_ATTRIBUTE_NAME)) return true;

--- a/packages/react-grab/src/utils/is-valid-grabbable-element.ts
+++ b/packages/react-grab/src/utils/is-valid-grabbable-element.ts
@@ -1,6 +1,7 @@
 import {
   DEV_TOOLS_OVERLAY_Z_INDEX_THRESHOLD,
   OVERLAY_Z_INDEX_THRESHOLD,
+  REACT_GRAB_ATTRIBUTE_NAME,
   USER_IGNORE_ATTRIBUTE,
   VIEWPORT_COVERAGE_THRESHOLD,
   VISIBILITY_CACHE_TTL_MS,
@@ -9,10 +10,10 @@ import { isElementVisible } from "./is-element-visible.js";
 import { isRootElement } from "./is-root-element.js";
 
 const isReactGrabElement = (element: Element): boolean => {
-  if (element.hasAttribute("data-react-grab")) return true;
+  if (element.hasAttribute(REACT_GRAB_ATTRIBUTE_NAME)) return true;
 
   const rootNode = element.getRootNode();
-  return rootNode instanceof ShadowRoot && rootNode.host.hasAttribute("data-react-grab");
+  return rootNode instanceof ShadowRoot && rootNode.host.hasAttribute(REACT_GRAB_ATTRIBUTE_NAME);
 };
 
 const isUserIgnoredElement = (element: Element): boolean =>

--- a/packages/react-grab/src/utils/mount-root.ts
+++ b/packages/react-grab/src/utils/mount-root.ts
@@ -1,8 +1,10 @@
-import { MOUNT_ROOT_RECHECK_DELAY_MS, Z_INDEX_OVERLAY } from "../constants.js";
+import {
+  MOUNT_ROOT_RECHECK_DELAY_MS,
+  REACT_GRAB_ATTRIBUTE_NAME,
+  Z_INDEX_OVERLAY,
+} from "../constants.js";
 import { detectCspNonce } from "./detect-csp-nonce.js";
 import { hideFromThirdParties } from "./hide-from-third-parties.js";
-
-const ATTRIBUTE_NAME = "data-react-grab";
 
 const FONT_IMPORT =
   '@import url("https://fonts.googleapis.com/css2?family=Geist:wght@500&display=swap");';
@@ -16,7 +18,7 @@ const attachHostToBody = (host: HTMLElement): void => {
   // If the app replaces or clones <body>, a shadowless clone of our host can
   // end up in the new body. Purge those so queries targeting the real host
   // (which owns the shadow DOM) aren't shadowed by the zombie.
-  const candidateHosts = document.querySelectorAll<HTMLElement>(`[${ATTRIBUTE_NAME}]`);
+  const candidateHosts = document.querySelectorAll<HTMLElement>(`[${REACT_GRAB_ATTRIBUTE_NAME}]`);
   for (const candidate of candidateHosts) {
     if (candidate === host) continue;
     if (candidate.parentNode === host) continue;
@@ -49,9 +51,9 @@ interface MountRootResult {
 }
 
 export const mountRoot = (cssText?: string): MountRootResult => {
-  const mountedHosts = document.querySelectorAll<HTMLElement>(`[${ATTRIBUTE_NAME}]`);
+  const mountedHosts = document.querySelectorAll<HTMLElement>(`[${REACT_GRAB_ATTRIBUTE_NAME}]`);
   for (const mountedHost of mountedHosts) {
-    const mountedRoot = mountedHost.shadowRoot?.querySelector(`[${ATTRIBUTE_NAME}]`);
+    const mountedRoot = mountedHost.shadowRoot?.querySelector(`[${REACT_GRAB_ATTRIBUTE_NAME}]`);
     if (mountedRoot instanceof HTMLDivElement) {
       return { root: mountedRoot, host: mountedHost };
     }
@@ -60,7 +62,7 @@ export const mountRoot = (cssText?: string): MountRootResult => {
 
   const host = document.createElement("div");
 
-  host.setAttribute(ATTRIBUTE_NAME, "true");
+  host.setAttribute(REACT_GRAB_ATTRIBUTE_NAME, "true");
   hideFromThirdParties(host);
   host.style.zIndex = String(Z_INDEX_OVERLAY);
   host.style.position = "fixed";
@@ -77,7 +79,7 @@ export const mountRoot = (cssText?: string): MountRootResult => {
 
   const root = document.createElement("div");
 
-  root.setAttribute(ATTRIBUTE_NAME, "true");
+  root.setAttribute(REACT_GRAB_ATTRIBUTE_NAME, "true");
 
   shadowRoot.appendChild(root);
 

--- a/packages/react-grab/src/utils/mount-root.ts
+++ b/packages/react-grab/src/utils/mount-root.ts
@@ -1,7 +1,10 @@
-import { MOUNT_ROOT_RECHECK_DELAY_MS, Z_INDEX_OVERLAY } from "../constants.js";
+import {
+  MOUNT_ROOT_RECHECK_DELAY_MS,
+  REACT_GRAB_ATTRIBUTE_NAME,
+  Z_INDEX_OVERLAY,
+} from "../constants.js";
 import { detectCspNonce } from "./detect-csp-nonce.js";
 import { hideFromThirdParties } from "./hide-from-third-parties.js";
-import { REACT_GRAB_ATTRIBUTE_NAME } from "./react-grab-attribute-name.js";
 
 const FONT_IMPORT =
   '@import url("https://fonts.googleapis.com/css2?family=Geist:wght@500&display=swap");';

--- a/packages/react-grab/src/utils/mount-root.ts
+++ b/packages/react-grab/src/utils/mount-root.ts
@@ -1,10 +1,7 @@
-import {
-  MOUNT_ROOT_RECHECK_DELAY_MS,
-  REACT_GRAB_ATTRIBUTE_NAME,
-  Z_INDEX_OVERLAY,
-} from "../constants.js";
+import { MOUNT_ROOT_RECHECK_DELAY_MS, Z_INDEX_OVERLAY } from "../constants.js";
 import { detectCspNonce } from "./detect-csp-nonce.js";
 import { hideFromThirdParties } from "./hide-from-third-parties.js";
+import { REACT_GRAB_ATTRIBUTE_NAME } from "./react-grab-attribute-name.js";
 
 const FONT_IMPORT =
   '@import url("https://fonts.googleapis.com/css2?family=Geist:wght@500&display=swap");';

--- a/packages/react-grab/src/utils/react-grab-attribute-name.ts
+++ b/packages/react-grab/src/utils/react-grab-attribute-name.ts
@@ -1,0 +1,1 @@
+export const REACT_GRAB_ATTRIBUTE_NAME = "data-react-grab";

--- a/packages/react-grab/tests/next-server-frames.test.ts
+++ b/packages/react-grab/tests/next-server-frames.test.ts
@@ -98,7 +98,9 @@ describe("symbolicateServerFrames", () => {
 
   it("returns the original frames when the endpoint responds with an error", async () => {
     globalThis.fetch = (() =>
-      Promise.resolve(new Response("error", { status: 500 }))) as FetchStub as typeof globalThis.fetch;
+      Promise.resolve(
+        new Response("error", { status: 500 }),
+      )) as FetchStub as typeof globalThis.fetch;
 
     const frames = [makeServerFrame()];
     expect(await symbolicateServerFrames(frames)).toEqual(frames);
@@ -108,7 +110,12 @@ describe("symbolicateServerFrames", () => {
 interface CapturedRequest {
   url: string;
   body: {
-    frames: Array<{ file: string; methodName: string; line1: number | null; column1: number | null }>;
+    frames: Array<{
+      file: string;
+      methodName: string;
+      line1: number | null;
+      column1: number | null;
+    }>;
     isServer: boolean;
     isEdgeServer: boolean;
     isAppDirectory: boolean;
@@ -140,12 +147,9 @@ const fulfilled = (file: string, line1: number, column1: number, ignored = false
 describe("symbolicateServerFrames — success path", () => {
   it("requests only the server frames, devirtualized, with the Next app-dir flags", async () => {
     let captured: CapturedRequest | undefined;
-    globalThis.fetch = respondWith(
-      [fulfilled("app/page.tsx", 12, 3)],
-      (request) => {
-        captured = request;
-      },
-    );
+    globalThis.fetch = respondWith([fulfilled("app/page.tsx", 12, 3)], (request) => {
+      captured = request;
+    });
 
     const frames = [makeClientFrame(), makeServerFrame()];
     await symbolicateServerFrames(frames);
@@ -167,10 +171,7 @@ describe("symbolicateServerFrames — success path", () => {
     const frames = [clientA, serverB, clientC, serverD];
 
     // Results are indexed by server-frame order: [serverB, serverD].
-    globalThis.fetch = respondWith([
-      fulfilled("app/b.tsx", 11, 1),
-      fulfilled("app/d.tsx", 33, 3),
-    ]);
+    globalThis.fetch = respondWith([fulfilled("app/b.tsx", 11, 1), fulfilled("app/d.tsx", 33, 3)]);
 
     const result = await symbolicateServerFrames(frames);
 
@@ -227,7 +228,10 @@ describe("symbolicateServerFrames — success path", () => {
     globalThis.fetch = respondWith([
       { status: "rejected", reason: "boom" },
       fulfilled("app/ignored.tsx", 1, 1, true),
-      { status: "fulfilled", value: { originalStackFrame: { file: null, line1: 1, column1: 1, ignored: false } } },
+      {
+        status: "fulfilled",
+        value: { originalStackFrame: { file: null, line1: 1, column1: 1, ignored: false } },
+      },
       fulfilled("app/ok.tsx", 9, 9),
     ]);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- removed confirmed-unused react-grab CSS theme tokens, keyframes, and animation class left over from prior badge/clock animation paths
- centralized the root `data-react-grab` overlay attribute through a tiny pure utility for tests and a production constants re-export for runtime imports
- cleaned duplicate e2e root-attribute constants and touched selector literals
- replaced the remaining double-bang CI check in the react-grab Playwright config
- applied repo formatter output after verification

## Validation
- `/thermos` bug/regression review: no findings
- `/thermos` code-quality review: addressed root-attribute boundary feedback
- `/simplify` code-quality/performance/reuse reviews: addressed production constants reuse and touched e2e selector dedupe; no performance findings
- `npx deslop-cli@latest analyze ...` for `packages/react-grab` with explicit runtime/test/e2e/script entries (no unused files/exports reported; remaining findings are style/refactor suggestions)
- `pnpm build`
- `pnpm typecheck`
- `npx -p node@22.18.0 -c 'pnpm lint'`
- `npx -p node@22.18.0 -c 'pnpm format'`
- `pnpm test`

## Notes
- Local agent Node is 22.14.0, but the current formatter/linter config loader requires Node >=22.18.0 for the TypeScript Vite config, so lint/format were run through `node@22.18.0` via `npx`.
- Playwright Chromium was installed in the agent environment before the passing test runs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73ba3cc2-6038-4cba-bf00-9b39acf0b4b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73ba3cc2-6038-4cba-bf00-9b39acf0b4b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up unused style hooks and centralized the overlay attribute constant in `react-grab` to reduce CSS and keep runtime/E2E selectors aligned. Also simplified attribute imports, tweaked the Playwright CI flag, and applied formatting.

- **Refactors**
  - Removed unused CSS variables, keyframes, and the `animate-clock-flash` class in `styles.css`.
  - Introduced `src/utils/react-grab-attribute-name.ts` exporting `REACT_GRAB_ATTRIBUTE_NAME`; re-exported via `src/constants.ts` and `e2e/constants.ts` (as `ATTRIBUTE_NAME`). Replaced hardcoded literals across `mount-root`, `is-valid-grabbable-element`, overlay event checks, and E2E specs.
  - Switched `!!process.env.CI` to `Boolean(process.env.CI)` in `playwright.config.ts`.
  - Applied formatter across tests/stories; no behavior changes.

<sup>Written for commit 55730af0b2b305c70f87ce8b0556129393f7070a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

