### PR TITLE
fix: treat undeclared transparent pages as light theme

### DIFF
--- a/.changeset/theme-detect-transparent-page.md
+++ b/.changeset/theme-detect-transparent-page.md
@@ -2,4 +2,4 @@
 "react-grab": patch
 ---
 
-Fix theme detection mis-classifying an undeclared light page as dark for visitors on a dark OS. A page with no theme marker, no painted background, and the default `color-scheme: normal` renders a white canvas regardless of the OS preference, so detection now treats it as light instead of falling through to `prefers-color-scheme`. The OS preference is only consulted when the page opts into an OS-following `color-scheme` (e.g. `light dark`).
+Fix theme detection mis-classifying an undeclared light page as dark for visitors on a dark OS. When a page has no theme marker, no `color-scheme`, and no painted background, detection now derives the real backdrop from the CSS `Canvas` system color instead of guessing from `prefers-color-scheme`. `Canvas` honors the root element's used `color-scheme`, so it stays light under the default `normal` (regardless of the OS) and only tracks the OS preference when the page opts into a dark-capable scheme such as `light dark` - matching exactly what the browser paints behind the page.

--- a/.changeset/theme-detect-transparent-page.md
+++ b/.changeset/theme-detect-transparent-page.md
@@ -1,0 +1,5 @@
+---
+"react-grab": patch
+---
+
+Fix theme detection mis-classifying an undeclared light page as dark for visitors on a dark OS. A page with no theme marker, no painted background, and the default `color-scheme: normal` renders a white canvas regardless of the OS preference, so detection now treats it as light instead of falling through to `prefers-color-scheme`. The OS preference is only consulted when the page opts into an OS-following `color-scheme` (e.g. `light dark`).

--- a/packages/react-grab/e2e/app-theme-detection.spec.ts
+++ b/packages/react-grab/e2e/app-theme-detection.spec.ts
@@ -110,6 +110,28 @@ test.describe("App Theme Detection", () => {
     );
   });
 
+  // A page with no theme marker, no painted background, and the default
+  // `color-scheme: normal` renders a white UA canvas regardless of the OS
+  // preference - the browser only paints a dark canvas when the page opts into a
+  // scheme that lists `dark`. Such a page must be treated as light, not
+  // misclassified by `prefers-color-scheme`.
+  test("treats an undeclared transparent page as light under a dark OS preference", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.page.emulateMedia({ colorScheme: "dark" });
+    await reactGrab.page.evaluate(() => {
+      document.documentElement.classList.remove("dark", "light");
+      document.documentElement.style.colorScheme = "";
+      document.body.style.colorScheme = "";
+      document.documentElement.style.backgroundColor = "";
+      document.body.style.backgroundColor = "";
+    });
+
+    expect(await waitForOverlayTheme(reactGrab, OVERLAY_THEME_ON_LIGHT_APP)).toBe(
+      OVERLAY_THEME_ON_LIGHT_APP,
+    );
+  });
+
   // Some apps (and a few Bootstrap/MUI setups) mark the theme on <body> rather
   // than <html>; the previous detector only inspected the document element.
   test("honors a theme marker set on the body element", async ({ reactGrab }) => {

--- a/packages/react-grab/e2e/app-theme-detection.spec.ts
+++ b/packages/react-grab/e2e/app-theme-detection.spec.ts
@@ -345,6 +345,32 @@ const FRAMEWORK_SCENARIOS: ThemeScenario[] = [
     },
     expected: OVERLAY_THEME_ON_LIGHT_APP,
   },
+  {
+    title: "translucent light root text is ignored (it composites toward the backdrop)",
+    os: "light",
+    mutate: () => {
+      document.documentElement.style.color = "rgba(229, 229, 229, 0.3)";
+    },
+    expected: OVERLAY_THEME_ON_LIGHT_APP,
+  },
+  {
+    title: "mid-gray root text is not over-classified as a dark theme",
+    os: "light",
+    mutate: () => {
+      document.documentElement.style.color = "rgb(150, 150, 150)";
+    },
+    expected: OVERLAY_THEME_ON_LIGHT_APP,
+  },
+  {
+    title: "a global `!important` background rule cannot corrupt the Canvas probe",
+    os: "light",
+    mutate: () => {
+      const styleElement = document.createElement("style");
+      styleElement.textContent = "div { background-color: rgb(0, 0, 0) !important }";
+      document.head.appendChild(styleElement);
+    },
+    expected: OVERLAY_THEME_ON_LIGHT_APP,
+  },
 ];
 
 test.describe("App Theme Detection - framework conventions", () => {

--- a/packages/react-grab/e2e/app-theme-detection.spec.ts
+++ b/packages/react-grab/e2e/app-theme-detection.spec.ts
@@ -132,6 +132,26 @@ test.describe("App Theme Detection", () => {
     );
   });
 
+  // Only the root element's `color-scheme` governs the UA canvas backdrop, so a
+  // dual scheme declared on <body> (with <html> left `normal`) does NOT make the
+  // canvas follow the OS - it stays light. The OS preference must be ignored here.
+  test("ignores a dual color-scheme on body when the root element stays normal", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.page.emulateMedia({ colorScheme: "dark" });
+    await reactGrab.page.evaluate(() => {
+      document.documentElement.classList.remove("dark", "light");
+      document.documentElement.style.colorScheme = "";
+      document.documentElement.style.backgroundColor = "";
+      document.body.style.backgroundColor = "";
+      document.body.style.colorScheme = "light dark";
+    });
+
+    expect(await waitForOverlayTheme(reactGrab, OVERLAY_THEME_ON_LIGHT_APP)).toBe(
+      OVERLAY_THEME_ON_LIGHT_APP,
+    );
+  });
+
   // Some apps (and a few Bootstrap/MUI setups) mark the theme on <body> rather
   // than <html>; the previous detector only inspected the document element.
   test("honors a theme marker set on the body element", async ({ reactGrab }) => {

--- a/packages/react-grab/e2e/app-theme-detection.spec.ts
+++ b/packages/react-grab/e2e/app-theme-detection.spec.ts
@@ -194,43 +194,43 @@ const FRAMEWORK_SCENARIOS: ThemeScenario[] = [
     expected: OVERLAY_THEME_ON_LIGHT_APP,
   },
   {
-    title: "next-themes `data-theme=\"dark\"` attribute",
+    title: 'next-themes `data-theme="dark"` attribute',
     os: "light",
     mutate: () => document.documentElement.setAttribute("data-theme", "dark"),
     expected: OVERLAY_THEME_ON_DARK_APP,
   },
   {
-    title: "case-insensitive `data-theme=\"DARK\"`",
+    title: 'case-insensitive `data-theme="DARK"`',
     os: "light",
     mutate: () => document.documentElement.setAttribute("data-theme", "DARK"),
     expected: OVERLAY_THEME_ON_DARK_APP,
   },
   {
-    title: "MUI `data-mui-color-scheme=\"dark\"`",
+    title: 'MUI `data-mui-color-scheme="dark"`',
     os: "light",
     mutate: () => document.documentElement.setAttribute("data-mui-color-scheme", "dark"),
     expected: OVERLAY_THEME_ON_DARK_APP,
   },
   {
-    title: "Bootstrap `data-bs-theme=\"dark\"`",
+    title: 'Bootstrap `data-bs-theme="dark"`',
     os: "light",
     mutate: () => document.documentElement.setAttribute("data-bs-theme", "dark"),
     expected: OVERLAY_THEME_ON_DARK_APP,
   },
   {
-    title: "Mantine `data-mantine-color-scheme=\"dark\"`",
+    title: 'Mantine `data-mantine-color-scheme="dark"`',
     os: "light",
     mutate: () => document.documentElement.setAttribute("data-mantine-color-scheme", "dark"),
     expected: OVERLAY_THEME_ON_DARK_APP,
   },
   {
-    title: "generic `data-mode=\"dark\"`",
+    title: 'generic `data-mode="dark"`',
     os: "light",
     mutate: () => document.documentElement.setAttribute("data-mode", "dark"),
     expected: OVERLAY_THEME_ON_DARK_APP,
   },
   {
-    title: "generic `data-color-scheme=\"dark\"`",
+    title: 'generic `data-color-scheme="dark"`',
     os: "light",
     mutate: () => document.documentElement.setAttribute("data-color-scheme", "dark"),
     expected: OVERLAY_THEME_ON_DARK_APP,
@@ -318,6 +318,30 @@ const FRAMEWORK_SCENARIOS: ThemeScenario[] = [
     os: "dark",
     mutate: () => {
       document.body.style.backgroundColor = "rgba(0, 0, 0, 0)";
+    },
+    expected: OVERLAY_THEME_ON_LIGHT_APP,
+  },
+  {
+    title: "wrapper-themed dark app: near-white root text on a transparent page resolves to dark",
+    os: "light",
+    mutate: () => {
+      document.documentElement.style.color = "rgb(229, 229, 229)";
+    },
+    expected: OVERLAY_THEME_ON_DARK_APP,
+  },
+  {
+    title: "dark root text on a transparent page stays light (defers to the Canvas backdrop)",
+    os: "dark",
+    mutate: () => {
+      document.documentElement.style.color = "rgb(17, 17, 17)";
+    },
+    expected: OVERLAY_THEME_ON_LIGHT_APP,
+  },
+  {
+    title: "light text on <body> only (root untouched) is ignored - root governs the page theme",
+    os: "dark",
+    mutate: () => {
+      document.body.style.color = "rgb(229, 229, 229)";
     },
     expected: OVERLAY_THEME_ON_LIGHT_APP,
   },

--- a/packages/react-grab/e2e/app-theme-detection.spec.ts
+++ b/packages/react-grab/e2e/app-theme-detection.spec.ts
@@ -166,3 +166,206 @@ test.describe("App Theme Detection", () => {
     );
   });
 });
