### PR TITLE
refactor(react-grab): shadcn/cmdk-style composition — compound Menu + ui primitives

### DIFF
--- a/packages/react-grab/src/components/context-menu.tsx
+++ b/packages/react-grab/src/components/context-menu.tsx
@@ -248,15 +248,19 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
         props.onHide();
       };
 
-      // Enter activates the highlighted row directly via its registered
-      // onSelect (which already closes the menu); with no active row we fall
-      // through so an action that binds Enter as its own shortcut still fires.
+      // A highlighted row absorbs Enter: run its onSelect (which closes the
+      // menu) when enabled, otherwise swallow the key. We must not fall through
+      // to a global Enter shortcut while a row is active, or a disabled
+      // selection would silently invoke a different action. Only with no active
+      // row does Enter reach an action that binds Enter as its own shortcut.
       if (event.key === "Enter") {
         const activeItem = menuStore.getActiveItem();
-        if (activeItem && activeItem.isEnabled()) {
-          event.preventDefault();
-          event.stopPropagation();
-          activeItem.onSelect();
+        if (activeItem) {
+          if (activeItem.isEnabled()) {
+            event.preventDefault();
+            event.stopPropagation();
+            activeItem.onSelect();
+          }
           return;
         }
       }

--- a/packages/react-grab/src/components/context-menu.tsx
+++ b/packages/react-grab/src/components/context-menu.tsx
@@ -27,11 +27,10 @@ import { cn } from "../utils/cn.js";
 import { Arrow } from "./selection-label/arrow.js";
 import { TagBadge } from "./selection-label/tag-badge.js";
 import { BottomSection } from "./selection-label/bottom-section.js";
-import { ShortcutHint } from "./shortcut-hint.js";
+import { Menu, createMenuStore } from "./menu/index.js";
 import { getTagDisplay } from "../utils/get-tag-display.js";
 import { resolveActionEnabled } from "../utils/resolve-action-enabled.js";
 import { nativeRequestAnimationFrame } from "../utils/native-raf.js";
-import { createMenuHighlight } from "../utils/create-menu-highlight.js";
 import { suppressMenuEvent } from "../utils/suppress-menu-event.js";
 import { registerOverlayDismiss } from "../utils/register-overlay-dismiss.js";
 import { findShortcutAction } from "../utils/action-shortcuts.js";
@@ -60,27 +59,22 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
   let containerRef: HTMLDivElement | undefined;
   let menuContainerRef: HTMLDivElement | undefined;
   let previouslyFocusedElement: Element | null = null;
-  const menuItemRefs: (HTMLButtonElement | undefined)[] = [];
-  const {
-    containerRef: highlightContainerRef,
-    highlightRef,
-    updateHighlight,
-    clearHighlight,
-  } = createMenuHighlight({
-    bottomCornerRadiusPx: MENU_PANEL_CORNER_RADIUS_PX,
-    cornerShape: MENU_HIGHLIGHT_CORNER_SHAPE,
+  // The menu store owns the active-row state and its visible highlight. We
+  // never call .focus() on the row itself: that would steal DOM focus from
+  // whatever the host page had focused (form inputs, comboboxes,
+  // focus-trapped modals), dispatch blur/focus events at the wrong time, and
+  // fight focus traps. Keyboard navigation is driven by a window-level
+  // keydown listener instead, which fires regardless of where DOM focus is.
+  const menuStore = createMenuStore({
+    keyboardNavigation: true,
+    highlight: {
+      bottomCornerRadiusPx: MENU_PANEL_CORNER_RADIUS_PX,
+      cornerShape: MENU_HIGHLIGHT_CORNER_SHAPE,
+    },
   });
 
   const [measuredWidth, setMeasuredWidth] = createSignal(0);
   const [measuredHeight, setMeasuredHeight] = createSignal(0);
-  // Tracks which menu row is "active" (hovered, arrowed-to, or invoked-via-
-  // shortcut). The visible highlight follows this signal. We never call
-  // .focus() on the row itself: that would steal DOM focus from whatever the
-  // host page had focused (form inputs, comboboxes, focus-trapped modals),
-  // dispatch blur/focus events at the wrong time, and fight focus traps.
-  // Keyboard navigation is handled by a window-level keydown listener
-  // instead, which fires regardless of where DOM focus is.
-  const [activeItemIndex, setActiveItemIndex] = createSignal(-1);
 
   const isVisible = createMemo(() => props.position !== null);
 
@@ -171,47 +165,6 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
     }));
   });
 
-  // Resets when items change so a freshly-opened menu doesn't carry over
-  // stale element refs (e.g. an action list that shrank).
-  createEffect(() => {
-    menuItemRefs.length = menuItems().length;
-  });
-
-  const findNextEnabledIndex = (startIndex: number, direction: 1 | -1): number => {
-    const items = menuItems();
-    if (items.length === 0) return -1;
-    const totalItems = items.length;
-    const wrap = (index: number) => ((index % totalItems) + totalItems) % totalItems;
-    let nextIndex = wrap(startIndex + direction);
-    for (let attempt = 0; attempt < totalItems; attempt++) {
-      if (items[nextIndex]?.enabled) return nextIndex;
-      nextIndex = wrap(nextIndex + direction);
-    }
-    return -1;
-  };
-
-  const findFirstEnabledIndex = (): number => menuItems().findIndex((item) => item.enabled);
-
-  const findLastEnabledIndex = (): number => {
-    const items = menuItems();
-    for (let itemIndex = items.length - 1; itemIndex >= 0; itemIndex--) {
-      if (items[itemIndex]?.enabled) return itemIndex;
-    }
-    return -1;
-  };
-
-  createEffect(() => {
-    const index = activeItemIndex();
-    if (index < 0) {
-      clearHighlight();
-      return;
-    }
-    const element = menuItemRefs[index];
-    if (element) {
-      updateHighlight(element);
-    }
-  });
-
   // Single, predictable focus move keyed strictly on visibility (not on
   // position): focus the menu container on open so aria-activedescendant
   // (driven by activeItemIndex) is announced by assistive tech. On close,
@@ -237,7 +190,7 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
         menuContainerRef?.focus({ preventScroll: true });
         return;
       }
-      setActiveItemIndex(-1);
+      menuStore.setActiveItem(null);
       const restoreTarget = previouslyFocusedElement;
       previouslyFocusedElement = null;
       if (!(restoreTarget instanceof HTMLElement) || !document.contains(restoreTarget)) return;
@@ -254,14 +207,6 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
     }),
   );
 
-  const handleAction = (item: MenuItem, event: Event) => {
-    event.stopPropagation();
-    if (item.enabled) {
-      item.action();
-      props.onHide();
-    }
-  };
-
   onMount(() => {
     measureContainer();
 
@@ -277,20 +222,16 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
       if (isArrowDown || isArrowUp || isHome || isEnd || isTab) {
         event.preventDefault();
         event.stopPropagation();
-        const currentIndex = activeItemIndex();
         const moveForward = isArrowDown || (isTab && !event.shiftKey);
-        let nextIndex: number;
         if (isHome) {
-          nextIndex = findFirstEnabledIndex();
+          menuStore.selectFirst();
         } else if (isEnd) {
-          nextIndex = findLastEnabledIndex();
+          menuStore.selectLast();
         } else if (moveForward) {
-          nextIndex = findNextEnabledIndex(currentIndex === -1 ? -1 : currentIndex, 1);
+          menuStore.selectNext();
         } else {
-          const itemsLength = menuItems().length;
-          nextIndex = findNextEnabledIndex(currentIndex === -1 ? itemsLength : currentIndex, -1);
+          menuStore.selectPrevious();
         }
-        if (nextIndex >= 0) setActiveItemIndex(nextIndex);
         return;
       }
 
@@ -306,11 +247,21 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
         props.onHide();
       };
 
-      const currentActiveItemIndex = activeItemIndex();
-      const activeShortcutAction =
-        currentActiveItemIndex >= 0 ? pluginActions[currentActiveItemIndex] : null;
+      // Enter activates the highlighted row directly via its registered
+      // onSelect; with no active row we fall through so an action that binds
+      // Enter as its own shortcut still fires.
+      if (event.key === "Enter") {
+        const activeItem = menuStore.getActiveItem();
+        if (activeItem && activeItem.isEnabled()) {
+          event.preventDefault();
+          event.stopPropagation();
+          activeItem.onSelect();
+          props.onHide();
+          return;
+        }
+      }
+
       const shortcutAction = findShortcutAction(pluginActions, event, {
-        activeAction: activeShortcutAction,
         includeModifierShortcuts: true,
       });
       if (shortcutAction) runActionIfAllowed(shortcutAction);
@@ -334,17 +285,6 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
     const displayName = componentName ? `${componentName}.${tagName}` : tagName;
     return `Actions for ${displayName}`;
   });
-
-  // Stable per-instance prefix so each open of the menu produces unique
-  // ids the active-descendant attribute can reference. Two menus mounted
-  // simultaneously (shouldn't happen today, but cheap to guard) won't
-  // collide on the same #menu-item-N id.
-  const menuIdPrefix = `react-grab-menu-${Math.random().toString(36).slice(2, 8)}`;
-  const menuItemId = (itemIndex: number) => `${menuIdPrefix}-item-${itemIndex}`;
-  const activeDescendantId = () => {
-    const index = activeItemIndex();
-    return index >= 0 ? menuItemId(index) : undefined;
-  };
 
   return (
     <Show when={isVisible()}>
@@ -392,65 +332,33 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
             />
           </div>
           <BottomSection>
-            <div
-              ref={(element) => {
-                menuContainerRef = element;
-                highlightContainerRef(element);
-              }}
-              role="menu"
-              tabindex={-1}
-              aria-orientation="vertical"
-              aria-label={accessibleMenuLabel()}
-              aria-activedescendant={activeDescendantId()}
-              class="relative flex flex-col w-[calc(100%+16px)] -mx-2 -my-1.5 outline-none"
-            >
-              <div
-                ref={highlightRef}
-                aria-hidden="true"
-                class="pointer-events-none absolute opacity-0 transition-[top,left,width,height,opacity,border-radius] duration-75 ease-out bg-[var(--rg-surface-hover)]"
-              />
-              <For each={menuItems()}>
-                {(item, itemIndex) => (
-                  <button
-                    ref={(element) => {
-                      menuItemRefs[itemIndex()] = element;
-                      onCleanup(() => {
-                        if (menuItemRefs[itemIndex()] === element) {
-                          menuItemRefs[itemIndex()] = undefined;
-                        }
-                      });
-                    }}
-                    id={menuItemId(itemIndex())}
-                    data-react-grab-ignore-events
-                    data-react-grab-menu-item={item.label.toLowerCase()}
-                    type="button"
-                    role="menuitem"
-                    tabindex={activeItemIndex() === itemIndex() ? 0 : -1}
-                    aria-disabled={!item.enabled}
-                    class="relative z-1 contain-layout flex items-center justify-between w-full px-2 py-1 cursor-pointer text-left border-none bg-transparent disabled:opacity-40 disabled:cursor-default"
-                    disabled={!item.enabled}
-                    onPointerDown={(event) => event.stopPropagation()}
-                    onPointerEnter={() => {
-                      if (item.enabled) setActiveItemIndex(itemIndex());
-                    }}
-                    onClick={(event) => handleAction(item, event)}
-                  >
-                    <span class="text-[13px] leading-4 font-sans font-medium text-[var(--rg-text-primary)]">
-                      {item.label}
-                    </span>
-                    <Show when={item.shortcut}>
-                      {(shortcut) => (
-                        <ShortcutHint
-                          shortcut={shortcut()}
-                          modifier={item.shortcutModifier}
-                          class="text-[11px] font-sans text-[var(--rg-text-secondary)] ml-4"
-                        />
-                      )}
-                    </Show>
-                  </button>
-                )}
-              </For>
-            </div>
+            <Menu.Provider store={menuStore}>
+              <Menu.List
+                ref={(element) => (menuContainerRef = element)}
+                label={accessibleMenuLabel()}
+                class="w-[calc(100%+16px)] -mx-2 -my-1.5 outline-none"
+              >
+                <For each={menuItems()}>
+                  {(item) => (
+                    <Menu.Item
+                      value={item.label.toLowerCase()}
+                      disabled={!item.enabled}
+                      onSelect={() => {
+                        item.action();
+                        props.onHide();
+                      }}
+                    >
+                      <Menu.Label class="text-[var(--rg-text-primary)]">{item.label}</Menu.Label>
+                      <Show when={item.shortcut}>
+                        {(shortcut) => (
+                          <Menu.Shortcut shortcut={shortcut()} modifier={item.shortcutModifier} />
+                        )}
+                      </Show>
+                    </Menu.Item>
+                  )}
+                </For>
+              </Menu.List>
+            </Menu.Provider>
           </BottomSection>
         </div>
       </div>

--- a/packages/react-grab/src/components/context-menu.tsx
+++ b/packages/react-grab/src/components/context-menu.tsx
@@ -23,7 +23,6 @@ import {
   MENU_PANEL_CORNER_RADIUS_PX,
   Z_INDEX_OVERLAY,
 } from "../constants.js";
-import { cn } from "../utils/cn.js";
 import { Arrow } from "./selection-label/arrow.js";
 import { TagBadge } from "./selection-label/tag-badge.js";
 import { BottomSection } from "./selection-label/bottom-section.js";
@@ -248,15 +247,14 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
       };
 
       // Enter activates the highlighted row directly via its registered
