### PR TITLE
test(react-grab): unit-test findTailwindClass across all chip scales

### DIFF
--- a/packages/react-grab/tests/find-tailwind-class.test.ts
+++ b/packages/react-grab/tests/find-tailwind-class.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vite-plus/test";
+import { findTailwindClass } from "../src/utils/find-tailwind-class.js";
+
+describe("findTailwindClass", () => {
+  it("returns null for property keys without a chip rule", () => {
+    expect(findTailwindClass("color", 0)).toBe(null);
+    expect(findTailwindClass("font-size", 16)).toBe(null);
+  });
+
+  describe("spacing scale", () => {
+    it("maps a 4px unit to the chip number", () => {
+      expect(findTailwindClass("padding", 0)).toBe("p-0");
+      expect(findTailwindClass("padding", 16)).toBe("p-4");
+      expect(findTailwindClass("margin-left", 8)).toBe("ml-2");
+    });
+
+    it("names the most-specific prefix for aggregate rows", () => {
+      expect(findTailwindClass("padding-top,padding-bottom", 8)).toBe("py-2");
+      expect(findTailwindClass("width,height", 16)).toBe("size-4");
+      expect(findTailwindClass("top,right,bottom,left", 0)).toBe("inset-0");
+    });
+
+    it("returns null for negative, non-integer-unit, or out-of-range values", () => {
+      expect(findTailwindClass("padding", -4)).toBe(null);
+      expect(findTailwindClass("padding", 6)).toBe(null);
+      // 96 units (384px) is the max; one unit past it falls back to null.
+      expect(findTailwindClass("padding", 384)).toBe("p-96");
+      expect(findTailwindClass("padding", 388)).toBe(null);
+    });
+  });
+
+  describe("border-width scale", () => {
+    it("uses the suffix-less form for a 1px border", () => {
+      expect(findTailwindClass("border-width", 1)).toBe("border");
+      expect(findTailwindClass("border-top-width", 1)).toBe("border-t");
+    });
+
+    it("uses a numeric suffix for other integer widths", () => {
+      expect(findTailwindClass("border-width", 0)).toBe("border-0");
+      expect(findTailwindClass("border-width", 2)).toBe("border-2");
+      expect(findTailwindClass("border-left-width", 4)).toBe("border-l-4");
+      expect(findTailwindClass("border-width", 8)).toBe("border-8");
+    });
+
+    it("returns null for negative, non-integer, or out-of-range widths", () => {
+      expect(findTailwindClass("border-width", -1)).toBe(null);
+      expect(findTailwindClass("border-width", 1.5)).toBe(null);
+      expect(findTailwindClass("border-width", 10)).toBe(null);
+    });
+  });
+
+  describe("z-index scale", () => {
+    it("maps integers in range to the chip number", () => {
+      expect(findTailwindClass("z-index", 0)).toBe("z-0");
+      expect(findTailwindClass("z-index", 10)).toBe("z-10");
+      expect(findTailwindClass("z-index", 50)).toBe("z-50");
+    });
+
+    it("returns null for negative, non-integer, or out-of-range values", () => {
+      expect(findTailwindClass("z-index", -1)).toBe(null);
+      expect(findTailwindClass("z-index", 1.5)).toBe(null);
+      expect(findTailwindClass("z-index", 60)).toBe(null);
+    });
+  });
+
+  describe("opacity scale", () => {
+    it("maps percent values on the 5% step to the chip number", () => {
+      expect(findTailwindClass("opacity", 0)).toBe("opacity-0");
+      expect(findTailwindClass("opacity", 55)).toBe("opacity-55");
+      expect(findTailwindClass("opacity", 100)).toBe("opacity-100");
+    });
+
+    it("returns null off the 5% step, out of range, or non-finite", () => {
+      expect(findTailwindClass("opacity", 52)).toBe(null);
+      expect(findTailwindClass("opacity", -5)).toBe(null);
+      expect(findTailwindClass("opacity", 105)).toBe(null);
+      expect(findTailwindClass("opacity", Number.POSITIVE_INFINITY)).toBe(null);
+      expect(findTailwindClass("opacity", Number.NaN)).toBe(null);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `findTailwindClass` is pure logic, but the edit-panel e2e flow only ever drove its **spacing** branch — border-width, z-index, and opacity were untested (~64% lines).
- Adds a `vite-plus/test` unit spec covering all four chip scales plus edge cases: the 1px suffix-less border form (`border` / `border-t`), numeric-suffix widths, z-index range, the opacity 5%-step rule, negative / non-integer / out-of-range / non-finite rejections, aggregate row prefixes (`py`, `size`, `inset`), and the unknown-key `null` path.

Pure functions are best covered by unit tests; note these run under `vp test` and so don't move the Playwright V8 e2e report, but they close the real logic gap deterministically.

## Test plan
- [x] `pnpm test:unit` — 69 passed (9 files)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` — 0 warnings / 0 errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code modifications.
> 
> **Overview**
> Adds a **`vite-plus/test`** unit spec for `findTailwindClass` so chip mapping logic is covered outside the edit-panel e2e path, which previously exercised mostly **spacing**.
> 
> The tests lock in behavior for all four chip scales—**spacing** (4px units, aggregate keys like `py` / `size` / `inset`), **border-width** (suffix-less `border` at 1px vs `border-N`), **z-index**, and **opacity** (5% steps)—plus rejections for unknown keys, negatives, non-integers, out-of-range values, and non-finite opacity inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1216182aeb9209ca9f70ce2c0bdb8d5c25eb1b98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `findTailwindClass` across spacing, border-width, z-index, and opacity scales to ensure correct class mapping and edge-case handling. Covers 1px suffix-less borders, 5% opacity steps, aggregate prefixes (`py`, `size`, `inset`), invalid values, and unknown keys that e2e tests missed.

<sup>Written for commit 1216182aeb9209ca9f70ce2c0bdb8d5c25eb1b98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