+
+interface ThemeScenario {
+  title: string;
+  // The OS preference the scenario runs under, to prove explicit signals win
+  // (or correctly defer to) `prefers-color-scheme`.
+  os: "dark" | "light";
+  // Runs in the browser to set up the framework's theme signal on a fresh page.
+  mutate: () => void;
+  expected: string;
+}
+
+// Each entry pins how one real-world framework convention (or CSS authoring
+// style) must resolve. The OS is deliberately set to the *opposite* of the
+// expected app theme wherever an explicit signal should override it.
+const FRAMEWORK_SCENARIOS: ThemeScenario[] = [
+  {
+    title: "Tailwind/next-themes `.dark` class on <html>",
+    os: "light",
+    mutate: () => document.documentElement.classList.add("dark"),
+    expected: OVERLAY_THEME_ON_DARK_APP,
+  },
+  {
+    title: "Tailwind `.light` class on <html> overrides a dark OS",
+    os: "dark",
+    mutate: () => document.documentElement.classList.add("light"),
+    expected: OVERLAY_THEME_ON_LIGHT_APP,
+  },
+  {
+    title: "next-themes `data-theme=\"dark\"` attribute",
+    os: "light",
+    mutate: () => document.documentElement.setAttribute("data-theme", "dark"),
+    expected: OVERLAY_THEME_ON_DARK_APP,
+  },
+  {
+    title: "case-insensitive `data-theme=\"DARK\"`",
+    os: "light",
+    mutate: () => document.documentElement.setAttribute("data-theme", "DARK"),
+    expected: OVERLAY_THEME_ON_DARK_APP,
+  },
+  {
+    title: "MUI `data-mui-color-scheme=\"dark\"`",
+    os: "light",
+    mutate: () => document.documentElement.setAttribute("data-mui-color-scheme", "dark"),
+    expected: OVERLAY_THEME_ON_DARK_APP,
+  },
+  {
+    title: "Bootstrap `data-bs-theme=\"dark\"`",
+    os: "light",
+    mutate: () => document.documentElement.setAttribute("data-bs-theme", "dark"),
+    expected: OVERLAY_THEME_ON_DARK_APP,
+  },
+  {
+    title: "Mantine `data-mantine-color-scheme=\"dark\"`",
+    os: "light",
+    mutate: () => document.documentElement.setAttribute("data-mantine-color-scheme", "dark"),
+    expected: OVERLAY_THEME_ON_DARK_APP,
+  },
+  {
+    title: "generic `data-mode=\"dark\"`",
+    os: "light",
+    mutate: () => document.documentElement.setAttribute("data-mode", "dark"),
+    expected: OVERLAY_THEME_ON_DARK_APP,
+  },
+  {
+    title: "generic `data-color-scheme=\"dark\"`",
+    os: "light",
+    mutate: () => document.documentElement.setAttribute("data-color-scheme", "dark"),
+    expected: OVERLAY_THEME_ON_DARK_APP,
+  },
+  {
+    title: "MUI presence attribute `data-dark`",
+    os: "light",
+    mutate: () => document.documentElement.setAttribute("data-dark", ""),
+    expected: OVERLAY_THEME_ON_DARK_APP,
+  },
+  {
+    title: "MUI presence attribute `data-light` overrides a dark OS",
+    os: "dark",
+    mutate: () => document.documentElement.setAttribute("data-light", ""),
+    expected: OVERLAY_THEME_ON_LIGHT_APP,
+  },
+  {
+    title: "single-value `color-scheme: light` overrides a dark OS",
+    os: "dark",
+    mutate: () => {
+      document.documentElement.style.colorScheme = "light";
+    },
+    expected: OVERLAY_THEME_ON_LIGHT_APP,
+  },
+  {
+    title: "`color-scheme: only dark` forces dark under a light OS",
+    os: "light",
+    mutate: () => {
+      document.documentElement.style.colorScheme = "only dark";
+    },
+    expected: OVERLAY_THEME_ON_DARK_APP,
+  },
+  {
+    title: "shadcn CSS-variable-driven dark background on <body>",
+    os: "light",
+    mutate: () => {
+      document.documentElement.style.setProperty("--background", "oklch(0.145 0 0)");
+      document.body.style.backgroundColor = "var(--background)";
+    },
+    expected: OVERLAY_THEME_ON_DARK_APP,
+  },
+  {
+    title: "CSS-module-style dark background painted on <body> (hsl)",
+    os: "light",
+    mutate: () => {
+      document.body.style.backgroundColor = "hsl(0 0% 7%)";
+    },
+    expected: OVERLAY_THEME_ON_DARK_APP,
+  },
+  {
+    title: "white background painted on <body> overrides a dark OS",
+    os: "dark",
+    mutate: () => {
+      document.body.style.backgroundColor = "rgb(255, 255, 255)";
+    },
+    expected: OVERLAY_THEME_ON_LIGHT_APP,
+  },
+  {
+    title: "dark background on <html> when <body> is transparent",
+    os: "light",
+    mutate: () => {
+      document.documentElement.style.backgroundColor = "#111111";
+    },
+    expected: OVERLAY_THEME_ON_DARK_APP,
+  },
+  {
+    title: "root `color-scheme: light dark` defers to a dark OS via the Canvas backdrop",
+    os: "dark",
+    mutate: () => {
+      document.documentElement.style.colorScheme = "light dark";
+    },
+    expected: OVERLAY_THEME_ON_DARK_APP,
+  },
+  {
+    title: "an explicit marker wins over a conflicting painted background",
+    os: "light",
+    mutate: () => {
+      document.documentElement.classList.add("dark");
+      document.body.style.backgroundColor = "rgb(255, 255, 255)";
+    },
+    expected: OVERLAY_THEME_ON_DARK_APP,
+  },
+  {
+    title: "a fully transparent background is ignored (falls through to light Canvas)",
+    os: "dark",
+    mutate: () => {
+      document.body.style.backgroundColor = "rgba(0, 0, 0, 0)";
+    },
+    expected: OVERLAY_THEME_ON_LIGHT_APP,
+  },
+];
+
+test.describe("App Theme Detection - framework conventions", () => {
+  for (const scenario of FRAMEWORK_SCENARIOS) {
+    test(scenario.title, async ({ reactGrab }) => {
+      await reactGrab.page.emulateMedia({ colorScheme: scenario.os });
+      await reactGrab.page.evaluate(scenario.mutate);
+
+      expect(await waitForOverlayTheme(reactGrab, scenario.expected)).toBe(scenario.expected);
+    });
+  }
+
+  // The MutationObserver must re-derive the theme when a framework toggles the
+  // marker at runtime (next-themes/Tailwind theme switchers).
+  test("reacts to a runtime class toggle from dark to light", async ({ reactGrab }) => {
+    await reactGrab.page.emulateMedia({ colorScheme: "light" });
+    await reactGrab.page.evaluate(() => document.documentElement.classList.add("dark"));
+    expect(await waitForOverlayTheme(reactGrab, OVERLAY_THEME_ON_DARK_APP)).toBe(
+      OVERLAY_THEME_ON_DARK_APP,
+    );
+
+    await reactGrab.page.evaluate(() => {
+      document.documentElement.classList.remove("dark");
+      document.documentElement.classList.add("light");
+    });
+    expect(await waitForOverlayTheme(reactGrab, OVERLAY_THEME_ON_LIGHT_APP)).toBe(
+      OVERLAY_THEME_ON_LIGHT_APP,
+    );
+  });
+
+  // When the page advertises both schemes, flipping the OS preference must
+  // re-derive the Canvas backdrop and update the overlay live.
+  test("reacts to an OS preference flip when color-scheme allows both", async ({ reactGrab }) => {
+    await reactGrab.page.evaluate(() => {
+      document.documentElement.style.colorScheme = "light dark";
+    });
+
+    await reactGrab.page.emulateMedia({ colorScheme: "dark" });
+    expect(await waitForOverlayTheme(reactGrab, OVERLAY_THEME_ON_DARK_APP)).toBe(
+      OVERLAY_THEME_ON_DARK_APP,
+    );
+
+    await reactGrab.page.emulateMedia({ colorScheme: "light" });
+    expect(await waitForOverlayTheme(reactGrab, OVERLAY_THEME_ON_LIGHT_APP)).toBe(
+      OVERLAY_THEME_ON_LIGHT_APP,
+    );
+  });
+});