-      // onSelect; with no active row we fall through so an action that binds
-      // Enter as its own shortcut still fires.
+      // onSelect (which already closes the menu); with no active row we fall
+      // through so an action that binds Enter as its own shortcut still fires.
       if (event.key === "Enter") {
         const activeItem = menuStore.getActiveItem();
         if (activeItem && activeItem.isEnabled()) {
           event.preventDefault();
           event.stopPropagation();
           activeItem.onSelect();
-          props.onHide();
           return;
         }
       }
@@ -310,12 +308,7 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
           leftOffsetPx={computedPosition().arrowLeft}
         />
 
-        <div
-          class={cn(
-            "contain-layout flex flex-col justify-center items-start rounded-[14px] antialiased w-fit h-fit min-w-[100px] [font-synthesis:none] [corner-shape:superellipse(1.25)]",
-            "bg-[var(--rg-panel-bg)]",
-          )}
-        >
+        <Menu.Panel class="justify-center items-start min-w-[100px]">
           <div class="contain-layout shrink-0 flex items-center gap-1 pt-1.5 pb-1 w-fit h-fit px-2">
             <TagBadge
               tagName={tagDisplayResult().tagName}
@@ -360,7 +353,7 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
               </Menu.List>
             </Menu.Provider>
           </BottomSection>
-        </div>
+        </Menu.Panel>
       </div>
     </Show>
   );

