### PR TITLE
feat: add isAutomatedBrowser helper to detect automated browsers

### DIFF
--- a/packages/react-grab/src/core/log-intro.ts
+++ b/packages/react-grab/src/core/log-intro.ts
@@ -1,5 +1,6 @@
 import { LOGO_SVG } from "./logo-svg.js";
 import { isExtensionContext } from "../utils/is-extension-context.js";
+import { isAutomatedBrowser } from "../utils/is-automated-browser.js";
 
 export const logIntro = (telemetryEnabled: boolean) => {
   try {
@@ -11,7 +12,8 @@ export const logIntro = (telemetryEnabled: boolean) => {
       "",
     );
     if (telemetryEnabled && navigator.onLine && version && !isExtensionContext()) {
-      fetch(`https://www.react-grab.com/api/version?source=browser&v=${version}&t=${Date.now()}`, {
+      const source = isAutomatedBrowser() ? "automated-browser" : "browser";
+      fetch(`https://www.react-grab.com/api/version?source=${source}&v=${version}&t=${Date.now()}`, {
         referrerPolicy: "origin",
         keepalive: true,
         priority: "low",

--- a/packages/react-grab/src/utils/is-automated-browser.ts
+++ b/packages/react-grab/src/utils/is-automated-browser.ts
@@ -1,8 +1,40 @@
 let cachedIsAutomatedBrowser: boolean | undefined;
 
+const hasAutomationGlobal = (): boolean => {
+  const global = globalThis as Record<string, unknown>;
+  return Boolean(
+    global.__playwright__ ||
+      global.__pwInitScripts ||
+      global.__puppeteer__ ||
+      global.domAutomation ||
+      global.domAutomationController ||
+      global._Selenium_IDE_Recorder ||
+      global._selenium ||
+      global.callSelenium,
+  );
+};
+
+const hasWebdriverDocumentMarker = (): boolean => {
+  if (typeof document === "undefined") return false;
+  const markers = document as Document & Record<string, unknown>;
+  return Boolean(
+    markers.__selenium_unwrapped ||
+      markers.__webdriver_evaluate ||
+      markers.__driver_evaluate ||
+      markers.__fxdriver_evaluate ||
+      markers.__webdriver_script_function ||
+      // ChromeDriver injects this oddly-named helper array on document.
+      markers.$cdc_asdjflasutopfhvcZLmcfl_ ||
+      markers.$chrome_asyncScriptInfo,
+  );
+};
+
+const hasAutomationNavigatorSignal = (): boolean =>
+  typeof navigator !== "undefined" &&
+  (navigator.webdriver === true || /HeadlessChrome/i.test(navigator.userAgent));
+
 export const isAutomatedBrowser = (): boolean => {
   cachedIsAutomatedBrowser ??=
-    typeof navigator !== "undefined" &&
-    (navigator.webdriver === true || /HeadlessChrome/i.test(navigator.userAgent));
+    hasAutomationNavigatorSignal() || hasAutomationGlobal() || hasWebdriverDocumentMarker();
   return cachedIsAutomatedBrowser;
 };

--- a/packages/react-grab/src/utils/is-automated-browser.ts
+++ b/packages/react-grab/src/utils/is-automated-browser.ts
@@ -3,48 +3,38 @@ let cachedIsAutomatedBrowser: boolean | undefined;
 const hasAutomationGlobal = (): boolean => {
   const global = globalThis as Record<string, unknown>;
   return Boolean(
-    // Playwright injects these when running scripts in the page.
     global.__playwright__ ||
       global.__pwInitScripts ||
-      // Puppeteer / generic CDP automation markers.
       global.__puppeteer__ ||
       global.domAutomation ||
       global.domAutomationController ||
-      // Selenium / WebDriver markers.
       global._Selenium_IDE_Recorder ||
       global._selenium ||
       global.callSelenium,
   );
 };
 
-const hasSeleniumDocumentMarker = (): boolean => {
+const hasWebdriverDocumentMarker = (): boolean => {
   if (typeof document === "undefined") return false;
-  const documentWithMarkers = document as Document & Record<string, unknown>;
+  const markers = document as Document & Record<string, unknown>;
   return Boolean(
-    documentWithMarkers.__selenium_unwrapped ||
-      documentWithMarkers.__webdriver_evaluate ||
-      documentWithMarkers.__driver_evaluate ||
-      documentWithMarkers.__fxdriver_evaluate ||
-      documentWithMarkers.__webdriver_script_function ||
-      // ChromeDriver injects a $cdc_* helper array on document.
-      documentWithMarkers.$cdc_asdjflasutopfhvcZLmcfl_ ||
-      documentWithMarkers.$chrome_asyncScriptInfo,
+    markers.__selenium_unwrapped ||
+      markers.__webdriver_evaluate ||
+      markers.__driver_evaluate ||
+      markers.__fxdriver_evaluate ||
+      markers.__webdriver_script_function ||
+      // ChromeDriver injects this oddly-named helper array on document.
+      markers.$cdc_asdjflasutopfhvcZLmcfl_ ||
+      markers.$chrome_asyncScriptInfo,
   );
 };
 
-export const isAutomatedBrowser = (shouldRevalidate?: boolean): boolean => {
-  if (shouldRevalidate) {
-    cachedIsAutomatedBrowser = undefined;
-  }
-  if (cachedIsAutomatedBrowser !== undefined) {
-    return cachedIsAutomatedBrowser;
-  }
+const hasAutomationNavigatorSignal = (): boolean =>
+  typeof navigator !== "undefined" &&
+  (navigator.webdriver === true || /HeadlessChrome/i.test(navigator.userAgent));
 
-  const isWebdriver = typeof navigator !== "undefined" && navigator.webdriver === true;
-  const isHeadlessUserAgent =
-    typeof navigator !== "undefined" && /HeadlessChrome/i.test(navigator.userAgent);
-
-  cachedIsAutomatedBrowser =
-    isWebdriver || isHeadlessUserAgent || hasAutomationGlobal() || hasSeleniumDocumentMarker();
+export const isAutomatedBrowser = (): boolean => {
+  cachedIsAutomatedBrowser ??=
+    hasAutomationNavigatorSignal() || hasAutomationGlobal() || hasWebdriverDocumentMarker();
   return cachedIsAutomatedBrowser;
 };

--- a/packages/react-grab/src/utils/is-automated-browser.ts
+++ b/packages/react-grab/src/utils/is-automated-browser.ts
@@ -1,0 +1,50 @@
+let cachedIsAutomatedBrowser: boolean | undefined;
+
+const hasAutomationGlobal = (): boolean => {
+  const global = globalThis as Record<string, unknown>;
+  return Boolean(
+    // Playwright injects these when running scripts in the page.
+    global.__playwright__ ||
+      global.__pwInitScripts ||
+      // Puppeteer / generic CDP automation markers.
+      global.__puppeteer__ ||
+      global.domAutomation ||
+      global.domAutomationController ||
+      // Selenium / WebDriver markers.
+      global._Selenium_IDE_Recorder ||
+      global._selenium ||
+      global.callSelenium,
+  );
+};
+
+const hasSeleniumDocumentMarker = (): boolean => {
+  if (typeof document === "undefined") return false;
+  const documentWithMarkers = document as Document & Record<string, unknown>;
+  return Boolean(
+    documentWithMarkers.__selenium_unwrapped ||
+      documentWithMarkers.__webdriver_evaluate ||
+      documentWithMarkers.__driver_evaluate ||
+      documentWithMarkers.__fxdriver_evaluate ||
+      documentWithMarkers.__webdriver_script_function ||
+      // ChromeDriver injects a $cdc_* helper array on document.
+      documentWithMarkers.$cdc_asdjflasutopfhvcZLmcfl_ ||
+      documentWithMarkers.$chrome_asyncScriptInfo,
+  );
+};
+
+export const isAutomatedBrowser = (shouldRevalidate?: boolean): boolean => {
+  if (shouldRevalidate) {
+    cachedIsAutomatedBrowser = undefined;
+  }
+  if (cachedIsAutomatedBrowser !== undefined) {
+    return cachedIsAutomatedBrowser;
+  }
+
+  const isWebdriver = typeof navigator !== "undefined" && navigator.webdriver === true;
+  const isHeadlessUserAgent =
+    typeof navigator !== "undefined" && /HeadlessChrome/i.test(navigator.userAgent);
+
+  cachedIsAutomatedBrowser =
+    isWebdriver || isHeadlessUserAgent || hasAutomationGlobal() || hasSeleniumDocumentMarker();
+  return cachedIsAutomatedBrowser;
+};

--- a/packages/react-grab/src/utils/is-automated-browser.ts
+++ b/packages/react-grab/src/utils/is-automated-browser.ts
@@ -1,40 +1,8 @@
 let cachedIsAutomatedBrowser: boolean | undefined;
 
-const hasAutomationGlobal = (): boolean => {
-  const global = globalThis as Record<string, unknown>;
-  return Boolean(
-    global.__playwright__ ||
-      global.__pwInitScripts ||
-      global.__puppeteer__ ||
-      global.domAutomation ||
-      global.domAutomationController ||
-      global._Selenium_IDE_Recorder ||
-      global._selenium ||
-      global.callSelenium,
-  );
-};
-
-const hasWebdriverDocumentMarker = (): boolean => {
-  if (typeof document === "undefined") return false;
-  const markers = document as Document & Record<string, unknown>;
-  return Boolean(
-    markers.__selenium_unwrapped ||
-      markers.__webdriver_evaluate ||
-      markers.__driver_evaluate ||
-      markers.__fxdriver_evaluate ||
-      markers.__webdriver_script_function ||
-      // ChromeDriver injects this oddly-named helper array on document.
-      markers.$cdc_asdjflasutopfhvcZLmcfl_ ||
-      markers.$chrome_asyncScriptInfo,
-  );
-};
-
-const hasAutomationNavigatorSignal = (): boolean =>
-  typeof navigator !== "undefined" &&
-  (navigator.webdriver === true || /HeadlessChrome/i.test(navigator.userAgent));
-
 export const isAutomatedBrowser = (): boolean => {
   cachedIsAutomatedBrowser ??=
-    hasAutomationNavigatorSignal() || hasAutomationGlobal() || hasWebdriverDocumentMarker();
+    typeof navigator !== "undefined" &&
+    (navigator.webdriver === true || /HeadlessChrome/i.test(navigator.userAgent));
   return cachedIsAutomatedBrowser;
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an `isAutomatedBrowser()` utility to `react-grab` that detects whether the library is running inside an automated/headless browser (Playwright, Puppeteer, Selenium/WebDriver), and uses it to label the version-check telemetry source.

## Changes

1. **New util `is-automated-browser.ts`** — detects automated browsers.
2. **`log-intro.ts`** — when fetching the latest version, the request's `source` query param is now `automated-browser` instead of `browser` when an automated browser is detected:

```ts
const source = isAutomatedBrowser() ? "automated-browser" : "browser";
fetch(`https://www.react-grab.com/api/version?source=${source}&v=${version}&t=${Date.now()}`, ...)
```

## What it detects

- **Navigator signal** — `navigator.webdriver === true` (W3C-standard flag set by all WebDriver-based tools) and `HeadlessChrome` in the user agent.
- **Automation globals** — Playwright (`__playwright__`, `__pwInitScripts`), Puppeteer (`__puppeteer__`), generic CDP (`domAutomation`, `domAutomationController`), and Selenium IDE (`_Selenium_IDE_Recorder`, `_selenium`, `callSelenium`).
- **WebDriver document markers** — `__selenium_unwrapped`, `__webdriver_evaluate`, `$cdc_*`, etc.

## Notes

- Follows existing util conventions (one util per file, arrow function, memoized result, matching `is-mac.ts` / `is-next-project-runtime.ts`).
- SSR-safe: guards against missing `navigator` / `document`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32eaf7b9-0f3c-48da-8ecd-3cafff5d476c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32eaf7b9-0f3c-48da-8ecd-3cafff5d476c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `isAutomatedBrowser()` to `react-grab` to detect automated/headless browsers and label version-check telemetry. Detection now covers navigator signals, common automation globals, and WebDriver document markers; it’s SSR-safe and memoized.

- **New Features**
  - Detects `navigator.webdriver`, `HeadlessChrome` UA, automation globals (Playwright/Puppeteer/Selenium), and WebDriver document markers.
  - Sets telemetry `source` to `automated-browser` when automation is detected.

- **Refactors**
  - Dropped the `revalidate` option; kept SSR guards and memoization.

<sup>Written for commit adf9ec1ef3a995a4a09ce1cfade408ae23e5c6c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

