### PR TITLE
Allow keyboard pass-through from selection prompt

### DIFF
--- a/packages/react-grab/e2e/keyboard-navigation.spec.ts
+++ b/packages/react-grab/e2e/keyboard-navigation.spec.ts
@@ -49,6 +49,16 @@ const getSelectionDiscardPromptState = async (
   }, ATTRIBUTE_NAME);
 };
 
+const showKeyboardSelectionDiscardPrompt = async (reactGrab: ReactGrabPageObject) => {
+  await reactGrab.activate();
+  await reactGrab.hoverElement("[data-testid='todo-list'] li:first-child");
+  await reactGrab.waitForSelectionBox();
+  await reactGrab.page.keyboard.press("ArrowDown");
+  await reactGrab.waitForSelectionBox();
+  await reactGrab.page.mouse.move(0, 0);
+  await expect.poll(() => reactGrab.isPendingDismissVisible()).toBe(true);
+};
+
 test.describe("Keyboard Navigation", () => {
   test("should navigate to next element with ArrowDown", async ({ reactGrab }) => {
     await reactGrab.activate();
@@ -240,19 +250,23 @@ test.describe("Keyboard Navigation", () => {
     await expect.poll(() => reactGrab.isPendingDismissVisible()).toBe(false);
   });
 
-  test("should confirm discard selection with Enter", async ({ reactGrab }) => {
-    await reactGrab.activate();
-    await reactGrab.hoverElement("li:first-child");
-    await reactGrab.waitForSelectionBox();
-
-    await reactGrab.page.keyboard.press("ArrowDown");
-    await reactGrab.waitForSelectionBox();
-    await reactGrab.page.mouse.move(0, 0);
-    await expect.poll(() => reactGrab.isPendingDismissVisible()).toBe(true);
+  test("Enter should continue through the discard-selection prompt", async ({ reactGrab }) => {
+    await reactGrab.registerCommentAction();
+    await showKeyboardSelectionDiscardPrompt(reactGrab);
 
     await reactGrab.page.keyboard.press("Enter");
 
-    await expect.poll(() => reactGrab.isPendingDismissVisible()).toBe(false);
+    await expect.poll(() => reactGrab.isPromptModeActive()).toBe(true);
+    expect(await reactGrab.isPendingDismissVisible()).toBe(false);
+  });
+
+  test("S should continue through the discard-selection prompt", async ({ reactGrab }) => {
+    await showKeyboardSelectionDiscardPrompt(reactGrab);
+
+    await reactGrab.page.keyboard.press("s");
+
+    await expect.poll(() => isEditPanelVisible(reactGrab.page)).toBe(true);
+    expect(await reactGrab.isPendingDismissVisible()).toBe(false);
   });
 
   test("Enter on the focused Copy button copies without opening the Style panel", async ({
@@ -295,23 +309,16 @@ test.describe("Keyboard Navigation", () => {
     expect(await reactGrab.getClipboardContent()).toBe("");
   });
 
-  test("arrow keys are ignored while the discard-selection prompt is open", async ({
+  test("arrow keys continue navigation while the discard-selection prompt is open", async ({
     reactGrab,
   }) => {
-    await reactGrab.activate();
-    await reactGrab.hoverElement("[data-testid='todo-list'] li:first-child");
-    await reactGrab.waitForSelectionBox();
+    await showKeyboardSelectionDiscardPrompt(reactGrab);
 
     await reactGrab.page.keyboard.press("ArrowDown");
     await reactGrab.waitForSelectionBox();
-    await reactGrab.page.mouse.move(0, 0);
-    await expect.poll(() => reactGrab.isPendingDismissVisible()).toBe(true);
 
-    // Navigation is suppressed while the prompt is up: a navigating key would
-    // re-select and clear the prompt, so it must stay open.
-    await reactGrab.page.keyboard.press("ArrowDown");
-    await reactGrab.page.waitForTimeout(100);
-    expect(await reactGrab.isPendingDismissVisible()).toBe(true);
+    expect(await reactGrab.isPendingDismissVisible()).toBe(false);
+    expect(await reactGrab.isSelectionBoxVisible()).toBe(true);
   });
 });
 

--- a/packages/react-grab/e2e/keyboard-navigation.spec.ts
+++ b/packages/react-grab/e2e/keyboard-navigation.spec.ts
@@ -53,7 +53,7 @@ const showKeyboardSelectionDiscardPrompt = async (reactGrab: ReactGrabPageObject
   await reactGrab.activate();
   await reactGrab.hoverElement("[data-testid='todo-list'] li:first-child");
   await reactGrab.waitForSelectionBox();
-  await reactGrab.page.keyboard.press("ArrowDown");
+  await reactGrab.pressArrowDown();
   await reactGrab.waitForSelectionBox();
   await reactGrab.page.mouse.move(0, 0);
   await expect.poll(() => reactGrab.isPendingDismissVisible()).toBe(true);
@@ -254,7 +254,7 @@ test.describe("Keyboard Navigation", () => {
     await reactGrab.registerCommentAction();
     await showKeyboardSelectionDiscardPrompt(reactGrab);
 
-    await reactGrab.page.keyboard.press("Enter");
+    await reactGrab.pressEnter();
 
     await expect.poll(() => reactGrab.isPromptModeActive()).toBe(true);
     expect(await reactGrab.isPendingDismissVisible()).toBe(false);
@@ -263,7 +263,7 @@ test.describe("Keyboard Navigation", () => {
   test("S should continue through the discard-selection prompt", async ({ reactGrab }) => {
     await showKeyboardSelectionDiscardPrompt(reactGrab);
 
-    await reactGrab.page.keyboard.press("s");
+    await reactGrab.pressKey("s");
 
     await expect.poll(() => isEditPanelVisible(reactGrab.page)).toBe(true);
     expect(await reactGrab.isPendingDismissVisible()).toBe(false);
@@ -314,7 +314,7 @@ test.describe("Keyboard Navigation", () => {
   }) => {
     await showKeyboardSelectionDiscardPrompt(reactGrab);
 
-    await reactGrab.page.keyboard.press("ArrowDown");
+    await reactGrab.pressArrowDown();
     await reactGrab.waitForSelectionBox();
 
     expect(await reactGrab.isPendingDismissVisible()).toBe(false);

--- a/packages/react-grab/e2e/keyboard-navigation.spec.ts
+++ b/packages/react-grab/e2e/keyboard-navigation.spec.ts
@@ -262,6 +262,7 @@ test.describe("Keyboard Navigation", () => {
 
   test("S should continue through the discard-selection prompt", async ({ reactGrab }) => {
     await showKeyboardSelectionDiscardPrompt(reactGrab);
+    await reactGrab.page.locator("[data-react-grab-discard-copy]").focus();
 
     await reactGrab.pressKey("s");
 

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -2447,28 +2447,31 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       );
     };
 
+    const tryHandleKeyboardSelectionPromptPassThrough = (event: KeyboardEvent): boolean => {
+      if (!keyboardSelection.isPendingDismiss()) return false;
+      if (isKeyboardSelectionPromptButtonEnter(event)) return true;
+
+      const shouldHandleArrow = ARROW_KEYS.has(event.key);
+      const shouldHandleBareShortcut = getBareKeyShortcut(event) !== null;
+      if (!shouldHandleArrow && !shouldHandleBareShortcut) return false;
+
+      clearArrowNavigation();
+
+      if (shouldHandleArrow) {
+        tryHandleArrowNavigation(event);
+        return true;
+      }
+
+      tryHandleBareKeyShortcut(event);
+      return true;
+    };
+
     eventListenerManager.addWindowListener(
       "keydown",
       (event: KeyboardEvent) => {
-        const isKeyboardSelectionPendingDismiss = keyboardSelection.isPendingDismiss();
-        const shouldPassThroughKeyboardSelectionPrompt =
-          isKeyboardSelectionPendingDismiss &&
-          (ARROW_KEYS.has(event.key) || getBareKeyShortcut(event) !== null);
+        if (tryHandleKeyboardSelectionPromptPassThrough(event)) return;
 
-        if (
-          isKeyboardSelectionPendingDismiss &&
-          isKeyboardSelectionPromptButtonEnter(event)
-        ) {
-          return;
-        }
-
-        if (shouldPassThroughKeyboardSelectionPrompt) {
-          clearArrowNavigation();
-        }
-
-        if (!shouldPassThroughKeyboardSelectionPrompt) {
-          blockEnterIfNeeded(event);
-        }
+        blockEnterIfNeeded(event);
 
         if (!isEnabled()) {
           if (isTargetKeyCombination(event, pluginRegistry.store.options) && !event.repeat) {

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -2155,11 +2155,15 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       });
     };
 
-    const tryHandleArrowNavigation = (event: KeyboardEvent): boolean => {
+    const tryHandleArrowNavigation = (
+      event: KeyboardEvent,
+      options: { allowPendingKeyboardSelection?: boolean } = {},
+    ): boolean => {
       if (!isActivated()) return false;
       if (isPromptMode()) return false;
       if (isShiftMultiSelecting()) return false;
-      if (keyboardSelection.isPendingDismiss()) return false;
+      if (keyboardSelection.isPendingDismiss() && !options.allowPendingKeyboardSelection)
+        return false;
       if (!ARROW_KEYS.has(event.key)) return false;
       if (isAnyPopoverOpen()) return false;
 
@@ -2175,9 +2179,9 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       const isVertical = event.key === "ArrowUp" || event.key === "ArrowDown";
 
       if (!isVertical) {
-        clearArrowNavigation();
         const nextElement = arrowNavigator.findNext(event.key, currentElement);
         if (!nextElement && !isInitialSelection) return false;
+        clearArrowNavigation();
         event.preventDefault();
         event.stopPropagation();
         selectAndFocusElement(nextElement ?? currentElement, true);
@@ -2455,14 +2459,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       const shouldHandleBareShortcut = getBareKeyShortcut(event) !== null;
       if (!shouldHandleArrow && !shouldHandleBareShortcut) return false;
 
-      clearArrowNavigation();
-
       if (shouldHandleArrow) {
-        tryHandleArrowNavigation(event);
-        return true;
+        return tryHandleArrowNavigation(event, { allowPendingKeyboardSelection: true });
       }
 
-      tryHandleBareKeyShortcut(event);
+      if (!tryHandleBareKeyShortcut(event)) return false;
+      clearArrowNavigation();
       return true;
     };
 

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -2139,13 +2139,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       clearArrowNavigation();
     };
 
-    const clearKeyboardSelectionHandoffPrompt = () => {
-      keyboardSelection.clear();
-      setArrowNavigationElements([]);
-      setArrowNavigationActiveIndex(0);
-      arrowNavigator.clearHistory();
-    };
-
     const copyArrowNavigationSelection = () => {
       const selectedElement = keyboardSelection.takeSelection(store.frozenElement);
       if (!selectedElement) {
@@ -2223,6 +2216,16 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       return store.frozenElement || targetElement();
     };
 
+    const getBareKeyShortcut = (event: KeyboardEvent) => {
+      const element = canDispatchBareKey(event);
+      if (!element) return null;
+
+      const action = findShortcutAction(pluginRegistry.store.actions, event);
+      if (!action) return null;
+
+      return { element, action };
+    };
+
     const buildImmediateActionContext = (
       element: Element,
       position: Position,
@@ -2263,11 +2266,9 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
 
     const tryHandleBareKeyShortcut = (event: KeyboardEvent): boolean => {
-      const element = canDispatchBareKey(event);
-      if (!element) return false;
-
-      const action = findShortcutAction(pluginRegistry.store.actions, event);
-      if (!action) return false;
+      const shortcut = getBareKeyShortcut(event);
+      if (!shortcut) return false;
+      const { element, action } = shortcut;
 
       if (isPromptMode()) {
         if (!runActionForCurrentSelection(action.id)) return false;
@@ -2436,29 +2437,33 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       }
     };
 
-    const isKeyboardSelectionPassThroughShortcut = (event: KeyboardEvent): boolean => {
-      if (event.metaKey || event.ctrlKey || event.altKey) return false;
-      if (event.repeat) return false;
-      if (isKeyboardEventTriggeredByInput(event)) return false;
-      return Boolean(findShortcutAction(pluginRegistry.store.actions, event));
+    const isKeyboardSelectionPromptButtonEnter = (event: KeyboardEvent): boolean => {
+      if (!isEnterCode(event.code)) return false;
+      const target = event.composedPath()[0];
+      const targetElement = target instanceof HTMLElement ? target : null;
+      return Boolean(
+        targetElement?.closest("[data-react-grab-discard-copy]") ||
+          targetElement?.closest("[data-react-grab-discard-yes]"),
+      );
     };
 
     eventListenerManager.addWindowListener(
       "keydown",
       (event: KeyboardEvent) => {
+        const isKeyboardSelectionPendingDismiss = keyboardSelection.isPendingDismiss();
         const shouldPassThroughKeyboardSelectionPrompt =
-          keyboardSelection.isPendingDismiss() &&
-          (ARROW_KEYS.has(event.key) || isKeyboardSelectionPassThroughShortcut(event));
+          isKeyboardSelectionPendingDismiss &&
+          (ARROW_KEYS.has(event.key) || getBareKeyShortcut(event) !== null);
 
-        if (keyboardSelection.isPendingDismiss() && isEnterCode(event.code)) {
-          const target = event.composedPath()[0];
-          const targetElement = target instanceof HTMLElement ? target : null;
-          if (targetElement?.closest("[data-react-grab-discard-copy]")) return;
-          if (targetElement?.closest("[data-react-grab-discard-yes]")) return;
+        if (
+          isKeyboardSelectionPendingDismiss &&
+          isKeyboardSelectionPromptButtonEnter(event)
+        ) {
+          return;
         }
 
         if (shouldPassThroughKeyboardSelectionPrompt) {
-          clearKeyboardSelectionHandoffPrompt();
+          clearArrowNavigation();
         }
 
         if (!shouldPassThroughKeyboardSelectionPrompt) {

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -2139,6 +2139,13 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       clearArrowNavigation();
     };
 
+    const clearKeyboardSelectionHandoffPrompt = () => {
+      keyboardSelection.clear();
+      setArrowNavigationElements([]);
+      setArrowNavigationActiveIndex(0);
+      arrowNavigator.clearHistory();
+    };
+
     const copyArrowNavigationSelection = () => {
       const selectedElement = keyboardSelection.takeSelection(store.frozenElement);
       if (!selectedElement) {
@@ -2429,21 +2436,34 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       }
     };
 
+    const isKeyboardSelectionPassThroughShortcut = (event: KeyboardEvent): boolean => {
+      if (event.metaKey || event.ctrlKey || event.altKey) return false;
+      if (event.repeat) return false;
+      if (isKeyboardEventTriggeredByInput(event)) return false;
+      return Boolean(findShortcutAction(pluginRegistry.store.actions, event));
+    };
+
     eventListenerManager.addWindowListener(
       "keydown",
       (event: KeyboardEvent) => {
+        const shouldPassThroughKeyboardSelectionPrompt =
+          keyboardSelection.isPendingDismiss() &&
+          (ARROW_KEYS.has(event.key) || isKeyboardSelectionPassThroughShortcut(event));
+
         if (keyboardSelection.isPendingDismiss() && isEnterCode(event.code)) {
           const target = event.composedPath()[0];
           const targetElement = target instanceof HTMLElement ? target : null;
           if (targetElement?.closest("[data-react-grab-discard-copy]")) return;
           if (targetElement?.closest("[data-react-grab-discard-yes]")) return;
-          event.preventDefault();
-          event.stopImmediatePropagation();
-          handleConfirmDismiss();
-          return;
         }
 
-        blockEnterIfNeeded(event);
+        if (shouldPassThroughKeyboardSelectionPrompt) {
+          clearKeyboardSelectionHandoffPrompt();
+        }
+
+        if (!shouldPassThroughKeyboardSelectionPrompt) {
+          blockEnterIfNeeded(event);
+        }
 
         if (!isEnabled()) {
           if (isTargetKeyCombination(event, pluginRegistry.store.options) && !event.repeat) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Let arrow keys continue navigation from the keyboard-selection discard prompt instead of getting stuck
- Let bare action shortcuts such as `s` and Enter pass through from that prompt
- Simplify the key handling by reusing the existing arrow-navigation clearing and bare-key shortcut resolution paths
- Preserve focused prompt button Enter behavior for Copy/Yes

## Tests
- `pnpm --filter react-grab exec playwright test e2e/keyboard-navigation.spec.ts --reporter=list`
- `pnpm --filter react-grab run typecheck`
- `pnpm --filter react-grab run test:unit`

## Notes
- To create a real PR after the earlier direct push to `main`, I reverted the prompt commits on `main` with a normal revert commit and reapplied them on this `cursor/` branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9bac055-6d3f-44f7-b6a7-c6fd78680b36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9bac055-6d3f-44f7-b6a7-c6fd78680b36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow keyboard pass-through from the discard-selection prompt in `react-grab`. Arrow keys continue navigation and dismiss the prompt only after a successful move; bare shortcuts (e.g., s, Enter) run their actions, and Enter on Copy/Yes still works.

- **Refactors**
  - Handle pass-through first in keydown via `tryHandleKeyboardSelectionPromptPassThrough`; extracted `getBareKeyShortcut` and `isKeyboardSelectionPromptButtonEnter`; added `allowPendingKeyboardSelection` to `tryHandleArrowNavigation` and only clear navigation/dismiss the prompt after a valid move.
  - Expanded e2e tests for Enter and s pass-through and for arrow navigation clearing the prompt; added `showKeyboardSelectionDiscardPrompt`.

<sup>Written for commit c48689783bc6b55245430df47602cb3606b902f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