--- a/packages/react-grab/src/components/context-menu.tsx
+++ b/packages/react-grab/src/components/context-menu.tsx
@@ -47,6 +47,7 @@ interface ContextMenuProps {
 }
 
 interface ContextMenuRow {
+  id: string;
   label: string;
   action: () => void;
   enabled: boolean;
@@ -152,6 +153,7 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
     const context = props.actionContext;
 
     return pluginActions.map((action) => ({
+      id: action.id,
       label: action.label,
       action: () => {
         if (context) {
@@ -334,7 +336,8 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
                 <For each={menuItems()}>
                   {(item) => (
                     <Menu.Item
-                      value={item.label.toLowerCase()}
+                      value={item.id}
+                      dataId={item.label.toLowerCase()}
                       disabled={!item.enabled}
                       onSelect={() => {
                         item.action();

--- a/packages/react-grab/src/components/context-menu.tsx
+++ b/packages/react-grab/src/components/context-menu.tsx
@@ -46,7 +46,7 @@ interface ContextMenuProps {
   onHide: () => void;
 }
 
-interface MenuItem {
+interface ContextMenuRow {
   label: string;
   action: () => void;
   enabled: boolean;
@@ -147,7 +147,7 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
     return { left: positionLeft, top: positionTop, arrowLeft, arrowPosition };
   });
 
-  const menuItems = createMemo<MenuItem[]>(() => {
+  const menuItems = createMemo<ContextMenuRow[]>(() => {
     const pluginActions = props.actions ?? [];
     const context = props.actionContext;
 

--- a/packages/react-grab/src/components/edit-panel/color-picker.tsx
+++ b/packages/react-grab/src/components/edit-panel/color-picker.tsx
@@ -2,6 +2,7 @@ import { createSignal, onCleanup, onMount, Show, type Component } from "solid-js
 import { IME_COMPOSING_KEY_CODE } from "../../constants.js";
 import { formatColorLabel } from "../../utils/format-color-label.js";
 import { parseAnyColor } from "../../utils/parse-any-color.js";
+import { Input } from "../ui/input.js";
 import { EDIT_LABEL_CLASS } from "./constants.js";
 
 // Native <input type="color"> only accepts `#rrggbb` (no alpha, no
@@ -111,23 +112,11 @@ export const ColorPicker: Component<ColorPickerProps> = (props) => {
             </span>
           }
         >
-          <input
-            ref={(element) => {
-              queueMicrotask(() => {
-                element.focus();
-                element.select();
-              });
-            }}
-            data-react-grab-ignore-events
-            data-react-grab-input
-            type="text"
+          <Input
+            autoFocusSelect
             inputmode="text"
             aria-label="Style color hex"
-            autocapitalize="none"
-            autocorrect="off"
-            autocomplete="off"
-            spellcheck={false}
-            class={`${HEX_CLASS} bg-transparent border-none outline-none text-[var(--rg-text-primary)] p-0 m-0 text-right`}
+            class={`${HEX_CLASS} text-right`}
             style={{
               "field-sizing": "content",
               "min-width": "32px",

--- a/packages/react-grab/src/components/edit-panel/copy-button.tsx
+++ b/packages/react-grab/src/components/edit-panel/copy-button.tsx
@@ -1,15 +1,14 @@
 import type { Component } from "solid-js";
+import { Button } from "../ui/button.js";
 
 interface EditPanelCopyButtonProps {
   onCopy: () => void;
 }
 
 export const EditPanelCopyButton: Component<EditPanelCopyButtonProps> = (props) => (
-  <button
+  <Button
     data-react-grab-ignore-events
     data-react-grab-copy-button
-    type="button"
-    class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[var(--rg-surface-hover)] [border-width:0.5px] border-solid border-[var(--rg-border-button)] cursor-pointer transition-all hover:bg-[var(--rg-surface-active)] press-scale h-[17px]"
     onClick={(event) => {
       event.preventDefault();
       event.stopPropagation();
@@ -19,5 +18,5 @@ export const EditPanelCopyButton: Component<EditPanelCopyButtonProps> = (props) 
     <span class="text-[var(--rg-text-primary)] text-[13px] leading-3.5 font-sans font-medium">
       Copy
     </span>
-  </button>
+  </Button>
 );

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -40,6 +40,7 @@ import { isEventFromOverlay } from "../../utils/is-event-from-overlay.js";
 import { registerOverlayDismiss } from "../../utils/register-overlay-dismiss.js";
 import { suppressMenuEvent } from "../../utils/suppress-menu-event.js";
 import { TagBadge } from "../selection-label/tag-badge.js";
+import { Surface } from "../ui/surface.js";
 import { ActivePropertyControl } from "./active-property-control.js";
 import { HIDDEN_FOCUS_PRESERVING_STYLE } from "./constants.js";
 import { EditPanelCopyButton } from "./copy-button.js";
@@ -571,9 +572,9 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
         onClick={suppressMenuEvent}
         onContextMenu={suppressMenuEvent}
       >
-        <div
-          ref={panelSurfaceRef}
-          class="contain-layout flex flex-col justify-center items-start rounded-[14px] overflow-hidden antialiased w-fit h-fit [font-synthesis:none] [corner-shape:superellipse(1.25)] bg-[var(--rg-panel-bg)]"
+        <Surface
+          ref={(element) => (panelSurfaceRef = element)}
+          class="flex flex-col justify-center items-start overflow-hidden w-fit h-fit"
           style={{
             "min-width": isCompact() ? undefined : `${EDIT_PANEL_MIN_WIDTH_PX}px`,
             "max-width": `${EDIT_PANEL_MAX_WIDTH_PX}px`,
@@ -766,7 +767,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
               </div>
             )}
           </Show>
-        </div>
+        </Surface>
       </div>
     </Show>
   );

--- a/packages/react-grab/src/components/edit-panel/value-stepper.tsx
+++ b/packages/react-grab/src/components/edit-panel/value-stepper.tsx
@@ -12,6 +12,7 @@ import {
 } from "../../constants.js";
 import { formatDisplayValue } from "../../utils/format-css-value.js";
 import { Slot } from "../slot.js";
+import { Input } from "../ui/input.js";
 import { EDIT_LABEL_CLASS } from "./constants.js";
 import { StepArrow } from "./step-arrow.js";
 
@@ -330,23 +331,11 @@ export const ValueStepper: Component<ValueStepperProps> = (props) => {
               </span>
             }
           >
-            <input
-              ref={(element) => {
-                queueMicrotask(() => {
-                  element.focus();
-                  element.select();
-                });
-              }}
-              data-react-grab-ignore-events
-              data-react-grab-input
-              type="text"
+            <Input
+              autoFocusSelect
               inputmode="decimal"
               aria-label="Style value"
-              autocapitalize="none"
-              autocorrect="off"
-              autocomplete="off"
-              spellcheck={false}
-              class={`${VALUE_CLASS} bg-transparent border-none outline-none text-[var(--rg-text-primary)] p-0 m-0 text-right pointer-events-auto ml-auto`}
+              class={`${VALUE_CLASS} text-right pointer-events-auto ml-auto`}
               style={{
                 "field-sizing": "content",
                 "min-width": "16px",

--- a/packages/react-grab/src/components/menu/index.ts
+++ b/packages/react-grab/src/components/menu/index.ts
@@ -1,4 +1,5 @@
 import { MenuProvider } from "./menu-provider.js";
+import { MenuPanel } from "./menu-panel.js";
 import { MenuList } from "./menu-list.js";
 import { MenuItem } from "./menu-item.js";
 import { MenuItemLabel } from "./menu-item-label.js";
@@ -7,10 +8,11 @@ import { MenuShortcut } from "./menu-shortcut.js";
 export { createMenuStore } from "./menu-store.js";
 export { useMenuStore } from "./menu-context.js";
 export type { MenuStore, MenuItemRegistration } from "./menu-context.js";
-export { MenuProvider, MenuList, MenuItem, MenuItemLabel, MenuShortcut };
+export { MenuProvider, MenuPanel, MenuList, MenuItem, MenuItemLabel, MenuShortcut };
 
 export const Menu = {
   Provider: MenuProvider,
+  Panel: MenuPanel,
   List: MenuList,
   Item: MenuItem,
   Label: MenuItemLabel,

--- a/packages/react-grab/src/components/menu/index.ts
+++ b/packages/react-grab/src/components/menu/index.ts
@@ -1,0 +1,18 @@
+import { MenuProvider } from "./menu-provider.js";
+import { MenuList } from "./menu-list.js";
+import { MenuItem } from "./menu-item.js";
+import { MenuItemLabel } from "./menu-item-label.js";
+import { MenuShortcut } from "./menu-shortcut.js";
+
+export { createMenuStore } from "./menu-store.js";
+export { useMenuStore } from "./menu-context.js";
+export type { MenuStore, MenuItemRegistration } from "./menu-context.js";
+export { MenuProvider, MenuList, MenuItem, MenuItemLabel, MenuShortcut };
+
+export const Menu = {
+  Provider: MenuProvider,
+  List: MenuList,
+  Item: MenuItem,
+  Label: MenuItemLabel,
+  Shortcut: MenuShortcut,
+};

--- a/packages/react-grab/src/components/menu/menu-context.ts
+++ b/packages/react-grab/src/components/menu/menu-context.ts
@@ -1,0 +1,37 @@
+import { createContext, useContext, type Accessor } from "solid-js";
+
+export interface MenuItemRegistration {
+  id: string;
+  element: HTMLButtonElement;
+  isEnabled: () => boolean;
+  onSelect: () => void;
+}
+
+export interface MenuStore {
+  keyboardNavigation: boolean;
+  clearActiveOnPointerLeave: boolean;
+  activeItemId: Accessor<string | null>;
+  setActiveItem: (id: string | null) => void;
+  createItemId: () => string;
+  registerItem: (registration: MenuItemRegistration) => void;
+  unregisterItem: (id: string) => void;
+  getActiveItem: () => MenuItemRegistration | undefined;
+  selectFirst: () => void;
+  selectLast: () => void;
+  selectNext: () => void;
+  selectPrevious: () => void;
+  setHighlightContainer: (element: HTMLElement) => void;
+  setHighlightRail: (element: HTMLElement) => void;
+}
+
+const MenuContext = createContext<MenuStore>();
+
+export const useMenuStore = (): MenuStore => {
+  const store = useContext(MenuContext);
+  if (!store) {
+    throw new Error("Menu subcomponents must be rendered inside <Menu.Provider>");
+  }
+  return store;
+};
+
+export { MenuContext };

--- a/packages/react-grab/src/components/menu/menu-context.ts
+++ b/packages/react-grab/src/components/menu/menu-context.ts
@@ -1,7 +1,8 @@
 import { createContext, useContext, type Accessor } from "solid-js";
 
 export interface MenuItemRegistration {
-  id: string;
+  value: string;
+  domId: string;
   element: HTMLButtonElement;
   isEnabled: () => boolean;
   onSelect: () => void;
@@ -10,11 +11,15 @@ export interface MenuItemRegistration {
 export interface MenuStore {
   keyboardNavigation: boolean;
   clearActiveOnPointerLeave: boolean;
-  activeItemId: Accessor<string | null>;
-  setActiveItem: (id: string | null) => void;
+  activeValue: Accessor<string | null>;
+  activeDescendantId: Accessor<string | undefined>;
+  setActiveItem: (value: string | null) => void;
   createItemId: () => string;
+  canActivateOnHover: () => boolean;
+  notePointerMove: () => void;
+  resetPointerMove: () => void;
   registerItem: (registration: MenuItemRegistration) => void;
-  unregisterItem: (id: string) => void;
+  unregisterItem: (value: string) => void;
   getActiveItem: () => MenuItemRegistration | undefined;
   selectFirst: () => void;
   selectLast: () => void;

--- a/packages/react-grab/src/components/menu/menu-item-label.tsx
+++ b/packages/react-grab/src/components/menu/menu-item-label.tsx
@@ -1,0 +1,13 @@
+import type { Component, JSX } from "solid-js";
+import { cn } from "../../utils/cn.js";
+
+interface MenuItemLabelProps {
+  class?: string;
+  children: JSX.Element;
+}
+
+export const MenuItemLabel: Component<MenuItemLabelProps> = (props) => (
+  <span class={cn("text-[13px] leading-4 font-sans font-medium", props.class)}>
+    {props.children}
+  </span>
+);

--- a/packages/react-grab/src/components/menu/menu-item.tsx
+++ b/packages/react-grab/src/components/menu/menu-item.tsx
@@ -14,28 +14,32 @@ interface MenuItemProps {
 
 export const MenuItem: Component<MenuItemProps> = (props) => {
   const store = useMenuStore();
-  const itemId = store.createItemId();
+  const domId = store.createItemId();
+  // Captured at mount so registration/cleanup stay keyed on a stable value
+  // even if the component instance is reused for a different row.
+  const itemValue = props.value;
   const role = (): "menuitem" | "menuitemradio" => props.role ?? "menuitem";
   const isEnabled = (): boolean => !props.disabled;
-  const isActive = (): boolean => store.activeItemId() === itemId;
+  const isActive = (): boolean => store.activeValue() === props.value;
 
   let buttonElement: HTMLButtonElement | undefined;
 
   onMount(() => {
     if (!buttonElement) return;
     store.registerItem({
-      id: itemId,
+      value: itemValue,
+      domId,
       element: buttonElement,
       isEnabled,
       onSelect: () => props.onSelect?.(),
     });
-    onCleanup(() => store.unregisterItem(itemId));
+    onCleanup(() => store.unregisterItem(itemValue));
   });
 
   return (
     <button
       ref={buttonElement}
-      id={itemId}
+      id={domId}
       data-react-grab-ignore-events
       data-react-grab-menu-item={props.value}
       type="button"
@@ -50,7 +54,7 @@ export const MenuItem: Component<MenuItemProps> = (props) => {
       )}
       onPointerDown={(event) => event.stopPropagation()}
       onPointerEnter={() => {
-        if (isEnabled()) store.setActiveItem(itemId);
+        if (isEnabled() && store.canActivateOnHover()) store.setActiveItem(props.value);
       }}
       onPointerLeave={() => {
         if (store.clearActiveOnPointerLeave) store.setActiveItem(null);

--- a/packages/react-grab/src/components/menu/menu-item.tsx
+++ b/packages/react-grab/src/components/menu/menu-item.tsx
@@ -4,6 +4,10 @@ import { useMenuStore } from "./menu-context.js";
 
 interface MenuItemProps {
   value: string;
+  // Test/debug hook rendered as data-react-grab-menu-item. Defaults to
+  // `value`; pass explicitly when the store identity must stay unique but the
+  // attribute should read as something else (e.g. a human label).
+  dataId?: string;
   role?: "menuitem" | "menuitemradio";
   disabled?: boolean;
   checked?: boolean;
@@ -38,7 +42,7 @@ export const MenuItem: Component<MenuItemProps> = (props) => {
       ref={buttonElement}
       id={domId}
       data-react-grab-ignore-events
-      data-react-grab-menu-item={props.value}
+      data-react-grab-menu-item={props.dataId ?? props.value}
       type="button"
       role={role()}
       aria-checked={role() === "menuitemradio" ? Boolean(props.checked) : undefined}

--- a/packages/react-grab/src/components/menu/menu-item.tsx
+++ b/packages/react-grab/src/components/menu/menu-item.tsx
@@ -1,0 +1,67 @@
+import { onCleanup, onMount, type Component, type JSX } from "solid-js";
+import { cn } from "../../utils/cn.js";
+import { useMenuStore } from "./menu-context.js";
+
+interface MenuItemProps {
+  value: string;
+  role?: "menuitem" | "menuitemradio";
+  disabled?: boolean;
+  checked?: boolean;
+  class?: string;
+  onSelect?: () => void;
+  children: JSX.Element;
+}
+
+export const MenuItem: Component<MenuItemProps> = (props) => {
+  const store = useMenuStore();
+  const itemId = store.createItemId();
+  const role = (): "menuitem" | "menuitemradio" => props.role ?? "menuitem";
+  const isEnabled = (): boolean => !props.disabled;
+  const isActive = (): boolean => store.activeItemId() === itemId;
+
+  let buttonElement: HTMLButtonElement | undefined;
+
+  onMount(() => {
+    if (!buttonElement) return;
+    store.registerItem({
+      id: itemId,
+      element: buttonElement,
+      isEnabled,
+      onSelect: () => props.onSelect?.(),
+    });
+    onCleanup(() => store.unregisterItem(itemId));
+  });
+
+  return (
+    <button
+      ref={buttonElement}
+      id={itemId}
+      data-react-grab-ignore-events
+      data-react-grab-menu-item={props.value}
+      type="button"
+      role={role()}
+      aria-checked={role() === "menuitemradio" ? Boolean(props.checked) : undefined}
+      aria-disabled={Boolean(props.disabled)}
+      tabindex={store.keyboardNavigation ? (isActive() ? 0 : -1) : undefined}
+      disabled={props.disabled}
+      class={cn(
+        "relative z-1 contain-layout flex items-center justify-between w-full px-2 py-1 cursor-pointer text-left border-none bg-transparent disabled:opacity-40 disabled:cursor-default",
+        props.class,
+      )}
+      onPointerDown={(event) => event.stopPropagation()}
+      onPointerEnter={() => {
+        if (isEnabled()) store.setActiveItem(itemId);
+      }}
+      onPointerLeave={() => {
+        if (store.clearActiveOnPointerLeave) store.setActiveItem(null);
+      }}
+      onClick={(event) => {
+        event.stopPropagation();
+        if (!isEnabled()) return;
+        props.onSelect?.();
+      }}
+    >
+      {props.children}
+    </button>
+  );
+};

--- a/packages/react-grab/src/components/menu/menu-item.tsx
+++ b/packages/react-grab/src/components/menu/menu-item.tsx
@@ -15,9 +15,6 @@ interface MenuItemProps {
 export const MenuItem: Component<MenuItemProps> = (props) => {
   const store = useMenuStore();
   const domId = store.createItemId();
-  // Captured at mount so registration/cleanup stay keyed on a stable value
-  // even if the component instance is reused for a different row.
-  const itemValue = props.value;
   const role = (): "menuitem" | "menuitemradio" => props.role ?? "menuitem";
   const isEnabled = (): boolean => !props.disabled;
   const isActive = (): boolean => store.activeValue() === props.value;
@@ -27,13 +24,13 @@ export const MenuItem: Component<MenuItemProps> = (props) => {
   onMount(() => {
     if (!buttonElement) return;
     store.registerItem({
-      value: itemValue,
+      value: props.value,
       domId,
       element: buttonElement,
       isEnabled,
       onSelect: () => props.onSelect?.(),
     });
-    onCleanup(() => store.unregisterItem(itemValue));
+    onCleanup(() => store.unregisterItem(props.value));
   });
 
   return (

--- a/packages/react-grab/src/components/menu/menu-list.tsx
+++ b/packages/react-grab/src/components/menu/menu-list.tsx
@@ -1,0 +1,38 @@
+import type { Component, JSX } from "solid-js";
+import { cn } from "../../utils/cn.js";
+import { useMenuStore } from "./menu-context.js";
+
+interface MenuListProps {
+  ref?: (element: HTMLDivElement) => void;
+  class?: string;
+  label?: string;
+  children: JSX.Element;
+}
+
+export const MenuList: Component<MenuListProps> = (props) => {
+  const store = useMenuStore();
+
+  return (
+    <div
+      ref={(element) => {
+        store.setHighlightContainer(element);
+        props.ref?.(element);
+      }}
+      role="menu"
+      aria-orientation="vertical"
+      aria-label={props.label}
+      aria-activedescendant={
+        store.keyboardNavigation ? (store.activeItemId() ?? undefined) : undefined
+      }
+      tabindex={store.keyboardNavigation ? -1 : undefined}
+      class={cn("relative flex flex-col", props.class)}
+    >
+      <div
+        ref={store.setHighlightRail}
+        aria-hidden="true"
+        class="pointer-events-none absolute opacity-0 transition-[top,left,width,height,opacity,border-radius] duration-75 ease-out bg-[var(--rg-surface-hover)]"
+      />
+      {props.children}
+    </div>
+  );
+};

--- a/packages/react-grab/src/components/menu/menu-list.tsx
+++ b/packages/react-grab/src/components/menu/menu-list.tsx
@@ -21,11 +21,10 @@ export const MenuList: Component<MenuListProps> = (props) => {
       role="menu"
       aria-orientation="vertical"
       aria-label={props.label}
-      aria-activedescendant={
-        store.keyboardNavigation ? (store.activeItemId() ?? undefined) : undefined
-      }
+      aria-activedescendant={store.keyboardNavigation ? store.activeDescendantId() : undefined}
       tabindex={store.keyboardNavigation ? -1 : undefined}
       class={cn("relative flex flex-col", props.class)}
+      onPointerMove={() => store.notePointerMove()}
     >
       <div
         ref={store.setHighlightRail}

--- a/packages/react-grab/src/components/menu/menu-panel.tsx
+++ b/packages/react-grab/src/components/menu/menu-panel.tsx
@@ -1,5 +1,6 @@
 import type { Component, JSX } from "solid-js";
 import { cn } from "../../utils/cn.js";
+import { Surface } from "../ui/surface.js";
 
 interface MenuPanelProps {
   class?: string;
@@ -8,13 +9,7 @@ interface MenuPanelProps {
 }
 
 export const MenuPanel: Component<MenuPanelProps> = (props) => (
-  <div
-    class={cn(
-      "contain-layout flex flex-col rounded-[14px] antialiased w-fit h-fit [font-synthesis:none] [corner-shape:superellipse(1.25)] bg-[var(--rg-panel-bg)]",
-      props.class,
-    )}
-    style={props.style}
-  >
+  <Surface class={cn("flex flex-col w-fit h-fit", props.class)} style={props.style}>
     {props.children}
-  </div>
+  </Surface>
 );

--- a/packages/react-grab/src/components/menu/menu-panel.tsx
+++ b/packages/react-grab/src/components/menu/menu-panel.tsx
@@ -1,0 +1,20 @@
+import type { Component, JSX } from "solid-js";
+import { cn } from "../../utils/cn.js";
+
+interface MenuPanelProps {
+  class?: string;
+  style?: JSX.CSSProperties;
+  children: JSX.Element;
+}
+
+export const MenuPanel: Component<MenuPanelProps> = (props) => (
+  <div
+    class={cn(
+      "contain-layout flex flex-col rounded-[14px] antialiased w-fit h-fit [font-synthesis:none] [corner-shape:superellipse(1.25)] bg-[var(--rg-panel-bg)]",
+      props.class,
+    )}
+    style={props.style}
+  >
+    {props.children}
+  </div>
+);

--- a/packages/react-grab/src/components/menu/menu-provider.tsx
+++ b/packages/react-grab/src/components/menu/menu-provider.tsx
@@ -1,0 +1,11 @@
+import type { Component, JSX } from "solid-js";
+import { MenuContext, type MenuStore } from "./menu-context.js";
+
+interface MenuProviderProps {
+  store: MenuStore;
+  children: JSX.Element;
+}
+
+export const MenuProvider: Component<MenuProviderProps> = (props) => (
+  <MenuContext.Provider value={props.store}>{props.children}</MenuContext.Provider>
+);

--- a/packages/react-grab/src/components/menu/menu-shortcut.tsx
+++ b/packages/react-grab/src/components/menu/menu-shortcut.tsx
@@ -1,0 +1,17 @@
+import type { Component } from "solid-js";
+import { cn } from "../../utils/cn.js";
+import { ShortcutHint } from "../shortcut-hint.js";
+
+interface MenuShortcutProps {
+  shortcut: string;
+  modifier?: boolean;
+  class?: string;
+}
+
+export const MenuShortcut: Component<MenuShortcutProps> = (props) => (
+  <ShortcutHint
+    shortcut={props.shortcut}
+    modifier={props.modifier}
+    class={cn("text-[11px] font-sans text-[var(--rg-text-secondary)] ml-4", props.class)}
+  />
+);

--- a/packages/react-grab/src/components/menu/menu-store.ts
+++ b/packages/react-grab/src/components/menu/menu-store.ts
@@ -1,0 +1,98 @@
+import { createEffect, createSignal, on } from "solid-js";
+import { createMenuHighlight } from "../../utils/create-menu-highlight.js";
+import type { MenuItemRegistration, MenuStore } from "./menu-context.js";
+
+interface CreateMenuStoreOptions {
+  keyboardNavigation?: boolean;
+  clearActiveOnPointerLeave?: boolean;
+  highlight?: {
+    topCornerRadiusPx?: number;
+    bottomCornerRadiusPx?: number;
+    cornerShape?: string;
+  };
+}
+
+export const createMenuStore = (options: CreateMenuStoreOptions = {}): MenuStore => {
+  const itemRegistry = new Map<string, MenuItemRegistration>();
+  const itemOrder: string[] = [];
+  const idPrefix = `react-grab-menu-${Math.random().toString(36).slice(2, 8)}`;
+  let idCounter = 0;
+
+  const [activeItemId, setActiveItemId] = createSignal<string | null>(null);
+
+  const highlight = createMenuHighlight(options.highlight ?? {});
+
+  createEffect(
+    on(activeItemId, (id) => {
+      if (id === null) {
+        highlight.clearHighlight();
+        return;
+      }
+      const registration = itemRegistry.get(id);
+      if (registration) {
+        highlight.updateHighlight(registration.element);
+      } else {
+        highlight.clearHighlight();
+      }
+    }),
+  );
+
+  const enabledIds = (): string[] => itemOrder.filter((id) => itemRegistry.get(id)?.isEnabled());
+
+  const selectFirst = (): void => {
+    const candidates = enabledIds();
+    if (candidates.length > 0) setActiveItemId(candidates[0]);
+  };
+
+  const selectLast = (): void => {
+    const candidates = enabledIds();
+    if (candidates.length > 0) setActiveItemId(candidates[candidates.length - 1]);
+  };
+
+  const selectNext = (): void => {
+    const candidates = enabledIds();
+    if (candidates.length === 0) return;
+    const currentIndex = candidates.indexOf(activeItemId() ?? "");
+    const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % candidates.length;
+    setActiveItemId(candidates[nextIndex]);
+  };
+
+  const selectPrevious = (): void => {
+    const candidates = enabledIds();
+    if (candidates.length === 0) return;
+    const currentIndex = candidates.indexOf(activeItemId() ?? "");
+    const previousIndex =
+      currentIndex === -1
+        ? candidates.length - 1
+        : (currentIndex - 1 + candidates.length) % candidates.length;
+    setActiveItemId(candidates[previousIndex]);
+  };
+
+  return {
+    keyboardNavigation: options.keyboardNavigation ?? false,
+    clearActiveOnPointerLeave: options.clearActiveOnPointerLeave ?? false,
+    activeItemId,
+    setActiveItem: setActiveItemId,
+    createItemId: () => `${idPrefix}-item-${idCounter++}`,
+    registerItem: (registration) => {
+      itemRegistry.set(registration.id, registration);
+      if (!itemOrder.includes(registration.id)) itemOrder.push(registration.id);
+    },
+    unregisterItem: (id) => {
+      itemRegistry.delete(id);
+      const orderIndex = itemOrder.indexOf(id);
+      if (orderIndex !== -1) itemOrder.splice(orderIndex, 1);
+      setActiveItemId((current) => (current === id ? null : current));
+    },
+    getActiveItem: () => {
+      const id = activeItemId();
+      return id === null ? undefined : itemRegistry.get(id);
+    },
+    selectFirst,
+    selectLast,
+    selectNext,
+    selectPrevious,
+    setHighlightContainer: highlight.containerRef,
+    setHighlightRail: highlight.highlightRef,
+  };
+};

--- a/packages/react-grab/src/components/menu/menu-store.ts
+++ b/packages/react-grab/src/components/menu/menu-store.ts
@@ -1,10 +1,20 @@
-import { createEffect, createSignal, on } from "solid-js";
+import { createEffect, createMemo, createSignal, on, type Accessor } from "solid-js";
 import { createMenuHighlight } from "../../utils/create-menu-highlight.js";
 import type { MenuItemRegistration, MenuStore } from "./menu-context.js";
 
 interface CreateMenuStoreOptions {
   keyboardNavigation?: boolean;
   clearActiveOnPointerLeave?: boolean;
+  // When set, hover only activates a row after the pointer has actually
+  // moved over the menu. Guards against a stationary cursor firing a
+  // phantom pointerenter (and yanking the active row) when the list mounts
+  // or repositions under it.
+  requirePointerMove?: boolean;
+  // Controlled mode (cmdk-style): when `value` is provided the active row is
+  // owned by the parent and every activation is reported through
+  // `onValueChange` instead of mutating internal state.
+  value?: Accessor<string | null>;
+  onValueChange?: (value: string | null) => void;
   highlight?: {
     topCornerRadiusPx?: number;
     bottomCornerRadiusPx?: number;
@@ -13,22 +23,37 @@ interface CreateMenuStoreOptions {
 }
 
 export const createMenuStore = (options: CreateMenuStoreOptions = {}): MenuStore => {
-  const itemRegistry = new Map<string, MenuItemRegistration>();
-  const itemOrder: string[] = [];
+  const itemsByValue = new Map<string, MenuItemRegistration>();
+  const orderedValues: string[] = [];
   const idPrefix = `react-grab-menu-${Math.random().toString(36).slice(2, 8)}`;
   let idCounter = 0;
+  let didPointerMove = false;
 
-  const [activeItemId, setActiveItemId] = createSignal<string | null>(null);
+  const isControlled = options.value !== undefined;
+  const [internalActiveValue, setInternalActiveValue] = createSignal<string | null>(null);
+  const [registryVersion, bumpRegistryVersion] = createSignal(0);
+
+  const activeValue = createMemo<string | null>(() =>
+    isControlled ? (options.value?.() ?? null) : internalActiveValue(),
+  );
+
+  const setActiveItem = (value: string | null): void => {
+    if (isControlled) {
+      options.onValueChange?.(value);
+      return;
+    }
+    setInternalActiveValue(value);
+  };
 
   const highlight = createMenuHighlight(options.highlight ?? {});
 
   createEffect(
-    on(activeItemId, (id) => {
-      if (id === null) {
+    on([activeValue, registryVersion], ([value]) => {
+      if (value === null) {
         highlight.clearHighlight();
         return;
       }
-      const registration = itemRegistry.get(id);
+      const registration = itemsByValue.get(value);
       if (registration) {
         highlight.updateHighlight(registration.element);
       } else {
@@ -37,56 +62,76 @@ export const createMenuStore = (options: CreateMenuStoreOptions = {}): MenuStore
     }),
   );
 
-  const enabledIds = (): string[] => itemOrder.filter((id) => itemRegistry.get(id)?.isEnabled());
+  const enabledValues = (): string[] =>
+    orderedValues.filter((value) => itemsByValue.get(value)?.isEnabled());
 
   const selectFirst = (): void => {
-    const candidates = enabledIds();
-    if (candidates.length > 0) setActiveItemId(candidates[0]);
+    const candidates = enabledValues();
+    if (candidates.length > 0) setActiveItem(candidates[0]);
   };
 
   const selectLast = (): void => {
-    const candidates = enabledIds();
-    if (candidates.length > 0) setActiveItemId(candidates[candidates.length - 1]);
+    const candidates = enabledValues();
+    if (candidates.length > 0) setActiveItem(candidates[candidates.length - 1]);
   };
 
   const selectNext = (): void => {
-    const candidates = enabledIds();
+    const candidates = enabledValues();
     if (candidates.length === 0) return;
-    const currentIndex = candidates.indexOf(activeItemId() ?? "");
+    const currentIndex = candidates.indexOf(activeValue() ?? "");
     const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % candidates.length;
-    setActiveItemId(candidates[nextIndex]);
+    setActiveItem(candidates[nextIndex]);
   };
 
   const selectPrevious = (): void => {
-    const candidates = enabledIds();
+    const candidates = enabledValues();
     if (candidates.length === 0) return;
-    const currentIndex = candidates.indexOf(activeItemId() ?? "");
+    const currentIndex = candidates.indexOf(activeValue() ?? "");
     const previousIndex =
       currentIndex === -1
         ? candidates.length - 1
         : (currentIndex - 1 + candidates.length) % candidates.length;
-    setActiveItemId(candidates[previousIndex]);
+    setActiveItem(candidates[previousIndex]);
   };
+
+  const activeDescendantId = createMemo<string | undefined>(() => {
+    registryVersion();
+    const value = activeValue();
+    if (value === null) return undefined;
+    return itemsByValue.get(value)?.domId;
+  });
 
   return {
     keyboardNavigation: options.keyboardNavigation ?? false,
     clearActiveOnPointerLeave: options.clearActiveOnPointerLeave ?? false,
-    activeItemId,
-    setActiveItem: setActiveItemId,
+    activeValue,
+    activeDescendantId,
+    setActiveItem,
     createItemId: () => `${idPrefix}-item-${idCounter++}`,
-    registerItem: (registration) => {
-      itemRegistry.set(registration.id, registration);
-      if (!itemOrder.includes(registration.id)) itemOrder.push(registration.id);
+    canActivateOnHover: () => !(options.requirePointerMove ?? false) || didPointerMove,
+    notePointerMove: () => {
+      didPointerMove = true;
     },
-    unregisterItem: (id) => {
-      itemRegistry.delete(id);
-      const orderIndex = itemOrder.indexOf(id);
-      if (orderIndex !== -1) itemOrder.splice(orderIndex, 1);
-      setActiveItemId((current) => (current === id ? null : current));
+    resetPointerMove: () => {
+      didPointerMove = false;
+    },
+    registerItem: (registration) => {
+      itemsByValue.set(registration.value, registration);
+      if (!orderedValues.includes(registration.value)) orderedValues.push(registration.value);
+      bumpRegistryVersion((version) => version + 1);
+    },
+    unregisterItem: (value) => {
+      itemsByValue.delete(value);
+      const orderIndex = orderedValues.indexOf(value);
+      if (orderIndex !== -1) orderedValues.splice(orderIndex, 1);
+      if (!isControlled) {
+        setInternalActiveValue((current) => (current === value ? null : current));
+      }
+      bumpRegistryVersion((version) => version + 1);
     },
     getActiveItem: () => {
-      const id = activeItemId();
-      return id === null ? undefined : itemRegistry.get(id);
+      const value = activeValue();
+      return value === null ? undefined : itemsByValue.get(value);
     },
     selectFirst,
     selectLast,

--- a/packages/react-grab/src/components/selection-label/arrow-navigation-menu.tsx
+++ b/packages/react-grab/src/components/selection-label/arrow-navigation-menu.tsx
@@ -1,7 +1,7 @@
 import { createEffect, For, Show, type Component } from "solid-js";
 import type { ArrowNavigationItem } from "../../types.js";
 import { MENU_HIGHLIGHT_CORNER_SHAPE, MENU_PANEL_CORNER_RADIUS_PX } from "../../constants.js";
-import { createMenuHighlight } from "../../utils/create-menu-highlight.js";
+import { Menu, createMenuStore } from "../menu/index.js";
 import { BottomSection } from "./bottom-section.js";
 
 interface ArrowNavigationMenuProps {
@@ -11,110 +11,58 @@ interface ArrowNavigationMenuProps {
 }
 
 export const ArrowNavigationMenu: Component<ArrowNavigationMenuProps> = (props) => {
-  const {
-    containerRef: highlightContainerRef,
-    highlightRef,
-    updateHighlight,
-    clearHighlight,
-  } = createMenuHighlight({
-    bottomCornerRadiusPx: MENU_PANEL_CORNER_RADIUS_PX,
-    cornerShape: MENU_HIGHLIGHT_CORNER_SHAPE,
+  const menuStore = createMenuStore({
+    keyboardNavigation: true,
+    requirePointerMove: true,
+    value: () => String(props.activeIndex),
+    onValueChange: (value) => {
+      if (value !== null) props.onSelect(Number(value));
+    },
+    highlight: {
+      bottomCornerRadiusPx: MENU_PANEL_CORNER_RADIUS_PX,
+      cornerShape: MENU_HIGHLIGHT_CORNER_SHAPE,
+    },
   });
 
-  let menuItemsRef: HTMLDivElement | undefined;
-  let didPointerMove = false;
-
-  const getMenuItemByIndex = (itemIndex: number): HTMLButtonElement | undefined => {
-    if (!menuItemsRef) return undefined;
-    const activeMenuButton = menuItemsRef.querySelector<HTMLButtonElement>(
-      `[data-react-grab-arrow-nav-index="${itemIndex}"]`,
-    );
-    return activeMenuButton ?? undefined;
-  };
-
-  // When items change we reset pointer tracking so that keyboard-driven
-  // active index changes are not overridden by phantom pointerenter events
-  // fired when the highlight element repositions under the cursor.
+  // The active row is driven by keyboard from the host; resetting the
+  // pointer-move gate whenever the chain changes keeps a phantom
+  // pointerenter (fired when the highlight repositions under a stationary
+  // cursor) from hijacking that keyboard-driven selection.
   createEffect(() => {
     void props.items;
-    didPointerMove = false;
-  });
-
-  createEffect(() => {
-    const activeMenuItem = getMenuItemByIndex(props.activeIndex);
-    if (activeMenuItem) {
-      updateHighlight(activeMenuItem);
-    }
+    menuStore.resetPointerMove();
   });
 
   return (
     <BottomSection>
-      <div
-        ref={(element) => {
-          menuItemsRef = element;
-          highlightContainerRef(element);
-        }}
-        role="menu"
-        aria-orientation="vertical"
-        aria-label="Navigate parent elements"
-        class="relative flex flex-col w-[calc(100%+16px)] -mx-2 -my-1.5"
-        onPointerMove={() => {
-          didPointerMove = true;
-        }}
-      >
-        <div
-          ref={highlightRef}
-          aria-hidden="true"
-          class="pointer-events-none absolute opacity-0 transition-[top,left,width,height,opacity,border-radius] duration-75 ease-out bg-[var(--rg-surface-hover)]"
-        />
-        <For each={props.items}>
-          {(item, itemIndex) => (
-            <button
-              data-react-grab-ignore-events
-              data-react-grab-arrow-nav-item={item.tagName}
-              data-react-grab-arrow-nav-index={itemIndex()}
-              type="button"
-              role="menuitemradio"
-              aria-checked={itemIndex() === props.activeIndex}
-              tabindex={itemIndex() === props.activeIndex ? 0 : -1}
-              class="relative z-1 contain-layout flex items-center w-full px-2 py-1 cursor-pointer text-left border-none bg-transparent"
-              onPointerDown={(event) => event.stopPropagation()}
-              onPointerEnter={(event) => {
-                updateHighlight(event.currentTarget);
-                if (didPointerMove) {
-                  props.onSelect(itemIndex());
-                }
-              }}
-              onPointerLeave={() => {
-                const activeMenuItem = getMenuItemByIndex(props.activeIndex);
-                if (activeMenuItem) {
-                  updateHighlight(activeMenuItem);
-                } else {
-                  clearHighlight();
-                }
-              }}
-              onClick={(event) => {
-                event.stopPropagation();
-                props.onSelect(itemIndex());
-              }}
-            >
-              <span
-                class="text-[13px] leading-4 h-fit font-medium overflow-hidden text-ellipsis whitespace-nowrap min-w-0 transition-colors"
-                classList={{
-                  "text-[var(--rg-text-primary)]": itemIndex() === props.activeIndex,
-                  "text-[var(--rg-text-secondary)]": itemIndex() !== props.activeIndex,
-                }}
+      <Menu.Provider store={menuStore}>
+        <Menu.List label="Navigate parent elements" class="w-[calc(100%+16px)] -mx-2 -my-1.5">
+          <For each={props.items}>
+            {(item, itemIndex) => (
+              <Menu.Item
+                value={String(itemIndex())}
+                role="menuitemradio"
+                checked={itemIndex() === props.activeIndex}
+                onSelect={() => props.onSelect(itemIndex())}
               >
-                <Show when={item.componentName}>
-                  {item.componentName}
-                  <span class="text-[var(--rg-text-secondary)]">.</span>
-                </Show>
-                {item.tagName}
-              </span>
-            </button>
-          )}
-        </For>
-      </div>
+                <span
+                  class="text-[13px] leading-4 h-fit font-medium overflow-hidden text-ellipsis whitespace-nowrap min-w-0 transition-colors"
+                  classList={{
+                    "text-[var(--rg-text-primary)]": itemIndex() === props.activeIndex,
+                    "text-[var(--rg-text-secondary)]": itemIndex() !== props.activeIndex,
+                  }}
+                >
+                  <Show when={item.componentName}>
+                    {item.componentName}
+                    <span class="text-[var(--rg-text-secondary)]">.</span>
+                  </Show>
+                  {item.tagName}
+                </span>
+              </Menu.Item>
+            )}
+          </For>
+        </Menu.List>
+      </Menu.Provider>
     </BottomSection>
   );
 };

--- a/packages/react-grab/src/components/selection-label/completion-view.tsx
+++ b/packages/react-grab/src/components/selection-label/completion-view.tsx
@@ -6,6 +6,8 @@ import { isKeyboardEventTriggeredByInput } from "../../utils/is-keyboard-event-t
 import { IconReturn } from "../icons/icon-return.jsx";
 import { IconEllipsis } from "../icons/icon-ellipsis.jsx";
 import { cn } from "../../utils/cn.js";
+import { Button, buttonVariants } from "../ui/button.js";
+import { Surface } from "../ui/surface.js";
 import { IconCheck } from "../icons/icon-check.jsx";
 
 interface MoreOptionsButtonProps {
@@ -17,7 +19,10 @@ const MoreOptionsButton: Component<MoreOptionsButtonProps> = (props) => {
     <button
       data-react-grab-ignore-events
       data-react-grab-more-options
-      class="group flex items-center justify-center size-4 rounded-sm cursor-pointer bg-transparent hover:bg-[var(--rg-surface-hover)] text-[var(--rg-text-secondary)] hover:text-[var(--rg-text-primary)] border-none outline-none p-0 shrink-0 press-scale"
+      class={cn(
+        buttonVariants({ variant: "ghost" }),
+        "group size-4 text-[var(--rg-text-secondary)] hover:text-[var(--rg-text-primary)]",
+      )}
       // The on: prefix attaches a native event listener (rather than using
       // SolidJS delegation) so stopImmediatePropagation can beat both
       // delegated handlers and document-level capture listeners.
@@ -98,15 +103,13 @@ export const CompletionView: Component<CompletionViewProps> = (props) => {
   });
 
   return (
-    <div
+    <Surface
+      shape="pill"
       data-react-grab-completion
       role="status"
       aria-live="polite"
       aria-atomic="true"
-      class={cn(
-        "contain-layout shrink-0 flex flex-col justify-center items-end rounded-full antialiased w-fit h-fit max-w-[280px] transition-opacity duration-100 ease-out [font-synthesis:none]",
-        "bg-[var(--rg-panel-bg)]",
-      )}
+      class="shrink-0 flex flex-col justify-center items-end w-fit h-fit max-w-[280px] transition-opacity duration-100 ease-out"
       style={{ opacity: isFading() ? 0 : 1 }}
       onPointerDown={handleFocus}
       onClick={handleFocus}
@@ -121,11 +124,10 @@ export const CompletionView: Component<CompletionViewProps> = (props) => {
               <MoreOptionsButton onClick={handleShowContextMenu} />
             </Show>
             <Show when={props.onDismiss}>
-              <button
+              <Button
                 data-react-grab-dismiss
-                type="button"
+                class="gap-1"
                 aria-keyshortcuts="Enter"
-                class="contain-layout shrink-0 flex items-center justify-center gap-1 px-[3px] py-px rounded-sm bg-[var(--rg-surface-hover)] [border-width:0.5px] border-solid border-[var(--rg-border-button)] cursor-pointer transition-all hover:bg-[var(--rg-surface-active)] press-scale h-[17px]"
                 onClick={handleAccept}
                 disabled={didCopy()}
                 aria-disabled={didCopy()}
@@ -136,7 +138,7 @@ export const CompletionView: Component<CompletionViewProps> = (props) => {
                 <Show when={!didCopy()}>
                   <IconReturn size={10} class="text-[var(--rg-text-secondary)]" />
                 </Show>
-              </button>
+              </Button>
             </Show>
           </div>
         </div>
@@ -156,6 +158,6 @@ export const CompletionView: Component<CompletionViewProps> = (props) => {
           </Show>
         </div>
       </Show>
-    </div>
+    </Surface>
   );
 };

--- a/packages/react-grab/src/components/selection-label/completion-view.tsx
+++ b/packages/react-grab/src/components/selection-label/completion-view.tsx
@@ -1,8 +1,7 @@
-import { createSignal, onCleanup, onMount, Show, type Component } from "solid-js";
+import { createSignal, onCleanup, Show, type Component } from "solid-js";
 import type { CompletionViewProps } from "../../types.js";
 import { FEEDBACK_DURATION_MS, FADE_DURATION_MS } from "../../constants.js";
-import { confirmationFocusManager } from "../../utils/confirmation-focus-manager.js";
-import { isKeyboardEventTriggeredByInput } from "../../utils/is-keyboard-event-triggered-by-input.js";
+import { createConfirmationKeyboard } from "../../utils/create-confirmation-keyboard.js";
 import { IconReturn } from "../icons/icon-return.jsx";
 import { IconEllipsis } from "../icons/icon-ellipsis.jsx";
 import { cn } from "../../utils/cn.js";
@@ -40,7 +39,6 @@ const MoreOptionsButton: Component<MoreOptionsButtonProps> = (props) => {
 };
 
 export const CompletionView: Component<CompletionViewProps> = (props) => {
-  const instanceId = Symbol();
   let fadeTimeoutId: number | undefined;
   let dismissTimeoutId: number | undefined;
   const [didCopy, setDidCopy] = createSignal(false);
@@ -67,37 +65,20 @@ export const CompletionView: Component<CompletionViewProps> = (props) => {
     }, FEEDBACK_DURATION_MS - FADE_DURATION_MS);
   };
 
-  const handleKeyDown = (event: KeyboardEvent) => {
-    if (!confirmationFocusManager.isActive(instanceId)) return;
-
-    const isEnter = event.code === "Enter";
-    const isEscape = event.code === "Escape";
-
-    if (isKeyboardEventTriggeredByInput(event)) return;
-
-    if (isEnter) {
+  const { claimFocus } = createConfirmationKeyboard({
+    onEnter: (event) => {
       event.preventDefault();
       event.stopPropagation();
       handleAccept();
-    } else if (isEscape) {
+    },
+    onEscape: (event) => {
       event.preventDefault();
       event.stopPropagation();
       props.onDismiss?.();
-    }
-  };
-
-  const handleFocus = () => {
-    confirmationFocusManager.claim(instanceId);
-  };
-
-  onMount(() => {
-    confirmationFocusManager.claim(instanceId);
-    window.addEventListener("keydown", handleKeyDown, { capture: true });
+    },
   });
 
   onCleanup(() => {
-    confirmationFocusManager.release(instanceId);
-    window.removeEventListener("keydown", handleKeyDown, { capture: true });
     if (fadeTimeoutId !== undefined) window.clearTimeout(fadeTimeoutId);
     if (dismissTimeoutId !== undefined) window.clearTimeout(dismissTimeoutId);
   });
@@ -111,8 +92,8 @@ export const CompletionView: Component<CompletionViewProps> = (props) => {
       aria-atomic="true"
       class="shrink-0 flex flex-col justify-center items-end w-fit h-fit max-w-[280px] transition-opacity duration-100 ease-out"
       style={{ opacity: isFading() ? 0 : 1 }}
-      onPointerDown={handleFocus}
-      onClick={handleFocus}
+      onPointerDown={claimFocus}
+      onClick={claimFocus}
     >
       <Show when={!didCopy() && props.onDismiss}>
         <div class="contain-layout shrink-0 flex items-center justify-between gap-2 pt-1.5 pb-1 px-2 w-full h-fit">

--- a/packages/react-grab/src/components/selection-label/discard-prompt.tsx
+++ b/packages/react-grab/src/components/selection-label/discard-prompt.tsx
@@ -3,6 +3,7 @@ import type { DiscardPromptProps } from "../../types.js";
 import { confirmationFocusManager } from "../../utils/confirmation-focus-manager.js";
 import { isKeyboardEventTriggeredByInput } from "../../utils/is-keyboard-event-triggered-by-input.js";
 import { IconReturn } from "../icons/icon-return.jsx";
+import { Button } from "../ui/button.js";
 import { BottomSection } from "./bottom-section.js";
 
 export const DiscardPrompt: Component<DiscardPromptProps> = (props) => {
@@ -73,37 +74,30 @@ export const DiscardPrompt: Component<DiscardPromptProps> = (props) => {
       <BottomSection>
         <div class="contain-layout shrink-0 flex items-center justify-end gap-[5px] w-full h-fit">
           <Show when={shouldShowCancel()}>
-            <button
-              data-react-grab-discard-no
-              class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[var(--rg-surface-hover)] [border-width:0.5px] border-solid border-[var(--rg-border-button)] cursor-pointer transition-all hover:bg-[var(--rg-surface-active)] press-scale h-[17px]"
-              onClick={props.onCancel}
-            >
+            <Button data-react-grab-discard-no onClick={props.onCancel}>
               <span class="text-[var(--rg-text-primary)] text-[13px] leading-3.5 font-sans font-medium">
                 No
               </span>
-            </button>
+            </Button>
           </Show>
           <Show when={props.onCopy}>
-            <button
-              data-react-grab-discard-copy
-              class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[var(--rg-surface-hover)] [border-width:0.5px] border-solid border-[var(--rg-border-button)] cursor-pointer transition-all hover:bg-[var(--rg-surface-active)] press-scale h-[17px]"
-              onClick={props.onCopy}
-            >
+            <Button data-react-grab-discard-copy onClick={props.onCopy}>
               <span class="text-[var(--rg-text-primary)] text-[13px] leading-3.5 font-sans font-medium">
                 Copy
               </span>
-            </button>
+            </Button>
           </Show>
-          <button
+          <Button
+            variant="destructive"
+            class="gap-0.5"
             data-react-grab-discard-yes
-            class="contain-layout shrink-0 flex items-center justify-center gap-0.5 px-[3px] py-px rounded-sm bg-[var(--rg-error-bg)] cursor-pointer transition-all hover:bg-[var(--rg-error-bg-hover)] press-scale h-[17px]"
             onClick={props.onConfirm}
           >
             <span class="text-[var(--rg-error-text)] text-[13px] leading-3.5 font-sans font-medium">
               Yes
             </span>
             <IconReturn size={10} class="text-[var(--rg-error-text)] opacity-50" />
-          </button>
+          </Button>
         </div>
       </BottomSection>
     </div>

--- a/packages/react-grab/src/components/selection-label/discard-prompt.tsx
+++ b/packages/react-grab/src/components/selection-label/discard-prompt.tsx
@@ -1,70 +1,54 @@
-import { onCleanup, onMount, Show, type Component } from "solid-js";
+import { Show, type Component } from "solid-js";
 import type { DiscardPromptProps } from "../../types.js";
-import { confirmationFocusManager } from "../../utils/confirmation-focus-manager.js";
-import { isKeyboardEventTriggeredByInput } from "../../utils/is-keyboard-event-triggered-by-input.js";
+import { createConfirmationKeyboard } from "../../utils/create-confirmation-keyboard.js";
 import { IconReturn } from "../icons/icon-return.jsx";
 import { Button } from "../ui/button.js";
 import { BottomSection } from "./bottom-section.js";
 
 export const DiscardPrompt: Component<DiscardPromptProps> = (props) => {
-  const instanceId = Symbol();
   const shouldShowCancel = () => props.showCancel ?? true;
 
-  const handleKeyDown = (event: KeyboardEvent) => {
-    if (!confirmationFocusManager.isActive(instanceId)) return;
-    if (isKeyboardEventTriggeredByInput(event)) return;
-
-    // Escape confirms the discard by default ("yes, throw it away") rather
-    // than canceling, which is intentionally opposite to most dialogs. The
-    // cancelOnEscape prop flips this when the prompt itself should be
-    // dismissible.
-    const isEnter = event.code === "Enter";
-    const isEscape = event.code === "Escape";
-    if (isEnter || isEscape) {
+  const { claimFocus } = createConfirmationKeyboard({
+    onEnter: (event) => {
       event.preventDefault();
       event.stopPropagation();
       const target = event.composedPath()[0];
       const targetElement = target instanceof HTMLElement ? target : null;
-      if (isEnter && targetElement?.closest("[data-react-grab-discard-copy]")) {
+      if (targetElement?.closest("[data-react-grab-discard-copy]")) {
         props.onCopy?.();
         return;
       }
-      if (isEnter && targetElement?.closest("[data-react-grab-discard-no]")) {
+      if (targetElement?.closest("[data-react-grab-discard-no]")) {
         props.onCancel?.();
         return;
       }
-      if (isEnter && targetElement?.closest("[data-react-grab-discard-yes]")) {
+      if (targetElement?.closest("[data-react-grab-discard-yes]")) {
         props.onConfirm?.();
         return;
       }
-      if (isEscape && props.cancelOnEscape) {
+      props.onConfirm?.();
+    },
+    onEscape: (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      // Escape confirms the discard by default ("yes, throw it away") rather
+      // than canceling, which is intentionally opposite to most dialogs. The
+      // cancelOnEscape prop flips this when the prompt itself should be
+      // dismissible.
+      if (props.cancelOnEscape) {
         props.onCancel?.();
       } else {
         props.onConfirm?.();
       }
-    }
-  };
-
-  const handleFocus = () => {
-    confirmationFocusManager.claim(instanceId);
-  };
-
-  onMount(() => {
-    confirmationFocusManager.claim(instanceId);
-    window.addEventListener("keydown", handleKeyDown, { capture: true });
-  });
-
-  onCleanup(() => {
-    confirmationFocusManager.release(instanceId);
-    window.removeEventListener("keydown", handleKeyDown, { capture: true });
+    },
   });
 
   return (
     <div
       data-react-grab-discard-prompt
       class="contain-layout shrink-0 flex flex-col justify-center items-end w-fit h-fit"
-      onPointerDown={handleFocus}
-      onClick={handleFocus}
+      onPointerDown={claimFocus}
+      onClick={claimFocus}
     >
       <div class="contain-layout shrink-0 flex items-center gap-1 pt-1.5 pb-1 px-2 w-full h-fit">
         <span class="text-[var(--rg-text-primary)] text-[13px] leading-4 shrink-0 font-sans font-medium w-fit h-fit">

--- a/packages/react-grab/src/components/selection-label/error-view.tsx
+++ b/packages/react-grab/src/components/selection-label/error-view.tsx
@@ -1,44 +1,22 @@
-import { onCleanup, onMount, Show, type Component } from "solid-js";
+import { Show, type Component } from "solid-js";
 import type { ErrorViewProps } from "../../types.js";
-import { confirmationFocusManager } from "../../utils/confirmation-focus-manager.js";
-import { isKeyboardEventTriggeredByInput } from "../../utils/is-keyboard-event-triggered-by-input.js";
+import { createConfirmationKeyboard } from "../../utils/create-confirmation-keyboard.js";
 import { IconRetry } from "../icons/icon-retry.jsx";
 import { Button } from "../ui/button.js";
 import { BottomSection } from "./bottom-section.js";
 
 export const ErrorView: Component<ErrorViewProps> = (props) => {
-  const instanceId = Symbol();
-
-  const handleKeyDown = (event: KeyboardEvent) => {
-    if (!confirmationFocusManager.isActive(instanceId)) return;
-    if (isKeyboardEventTriggeredByInput(event)) return;
-
-    const isEnter = event.code === "Enter";
-    const isEscape = event.code === "Escape";
-
-    if (isEnter) {
+  const { claimFocus } = createConfirmationKeyboard({
+    onEnter: (event) => {
       event.preventDefault();
       event.stopPropagation();
       props.onRetry?.();
-    } else if (isEscape) {
+    },
+    onEscape: (event) => {
       event.preventDefault();
       event.stopPropagation();
       props.onAcknowledge?.();
-    }
-  };
-
-  const handleFocus = () => {
-    confirmationFocusManager.claim(instanceId);
-  };
-
-  onMount(() => {
-    confirmationFocusManager.claim(instanceId);
-    window.addEventListener("keydown", handleKeyDown, { capture: true });
-  });
-
-  onCleanup(() => {
-    confirmationFocusManager.release(instanceId);
-    window.removeEventListener("keydown", handleKeyDown, { capture: true });
+    },
   });
 
   const hasActions = () => Boolean(props.onRetry || props.onAcknowledge);
@@ -49,8 +27,8 @@ export const ErrorView: Component<ErrorViewProps> = (props) => {
       role="alert"
       aria-live="assertive"
       class="contain-layout shrink-0 flex flex-col justify-center items-end w-fit h-fit max-w-[280px]"
-      onPointerDown={handleFocus}
-      onClick={handleFocus}
+      onPointerDown={claimFocus}
+      onClick={claimFocus}
     >
       <div
         class="contain-layout shrink-0 flex items-start gap-1 px-2 w-full h-fit"

--- a/packages/react-grab/src/components/selection-label/error-view.tsx
+++ b/packages/react-grab/src/components/selection-label/error-view.tsx
@@ -3,6 +3,7 @@ import type { ErrorViewProps } from "../../types.js";
 import { confirmationFocusManager } from "../../utils/confirmation-focus-manager.js";
 import { isKeyboardEventTriggeredByInput } from "../../utils/is-keyboard-event-triggered-by-input.js";
 import { IconRetry } from "../icons/icon-retry.jsx";
+import { Button } from "../ui/button.js";
 import { BottomSection } from "./bottom-section.js";
 
 export const ErrorView: Component<ErrorViewProps> = (props) => {
@@ -66,31 +67,29 @@ export const ErrorView: Component<ErrorViewProps> = (props) => {
         <BottomSection>
           <div class="contain-layout shrink-0 flex items-center justify-end gap-[5px] w-full h-fit">
             <Show when={props.onRetry}>
-              <button
+              <Button
                 data-react-grab-retry
-                type="button"
+                class="gap-1"
                 aria-keyshortcuts="Enter"
-                class="contain-layout shrink-0 flex items-center justify-center gap-1 px-[3px] py-px rounded-sm bg-[var(--rg-surface-hover)] [border-width:0.5px] border-solid border-[var(--rg-border-button)] cursor-pointer transition-all hover:bg-[var(--rg-surface-active)] press-scale h-[17px]"
                 onClick={props.onRetry}
               >
                 <span class="text-[var(--rg-text-primary)] text-[13px] leading-3.5 font-sans font-medium">
                   Retry
                 </span>
                 <IconRetry size={10} aria-hidden="true" class="text-[var(--rg-text-secondary)]" />
-              </button>
+              </Button>
             </Show>
             <Show when={props.onAcknowledge}>
-              <button
+              <Button
                 data-react-grab-error-ok
-                type="button"
+                class="gap-1"
                 aria-keyshortcuts="Escape"
-                class="contain-layout shrink-0 flex items-center justify-center gap-1 px-[3px] py-px rounded-sm bg-[var(--rg-surface-hover)] [border-width:0.5px] border-solid border-[var(--rg-border-button)] cursor-pointer transition-all hover:bg-[var(--rg-surface-active)] press-scale h-[17px]"
                 onClick={props.onAcknowledge}
               >
                 <span class="text-[var(--rg-text-primary)] text-[13px] leading-3.5 font-sans font-medium">
                   Ok
                 </span>
-              </button>
+              </Button>
             </Show>
           </div>
         </BottomSection>

--- a/packages/react-grab/src/components/selection-label/index.tsx
+++ b/packages/react-grab/src/components/selection-label/index.tsx
@@ -31,6 +31,7 @@ import { IconLoader } from "../icons/icon-loader.jsx";
 import { Arrow } from "./arrow.js";
 import { TagBadge } from "./tag-badge.js";
 import { BottomSection } from "./bottom-section.js";
+import { Surface } from "../ui/surface.js";
 import { DiscardPrompt } from "./discard-prompt.js";
 import { ErrorView } from "./error-view.js";
 import { CompletionView } from "./completion-view.js";
@@ -418,16 +419,10 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
           />
         </Show>
 
-        <div
-          ref={panelRef}
-          class={cn(
-            "contain-layout flex items-center gap-[5px] antialiased w-fit h-fit p-0 [font-synthesis:none]",
-            isSinglePanelLine()
-              ? "rounded-full"
-              : "rounded-[14px] [corner-shape:superellipse(1.25)]",
-            "bg-[var(--rg-panel-bg)]",
-            isShaking() && "animate-shake",
-          )}
+        <Surface
+          ref={(element) => (panelRef = element)}
+          shape={isSinglePanelLine() ? "pill" : "panel"}
+          class={cn("flex items-center gap-[5px] w-fit h-fit p-0", isShaking() && "animate-shake")}
           style={{
             display: isCompletedStatus() && !props.error ? "none" : undefined,
           }}
@@ -569,7 +564,7 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
               onRetry={props.onRetry}
             />
           </Show>
-        </div>
+        </Surface>
       </div>
     </Show>
   );

--- a/packages/react-grab/src/components/toolbar/toolbar-menu.tsx
+++ b/packages/react-grab/src/components/toolbar/toolbar-menu.tsx
@@ -76,11 +76,8 @@ export const ToolbarMenu: Component<ToolbarMenuProps> = (props) => {
         onClick={suppressMenuEvent}
         onContextMenu={suppressMenuEvent}
       >
-        <div
-          class={cn(
-            "contain-layout flex flex-col rounded-[14px] antialiased w-fit h-fit overflow-hidden [font-synthesis:none] [corner-shape:superellipse(1.25)]",
-            "bg-[var(--rg-panel-bg)]",
-          )}
+        <Menu.Panel
+          class="overflow-hidden"
           style={{ "min-width": `${TOOLBAR_MENU_MIN_WIDTH_PX}px` }}
         >
           <Menu.Provider store={menuStore}>
@@ -122,7 +119,7 @@ export const ToolbarMenu: Component<ToolbarMenuProps> = (props) => {
               </For>
             </Menu.List>
           </Menu.Provider>
-        </div>
+        </Menu.Panel>
       </div>
     </Show>
   );

--- a/packages/react-grab/src/components/toolbar/toolbar-menu.tsx
+++ b/packages/react-grab/src/components/toolbar/toolbar-menu.tsx
@@ -8,8 +8,7 @@ import {
   Z_INDEX_OVERLAY,
 } from "../../constants.js";
 import { cn } from "../../utils/cn.js";
-import { ShortcutHint } from "../shortcut-hint.js";
-import { createMenuHighlight } from "../../utils/create-menu-highlight.js";
+import { Menu, createMenuStore } from "../menu/index.js";
 import { suppressMenuEvent } from "../../utils/suppress-menu-event.js";
 import { createAnchoredDropdown } from "../../utils/create-anchored-dropdown.js";
 import { registerOverlayDismiss } from "../../utils/register-overlay-dismiss.js";
@@ -24,27 +23,19 @@ interface ToolbarMenuProps {
 
 export const ToolbarMenu: Component<ToolbarMenuProps> = (props) => {
   let containerRef: HTMLDivElement | undefined;
-  const {
-    containerRef: highlightContainerRef,
-    highlightRef,
-    updateHighlight,
-    clearHighlight,
-  } = createMenuHighlight({
-    topCornerRadiusPx: MENU_PANEL_CORNER_RADIUS_PX,
-    bottomCornerRadiusPx: MENU_PANEL_CORNER_RADIUS_PX,
-    cornerShape: MENU_HIGHLIGHT_CORNER_SHAPE,
+  const menuStore = createMenuStore({
+    clearActiveOnPointerLeave: true,
+    highlight: {
+      topCornerRadiusPx: MENU_PANEL_CORNER_RADIUS_PX,
+      bottomCornerRadiusPx: MENU_PANEL_CORNER_RADIUS_PX,
+      cornerShape: MENU_HIGHLIGHT_CORNER_SHAPE,
+    },
   });
 
   const dropdown = createAnchoredDropdown(
     () => containerRef,
     () => props.position,
   );
-
-  const handleActionClick = (action: ContextMenuAction, event: Event) => {
-    event.stopPropagation();
-    props.onSetDefaultAction(action.id);
-    props.onDismiss();
-  };
 
   onMount(() => {
     dropdown.measure();
@@ -92,59 +83,45 @@ export const ToolbarMenu: Component<ToolbarMenuProps> = (props) => {
           )}
           style={{ "min-width": `${TOOLBAR_MENU_MIN_WIDTH_PX}px` }}
         >
-          <div
-            ref={highlightContainerRef}
-            role="menu"
-            aria-orientation="vertical"
-            aria-label="Default action"
-            class="relative flex flex-col"
-          >
-            <div
-              ref={highlightRef}
-              aria-hidden="true"
-              class="pointer-events-none absolute opacity-0 transition-[top,left,width,height,opacity,border-radius] duration-75 ease-out bg-[var(--rg-surface-hover)]"
-            />
-            <For each={props.actions}>
-              {(action) => {
-                const isDefault = () => action.id === props.defaultActionId;
+          <Menu.Provider store={menuStore}>
+            <Menu.List label="Default action">
+              <For each={props.actions}>
+                {(action) => {
+                  const isDefault = () => action.id === props.defaultActionId;
 
-                return (
-                  <button
-                    data-react-grab-ignore-events
-                    data-react-grab-menu-item={action.id}
-                    type="button"
-                    role="menuitemradio"
-                    aria-checked={isDefault()}
-                    class="relative z-1 contain-layout flex items-center justify-between w-full px-2 py-1 cursor-pointer text-left border-none bg-transparent"
-                    onPointerDown={(event) => event.stopPropagation()}
-                    onPointerEnter={(event) => updateHighlight(event.currentTarget)}
-                    onPointerLeave={clearHighlight}
-                    onClick={(event) => handleActionClick(action, event)}
-                  >
-                    <span
-                      class={cn(
-                        "text-[13px] leading-4 font-sans font-medium",
-                        isDefault()
-                          ? "text-[var(--rg-text-primary)]"
-                          : "text-[var(--rg-text-secondary)]",
-                      )}
+                  return (
+                    <Menu.Item
+                      value={action.id}
+                      role="menuitemradio"
+                      checked={isDefault()}
+                      onSelect={() => {
+                        props.onSetDefaultAction(action.id);
+                        props.onDismiss();
+                      }}
                     >
-                      {action.label}
-                    </span>
-                    <Show when={action.shortcut}>
-                      {(shortcutKey) => (
-                        <ShortcutHint
-                          shortcut={shortcutKey()}
-                          modifier={action.shortcutModifier}
-                          class="text-[11px] font-sans text-[var(--rg-text-secondary)] ml-4"
-                        />
-                      )}
-                    </Show>
-                  </button>
-                );
-              }}
-            </For>
-          </div>
+                      <Menu.Label
+                        class={
+                          isDefault()
+                            ? "text-[var(--rg-text-primary)]"
+                            : "text-[var(--rg-text-secondary)]"
+                        }
+                      >
+                        {action.label}
+                      </Menu.Label>
+                      <Show when={action.shortcut}>
+                        {(shortcutKey) => (
+                          <Menu.Shortcut
+                            shortcut={shortcutKey()}
+                            modifier={action.shortcutModifier}
+                          />
+                        )}
+                      </Show>
+                    </Menu.Item>
+                  );
+                }}
+              </For>
+            </Menu.List>
+          </Menu.Provider>
         </div>
       </div>
     </Show>

--- a/packages/react-grab/src/components/ui/button.tsx
+++ b/packages/react-grab/src/components/ui/button.tsx
@@ -27,7 +27,7 @@ export const Button: Component<ButtonProps> = (props) => {
   return (
     <button
       type={local.type ?? "button"}
-      class={cn(buttonVariants({ variant: local.variant ?? "chip" }), local.class)}
+      class={cn(buttonVariants({ variant: local.variant }), local.class)}
       {...rest}
     />
   );

--- a/packages/react-grab/src/components/ui/button.tsx
+++ b/packages/react-grab/src/components/ui/button.tsx
@@ -1,0 +1,34 @@
+import { splitProps, type Component, type JSX } from "solid-js";
+import { cn } from "../../utils/cn.js";
+import { createVariants } from "../../utils/create-variants.js";
+
+export const buttonVariants = createVariants(
+  "contain-layout shrink-0 flex items-center justify-center cursor-pointer transition-all press-scale",
+  {
+    variants: {
+      variant: {
+        chip: "px-[3px] py-px h-[17px] rounded-sm bg-[var(--rg-surface-hover)] [border-width:0.5px] border-solid border-[var(--rg-border-button)] hover:bg-[var(--rg-surface-active)] text-[var(--rg-text-primary)]",
+        destructive:
+          "px-[3px] py-px h-[17px] rounded-sm bg-[var(--rg-error-bg)] hover:bg-[var(--rg-error-bg-hover)] text-[var(--rg-error-text)]",
+        ghost:
+          "rounded-sm bg-transparent hover:bg-[var(--rg-surface-hover)] border-none outline-none p-0",
+      },
+    },
+    defaultVariants: { variant: "chip" },
+  },
+);
+
+interface ButtonProps extends JSX.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "chip" | "destructive" | "ghost";
+}
+
+export const Button: Component<ButtonProps> = (props) => {
+  const [local, rest] = splitProps(props, ["variant", "class", "type"]);
+  return (
+    <button
+      type={local.type ?? "button"}
+      class={cn(buttonVariants({ variant: local.variant ?? "chip" }), local.class)}
+      {...rest}
+    />
+  );
+};

--- a/packages/react-grab/src/components/ui/input.tsx
+++ b/packages/react-grab/src/components/ui/input.tsx
@@ -1,0 +1,36 @@
+import { splitProps, type Component, type JSX } from "solid-js";
+import { cn } from "../../utils/cn.js";
+
+interface InputProps extends Omit<JSX.InputHTMLAttributes<HTMLInputElement>, "ref"> {
+  ref?: (element: HTMLInputElement) => void;
+  autoFocusSelect?: boolean;
+}
+
+export const Input: Component<InputProps> = (props) => {
+  const [local, rest] = splitProps(props, ["class", "ref", "autoFocusSelect"]);
+  return (
+    <input
+      data-react-grab-ignore-events
+      data-react-grab-input
+      type="text"
+      autocapitalize="none"
+      autocorrect="off"
+      autocomplete="off"
+      spellcheck={false}
+      ref={(element) => {
+        if (local.autoFocusSelect) {
+          queueMicrotask(() => {
+            element.focus();
+            element.select();
+          });
+        }
+        local.ref?.(element);
+      }}
+      class={cn(
+        "bg-transparent border-none outline-none text-[var(--rg-text-primary)] p-0 m-0",
+        local.class,
+      )}
+      {...rest}
+    />
+  );
+};

--- a/packages/react-grab/src/components/ui/surface.tsx
+++ b/packages/react-grab/src/components/ui/surface.tsx
@@ -1,0 +1,27 @@
+import { splitProps, type Component, type JSX } from "solid-js";
+import { cn } from "../../utils/cn.js";
+import { createVariants } from "../../utils/create-variants.js";
+
+export const surfaceVariants = createVariants(
+  "contain-layout antialiased [font-synthesis:none] bg-[var(--rg-panel-bg)]",
+  {
+    variants: {
+      shape: {
+        panel: "rounded-[14px] [corner-shape:superellipse(1.25)]",
+        pill: "rounded-full",
+      },
+    },
+    defaultVariants: { shape: "panel" },
+  },
+);
+
+interface SurfaceProps extends JSX.HTMLAttributes<HTMLDivElement> {
+  shape?: "panel" | "pill";
+}
+
+export const Surface: Component<SurfaceProps> = (props) => {
+  const [local, rest] = splitProps(props, ["shape", "class"]);
+  return (
+    <div class={cn(surfaceVariants({ shape: local.shape ?? "panel" }), local.class)} {...rest} />
+  );
+};

--- a/packages/react-grab/src/components/ui/surface.tsx
+++ b/packages/react-grab/src/components/ui/surface.tsx
@@ -21,7 +21,5 @@ interface SurfaceProps extends JSX.HTMLAttributes<HTMLDivElement> {
 
 export const Surface: Component<SurfaceProps> = (props) => {
   const [local, rest] = splitProps(props, ["shape", "class"]);
-  return (
-    <div class={cn(surfaceVariants({ shape: local.shape ?? "panel" }), local.class)} {...rest} />
-  );
+  return <div class={cn(surfaceVariants({ shape: local.shape }), local.class)} {...rest} />;
 };

--- a/packages/react-grab/src/utils/action-shortcuts.ts
+++ b/packages/react-grab/src/utils/action-shortcuts.ts
@@ -1,7 +1,6 @@
 import type { ContextMenuAction } from "../types.js";
 
 interface FindShortcutActionOptions {
-  activeAction?: ContextMenuAction | null;
   includeModifierShortcuts?: boolean;
 }
 
@@ -17,7 +16,7 @@ export const findShortcutAction = (
   if (!event.key) return null;
 
   if (isEnterShortcut(event)) {
-    return options.activeAction ?? actions.find((action) => action.shortcut === "Enter") ?? null;
+    return actions.find((action) => action.shortcut === "Enter") ?? null;
   }
 
   if (event.repeat) return null;

--- a/packages/react-grab/src/utils/create-confirmation-keyboard.ts
+++ b/packages/react-grab/src/utils/create-confirmation-keyboard.ts
@@ -1,0 +1,46 @@
+import { onCleanup, onMount } from "solid-js";
+import { confirmationFocusManager } from "./confirmation-focus-manager.js";
+import { isKeyboardEventTriggeredByInput } from "./is-keyboard-event-triggered-by-input.js";
+
+interface ConfirmationKeyboardHandlers {
+  onEnter?: (event: KeyboardEvent) => void;
+  onEscape?: (event: KeyboardEvent) => void;
+}
+
+interface ConfirmationKeyboardController {
+  claimFocus: () => void;
+}
+
+// Shared wiring for the confirmation prompts (completion/discard/error): claim
+// a slot in the focus manager, listen for Enter/Escape at the window in capture
+// phase so it wins against focus traps, and ignore keystrokes that belong to a
+// focused input. Each prompt supplies only its Enter/Escape bodies.
+export const createConfirmationKeyboard = (
+  handlers: ConfirmationKeyboardHandlers,
+): ConfirmationKeyboardController => {
+  const instanceId = Symbol();
+
+  const handleKeyDown = (event: KeyboardEvent): void => {
+    if (!confirmationFocusManager.isActive(instanceId)) return;
+    if (isKeyboardEventTriggeredByInput(event)) return;
+    if (event.code === "Enter") {
+      handlers.onEnter?.(event);
+    } else if (event.code === "Escape") {
+      handlers.onEscape?.(event);
+    }
+  };
+
+  onMount(() => {
+    confirmationFocusManager.claim(instanceId);
+    window.addEventListener("keydown", handleKeyDown, { capture: true });
+  });
+
+  onCleanup(() => {
+    confirmationFocusManager.release(instanceId);
+    window.removeEventListener("keydown", handleKeyDown, { capture: true });
+  });
+
+  return {
+    claimFocus: () => confirmationFocusManager.claim(instanceId),
+  };
+};

--- a/packages/react-grab/src/utils/create-variants.ts
+++ b/packages/react-grab/src/utils/create-variants.ts
@@ -24,7 +24,7 @@ export const createVariants =
     for (const group in schema) {
       const chosen = selection[group] ?? config.defaultVariants?.[group];
       if (chosen === undefined) continue;
-      const className = schema[group][chosen as string];
+      const className = schema[group][String(chosen)];
       if (className) picked.push(className);
     }
     return cn(...picked);

--- a/packages/react-grab/src/utils/create-variants.ts
+++ b/packages/react-grab/src/utils/create-variants.ts
@@ -1,0 +1,31 @@
+import { cn } from "./cn.js";
+
+type VariantOptions = Record<string, string>;
+type VariantsSchema = Record<string, VariantOptions>;
+
+export type VariantSelection<Schema extends VariantsSchema> = {
+  [Group in keyof Schema]?: keyof Schema[Group];
+};
+
+interface VariantsConfig<Schema extends VariantsSchema> {
+  variants?: Schema;
+  defaultVariants?: VariantSelection<Schema>;
+}
+
+// A tiny class-variance-authority-style helper: map a base class plus named
+// variant groups to a single className. Returns a function so call sites read
+// like shadcn's `buttonVariants({ variant: "ghost" })`.
+export const createVariants =
+  <Schema extends VariantsSchema>(base: string, config: VariantsConfig<Schema> = {}) =>
+  (selection: VariantSelection<Schema> = {}): string => {
+    const schema = config.variants;
+    if (!schema) return base;
+    const picked: string[] = [base];
+    for (const group in schema) {
+      const chosen = selection[group] ?? config.defaultVariants?.[group];
+      if (chosen === undefined) continue;
+      const className = schema[group][chosen as string];
+      if (className) picked.push(className);
+    }
+    return cn(...picked);
+  };

--- a/packages/react-grab/tests/create-variants.test.ts
+++ b/packages/react-grab/tests/create-variants.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vite-plus/test";
+import { createVariants } from "../src/utils/create-variants.js";
+
+describe("createVariants", () => {
+  const button = createVariants("base", {
+    variants: {
+      variant: { solid: "solid-class", ghost: "ghost-class" },
+      size: { sm: "sm-class", lg: "lg-class" },
+    },
+    defaultVariants: { variant: "solid" },
+  });
+
+  it("applies the default variant when none is selected", () => {
+    expect(button()).toBe("base solid-class");
+  });
+
+  it("applies the selected variant over the default", () => {
+    expect(button({ variant: "ghost" })).toBe("base ghost-class");
+  });
+
+  it("combines multiple variant groups", () => {
+    expect(button({ variant: "ghost", size: "lg" })).toBe("base ghost-class lg-class");
+  });
+
+  it("omits groups without a default or selection", () => {
+    expect(button({ size: "sm" })).toBe("base solid-class sm-class");
+  });
+
+  it("returns just the base when no variants are configured", () => {
+    expect(createVariants("only-base")()).toBe("only-base");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Brings **shadcn/ui** (compound components, namespaced/named parts, a `cva` variants layer, small styled `ui/` primitives) and **cmdk** (Context-provided store, self-registering items, controlled `value`, shared stateful primitives) composition patterns into our SolidJS overlay — at the markup, styling, *and* behavior layers.

## 1. Compound `Menu` — `src/components/menu/`

cmdk-style store + shadcn-style parts; replaces three hand-rolled `role="menu"` implementations.

- `createMenuStore(options)` — store keyed by item `value`: active state, self-registering registry (DOM order), keyboard nav, highlight follower. **Controlled mode** (`value`/`onValueChange`) + **pointer-move gate** (`requirePointerMove`).
- `Menu.Provider` / `Menu.Panel` / `Menu.List` / `Menu.Item` / `Menu.Label` / `Menu.Shortcut` (namespaced + named). `Menu.Item` has a `dataId` hook so store identity stays unique while `data-react-grab-menu-item` reads as a human label.

Migrated: `ContextMenu`, `ToolbarMenu`, `ArrowNavigationMenu`.

## 2. `cva` variants + `components/ui/` primitives

- `utils/create-variants.ts` — class-variance-authority-style helper (unit-tested).
- `ui/button.tsx` — `Button` + `buttonVariants` (`chip` / `destructive` / `ghost`).
- `ui/surface.tsx` — `Surface` + `surfaceVariants` (`panel` / `pill`) — card/menu panel chrome.
- `ui/input.tsx` — `Input` — standardized inline-text-input attributes + base class + `autoFocusSelect`.

**Adopted across the component set:**
- `Button` → edit-panel `copy-button`, `discard-prompt`, `error-view`, `completion-view`.
- `Surface` → `Menu.Panel`, `completion-view` pill, `edit-panel/index`, `selection-label/index` (callback refs through the boundary). No inline panel chrome remains in card/menu surfaces.
- `Input` → `value-stepper`, `color-picker`.

## 3. Shared behavior primitive (deeper than styling)

- `utils/create-confirmation-keyboard.ts` — `completion-view`, `discard-prompt`, and `error-view` each hand-rolled the identical confirmation-focus + capture-phase keydown wiring (instanceId, claim/release, `isActive` + input guards). Extracted into `createConfirmationKeyboard({ onEnter, onEscape })` returning `claimFocus`; each prompt now declares only its key semantics. Removes ~20 lines of duplicated lifecycle wiring per file.

## Deliberately left bespoke (philosophy does not fit — no forced abstractions)

- **`toolbar-content`** (draggable bar) and **`tooltip`**: floating chrome needing `overflow-visible` + `box-shadow`, must *not* establish layout containment, so `Surface` is the wrong tool.
- **`PropertyList`**: rows morph into live editable controls with focus-lock / scroll-into-view logic that doesn't fit the menu store.
- **`icons/*`, `slot` (number roller), `step-arrow`, `overlay-canvas`, `renderer`**: leaf SVGs / bespoke animations / canvas+DOM renderers.

## Behavior preserved

All DOM/ARIA contracts the e2e suite relies on are unchanged (menu roles/attrs/`aria-*`, button + input `data-*` hooks, panel measurement refs, keyboard nav, copy/keep/discard/error flows).

## Verification

- `pnpm build` / `typecheck` / `lint` (0/0) / `format` ✅
- unit: `createVariants` ✅
- e2e (chromium): **full suite, 696 passed** (re-run after the behavior-primitive extraction)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fb613e1-7cf6-45ce-ad8b-54454cdd789a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fb613e1-7cf6-45ce-ad8b-54454cdd789a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates duplicated menu logic into a compound `Menu` primitive with a shared store, and refactors `ContextMenu`, `ToolbarMenu`, and `ArrowNavigationMenu` to use it. Also adds small `ui/` primitives and unifies confirmation keyboard handling.

- **New Features**
  - Added `Menu` primitive: `Menu.Provider`, `Menu.Panel`, `Menu.List`, `Menu.Item`, `Menu.Label`, `Menu.Shortcut`.
  - Extended `createMenuStore` with controlled mode (`value`/`onValueChange`), a pointer-move hover gate (`requirePointerMove`), keyboard mode toggles, `clearActiveOnPointerLeave`, and a single highlight follower.
  - Exposed `useMenuStore` and related types; provides both namespaced (`Menu.Item`) and named (`MenuItem`) exports.
  - Introduced a `cva`-style variants helper (`createVariants`) and `ui/` primitives: `Button` (`chip`/`destructive`/`ghost`), `Surface` (`panel`/`pill`), and `Input` (standardized inline input with `autoFocusSelect`). Adopted across copy/discard/error/completion views, `Menu.Panel`, the edit-panel and selection-label panels, and inline inputs in `value-stepper` and `color-picker`.

- **Refactors & Fixes**
  - `ContextMenu`, `ToolbarMenu`, and `ArrowNavigationMenu` now compose `Menu`, delegating highlight, ids, and navigation to the store (`ArrowNavigationMenu` runs in controlled mode).
  - Preserves existing DOM/ARIA and keyboard behavior; Enter activates the active row. A highlighted row now absorbs Enter: if enabled it runs `onSelect`, if disabled it swallows the key, preventing fallthrough to other Enter-bound actions. Dropped the `activeAction` option from `findShortcutAction` and handle Enter locally in `ContextMenu`.
  - Removes hand-rolled item refs/ids and duplicate highlight wiring across three menus.
  - `Menu.Item` adds `dataId` to decouple store identity from test data attributes; `ContextMenu` keys items by `action.id` while keeping the label-based `data-react-grab-menu-item`, fixing duplicate-label collisions in keyboard nav/highlight/aria.
  - Standardized chip buttons via `Button` and inline text inputs via `Input`; dropped redundant default-variant specs in `Button`/`Surface`.
  - Extracted `createConfirmationKeyboard` and adopted it in `completion-view`, `discard-prompt`, and `error-view` to centralize Enter/Escape capture and focus-claim logic.

<sup>Written for commit 0160d311f49d496207a350428b06e2975e3703c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