--- a/packages/react-grab/src/components/edit-panel/property-list.tsx
+++ b/packages/react-grab/src/components/edit-panel/property-list.tsx
@@ -6,7 +6,7 @@ import { formatDisplayValue } from "../../utils/format-css-value.js";
 import { ActivePropertyControl } from "./active-property-control.js";
 import { narrowColor, narrowEnum, narrowNumeric } from "./narrow-property.js";
 
-const enumDisplayValue = (property: EditableProperty): string => {
+const getEnumDisplayValue = (property: EditableProperty): string => {
   const enumProperty = narrowEnum(property);
   if (!enumProperty) return "";
   return (
@@ -215,7 +215,7 @@ export const PropertyList: Component<PropertyListProps> = (props) => {
                       <Match when={narrowEnum(property())}>
                         {(enumProp) => (
                           <span class="text-[11px] font-sans text-[var(--rg-text-secondary)] shrink-0">
-                            {enumDisplayValue(enumProp())}
+                            {getEnumDisplayValue(enumProp())}
                           </span>
                         )}
                       </Match>

--- a/packages/react-grab/src/components/edit-panel/step-controller.ts
+++ b/packages/react-grab/src/components/edit-panel/step-controller.ts
@@ -7,7 +7,7 @@ import {
 type ArrowKey = "ArrowLeft" | "ArrowRight";
 type Direction = 1 | -1;
 
-const directionFor = (key: ArrowKey): Direction => (key === "ArrowLeft" ? -1 : 1);
+const getDirectionForKey = (key: ArrowKey): Direction => (key === "ArrowLeft" ? -1 : 1);
 
 interface StepControllerOptions {
   step: (direction: Direction, shift: boolean, isRepeat: boolean) => void;
@@ -43,7 +43,7 @@ export const createStepController = (options: StepControllerOptions): StepContro
   const startRepeat = (key: ArrowKey) => {
     clearRepeatTimers();
     pressedArrowKey = key;
-    const direction = directionFor(key);
+    const direction = getDirectionForKey(key);
     repeatInitialDelayId = setTimeout(() => {
       repeatIntervalId = setInterval(() => {
         options.step(direction, options.isShiftHeld(), true);
@@ -53,7 +53,7 @@ export const createStepController = (options: StepControllerOptions): StepContro
 
   const pressArrow = (key: ArrowKey, isRepeat: boolean, shiftKey: boolean): void => {
     if (isRepeat) return;
-    const direction = directionFor(key);
+    const direction = getDirectionForKey(key);
     startRepeat(key);
     setHeldDirection(direction);
     options.step(direction, shiftKey, false);

--- a/packages/react-grab/src/components/edit-panel/tailwind-autoapply.ts
+++ b/packages/react-grab/src/components/edit-panel/tailwind-autoapply.ts
@@ -15,8 +15,8 @@ import { splitNegativePrefix } from "../../utils/split-negative-prefix.js";
 import {
   normalizeTailwindClassInput,
   tailwindClassToEnumValue,
-  tailwindColorPropertyForClassName,
-  tailwindNamedColorHex,
+  getTailwindColorPropertyForClassName,
+  getTailwindNamedColorHex,
   tailwindPrefixToProperty,
 } from "../../utils/tailwind-class-map.js";
 
@@ -78,7 +78,7 @@ const cleanArbitraryValue = (rawValue: string): string => {
   return /(?:var|url)\(/i.test(value) ? value : value.replace(/_/g, " ");
 };
 
-const arbitraryPrefix = (rawPrefix: string): string => {
+const getArbitraryPrefix = (rawPrefix: string): string => {
   const lastVariantColon = rawPrefix.lastIndexOf(":");
   const withoutVariant = lastVariantColon >= 0 ? rawPrefix.slice(lastVariantColon + 1) : rawPrefix;
   const withoutImportant = withoutVariant.startsWith("!")
@@ -113,7 +113,7 @@ const findNumericLonghands = (
   return Array.from(matchedByRowKey.values());
 };
 
-const clampedFor = (property: NumericEditableProperty, candidate: number): number =>
+const getClampedValue = (property: NumericEditableProperty, candidate: number): number =>
   roundEditableNumericValue(clampToRange(candidate, property.min, property.max));
 
 interface TailwindAutoApplyOptions {
@@ -196,7 +196,7 @@ export const createTailwindAutoApply = (
     if (parsed.unit !== "" && parsed.unit !== propertyUnit) {
       return isUnitDraftForProperty(parsed.unit, property.unit);
     }
-    const nextValue = clampedFor(property, parsed.value);
+    const nextValue = getClampedValue(property, parsed.value);
     if (nextValue !== property.value) commit(property, nextValue);
     return true;
   };
@@ -207,7 +207,7 @@ export const createTailwindAutoApply = (
       // px lengths only apply to px-measured props, not opacity/z-index.
       if (numericTarget.unit !== "px") return false;
       setIsCompact(true);
-      commit(numericTarget, clampedFor(numericTarget, value), { shouldCompact: true });
+      commit(numericTarget, getClampedValue(numericTarget, value), { shouldCompact: true });
       return true;
     }
     const sideProperties = findNumericLonghands(initialProperties, propertyKey);
@@ -215,7 +215,7 @@ export const createTailwindAutoApply = (
     setIsCompact(true);
     batch(() => {
       for (const sideProperty of sideProperties) {
-        commit(sideProperty, clampedFor(sideProperty, value), { shouldCompact: true });
+        commit(sideProperty, getClampedValue(sideProperty, value), { shouldCompact: true });
       }
     });
     return true;
@@ -226,12 +226,12 @@ export const createTailwindAutoApply = (
   // (`bg-red-500`, resolved here). A null arbitraryValue means "resolve
   // the named token".
   const applyColorClass = (rawClass: string, arbitraryValue: string | null): boolean => {
-    const colorCssKey = tailwindColorPropertyForClassName(rawClass);
+    const colorCssKey = getTailwindColorPropertyForClassName(rawClass);
     if (!colorCssKey) return false;
     const colorTarget = findColor(initialProperties, colorCssKey);
     if (!colorTarget) return false;
     const colorHex =
-      arbitraryValue === null ? tailwindNamedColorHex(rawClass) : parseAnyColor(arbitraryValue);
+      arbitraryValue === null ? getTailwindNamedColorHex(rawClass) : parseAnyColor(arbitraryValue);
     if (!colorHex) return false;
     setIsCompact(true);
     commit(colorTarget, colorHex, { shouldCompact: true });
@@ -249,7 +249,7 @@ export const createTailwindAutoApply = (
     const lengthPx = parseArbitraryLengthPx(value, ARBITRARY_LENGTH_HINT.test(rawValue.trim()));
     if (lengthPx === null) return false;
     const { isNegative, base: basePrefix } = splitNegativePrefix(arbitraryMatch[1]);
-    const propertyKey = tailwindPrefixToProperty(arbitraryPrefix(basePrefix));
+    const propertyKey = tailwindPrefixToProperty(getArbitraryPrefix(basePrefix));
     return propertyKey ? commitLengthPx(propertyKey, isNegative ? -lengthPx : lengthPx) : false;
   };
 
@@ -293,7 +293,7 @@ export const createTailwindAutoApply = (
 
     const numericTarget = findNumeric(initialProperties, propertyKey);
     if (numericTarget) {
-      commit(numericTarget, clampedFor(numericTarget, candidate), { shouldCompact: true });
+      commit(numericTarget, getClampedValue(numericTarget, candidate), { shouldCompact: true });
       return;
     }
 
@@ -316,7 +316,7 @@ export const createTailwindAutoApply = (
     if (sideProperties.length === 0) return;
     batch(() => {
       for (const sideProperty of sideProperties) {
-        commit(sideProperty, clampedFor(sideProperty, candidate), { shouldCompact: true });
+        commit(sideProperty, getClampedValue(sideProperty, candidate), { shouldCompact: true });
       }
     });
   };

--- a/packages/react-grab/src/utils/css-property-builders.ts
+++ b/packages/react-grab/src/utils/css-property-builders.ts
@@ -11,7 +11,7 @@ import { parseAnyColor } from "./parse-any-color.js";
 import { parseHexChannels } from "./parse-color.js";
 import type { NumericValue } from "./parse-numeric-value.js";
 import type { AggregateDefinition, EnumPropertyDefinition } from "./property-definitions.js";
-import { tailwindAliasesForProperty } from "./tailwind-class-map.js";
+import { getTailwindAliasesForProperty } from "./tailwind-class-map.js";
 
 export const buildNumericProperty = (
   definition: AggregateDefinition,
@@ -43,7 +43,7 @@ export const buildNumericProperty = (
     value,
     original: value,
     unit: normalized.unit,
-    tailwindAliases: tailwindAliasesForProperty(definition.key),
+    tailwindAliases: getTailwindAliasesForProperty(definition.key),
     isPrioritized: false,
     isDefault: false,
     isCanonical,
@@ -68,7 +68,7 @@ export const buildColorProperty = (
     cssProperties: [cssKey],
     value,
     original: value,
-    tailwindAliases: tailwindAliasesForProperty(cssKey),
+    tailwindAliases: getTailwindAliasesForProperty(cssKey),
     isPrioritized: alwaysShow,
     isDefault: false,
     isCanonical: true,
@@ -92,7 +92,7 @@ export const buildEnumProperty = (
     value: trimmedCssValue,
     original: trimmedCssValue,
     options,
-    tailwindAliases: tailwindAliasesForProperty(definition.key),
+    tailwindAliases: getTailwindAliasesForProperty(definition.key),
     isPrioritized: false,
     isDefault: false,
     isCanonical: true,

--- a/packages/react-grab/src/utils/detect-app-theme.ts
+++ b/packages/react-grab/src/utils/detect-app-theme.ts
@@ -81,9 +81,12 @@ const themeFromColorSchemeOf = (element: HTMLElement): AppTheme | null => {
 // drive the rendered theme) when the page opts in with a `color-scheme` that
 // lists `dark` - typically `light dark`. With the default `normal` scheme the
 // canvas stays light no matter the OS preference, so a transparent page must
-// NOT be classified by `prefers-color-scheme` in that case.
-const pageColorSchemeFollowsOs = (element: HTMLElement): boolean => {
-  const colorSchemeValue = element.style.colorScheme || getComputedStyle(element).colorScheme;
+// NOT be classified by `prefers-color-scheme` in that case. Only the root
+// element's `color-scheme` governs the canvas backdrop - a scheme declared on
+// <body> does not - so this is inspected on <html> alone.
+const rootColorSchemeFollowsOs = (): boolean => {
+  const root = document.documentElement;
+  const colorSchemeValue = root.style.colorScheme || getComputedStyle(root).colorScheme;
   return colorSchemeValue ? colorSchemeValue.toLowerCase().split(/\s+/).includes("dark") : false;
 };
 
@@ -134,10 +137,9 @@ const detectTheme = (): AppTheme => {
   if (explicit) return explicit;
 
   // No theme marker, no single-value `color-scheme`, and no painted background.
-  // The OS preference only governs the rendered canvas when the page opted into
-  // a scheme that includes `dark`; otherwise the canvas is light.
-  const followsOs = rootFirst.some(pageColorSchemeFollowsOs);
-  if (!followsOs) return "light";
+  // The OS preference only governs the rendered canvas when the root element
+  // opted into a scheme that includes `dark`; otherwise the canvas is light.
+  if (!rootColorSchemeFollowsOs()) return "light";
   return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 };
 

--- a/packages/react-grab/src/utils/detect-app-theme.ts
+++ b/packages/react-grab/src/utils/detect-app-theme.ts
@@ -54,41 +54,28 @@ const themeFromAttributeValue = (attributeValue: string): AppTheme | null => {
   return null;
 };
 
-// `color-scheme` only forces a theme when it lists a single value. When it
-// lists both ("light dark" / "dark light") the active scheme is chosen by the
-// user's OS preference and reflected in the actual paint - token order does NOT
-// decide it - so we defer to luminance / prefers-color-scheme instead of
-// guessing the first token.
-const themeFromColorScheme = (colorSchemeValue: string): AppTheme | null => {
-  const normalized = colorSchemeValue.trim().toLowerCase();
-  if (!normalized || normalized === "normal" || normalized === "auto") return null;
-
-  const tokens = normalized.split(/\s+/);
-  const allowsDark = tokens.includes("dark");
-  const allowsLight = tokens.includes("light");
-  if (allowsDark && allowsLight) return null;
-  if (allowsDark) return "dark";
-  if (allowsLight) return "light";
-  return null;
+const getColorSchemeTokens = (element: HTMLElement): readonly string[] => {
+  const colorSchemeValue = element.style.colorScheme || getComputedStyle(element).colorScheme;
+  return colorSchemeValue ? colorSchemeValue.trim().toLowerCase().split(/\s+/) : [];
 };
 
+// `color-scheme` only forces a theme when it lists a single value. When it lists
+// both ("light dark") the active scheme follows the OS preference, not token
+// order, so we defer; `normal`/`auto` list neither and likewise defer.
 const themeFromColorSchemeOf = (element: HTMLElement): AppTheme | null => {
-  const colorSchemeValue = element.style.colorScheme || getComputedStyle(element).colorScheme;
-  return colorSchemeValue ? themeFromColorScheme(colorSchemeValue) : null;
+  const tokens = getColorSchemeTokens(element);
+  const allowsDark = tokens.includes("dark");
+  const allowsLight = tokens.includes("light");
+  if (allowsDark === allowsLight) return null;
+  return allowsDark ? "dark" : "light";
 };
 
 // The UA only paints a dark default canvas (and lets `prefers-color-scheme`
-// drive the rendered theme) when the page opts in with a `color-scheme` that
-// lists `dark` - typically `light dark`. With the default `normal` scheme the
-// canvas stays light no matter the OS preference, so a transparent page must
-// NOT be classified by `prefers-color-scheme` in that case. Only the root
-// element's `color-scheme` governs the canvas backdrop - a scheme declared on
-// <body> does not - so this is inspected on <html> alone.
-const rootColorSchemeFollowsOs = (): boolean => {
-  const root = document.documentElement;
-  const colorSchemeValue = root.style.colorScheme || getComputedStyle(root).colorScheme;
-  return colorSchemeValue ? colorSchemeValue.toLowerCase().split(/\s+/).includes("dark") : false;
-};
+// drive the rendered theme) when the root element opts into a `color-scheme`
+// listing `dark` - typically `light dark`. A scheme declared on <body> does not
+// affect the canvas, so only <html> is inspected.
+const rootColorSchemeFollowsOs = (): boolean =>
+  getColorSchemeTokens(document.documentElement).includes("dark");
 
 // Most frameworks mark the theme on <html> (Tailwind, next-themes), but some
 // put it on <body> (a few Bootstrap/MUI setups and hand-rolled apps), so both

--- a/packages/react-grab/src/utils/detect-app-theme.ts
+++ b/packages/react-grab/src/utils/detect-app-theme.ts
@@ -38,13 +38,32 @@ const relativeLuminance = (red: number, green: number, blue: number): number => 
 // canvas, plus oklch via exact math) to a hex string, which `parseHexChannels`
 // turns into channels - covering modern computed values like `oklch(...)` that a
 // naive `rgb()` parse would miss.
-const themeFromElementBackground = (element: HTMLElement): AppTheme | null => {
-  const hex = parseAnyColor(getComputedStyle(element).backgroundColor);
+const themeFromColor = (color: string): AppTheme | null => {
+  const hex = parseAnyColor(color);
   const channels = hex ? parseHexChannels(hex) : null;
-  // A transparent background tells us nothing about the rendered theme.
+  // A fully transparent color tells us nothing about the rendered theme.
   if (!channels || channels.alpha === 0) return null;
   const luminance = relativeLuminance(channels.red, channels.green, channels.blue);
   return luminance < LUMINANCE_DARK_THRESHOLD ? "dark" : "light";
+};
+
+const themeFromElementBackground = (element: HTMLElement): AppTheme | null =>
+  themeFromColor(getComputedStyle(element).backgroundColor);
+
+// When nothing on the page is painted, the visible backdrop is the UA canvas,
+// whose color is exposed on no element. The `Canvas` system color resolves to
+// exactly that, honoring the root element's used `color-scheme` (so it tracks
+// the OS preference only when the page opted into a dark-capable scheme, and
+// stays light under the default `normal`). A throwaway probe attached under
+// <html> inherits the root scheme - deliberately not <body>, whose scheme does
+// not drive the canvas - and reads the precise color the browser paints.
+const themeFromCanvasBackdrop = (): AppTheme | null => {
+  const probe = document.createElement("div");
+  probe.style.cssText = "position:fixed;width:0;height:0;background-color:Canvas";
+  document.documentElement.appendChild(probe);
+  const theme = themeFromColor(getComputedStyle(probe).backgroundColor);
+  probe.remove();
+  return theme;
 };
 
 const themeFromAttributeValue = (attributeValue: string): AppTheme | null => {
@@ -69,13 +88,6 @@ const themeFromColorSchemeOf = (element: HTMLElement): AppTheme | null => {
   if (allowsDark === allowsLight) return null;
   return allowsDark ? "dark" : "light";
 };
-
-// The UA only paints a dark default canvas (and lets `prefers-color-scheme`
-// drive the rendered theme) when the root element opts into a `color-scheme`
-// listing `dark` - typically `light dark`. A scheme declared on <body> does not
-// affect the canvas, so only <html> is inspected.
-const rootColorSchemeFollowsOs = (): boolean =>
-  getColorSchemeTokens(document.documentElement).includes("dark");
 
 // Most frameworks mark the theme on <html> (Tailwind, next-themes), but some
 // put it on <body> (a few Bootstrap/MUI setups and hand-rolled apps), so both
@@ -117,17 +129,15 @@ const detectTheme = (): AppTheme => {
   const rootFirst = [document.documentElement, document.body] as const;
   const bodyFirst = [document.body, document.documentElement] as const;
 
-  const explicit =
+  // With nothing explicit and nothing painted, the `Canvas` backdrop is the
+  // rendered truth; `light` is only a last resort if it cannot be read.
+  return (
     firstThemeFromRoots(rootFirst, themeFromElementMarkers) ??
     firstThemeFromRoots(rootFirst, themeFromColorSchemeOf) ??
-    firstThemeFromRoots(bodyFirst, themeFromElementBackground);
-  if (explicit) return explicit;
-
-  // No theme marker, no single-value `color-scheme`, and no painted background.
-  // The OS preference only governs the rendered canvas when the root element
-  // opted into a scheme that includes `dark`; otherwise the canvas is light.
-  if (!rootColorSchemeFollowsOs()) return "light";
-  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    firstThemeFromRoots(bodyFirst, themeFromElementBackground) ??
+    themeFromCanvasBackdrop() ??
+    "light"
+  );
 };
 
 const invertTheme = (theme: AppTheme): AppTheme => (theme === "dark" ? "light" : "dark");

--- a/packages/react-grab/src/utils/detect-app-theme.ts
+++ b/packages/react-grab/src/utils/detect-app-theme.ts
@@ -30,7 +30,7 @@ const LUMINANCE_DARK_THRESHOLD = 0.18;
 // it expects a dark surface behind it, so it reveals a dark theme.
 const LIGHT_TEXT_LUMINANCE_THRESHOLD = 0.5;
 
-const relativeLuminance = (red: number, green: number, blue: number): number => {
+const getRelativeLuminance = (red: number, green: number, blue: number): number => {
   const [linearRed, linearGreen, linearBlue] = [red, green, blue].map((channel) => {
     const normalized = channel / 255;
     return normalized <= 0.03928 ? normalized / 12.92 : ((normalized + 0.055) / 1.055) ** 2.4;
@@ -42,22 +42,22 @@ const relativeLuminance = (red: number, green: number, blue: number): number => 
 // canvas, plus oklch via exact math) to a hex string, which `parseHexChannels`
 // turns into channels - covering modern computed values like `oklch(...)` that a
 // naive `rgb()` parse would miss.
-const luminanceOfColor = (color: string): number | null => {
+const getColorLuminance = (color: string): number | null => {
   const hex = parseAnyColor(color);
   const channels = hex ? parseHexChannels(hex) : null;
   // A fully transparent color tells us nothing about the rendered theme.
   if (!channels || channels.alpha === 0) return null;
-  return relativeLuminance(channels.red, channels.green, channels.blue);
+  return getRelativeLuminance(channels.red, channels.green, channels.blue);
 };
 
-const themeFromBackgroundColor = (color: string): AppTheme | null => {
-  const luminance = luminanceOfColor(color);
+const getThemeFromBackgroundColor = (color: string): AppTheme | null => {
+  const luminance = getColorLuminance(color);
   if (luminance === null) return null;
   return luminance < LUMINANCE_DARK_THRESHOLD ? "dark" : "light";
 };
 
-const themeFromElementBackground = (element: HTMLElement): AppTheme | null =>
-  themeFromBackgroundColor(getComputedStyle(element).backgroundColor);
+const getThemeFromElementBackground = (element: HTMLElement): AppTheme | null =>
+  getThemeFromBackgroundColor(getComputedStyle(element).backgroundColor);
 
 // When nothing is painted we can't read a wrapper-themed app's real backdrop,
 // but its text color still betrays the intent: near-white text only makes sense
@@ -65,8 +65,8 @@ const themeFromElementBackground = (element: HTMLElement): AppTheme | null =>
 // the page, unlike <body> which may opt into its own), and only conclude `dark`
 // - dark text is the default even on undeclared light pages, so it defers to the
 // Canvas backdrop instead.
-const themeFromRootForegroundText = (): AppTheme | null => {
-  const luminance = luminanceOfColor(getComputedStyle(document.documentElement).color);
+const getThemeFromRootForegroundText = (): AppTheme | null => {
+  const luminance = getColorLuminance(getComputedStyle(document.documentElement).color);
   if (luminance === null) return null;
   return luminance > LIGHT_TEXT_LUMINANCE_THRESHOLD ? "dark" : null;
 };
@@ -78,16 +78,16 @@ const themeFromRootForegroundText = (): AppTheme | null => {
 // stays light under the default `normal`). A throwaway probe attached under
 // <html> inherits the root scheme - deliberately not <body>, whose scheme does
 // not drive the canvas - and reads the precise color the browser paints.
-const themeFromCanvasBackdrop = (): AppTheme | null => {
-  const probe = document.createElement("div");
-  probe.style.cssText = "position:fixed;width:0;height:0;background-color:Canvas";
-  document.documentElement.appendChild(probe);
-  const theme = themeFromBackgroundColor(getComputedStyle(probe).backgroundColor);
-  probe.remove();
+const getThemeFromCanvasBackdrop = (): AppTheme | null => {
+  const probeElement = document.createElement("div");
+  probeElement.style.cssText = "position:fixed;width:0;height:0;background-color:Canvas";
+  document.documentElement.appendChild(probeElement);
+  const theme = getThemeFromBackgroundColor(getComputedStyle(probeElement).backgroundColor);
+  probeElement.remove();
   return theme;
 };
 
-const themeFromAttributeValue = (attributeValue: string): AppTheme | null => {
+const getThemeFromAttributeValue = (attributeValue: string): AppTheme | null => {
   const normalized = attributeValue.toLowerCase();
   if (normalized === "dark") return "dark";
   if (normalized === "light") return "light";
@@ -102,7 +102,7 @@ const getColorSchemeTokens = (element: HTMLElement): readonly string[] => {
 // `color-scheme` only forces a theme when it lists a single value. When it lists
 // both ("light dark") the active scheme follows the OS preference, not token
 // order, so we defer; `normal`/`auto` list neither and likewise defer.
-const themeFromColorSchemeOf = (element: HTMLElement): AppTheme | null => {
+const getThemeFromColorScheme = (element: HTMLElement): AppTheme | null => {
   const tokens = getColorSchemeTokens(element);
   const allowsDark = tokens.includes("dark");
   const allowsLight = tokens.includes("light");
@@ -113,15 +113,15 @@ const themeFromColorSchemeOf = (element: HTMLElement): AppTheme | null => {
 // Most frameworks mark the theme on <html> (Tailwind, next-themes), but some
 // put it on <body> (a few Bootstrap/MUI setups and hand-rolled apps), so both
 // roots are inspected.
-const themeFromElementMarkers = (element: HTMLElement): AppTheme | null => {
+const getThemeFromElementMarkers = (element: HTMLElement): AppTheme | null => {
   if (element.classList.contains("dark")) return "dark";
   if (element.classList.contains("light")) return "light";
 
   for (const attributeName of THEME_ATTRIBUTES) {
     const attributeValue = element.getAttribute(attributeName);
     if (!attributeValue) continue;
-    const result = themeFromAttributeValue(attributeValue);
-    if (result) return result;
+    const markerTheme = getThemeFromAttributeValue(attributeValue);
+    if (markerTheme) return markerTheme;
   }
 
   for (const { attribute, theme } of PRESENCE_ATTRIBUTES) {
@@ -131,13 +131,13 @@ const themeFromElementMarkers = (element: HTMLElement): AppTheme | null => {
   return null;
 };
 
-const firstThemeFromRoots = (
+const getFirstThemeFromRoots = (
   roots: readonly (HTMLElement | null)[],
-  classify: (element: HTMLElement) => AppTheme | null,
+  getThemeForElement: (element: HTMLElement) => AppTheme | null,
 ): AppTheme | null => {
   for (const root of roots) {
     if (!root) continue;
-    const theme = classify(root);
+    const theme = getThemeForElement(root);
     if (theme) return theme;
   }
   return null;
@@ -154,11 +154,11 @@ const detectTheme = (): AppTheme => {
   // dark wrapper, then the `Canvas` backdrop is the rendered truth; `light` is
   // only a last resort if neither can be read.
   return (
-    firstThemeFromRoots(rootFirst, themeFromElementMarkers) ??
-    firstThemeFromRoots(rootFirst, themeFromColorSchemeOf) ??
-    firstThemeFromRoots(bodyFirst, themeFromElementBackground) ??
-    themeFromRootForegroundText() ??
-    themeFromCanvasBackdrop() ??
+    getFirstThemeFromRoots(rootFirst, getThemeFromElementMarkers) ??
+    getFirstThemeFromRoots(rootFirst, getThemeFromColorScheme) ??
+    getFirstThemeFromRoots(bodyFirst, getThemeFromElementBackground) ??
+    getThemeFromRootForegroundText() ??
+    getThemeFromCanvasBackdrop() ??
     "light"
   );
 };

--- a/packages/react-grab/src/utils/detect-app-theme.ts
+++ b/packages/react-grab/src/utils/detect-app-theme.ts
@@ -15,6 +15,7 @@ const THEME_ATTRIBUTES = [
   "data-color-scheme",
   "data-bs-theme",
   "data-mui-color-scheme",
+  "data-mantine-color-scheme",
 ] as const;
 
 // MUI with `colorSchemeSelector: 'data'` sets bare presence attributes

--- a/packages/react-grab/src/utils/detect-app-theme.ts
+++ b/packages/react-grab/src/utils/detect-app-theme.ts
@@ -77,6 +77,16 @@ const themeFromColorSchemeOf = (element: HTMLElement): AppTheme | null => {
   return colorSchemeValue ? themeFromColorScheme(colorSchemeValue) : null;
 };
 
+// The UA only paints a dark default canvas (and lets `prefers-color-scheme`
+// drive the rendered theme) when the page opts in with a `color-scheme` that
+// lists `dark` - typically `light dark`. With the default `normal` scheme the
+// canvas stays light no matter the OS preference, so a transparent page must
+// NOT be classified by `prefers-color-scheme` in that case.
+const pageColorSchemeFollowsOs = (element: HTMLElement): boolean => {
+  const colorSchemeValue = element.style.colorScheme || getComputedStyle(element).colorScheme;
+  return colorSchemeValue ? colorSchemeValue.toLowerCase().split(/\s+/).includes("dark") : false;
+};
+
 // Most frameworks mark the theme on <html> (Tailwind, next-themes), but some
 // put it on <body> (a few Bootstrap/MUI setups and hand-rolled apps), so both
 // roots are inspected.
@@ -117,12 +127,18 @@ const detectTheme = (): AppTheme => {
   const rootFirst = [document.documentElement, document.body] as const;
   const bodyFirst = [document.body, document.documentElement] as const;
 
-  return (
+  const explicit =
     firstThemeFromRoots(rootFirst, themeFromElementMarkers) ??
     firstThemeFromRoots(rootFirst, themeFromColorSchemeOf) ??
-    firstThemeFromRoots(bodyFirst, themeFromElementBackground) ??
-    (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light")
-  );
+    firstThemeFromRoots(bodyFirst, themeFromElementBackground);
+  if (explicit) return explicit;
+
+  // No theme marker, no single-value `color-scheme`, and no painted background.
+  // The OS preference only governs the rendered canvas when the page opted into
+  // a scheme that includes `dark`; otherwise the canvas is light.
+  const followsOs = rootFirst.some(pageColorSchemeFollowsOs);
+  if (!followsOs) return "light";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 };
 
 const invertTheme = (theme: AppTheme): AppTheme => (theme === "dark" ? "light" : "dark");

--- a/packages/react-grab/src/utils/detect-app-theme.ts
+++ b/packages/react-grab/src/utils/detect-app-theme.ts
@@ -26,9 +26,12 @@ const PRESENCE_ATTRIBUTES: readonly { attribute: string; theme: AppTheme }[] = [
 ];
 
 const LUMINANCE_DARK_THRESHOLD = 0.18;
-// Text brighter than this is near-white; an app only paints near-white text when
-// it expects a dark surface behind it, so it reveals a dark theme.
-const LIGHT_TEXT_LUMINANCE_THRESHOLD = 0.5;
+// Text this light sits well above any light theme's (dark) body text, so it only
+// appears when the app paints onto a dark surface - revealing a dark theme.
+const LIGHT_TEXT_LUMINANCE_THRESHOLD = 0.6;
+// Faint text composites toward the backdrop, making its own color an unreliable
+// theme signal, so the foreground heuristic ignores anything more translucent.
+const OPAQUE_TEXT_MIN_ALPHA = 0.5;
 
 const getRelativeLuminance = (red: number, green: number, blue: number): number => {
   const [linearRed, linearGreen, linearBlue] = [red, green, blue].map((channel) => {
@@ -42,11 +45,12 @@ const getRelativeLuminance = (red: number, green: number, blue: number): number 
 // canvas, plus oklch via exact math) to a hex string, which `parseHexChannels`
 // turns into channels - covering modern computed values like `oklch(...)` that a
 // naive `rgb()` parse would miss.
-const getColorLuminance = (color: string): number | null => {
+const getColorLuminance = (color: string, minAlpha = 0): number | null => {
   const hex = parseAnyColor(color);
   const channels = hex ? parseHexChannels(hex) : null;
-  // A fully transparent color tells us nothing about the rendered theme.
-  if (!channels || channels.alpha === 0) return null;
+  // Too transparent to composite into a reliable signal - a fully transparent
+  // color tells us nothing, and faint text bleeds into whatever sits behind it.
+  if (!channels || channels.alpha <= minAlpha) return null;
   return getRelativeLuminance(channels.red, channels.green, channels.blue);
 };
 
@@ -60,13 +64,16 @@ const getThemeFromElementBackground = (element: HTMLElement): AppTheme | null =>
   getThemeFromBackgroundColor(getComputedStyle(element).backgroundColor);
 
 // When nothing is painted we can't read a wrapper-themed app's real backdrop,
-// but its text color still betrays the intent: near-white text only makes sense
-// over a dark surface. Read it from the root (whose used `color-scheme` governs
-// the page, unlike <body> which may opt into its own), and only conclude `dark`
-// - dark text is the default even on undeclared light pages, so it defers to the
-// Canvas backdrop instead.
+// but its text color still betrays the intent: light text only makes sense over
+// a dark surface. Read it from the root (whose used `color-scheme` governs the
+// page, unlike <body> which may opt into its own), require a near-opaque color,
+// and only conclude `dark` - dark text is the default even on undeclared light
+// pages, so it defers to the Canvas backdrop instead.
 const getThemeFromRootForegroundText = (): AppTheme | null => {
-  const luminance = getColorLuminance(getComputedStyle(document.documentElement).color);
+  const luminance = getColorLuminance(
+    getComputedStyle(document.documentElement).color,
+    OPAQUE_TEXT_MIN_ALPHA,
+  );
   if (luminance === null) return null;
   return luminance > LIGHT_TEXT_LUMINANCE_THRESHOLD ? "dark" : null;
 };
@@ -80,7 +87,10 @@ const getThemeFromRootForegroundText = (): AppTheme | null => {
 // not drive the canvas - and reads the precise color the browser paints.
 const getThemeFromCanvasBackdrop = (): AppTheme | null => {
   const probeElement = document.createElement("div");
-  probeElement.style.cssText = "position:fixed;width:0;height:0;background-color:Canvas";
+  // Inline `!important` outranks any author `!important` rule that might target
+  // the probe (e.g. a global `div { background: ... !important }`) and corrupt
+  // the Canvas read.
+  probeElement.style.cssText = "position:fixed;width:0;height:0;background-color:Canvas!important";
   document.documentElement.appendChild(probeElement);
   const theme = getThemeFromBackgroundColor(getComputedStyle(probeElement).backgroundColor);
   probeElement.remove();

--- a/packages/react-grab/src/utils/detect-app-theme.ts
+++ b/packages/react-grab/src/utils/detect-app-theme.ts
@@ -26,6 +26,9 @@ const PRESENCE_ATTRIBUTES: readonly { attribute: string; theme: AppTheme }[] = [
 ];
 
 const LUMINANCE_DARK_THRESHOLD = 0.18;
+// Text brighter than this is near-white; an app only paints near-white text when
+// it expects a dark surface behind it, so it reveals a dark theme.
+const LIGHT_TEXT_LUMINANCE_THRESHOLD = 0.5;
 
 const relativeLuminance = (red: number, green: number, blue: number): number => {
   const [linearRed, linearGreen, linearBlue] = [red, green, blue].map((channel) => {
@@ -39,17 +42,34 @@ const relativeLuminance = (red: number, green: number, blue: number): number => 
 // canvas, plus oklch via exact math) to a hex string, which `parseHexChannels`
 // turns into channels - covering modern computed values like `oklch(...)` that a
 // naive `rgb()` parse would miss.
-const themeFromColor = (color: string): AppTheme | null => {
+const luminanceOfColor = (color: string): number | null => {
   const hex = parseAnyColor(color);
   const channels = hex ? parseHexChannels(hex) : null;
   // A fully transparent color tells us nothing about the rendered theme.
   if (!channels || channels.alpha === 0) return null;
-  const luminance = relativeLuminance(channels.red, channels.green, channels.blue);
+  return relativeLuminance(channels.red, channels.green, channels.blue);
+};
+
+const themeFromBackgroundColor = (color: string): AppTheme | null => {
+  const luminance = luminanceOfColor(color);
+  if (luminance === null) return null;
   return luminance < LUMINANCE_DARK_THRESHOLD ? "dark" : "light";
 };
 
 const themeFromElementBackground = (element: HTMLElement): AppTheme | null =>
-  themeFromColor(getComputedStyle(element).backgroundColor);
+  themeFromBackgroundColor(getComputedStyle(element).backgroundColor);
+
+// When nothing is painted we can't read a wrapper-themed app's real backdrop,
+// but its text color still betrays the intent: near-white text only makes sense
+// over a dark surface. Read it from the root (whose used `color-scheme` governs
+// the page, unlike <body> which may opt into its own), and only conclude `dark`
+// - dark text is the default even on undeclared light pages, so it defers to the
+// Canvas backdrop instead.
+const themeFromRootForegroundText = (): AppTheme | null => {
+  const luminance = luminanceOfColor(getComputedStyle(document.documentElement).color);
+  if (luminance === null) return null;
+  return luminance > LIGHT_TEXT_LUMINANCE_THRESHOLD ? "dark" : null;
+};
 
 // When nothing on the page is painted, the visible backdrop is the UA canvas,
 // whose color is exposed on no element. The `Canvas` system color resolves to
@@ -62,7 +82,7 @@ const themeFromCanvasBackdrop = (): AppTheme | null => {
   const probe = document.createElement("div");
   probe.style.cssText = "position:fixed;width:0;height:0;background-color:Canvas";
   document.documentElement.appendChild(probe);
-  const theme = themeFromColor(getComputedStyle(probe).backgroundColor);
+  const theme = themeFromBackgroundColor(getComputedStyle(probe).backgroundColor);
   probe.remove();
   return theme;
 };
@@ -130,12 +150,14 @@ const detectTheme = (): AppTheme => {
   const rootFirst = [document.documentElement, document.body] as const;
   const bodyFirst = [document.body, document.documentElement] as const;
 
-  // With nothing explicit and nothing painted, the `Canvas` backdrop is the
-  // rendered truth; `light` is only a last resort if it cannot be read.
+  // With nothing explicit and nothing painted, near-white root text reveals a
+  // dark wrapper, then the `Canvas` backdrop is the rendered truth; `light` is
+  // only a last resort if neither can be read.
   return (
     firstThemeFromRoots(rootFirst, themeFromElementMarkers) ??
     firstThemeFromRoots(rootFirst, themeFromColorSchemeOf) ??
     firstThemeFromRoots(bodyFirst, themeFromElementBackground) ??
+    themeFromRootForegroundText() ??
     themeFromCanvasBackdrop() ??
     "light"
   );

--- a/packages/react-grab/src/utils/property-search-index.ts
+++ b/packages/react-grab/src/utils/property-search-index.ts
@@ -11,8 +11,8 @@ import {
 import type { EditableProperty } from "../types.js";
 import { isNumericQuery } from "./is-numeric-query.js";
 import {
-  tailwindPrefixPropertyKeysForSearchQuery,
-  tailwindPropertyKeysForSearchQuery,
+  getTailwindPrefixPropertyKeysForSearchQuery,
+  getTailwindPropertyKeysForSearchQuery,
 } from "./tailwind-class-map.js";
 
 interface PropertySearchEntry {
@@ -35,7 +35,7 @@ export interface PropertySearchIndex {
 const normalizeSearchText = (value: string): string =>
   value.toLowerCase().replace(/[^a-z0-9]+/g, "");
 
-const enumOptionTexts = (property: EditableProperty): readonly string[] => {
+const getEnumOptionTexts = (property: EditableProperty): readonly string[] => {
   if (property.kind !== "enum") return [];
   const optionSearchTerms: string[] = [];
   for (const option of property.options) {
@@ -57,7 +57,7 @@ const createSearchEntries = (properties: readonly EditableProperty[]): PropertyS
         searchEntries.push({ property, originalIndex, kind: "alias", term: normalizedAlias });
       }
     }
-    for (const optionSearchTerm of enumOptionTexts(property)) {
+    for (const optionSearchTerm of getEnumOptionTexts(property)) {
       searchEntries.push({
         property,
         originalIndex,
@@ -142,12 +142,12 @@ export const createPropertySearchIndex = (properties: EditableProperty[]): Prope
     const candidatesByKey = new Map<string, PropertySearchCandidate>();
     addPropertyKeyCandidates(
       candidatesByKey,
-      tailwindPropertyKeysForSearchQuery(query),
+      getTailwindPropertyKeysForSearchQuery(query),
       EDIT_SEARCH_TAILWIND_INTENT_SCORE,
     );
     addPropertyKeyCandidates(
       candidatesByKey,
-      tailwindPrefixPropertyKeysForSearchQuery(query),
+      getTailwindPrefixPropertyKeysForSearchQuery(query),
       EDIT_SEARCH_TAILWIND_PREFIX_SCORE,
     );
     for (const searchEntry of searchEntries) {

--- a/packages/react-grab/src/utils/tailwind-class-map.ts
+++ b/packages/react-grab/src/utils/tailwind-class-map.ts
@@ -275,14 +275,14 @@ export const normalizeTailwindClassInput = (query: string): string =>
 const isTailwindArbitraryColor = (value: string): boolean =>
   CSS_COLOR_ARBITRARY_PATTERN.test(value) && !CSS_LENGTH_ARBITRARY_PATTERN.test(value);
 
-const tailwindClassTail = (baseClassName: string, prefix: string): string | null => {
+const getTailwindClassTail = (baseClassName: string, prefix: string): string | null => {
   if (baseClassName === prefix) return "";
   const prefixWithSeparator = `${prefix}-`;
   if (!baseClassName.startsWith(prefixWithSeparator)) return null;
   return baseClassName.slice(prefixWithSeparator.length);
 };
 
-export const tailwindColorPropertyForClassName = (className: string): string | null => {
+export const getTailwindColorPropertyForClassName = (className: string): string | null => {
   const baseClassName = stripTailwindModifiers(normalizeTailwindClassInput(className));
   const prefix = matchTailwindPrefix(baseClassName);
   if (!prefix) return null;
@@ -295,7 +295,7 @@ export const tailwindColorPropertyForClassName = (className: string): string | n
     return isTailwindArbitraryColor(arbitraryValue) ? propertyKey : null;
   }
 
-  const tail = tailwindClassTail(baseClassName, prefix);
+  const tail = getTailwindClassTail(baseClassName, prefix);
   if (tail === null) return null;
   if (prefix === "bg" && tail === "") return propertyKey;
   if ((prefix === "fill" || prefix === "stroke") && tail === "") return propertyKey;
@@ -313,13 +313,13 @@ const TAILWIND_KEYWORD_COLOR_HEX: Partial<Record<string, string>> = {
 // Returns null for arbitrary values, theme tokens (primary/accent/…), the
 // `current`/`inherit` keywords, and prefix-only classes (`bg`) — none of
 // which map to a fixed palette hex.
-export const tailwindNamedColorHex = (className: string): string | null => {
+export const getTailwindNamedColorHex = (className: string): string | null => {
   const baseClassName = stripTailwindModifiers(normalizeTailwindClassInput(className));
   const prefix = matchTailwindPrefix(baseClassName);
   if (!prefix || TAILWIND_COLOR_PREFIX_TO_PROPERTY[prefix] === undefined) return null;
   if (baseClassName.includes("[")) return null;
 
-  const tail = tailwindClassTail(baseClassName, prefix);
+  const tail = getTailwindClassTail(baseClassName, prefix);
   if (!tail) return null;
 
   const keywordHex = TAILWIND_KEYWORD_COLOR_HEX[tail];
@@ -412,25 +412,25 @@ const TAILWIND_CLASS_TO_ENUM_VALUE: Partial<Record<string, TailwindEnumValueMapp
   "border-none": { property: "border-style", value: "none" },
 };
 
-export const tailwindPropertyKeysForSearchQuery = (query: string): string[] => {
+export const getTailwindPropertyKeysForSearchQuery = (query: string): string[] => {
   const normalizedQuery = normalizeTailwindClassInput(query);
   if (!normalizedQuery) return [];
 
   const enumMapping = tailwindClassToEnumValue(normalizedQuery);
   if (enumMapping) return [enumMapping.property];
 
-  const colorPropertyKey = tailwindColorPropertyForClassName(normalizedQuery);
+  const colorPropertyKey = getTailwindColorPropertyForClassName(normalizedQuery);
   if (colorPropertyKey) return [colorPropertyKey];
   return [];
 };
 
-export const tailwindPrefixPropertyKeysForSearchQuery = (query: string): string[] => {
+export const getTailwindPrefixPropertyKeysForSearchQuery = (query: string): string[] => {
   const normalizedQuery = normalizeTailwindClassInput(query);
   if (!normalizedQuery) return [];
 
   const prefix = matchTailwindPrefix(normalizedQuery);
   if (!prefix) return [];
-  const tail = tailwindClassTail(stripTailwindModifiers(normalizedQuery), prefix);
+  const tail = getTailwindClassTail(stripTailwindModifiers(normalizedQuery), prefix);
   if (tail === null || !isTailwindPrefixFallbackValue(prefix, tail)) return [];
   const prefixPropertyKey = tailwindPrefixToProperty(prefix);
   return prefixPropertyKey ? [prefixPropertyKey] : [];
@@ -458,7 +458,7 @@ export const getElementTailwindProperties = (element: Element): Set<string> => {
   return properties;
 };
 
-export const tailwindAliasesForProperty = (property: string): string[] =>
+export const getTailwindAliasesForProperty = (property: string): string[] =>
   PROPERTY_ALIASES[property] ?? [];
 
 export const tailwindPrefixToProperty = (prefix: string): string | null => {


### PR DESCRIPTION
## Summary

react-grab paints its overlay in the *inverse* of the detected app theme. For a page with **no theme marker, no painted background, and the default `color-scheme: normal`**, detection fell all the way through to the `prefers-color-scheme` fallback. On a dark-OS visitor that returns `dark`, so a visually-white page (e.g. the Vite e2e app) was mis-detected as dark and the overlay rendered light.

A browser only paints a *dark* default canvas when the page opts into a `color-scheme` that lists `dark` (e.g. `light dark`). With `color-scheme: normal` the canvas stays white regardless of OS preference.

- Gate the `prefers-color-scheme` fallback on the page actually opting into an OS-following `color-scheme`; otherwise classify an undeclared/transparent page as **light**.
- Add a regression test: an undeclared transparent page under a dark OS preference resolves to a dark overlay (light app).

## Test plan

- [x] `pnpm exec playwright test e2e/app-theme-detection.spec.ts` — 7 passed (6 existing + 1 new)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] Verified live in the Vite e2e app under emulated dark OS: overlay now `dark` (was `light`); `color-scheme: light dark` still correctly follows the OS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes overlay contrast logic in detect-app-theme for edge cases (transparent pages, dual schemes on body); wrong classification affects UX but scope is localized and heavily e2e-tested.
> 
> **Overview**
> Fixes **overlay theme mis-detection** when a page has no theme markers, no painted background, and default `color-scheme: normal`. Detection no longer falls back to **`prefers-color-scheme`** (which wrongly treated white UA canvas pages as dark on dark-OS visitors).
> 
> **`detect-app-theme.ts`** now resolves ambiguous pages by inferring dark from **near-white root text**, then reading the real backdrop via the CSS **`Canvas`** system color on a probe under `<html>` (root `color-scheme` governs canvas, not `<body>`). Final fallback is **`light`**. Adds **`data-mantine-color-scheme`** and refactors helpers to `get*` naming.
> 
> **E2E** expands `app-theme-detection.spec.ts` with transparent-page regressions, framework marker matrix, runtime toggles, and OS flips when `color-scheme: light dark`.
> 
> Unrelated **rename-only** `get*` exports across edit-panel and tailwind utilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ab5ea45738cdbca1d918c5e267344709f2351e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes theme detection in `react-grab` so transparent, undeclared pages resolve correctly. We now read the real backdrop via CSS `Canvas`, only follow the OS when `<html>` lists `dark`, and harden the foreground-text and Canvas fallbacks.

- **Bug Fixes**
  - Infer dark on transparent pages when root text is near-white and opaque; otherwise use the `Canvas` backdrop under `<html>`; final fallback is `light`.
  - Treat `color-scheme: normal` as light; follow the OS only when the root lists `dark` (ignore `<body>`).
  - Hardened edge cases: require text alpha ≥ 0.5, raise the light-text threshold to 0.6, and mark the Canvas probe background `!important` to resist author overrides.
  - Expand e2e across framework markers, background/transparent cases, runtime toggles, OS flips, translucent/mid-gray text, and a global `!important` rule; recognize `data-mantine-color-scheme`.

- **Refactors**
  - Deduplicate `color-scheme` token parsing via `getColorSchemeTokens`.
  - Standardize value-returning helper names to `get*` across theme detection, Tailwind mapping/search, and edit panel utilities; behavior unchanged.

<sup>Written for commit e4b487e22656ab7fa516afcea7f4c802b34694a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

