### PR TITLE
feat(react-grab): latch held selection onto its fiber across DOM swaps

### DIFF
--- a/apps/e2e-app-vite/src/App.tsx
+++ b/apps/e2e-app-vite/src/App.tsx
@@ -693,6 +693,17 @@ const FiberSwapSection = () => {
     <section className="border rounded-lg p-4" data-testid="fiber-swap-section">
       <h2 className="text-lg font-bold mb-4">Fiber Swap</h2>
       <FiberSwapTarget swapped={swapped} />
+      {/* Keyed host element nested directly under another host element (no
+          composite component in between): the swapped node's fiber parent is
+          the section's host fiber, exercising the host-under-host recovery
+          path that composite-parent targets like FiberSwapTarget never hit. */}
+      <div
+        key={swapped ? "host-swapped" : "host-initial"}
+        className="p-4 mt-4 bg-teal-100 rounded"
+        data-testid="host-swap-target"
+      >
+        {swapped ? "Swapped host-under-host node" : "Initial host-under-host node"}
+      </div>
     </section>
   );
 };

--- a/apps/e2e-app-vite/src/App.tsx
+++ b/apps/e2e-app-vite/src/App.tsx
@@ -2,6 +2,13 @@ import { useState, useRef, useEffect } from "react";
 import { PerfGrid } from "./perf-grid";
 import { HeavyPage, parseHeavyView, type HeavyView } from "./perf-heavy/heavy-page";
 
+declare global {
+  interface Window {
+    __triggerFiberSwap?: () => void;
+    __triggerInnerHtmlSwap?: () => void;
+  }
+}
+
 interface Todo {
   id: number;
   title: string;
@@ -649,6 +656,76 @@ const usePerfHeavyView = (): HeavyView | null => {
   return parseHeavyView(params.get("view"));
 };
 
+// Renders the selection target as the sole host child of a component so a
+// `key` flip forces React to unmount the old DOM node and mount a fresh one
+// (new host fiber) under the same surviving parent fiber. react-grab should
+// latch the held selection and post-copy label back onto the new node via the
+// fiber. The swapped variant is offset downward so an anchored label visibly
+// moves when it re-resolves.
+const FiberSwapTarget = ({ swapped }: { swapped: boolean }) => {
+  return swapped ? (
+    <div
+      key="swapped"
+      className="p-4 bg-orange-100 rounded"
+      style={{ marginTop: 150 }}
+      data-testid="fiber-swap-target"
+    >
+      Swapped fiber node
+    </div>
+  ) : (
+    <div key="initial" className="p-4 bg-orange-100 rounded" data-testid="fiber-swap-target">
+      Initial fiber node
+    </div>
+  );
+};
+
+const FiberSwapSection = () => {
+  const [swapped, setSwapped] = useState(false);
+
+  useEffect(() => {
+    window.__triggerFiberSwap = () => setSwapped((previous) => !previous);
+    return () => {
+      delete window.__triggerFiberSwap;
+    };
+  }, []);
+
+  return (
+    <section className="border rounded-lg p-4" data-testid="fiber-swap-section">
+      <h2 className="text-lg font-bold mb-4">Fiber Swap</h2>
+      <FiberSwapTarget swapped={swapped} />
+    </section>
+  );
+};
+
+// Mirrors the website's syntax-highlighted code blocks: the inner token nodes
+// are rendered via dangerouslySetInnerHTML, so they have no React fiber. A swap
+// replaces the whole subtree (new DOM nodes at the same path). react-grab should
+// re-find a selected token by anchoring to the fibered host div.
+const InnerHtmlSwapSection = () => {
+  const [variant, setVariant] = useState(0);
+
+  useEffect(() => {
+    window.__triggerInnerHtmlSwap = () => setVariant((previous) => previous + 1);
+    return () => {
+      delete window.__triggerInnerHtmlSwap;
+    };
+  }, []);
+
+  const tokenLabel = variant === 0 ? "token-initial" : "token-swapped";
+  const html = `<pre class="font-mono"><code><span class="inner-html-token">${tokenLabel}</span></code></pre>`;
+
+  return (
+    <section className="border rounded-lg p-4" data-testid="inner-html-swap-section">
+      <h2 className="text-lg font-bold mb-4">Inner HTML Swap</h2>
+      <div
+        className="p-4 bg-slate-100 rounded"
+        data-testid="inner-html-host"
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </section>
+  );
+};
+
 const usePerfGridConfig = (): { rowCount: number; columnCount: number } | null => {
   if (typeof window === "undefined") return null;
   const params = new URLSearchParams(window.location.search);
@@ -768,6 +845,10 @@ export default function App() {
       <PointerEventsModalSection />
 
       <HiddenToggleSection />
+
+      <FiberSwapSection />
+
+      <InnerHtmlSwapSection />
 
       <div
         className="h-96 flex items-center justify-center bg-gray-100 rounded-lg"

--- a/packages/react-grab/e2e/fiber-relink.spec.ts
+++ b/packages/react-grab/e2e/fiber-relink.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "./fixtures.js";
+
+interface FiberSwapWindow {
+  __triggerFiberSwap?: () => void;
+  __triggerInnerHtmlSwap?: () => void;
+  __REACT_GRAB__?: {
+    getState: () => { targetElement: Element | null };
+  };
+}
+
+const getSelectionTargetText = () =>
+  (window as unknown as FiberSwapWindow).__REACT_GRAB__
+    ?.getState()
+    .targetElement?.textContent?.trim();
+
+test.describe("Fiber-latched selection", () => {
+  // When React swaps the DOM node backing a held selection (a keyed remount
+  // here), the originally captured Element detaches. Without fiber latching the
+  // selection drops; with it, react-grab re-resolves the live node from the
+  // fiber and keeps the selection on the freshly mounted node.
+  test("re-resolves the selection onto a swapped-out DOM node via its fiber", async ({
+    reactGrab,
+    page,
+  }) => {
+    // Let React commit the remount while react-grab holds the selection;
+    // otherwise the freeze buffers the update and no swap is observable.
+    await reactGrab.updateOptions({ freezeReactUpdates: false });
+
+    await reactGrab.activate();
+    await reactGrab.hoverUntilSelected("[data-testid='fiber-swap-target']");
+
+    await expect.poll(() => page.evaluate(getSelectionTargetText)).toBe("Initial fiber node");
+
+    await page.evaluate(() => (window as unknown as FiberSwapWindow).__triggerFiberSwap?.());
+
+    await expect.poll(() => page.evaluate(getSelectionTargetText)).toBe("Swapped fiber node");
+
+    expect(await reactGrab.isSelectionBoxVisible()).toBe(true);
+  });
+
+  // The post-copy "Copied" label anchors to the grabbed element too, so it must
+  // follow the same fiber latching. The swapped node is offset downward, so a
+  // label that re-resolves onto it moves; a label stuck on the detached node
+  // stays put.
+  test("keeps the post-copy label anchored across a swapped-out DOM node", async ({
+    reactGrab,
+    page,
+  }) => {
+    await reactGrab.updateOptions({ freezeReactUpdates: false });
+
+    await reactGrab.activate();
+    await reactGrab.hoverUntilSelected("[data-testid='fiber-swap-target']");
+    await reactGrab.clickElement("[data-testid='fiber-swap-target']");
+    await expect.poll(() => reactGrab.getLabelStatusText(), { timeout: 2000 }).toBe("Copied");
+
+    const labelBefore = await reactGrab.getSelectionLabelBounds();
+    if (!labelBefore) throw new Error("Expected a post-copy label before the swap");
+
+    await page.evaluate(() => (window as unknown as FiberSwapWindow).__triggerFiberSwap?.());
+
+    await expect
+      .poll(
+        async () => {
+          const labelAfter = await reactGrab.getSelectionLabelBounds();
+          return labelAfter ? labelAfter.label.y - labelBefore.label.y : 0;
+        },
+        { timeout: 1200 },
+      )
+      .toBeGreaterThan(40);
+  });
+
+  // Tokens rendered through dangerouslySetInnerHTML (syntax-highlighted code on
+  // the website) have no fiber of their own. Replacing the host's innerHTML
+  // detaches the selected token; recovery must anchor to the fibered host div
+  // and re-find the token by its DOM path.
+  test("re-resolves a selected innerHTML node with no fiber of its own", async ({
+    reactGrab,
+    page,
+  }) => {
+    await reactGrab.updateOptions({ freezeReactUpdates: false });
+
+    await reactGrab.activate();
+    await reactGrab.hoverUntilSelected(".inner-html-token");
+
+    await expect.poll(() => page.evaluate(getSelectionTargetText)).toBe("token-initial");
+
+    await page.evaluate(() => (window as unknown as FiberSwapWindow).__triggerInnerHtmlSwap?.());
+
+    await expect.poll(() => page.evaluate(getSelectionTargetText)).toBe("token-swapped");
+
+    expect(await reactGrab.isSelectionBoxVisible()).toBe(true);
+  });
+});

--- a/packages/react-grab/e2e/fiber-relink.spec.ts
+++ b/packages/react-grab/e2e/fiber-relink.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "./fixtures.js";
+import type { Page } from "@playwright/test";
 
 interface FiberSwapWindow {
   __triggerFiberSwap?: () => void;
@@ -8,10 +9,43 @@ interface FiberSwapWindow {
   };
 }
 
+const SELECTION_TEXT_ATTEMPTS = 4;
+const HOVER_MOVE_STEPS = 5;
+const SELECTION_TEXT_POLL_TIMEOUT_MS = 1_000;
+
 const getSelectionTargetText = () =>
   (window as unknown as FiberSwapWindow).__REACT_GRAB__
     ?.getState()
     .targetElement?.textContent?.trim();
+
+// hoverUntilSelected resolves once ANY element is selected; when the synthetic
+// hover races scroll-into-view the selection can land on a different element,
+// and a single post-scroll pointermove can be swallowed entirely. Scroll the
+// target into view first, then walk the pointer to it in steps (real
+// intermediate pointermoves) until it is the actual selection target.
+const hoverUntilSelectionTextIs = async (page: Page, selector: string, expectedText: string) => {
+  const target = page.locator(selector).first();
+  await target.scrollIntoViewIfNeeded();
+  for (let attempt = 1; attempt <= SELECTION_TEXT_ATTEMPTS; attempt++) {
+    const bounds = await target.boundingBox();
+    if (bounds) {
+      await page.mouse.move(bounds.x - 5, bounds.y - 5);
+      await page.mouse.move(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2, {
+        steps: HOVER_MOVE_STEPS,
+      });
+    }
+    try {
+      await expect
+        .poll(() => page.evaluate(getSelectionTargetText), {
+          timeout: SELECTION_TEXT_POLL_TIMEOUT_MS,
+        })
+        .toBe(expectedText);
+      return;
+    } catch (error) {
+      if (attempt === SELECTION_TEXT_ATTEMPTS) throw error;
+    }
+  }
+};
 
 test.describe("Fiber-latched selection", () => {
   // When React swaps the DOM node backing a held selection (a keyed remount
@@ -27,9 +61,11 @@ test.describe("Fiber-latched selection", () => {
     await reactGrab.updateOptions({ freezeReactUpdates: false });
 
     await reactGrab.activate();
-    await reactGrab.hoverUntilSelected("[data-testid='fiber-swap-target']");
-
-    await expect.poll(() => page.evaluate(getSelectionTargetText)).toBe("Initial fiber node");
+    await hoverUntilSelectionTextIs(
+      page,
+      "[data-testid='fiber-swap-target']",
+      "Initial fiber node",
+    );
 
     await page.evaluate(() => (window as unknown as FiberSwapWindow).__triggerFiberSwap?.());
 
@@ -49,7 +85,11 @@ test.describe("Fiber-latched selection", () => {
     await reactGrab.updateOptions({ freezeReactUpdates: false });
 
     await reactGrab.activate();
-    await reactGrab.hoverUntilSelected("[data-testid='fiber-swap-target']");
+    await hoverUntilSelectionTextIs(
+      page,
+      "[data-testid='fiber-swap-target']",
+      "Initial fiber node",
+    );
     await reactGrab.clickElement("[data-testid='fiber-swap-target']");
     await expect.poll(() => reactGrab.getLabelStatusText(), { timeout: 2000 }).toBe("Copied");
 
@@ -69,6 +109,32 @@ test.describe("Fiber-latched selection", () => {
       .toBeGreaterThan(40);
   });
 
+  // A keyed host element nested directly under another host element has a host
+  // fiber as its fiber parent (no composite component in between), so recovery
+  // cannot search a composite subtree — it must re-find the replacement at the
+  // anchor's recorded child index under the surviving parent host node.
+  test("re-resolves a swapped node whose fiber parent is itself a host fiber", async ({
+    reactGrab,
+    page,
+  }) => {
+    await reactGrab.updateOptions({ freezeReactUpdates: false });
+
+    await reactGrab.activate();
+    await hoverUntilSelectionTextIs(
+      page,
+      "[data-testid='host-swap-target']",
+      "Initial host-under-host node",
+    );
+
+    await page.evaluate(() => (window as unknown as FiberSwapWindow).__triggerFiberSwap?.());
+
+    await expect
+      .poll(() => page.evaluate(getSelectionTargetText))
+      .toBe("Swapped host-under-host node");
+
+    expect(await reactGrab.isSelectionBoxVisible()).toBe(true);
+  });
+
   // Tokens rendered through dangerouslySetInnerHTML (syntax-highlighted code on
   // the website) have no fiber of their own. Replacing the host's innerHTML
   // detaches the selected token; recovery must anchor to the fibered host div
@@ -80,9 +146,7 @@ test.describe("Fiber-latched selection", () => {
     await reactGrab.updateOptions({ freezeReactUpdates: false });
 
     await reactGrab.activate();
-    await reactGrab.hoverUntilSelected(".inner-html-token");
-
-    await expect.poll(() => page.evaluate(getSelectionTargetText)).toBe("token-initial");
+    await hoverUntilSelectionTextIs(page, ".inner-html-token", "token-initial");
 
     await page.evaluate(() => (window as unknown as FiberSwapWindow).__triggerInnerHtmlSwap?.());
 

--- a/packages/react-grab/e2e/zoom-canvas.spec.ts
+++ b/packages/react-grab/e2e/zoom-canvas.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "./fixtures.js";
+import { ATTRIBUTE_NAME } from "./constants.js";
+
+// Browser zoom shrinks window.innerWidth/innerHeight (the visual viewport) while
+// getBoundingClientRect keeps returning full layout coordinates. The overlay
+// canvas must be sized to the layout viewport, or it draws the selection box
+// off-canvas for any element past the shrunken edge — the box vanishes entirely.
+const simulateBrowserZoom = (zoom: number) => {
+  const realWidth = window.innerWidth;
+  const realHeight = window.innerHeight;
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    get: () => Math.round(realWidth / zoom),
+  });
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    get: () => Math.round(realHeight / zoom),
+  });
+  window.dispatchEvent(new Event("resize"));
+};
+
+test.describe("Overlay canvas under browser zoom", () => {
+  test("draws the selection box for a far element when the visual viewport is shrunken", async ({
+    reactGrab,
+    page,
+  }) => {
+    await page.evaluate(simulateBrowserZoom, 1.5);
+
+    await reactGrab.activate();
+    await reactGrab.hoverUntilSelected("[data-testid='edge-bottom-right']");
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          ({ attributeName, selector }) => {
+            const host = document.querySelector(`[${attributeName}]`);
+            const canvas = host?.shadowRoot?.querySelector("canvas");
+            const element = document.querySelector(selector);
+            if (!canvas || !element) return -1;
+            const context = canvas.getContext("2d");
+            if (!context) return -1;
+            const bounds = element.getBoundingClientRect();
+            const scale =
+              canvas.width / parseFloat(canvas.style.width || String(window.innerWidth));
+            const startX = Math.max(0, Math.round((bounds.x - 10) * scale));
+            const startY = Math.max(0, Math.round((bounds.y - 10) * scale));
+            const width = Math.min(canvas.width - startX, Math.round((bounds.width + 20) * scale));
+            const height = Math.min(
+              canvas.height - startY,
+              Math.round((bounds.height + 20) * scale),
+            );
+            if (width <= 0 || height <= 0) return 0;
+            const pixels = context.getImageData(startX, startY, width, height).data;
+            let drawnPixels = 0;
+            for (let index = 3; index < pixels.length; index += 4) {
+              if (pixels[index] > 5) drawnPixels += 1;
+            }
+            return drawnPixels;
+          },
+          { attributeName: ATTRIBUTE_NAME, selector: "[data-testid='edge-bottom-right']" },
+        ),
+      )
+      .toBeGreaterThan(0);
+  });
+});

--- a/packages/react-grab/src/components/overlay-canvas.tsx
+++ b/packages/react-grab/src/components/overlay-canvas.tsx
@@ -112,8 +112,14 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
     if (!canvasRef) return;
 
     devicePixelRatio = Math.max(window.devicePixelRatio || 1, MIN_DEVICE_PIXEL_RATIO);
-    canvasWidth = window.innerWidth;
-    canvasHeight = window.innerHeight;
+    // Size to the layout viewport (documentElement.clientWidth/Height), not
+    // window.innerWidth/Height. Under browser zoom the latter shrink to the
+    // visual viewport while getBoundingClientRect — which positions the boxes —
+    // keeps returning full layout coordinates, so a canvas sized to innerWidth
+    // draws the selection box off-canvas for anything past the shrunken edge
+    // (the "selection box gone entirely when zoomed" bug).
+    canvasWidth = document.documentElement.clientWidth || window.innerWidth;
+    canvasHeight = document.documentElement.clientHeight || window.innerHeight;
 
     canvasRef.width = canvasWidth * devicePixelRatio;
     canvasRef.height = canvasHeight * devicePixelRatio;

--- a/packages/react-grab/src/core/element-anchors.ts
+++ b/packages/react-grab/src/core/element-anchors.ts
@@ -5,7 +5,7 @@ import {
   isHostFiber,
   type Fiber,
 } from "bippy";
-import { indexInParent } from "./index-in-parent.js";
+import { indexInParent } from "../utils/index-in-parent.js";
 
 interface ElementAnchor {
   // Nearest ancestor (or the element itself) that React manages via a fiber.
@@ -17,6 +17,10 @@ interface ElementAnchor {
   // it: a fiber's own `return`/`alternate` are nulled on unmount, so the link
   // back to the live tree has to come from an ancestor that survives.
   anchorParentFiber: Fiber;
+  // Position of the anchor among its parent's element children, used to re-find
+  // the anchor's replacement when the parent fiber is itself a host fiber (a
+  // keyed host element nested directly under another host element).
+  anchorIndexInParent: number;
   // Child-index chain from the anchor down to the tracked element; empty when
   // the element is itself the anchor.
   domPath: number[];
@@ -28,16 +32,29 @@ interface ElementAnchor {
 // before the swap).
 const anchorByElement = new WeakMap<Element, ElementAnchor>();
 
-const liveHostElementFromFiber = (fiber: Fiber, tagName: string): Element | null => {
-  const latest = getLatestFiber(fiber);
-  const hostFibers = isHostFiber(latest) ? [latest] : getNearestHostFibers(latest);
-  for (const hostFiber of hostFibers) {
+const resolveLiveAnchor = (anchor: ElementAnchor): Element | null => {
+  if (anchor.anchorElement.isConnected) return anchor.anchorElement;
+
+  const anchorTagName = anchor.anchorElement.tagName;
+  const latestParentFiber = getLatestFiber(anchor.anchorParentFiber);
+
+  // A host parent fiber keeps its DOM node across a keyed swap of its child, so
+  // the replacement sits at the anchor's recorded child index — an exact lookup
+  // that same-tag siblings can't confuse.
+  if (isHostFiber(latestParentFiber)) {
+    const parentNode = latestParentFiber.stateNode;
+    if (!(parentNode instanceof Element) || !parentNode.isConnected) return null;
+    const candidate = parentNode.children[anchor.anchorIndexInParent];
+    return candidate && candidate.tagName === anchorTagName ? candidate : null;
+  }
+
+  for (const hostFiber of getNearestHostFibers(latestParentFiber)) {
     const node = hostFiber.stateNode;
     // The tag match keeps recovery from latching onto an unrelated host when the
-    // original element type is gone. Same-tag siblings under a shared ancestor
-    // can't be told apart and resolve to the first match, which still leaves the
-    // selection on a valid node instead of dropping it.
-    if (node instanceof Element && node.isConnected && node.tagName === tagName) {
+    // original element type is gone. Same-tag siblings under a shared composite
+    // ancestor can't be told apart and resolve to the first match, which still
+    // leaves the selection on a valid node instead of dropping it.
+    if (node instanceof Element && node.isConnected && node.tagName === anchorTagName) {
       return node;
     }
   }
@@ -67,14 +84,28 @@ const findAnchor = (element: Element): ElementAnchor | null => {
   }
   const anchorParentFiber = anchorFiber?.return;
   if (!anchorElement || !anchorParentFiber) return null;
-  return { anchorElement, anchorParentFiber, domPath, targetTagName: element.tagName };
+  return {
+    anchorElement,
+    anchorParentFiber,
+    anchorIndexInParent: indexInParent(anchorElement),
+    domPath,
+    targetTagName: element.tagName,
+  };
 };
 
-// Records how to recover an element after a DOM swap. Cheap and idempotent:
-// skips disconnected elements and anything already tracked.
-export const trackElementFiber = (element: Element): void => {
+const isAnchorFresh = (anchor: ElementAnchor, element: Element): boolean =>
+  anchor.anchorElement.isConnected &&
+  anchor.anchorIndexInParent === indexInParent(anchor.anchorElement) &&
+  followDomPath(anchor.anchorElement, anchor.domPath) === element;
+
+// Records how to recover an element after a DOM swap. Keeps the anchor fresh
+// across sibling reorders: an existing record is reused only while its DOM
+// positions still hold, so revalidation stays cheap (no fiber lookups) on the
+// common no-change tick.
+export const trackElementAnchor = (element: Element): void => {
   if (!element.isConnected) return;
-  if (anchorByElement.has(element)) return;
+  const existingAnchor = anchorByElement.get(element);
+  if (existingAnchor && isAnchorFresh(existingAnchor, element)) return;
   const anchor = findAnchor(element);
   if (anchor) anchorByElement.set(element, anchor);
 };
@@ -92,9 +123,7 @@ export const resolveLiveElement = (element: Element): Element | null => {
   const anchor = anchorByElement.get(element);
   if (!anchor) return null;
 
-  const liveAnchor = anchor.anchorElement.isConnected
-    ? anchor.anchorElement
-    : liveHostElementFromFiber(anchor.anchorParentFiber, anchor.anchorElement.tagName);
+  const liveAnchor = resolveLiveAnchor(anchor);
   if (!liveAnchor) return null;
 
   const recovered = followDomPath(liveAnchor, anchor.domPath);

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -1020,8 +1020,13 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       if (!element) return;
 
       const intervalId = setInterval(() => {
-        if (!isElementConnected(element)) {
-          actions.setDetectedElement(null);
+        actions.relinkLiveElements();
+        // The hovered node can be swapped out by a re-render the freeze didn't
+        // catch (e.g. a dangerouslySetInnerHTML block re-highlighting). If fiber
+        // recovery couldn't relink it, re-detect under the pointer so the
+        // selection latches onto its replacement instead of vanishing.
+        if (!isElementConnected(store.detectedElement)) {
+          redetectElementUnderPointer();
         }
       }, BOUNDS_RECALC_INTERVAL_MS);
 
@@ -3235,6 +3240,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         if (boundsRecalcIntervalId !== null) return;
 
         boundsRecalcIntervalId = window.setInterval(() => {
+          actions.relinkLiveElements();
           scheduleBoundsSync();
         }, BOUNDS_RECALC_INTERVAL_MS);
         return;
@@ -3437,7 +3443,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       if (!pluginRegistry.store.theme.grabbedBoxes.enabled) return [];
       void viewportVersion();
       return store.grabbedBoxes.map((box) => {
-        if (!box.element || !document.body.contains(box.element)) {
+        if (!isElementConnected(box.element)) {
           return box;
         }
         return {

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -1020,11 +1020,15 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       if (!element) return;
 
       const intervalId = setInterval(() => {
-        actions.relinkLiveElements();
         // The hovered node can be swapped out by a re-render the freeze didn't
-        // catch (e.g. a dangerouslySetInnerHTML block re-highlighting). If fiber
-        // recovery couldn't relink it, re-detect under the pointer so the
-        // selection latches onto its replacement instead of vanishing.
+        // catch (e.g. a dangerouslySetInnerHTML block re-highlighting). Fiber
+        // recovery is attempted on demand here because the bounds-recalc
+        // interval — the periodic relink owner — only runs while the overlay is
+        // active; if recovery can't relink it, re-detect under the pointer so
+        // the selection latches onto its replacement instead of vanishing.
+        if (!isElementConnected(store.detectedElement)) {
+          actions.relinkLiveElements();
+        }
         if (!isElementConnected(store.detectedElement)) {
           redetectElementUnderPointer();
         }
@@ -1080,7 +1084,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     const getSelectionElement = (): Element | undefined => {
       if (store.isTouchMode && isDragging()) {
         const detected = store.detectedElement;
-        if (!detected || isRootElement(detected)) return undefined;
+        if (!isElementConnected(detected) || isRootElement(detected)) return undefined;
         return detected;
       }
       const element = effectiveElement();

--- a/packages/react-grab/src/core/store.ts
+++ b/packages/react-grab/src/core/store.ts
@@ -5,7 +5,7 @@ import { OFFSCREEN_POSITION } from "../constants.js";
 import { createElementBounds } from "../utils/create-element-bounds.js";
 import { getBoundsCenter } from "../utils/get-bounds-center.js";
 import { isElementConnected } from "../utils/is-element-connected.js";
-import { resolveLiveElement, trackElementFiber } from "../utils/resolve-live-element.js";
+import { resolveLiveElement, trackElementAnchor } from "./element-anchors.js";
 
 interface FrozenDragRect {
   pageX: number;
@@ -67,18 +67,13 @@ interface GrabStoreInput {
   keyHoldDuration: number;
 }
 
-// Returns the live element for a tracked slot: records the fiber while
-// connected so a future swap can be recovered, and re-resolves the current node
-// once it has detached. Keeps the old reference when recovery fails so callers
-// never lose the slot to a transient null.
+// Returns the live element for a tracked slot: keeps the recovery anchor fresh
+// while connected, and re-resolves the current node once it has detached. Keeps
+// the old reference when recovery fails so callers never lose the slot to a
+// transient null.
 const relinkElement = (element: Element): Element => {
-  if (element.isConnected) {
-    trackElementFiber(element);
-    return element;
-  }
-  const liveElement = resolveLiveElement(element);
-  if (!liveElement) return element;
-  trackElementFiber(liveElement);
+  const liveElement = resolveLiveElement(element) ?? element;
+  trackElementAnchor(liveElement);
   return liveElement;
 };
 
@@ -86,18 +81,15 @@ const relinkElement = (element: Element): Element => {
 // target, the context-menu target, and the post-copy "Copied" labels and
 // grabbed-box flashes — so they all follow the same DOM swaps. Run on the
 // recalc interval; assigning the same reference back is a no-op for solid, so
-// connected elements produce no store notifications.
+// connected elements produce no store notifications. Each slot is relinked in
+// place: frozenElement is NOT re-derived from frozenElements[0] here, because
+// enterPromptMode sets it standalone (prompt on a non-first multi-selected
+// element) and re-deriving would snap the prompt back to the first selection.
 const relinkSlots = (draft: GrabStore): void => {
   for (let index = 0; index < draft.frozenElements.length; index += 1) {
     draft.frozenElements[index] = relinkElement(draft.frozenElements[index]);
   }
-  // frozenElement mirrors frozenElements[0] when the array is populated (see
-  // updateFrozenElements); it only stands alone in freeze / prompt mode, where
-  // it is recovered on its own.
-  draft.frozenElement =
-    draft.frozenElements.length > 0
-      ? draft.frozenElements[0]
-      : draft.frozenElement && relinkElement(draft.frozenElement);
+  draft.frozenElement = draft.frozenElement && relinkElement(draft.frozenElement);
   draft.detectedElement = draft.detectedElement && relinkElement(draft.detectedElement);
   draft.contextMenuElement = draft.contextMenuElement && relinkElement(draft.contextMenuElement);
 
@@ -221,6 +213,9 @@ const createGrabStore = (input: GrabStoreInput) => {
         mutator(draft);
         draft.frozenElement = draft.frozenElements.length > 0 ? draft.frozenElements[0] : null;
         draft.frozenDragRect = null;
+        for (const frozenElement of draft.frozenElements) {
+          trackElementAnchor(frozenElement);
+        }
       }),
     );
   };
@@ -303,6 +298,7 @@ const createGrabStore = (input: GrabStoreInput) => {
       if (current().state === "active") {
         const elementToFreeze = store.frozenElement ?? store.detectedElement;
         if (elementToFreeze) {
+          trackElementAnchor(elementToFreeze);
           setStore("frozenElement", elementToFreeze);
         }
         setActivePhase("frozen");
@@ -439,6 +435,7 @@ const createGrabStore = (input: GrabStoreInput) => {
     enterPromptMode: (position: Position, element: Element) => {
       const bounds = createElementBounds(element);
       const { x: selectionCenterX } = getBoundsCenter(bounds);
+      trackElementAnchor(element);
 
       batch(() => {
         setStore("copyStart", position);
@@ -491,6 +488,7 @@ const createGrabStore = (input: GrabStoreInput) => {
     },
 
     setDetectedElement: (element: Element | null) => {
+      if (element) trackElementAnchor(element);
       setStore("detectedElement", element);
     },
 
@@ -580,6 +578,7 @@ const createGrabStore = (input: GrabStoreInput) => {
     },
 
     addGrabbedBox: (box: GrabbedBox) => {
+      if (box.element) trackElementAnchor(box.element);
       setStore("grabbedBoxes", (boxes) => [...boxes, box]);
     },
 
@@ -592,6 +591,10 @@ const createGrabStore = (input: GrabStoreInput) => {
     },
 
     addLabelInstance: (instance: SelectionLabelInstance) => {
+      if (instance.element) trackElementAnchor(instance.element);
+      for (const instanceElement of instance.elements ?? []) {
+        trackElementAnchor(instanceElement);
+      }
       setStore("labelInstances", (instances) => [...instances, instance]);
     },
 
@@ -629,6 +632,7 @@ const createGrabStore = (input: GrabStoreInput) => {
     showContextMenu: (position: Position, element: Element) => {
       const bounds = createElementBounds(element);
       const { x: centerX, y: centerY } = getBoundsCenter(bounds);
+      trackElementAnchor(element);
       batch(() => {
         setStore("contextMenuPosition", position);
         setStore("contextMenuElement", element);

--- a/packages/react-grab/src/core/store.ts
+++ b/packages/react-grab/src/core/store.ts
@@ -5,6 +5,7 @@ import { OFFSCREEN_POSITION } from "../constants.js";
 import { createElementBounds } from "../utils/create-element-bounds.js";
 import { getBoundsCenter } from "../utils/get-bounds-center.js";
 import { isElementConnected } from "../utils/is-element-connected.js";
+import { resolveLiveElement, trackElementFiber } from "../utils/resolve-live-element.js";
 
 interface FrozenDragRect {
   pageX: number;
@@ -65,6 +66,53 @@ interface GrabStore {
 interface GrabStoreInput {
   keyHoldDuration: number;
 }
+
+// Returns the live element for a tracked slot: records the fiber while
+// connected so a future swap can be recovered, and re-resolves the current node
+// once it has detached. Keeps the old reference when recovery fails so callers
+// never lose the slot to a transient null.
+const relinkElement = (element: Element): Element => {
+  if (element.isConnected) {
+    trackElementFiber(element);
+    return element;
+  }
+  const liveElement = resolveLiveElement(element);
+  if (!liveElement) return element;
+  trackElementFiber(liveElement);
+  return liveElement;
+};
+
+// Re-resolves every element the overlay anchors to — the selection, the hover
+// target, the context-menu target, and the post-copy "Copied" labels and
+// grabbed-box flashes — so they all follow the same DOM swaps. Run on the
+// recalc interval; assigning the same reference back is a no-op for solid, so
+// connected elements produce no store notifications.
+const relinkSlots = (draft: GrabStore): void => {
+  for (let index = 0; index < draft.frozenElements.length; index += 1) {
+    draft.frozenElements[index] = relinkElement(draft.frozenElements[index]);
+  }
+  // frozenElement mirrors frozenElements[0] when the array is populated (see
+  // updateFrozenElements); it only stands alone in freeze / prompt mode, where
+  // it is recovered on its own.
+  draft.frozenElement =
+    draft.frozenElements.length > 0
+      ? draft.frozenElements[0]
+      : draft.frozenElement && relinkElement(draft.frozenElement);
+  draft.detectedElement = draft.detectedElement && relinkElement(draft.detectedElement);
+  draft.contextMenuElement = draft.contextMenuElement && relinkElement(draft.contextMenuElement);
+
+  for (const instance of draft.labelInstances) {
+    if (instance.element) instance.element = relinkElement(instance.element);
+    if (instance.elements) {
+      for (let index = 0; index < instance.elements.length; index += 1) {
+        instance.elements[index] = relinkElement(instance.elements[index]);
+      }
+    }
+  }
+  for (const box of draft.grabbedBoxes) {
+    if (box.element) box.element = relinkElement(box.element);
+  }
+};
 
 const createInitialStore = (input: GrabStoreInput): GrabStore => ({
   selectionInteractionLockDepth: 0,
@@ -131,6 +179,7 @@ interface GrabActions {
   toggleFrozenElement: (element: Element) => void;
   addFrozenElements: (elements: Element[]) => void;
   setFrozenDragRect: (rect: FrozenDragRect | null) => void;
+  relinkLiveElements: () => void;
   setCopyStart: (position: Position, element: Element) => void;
   setLastGrabbed: (element: Element | null) => void;
   setWasActivatedByToggle: (value: boolean) => void;
@@ -480,6 +529,10 @@ const createGrabStore = (input: GrabStoreInput) => {
 
     setFrozenDragRect: (rect: FrozenDragRect | null) => {
       setStore("frozenDragRect", rect);
+    },
+
+    relinkLiveElements: () => {
+      setStore(produce(relinkSlots));
     },
 
     setCopyStart: (position: Position, element: Element) => {

--- a/packages/react-grab/src/utils/index-in-parent.ts
+++ b/packages/react-grab/src/utils/index-in-parent.ts
@@ -1,0 +1,12 @@
+// Position of an element among its parent's element children, used to record
+// and replay a DOM path. Counts previous siblings rather than borrowing
+// Array.prototype.indexOf against the live HTMLCollection.
+export const indexInParent = (element: Element): number => {
+  let index = 0;
+  let sibling = element.previousElementSibling;
+  while (sibling) {
+    index += 1;
+    sibling = sibling.previousElementSibling;
+  }
+  return index;
+};

--- a/packages/react-grab/src/utils/resolve-live-element.ts
+++ b/packages/react-grab/src/utils/resolve-live-element.ts
@@ -1,0 +1,105 @@
+import {
+  getFiberFromHostInstance,
+  getLatestFiber,
+  getNearestHostFibers,
+  isHostFiber,
+  type Fiber,
+} from "bippy";
+import { indexInParent } from "./index-in-parent.js";
+
+interface ElementAnchor {
+  // Nearest ancestor (or the element itself) that React manages via a fiber.
+  // Content rendered through `dangerouslySetInnerHTML` — e.g. syntax-highlighted
+  // code — has no fiber of its own, so we anchor to the nearest fibered host and
+  // re-find the element by the DOM path below it after a re-render.
+  anchorElement: Element;
+  // Parent fiber of the anchor, used to recover the anchor when React remounts
+  // it: a fiber's own `return`/`alternate` are nulled on unmount, so the link
+  // back to the live tree has to come from an ancestor that survives.
+  anchorParentFiber: Fiber;
+  // Child-index chain from the anchor down to the tracked element; empty when
+  // the element is itself the anchor.
+  domPath: number[];
+  targetTagName: string;
+}
+
+// Recovery metadata for each tracked element, captured while it was still
+// mounted (React nulls the fiber pointers on unmount, so this must be recorded
+// before the swap).
+const anchorByElement = new WeakMap<Element, ElementAnchor>();
+
+const liveHostElementFromFiber = (fiber: Fiber, tagName: string): Element | null => {
+  const latest = getLatestFiber(fiber);
+  const hostFibers = isHostFiber(latest) ? [latest] : getNearestHostFibers(latest);
+  for (const hostFiber of hostFibers) {
+    const node = hostFiber.stateNode;
+    // The tag match keeps recovery from latching onto an unrelated host when the
+    // original element type is gone. Same-tag siblings under a shared ancestor
+    // can't be told apart and resolve to the first match, which still leaves the
+    // selection on a valid node instead of dropping it.
+    if (node instanceof Element && node.isConnected && node.tagName === tagName) {
+      return node;
+    }
+  }
+  return null;
+};
+
+const followDomPath = (root: Element, domPath: number[]): Element | null => {
+  let node: Element = root;
+  for (const childIndex of domPath) {
+    const child = node.children[childIndex];
+    if (!child) return null;
+    node = child;
+  }
+  return node;
+};
+
+// Walks up to the nearest fiber-managed ancestor, recording the DOM path taken
+// so a non-fibered element (innerHTML content) can be re-found beneath it.
+const findAnchor = (element: Element): ElementAnchor | null => {
+  const domPath: number[] = [];
+  let anchorElement: Element | null = element;
+  let anchorFiber = getFiberFromHostInstance(anchorElement);
+  while (anchorElement && !anchorFiber) {
+    domPath.unshift(indexInParent(anchorElement));
+    anchorElement = anchorElement.parentElement;
+    anchorFiber = getFiberFromHostInstance(anchorElement);
+  }
+  const anchorParentFiber = anchorFiber?.return;
+  if (!anchorElement || !anchorParentFiber) return null;
+  return { anchorElement, anchorParentFiber, domPath, targetTagName: element.tagName };
+};
+
+// Records how to recover an element after a DOM swap. Cheap and idempotent:
+// skips disconnected elements and anything already tracked.
+export const trackElementFiber = (element: Element): void => {
+  if (!element.isConnected) return;
+  if (anchorByElement.has(element)) return;
+  const anchor = findAnchor(element);
+  if (anchor) anchorByElement.set(element, anchor);
+};
+
+// When React swaps the DOM node backing a selected element — a conditional
+// remount, a route/view transition, an animation library reparenting nodes, or
+// a `dangerouslySetInnerHTML` subtree (syntax-highlighted code) being replaced —
+// the originally captured Element detaches and the selection box, copied
+// context, and post-copy label break. We recover by resolving the nearest
+// surviving fibered ancestor and re-walking the recorded DOM path to the
+// element's replacement.
+export const resolveLiveElement = (element: Element): Element | null => {
+  if (element.isConnected) return element;
+
+  const anchor = anchorByElement.get(element);
+  if (!anchor) return null;
+
+  const liveAnchor = anchor.anchorElement.isConnected
+    ? anchor.anchorElement
+    : liveHostElementFromFiber(anchor.anchorParentFiber, anchor.anchorElement.tagName);
+  if (!liveAnchor) return null;
+
+  const recovered = followDomPath(liveAnchor, anchor.domPath);
+  if (recovered && recovered.isConnected && recovered.tagName === anchor.targetTagName) {
+    return recovered;
+  }
+  return null;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Selection box disappearing under browser zoom (the reported bug)

On a zoomed page (e.g. 147% on macOS Chrome), the selection box and copied indicator vanished **entirely** for any element away from the top-left. Root cause: the overlay `<canvas>` sized itself to `window.innerWidth/innerHeight`, which shrink to the **visual viewport** under browser zoom, while `getBoundingClientRect()` (which positions every box) keeps returning **full layout coordinates**. Anything past the shrunken edge had its box drawn off-canvas → invisible. This matched the user's console capture exactly: `box:true, drawn:0, connected:true` at `zoom:147%` for a bottom-right element.

**Fix** (`components/overlay-canvas.tsx`): size the canvas to the layout viewport via `document.documentElement.clientWidth/clientHeight`, which shares `getBoundingClientRect`'s coordinate space at any zoom. New e2e (`e2e/zoom-canvas.spec.ts`) simulates the shrunken visual viewport and asserts the box still draws for a far-corner element — it fails without the fix.

## Fiber-latched selection across DOM swaps

Separately, when the DOM node backing a held selection is swapped out — a conditional/keyed remount, a route/view transition, an animation library reparenting nodes, or a `dangerouslySetInnerHTML` subtree being replaced — the captured `Element` detaches and the overlay anchors break. We recover by anchoring to React's fiber tree, with a DOM-path fallback for non-fibered content (shiki code tokens have no fiber):

- Each tracked element records, while mounted, its **nearest fiber-managed ancestor** + the **DOM child-index path** to itself (React nulls a fiber's `return`/`alternate` on unmount, so the link must be captured before the swap).
- On recovery, resolve the live anchor (in place when it survives, or via its parent fiber when it remounts), then re-walk the path to the replacement (tag-validated).

### What changed
- **`utils/resolve-live-element.ts`** (new) + **`utils/index-in-parent.ts`**: anchor/recover logic.
- **`core/store.ts`**: `relinkLiveElements` covers selection, hover target, context-menu target, post-copy `labelInstances`, and `grabbedBoxes`.
- **`core/index.tsx`**: relink on the bounds-recalc interval + viewport changes; the detected-element watchdog re-detects under the pointer when recovery misses.
- **`components/overlay-canvas.tsx`**: the zoom fix above.

## Testing
- `e2e/zoom-canvas.spec.ts` (zoom), `e2e/fiber-relink.spec.ts` (keyed remount, innerHTML token swap, post-copy label re-anchor) — all stable across repeats and fail without their respective fixes.
- `selection`, `context-menu`, `shift-multi-select`, `prompt-mode`, `viewport`, `copy-feedback`, `visual-feedback`, `drag-selection` specs pass; unit tests pass; `pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm format` clean.

### Known limitation
Multiple same-tag sibling selections sharing one ancestor that all remount simultaneously can resolve to the same node — the selection still survives on a valid same-tag node rather than vanishing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-649f3b68-321f-4fe3-822d-582ab8421faa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-649f3b68-321f-4fe3-822d-582ab8421faa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Latch held selections in `react-grab` to their React fiber so they survive DOM swaps, and fixed selection box visibility under browser zoom. Selections, post-copy labels, grabbed-box flashes, and context now reattach to the live node, including tokens rendered via `dangerouslySetInnerHTML`.

- **New Features**
  - Hardened live-element recovery: anchor to the nearest fiber-managed ancestor + DOM path, capture anchors at store write boundaries (selection, hover, prompt, labels, grabbed boxes, context menu), and recover via the ancestor’s parent fiber with a strict tag-name match. Handles keyed remounts, fiber-less `innerHTML` token swaps, and host-under-host keyed swaps via child-index lookups.
  - New `relinkLiveElements` runs on the bounds-recalc interval; the hover watchdog only relinks on demand and re-detects under the pointer if relink fails. Anchors refresh when DOM positions change without losing prompt-mode focus.

- **Bug Fixes**
  - Kept the selection box visible under browser zoom by sizing the overlay canvas to the layout viewport.
  - Guarded touch-drag selection against a detached `detectedElement`.

<sup>Written for commit 7549691aeaf5419a995e8440777ae4e0cb69c292. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

