### PR TITLE
test(react-grab): unit-test pure utils + error classes

### DIFF
--- a/packages/react-grab/tests/clamp-to-range.test.ts
+++ b/packages/react-grab/tests/clamp-to-range.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vite-plus/test";
+import { clampToRange } from "../src/utils/clamp-to-range.js";
+
+describe("clampToRange", () => {
+  it("returns the value unchanged when inside the range", () => {
+    expect(clampToRange(5, 0, 10)).toBe(5);
+  });
+
+  it("clamps to the lower bound", () => {
+    expect(clampToRange(-3, 0, 10)).toBe(0);
+  });
+
+  it("clamps to the upper bound", () => {
+    expect(clampToRange(42, 0, 10)).toBe(10);
+  });
+
+  it("returns the bound when the value sits on it", () => {
+    expect(clampToRange(0, 0, 10)).toBe(0);
+    expect(clampToRange(10, 0, 10)).toBe(10);
+  });
+
+  it("supports negative ranges", () => {
+    expect(clampToRange(-5, -10, -1)).toBe(-5);
+    expect(clampToRange(0, -10, -1)).toBe(-1);
+  });
+});

--- a/packages/react-grab/tests/errors.test.ts
+++ b/packages/react-grab/tests/errors.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  CopyFailedError,
+  NonElementNodeError,
+  ReactGrabError,
+  SelectorNotFoundError,
+  SelectorTimeoutError,
+} from "../src/errors.js";
+
+describe("react-grab errors", () => {
+  it("ReactGrabError carries the given message and name", () => {
+    const error = new ReactGrabError("boom");
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe("ReactGrabError");
+    expect(error.message).toBe("boom");
+  });
+
+  it("NonElementNodeError has a fixed message and subclasses ReactGrabError", () => {
+    const error = new NonElementNodeError();
+    expect(error).toBeInstanceOf(ReactGrabError);
+    expect(error.name).toBe("NonElementNodeError");
+    expect(error.message).toBe("Can't generate CSS selector for non-element node type.");
+  });
+
+  it("SelectorTimeoutError reports the timeout in its message and field", () => {
+    const error = new SelectorTimeoutError(250);
+    expect(error).toBeInstanceOf(ReactGrabError);
+    expect(error.name).toBe("SelectorTimeoutError");
+    expect(error.timeoutMs).toBe(250);
+    expect(error.message).toBe("Timeout: Can't find a unique selector after 250ms");
+  });
+
+  it("SelectorNotFoundError has a fixed message", () => {
+    const error = new SelectorNotFoundError();
+    expect(error).toBeInstanceOf(ReactGrabError);
+    expect(error.name).toBe("SelectorNotFoundError");
+    expect(error.message).toBe("Selector was not found.");
+  });
+
+  it("CopyFailedError has a fixed message", () => {
+    const error = new CopyFailedError();
+    expect(error).toBeInstanceOf(ReactGrabError);
+    expect(error.name).toBe("CopyFailedError");
+    expect(error.message).toBe("Failed to copy");
+  });
+});

--- a/packages/react-grab/tests/format-color-label.test.ts
+++ b/packages/react-grab/tests/format-color-label.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vite-plus/test";
+import { formatColorLabel } from "../src/utils/format-color-label.js";
+import { EDIT_TRANSPARENT_COLOR_LABEL } from "../src/constants.js";
+
+describe("formatColorLabel", () => {
+  it("uppercases a regular hex color", () => {
+    expect(formatColorLabel("#ff8800")).toBe("#FF8800");
+  });
+
+  it("labels the fully transparent hex as 'transparent' (case-insensitive)", () => {
+    expect(formatColorLabel("#00000000")).toBe(EDIT_TRANSPARENT_COLOR_LABEL);
+    expect(formatColorLabel("#00000000".toUpperCase())).toBe(EDIT_TRANSPARENT_COLOR_LABEL);
+  });
+
+  it("does not treat opaque black as transparent", () => {
+    expect(formatColorLabel("#000000")).toBe("#000000");
+  });
+});

--- a/packages/react-grab/tests/parse-activation-key.test.ts
+++ b/packages/react-grab/tests/parse-activation-key.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  getModifiersFromActivationKey,
+  parseActivationKey,
+} from "../src/utils/parse-activation-key.js";
+
+const makeKeyEvent = (overrides: Partial<KeyboardEvent>): KeyboardEvent =>
+  ({
+    key: "",
+    code: "",
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    ...overrides,
+  }) as KeyboardEvent;
+
+describe("parseActivationKey", () => {
+  it("returns a custom matcher function untouched", () => {
+    const custom = (_event: KeyboardEvent): boolean => true;
+    expect(parseActivationKey(custom)).toBe(custom);
+  });
+
+  it("matches a single key with no modifiers held", () => {
+    const matches = parseActivationKey("k");
+    expect(matches(makeKeyEvent({ key: "k" }))).toBe(true);
+    expect(matches(makeKeyEvent({ key: "a" }))).toBe(false);
+    expect(matches(makeKeyEvent({ key: "k", ctrlKey: true }))).toBe(false);
+  });
+
+  it("matches via event.code when event.key does not", () => {
+    const matches = parseActivationKey("k");
+    expect(matches(makeKeyEvent({ key: "Unidentified", code: "KeyK" }))).toBe(true);
+  });
+
+  it("requires the configured modifier alongside the key", () => {
+    const matches = parseActivationKey("meta+k");
+    expect(matches(makeKeyEvent({ key: "k", metaKey: true }))).toBe(true);
+    expect(matches(makeKeyEvent({ key: "k" }))).toBe(false);
+  });
+
+  it("matches a modifier-only chord while it is held", () => {
+    const matches = parseActivationKey("meta+shift");
+    expect(matches(makeKeyEvent({ metaKey: true, shiftKey: true }))).toBe(true);
+    expect(matches(makeKeyEvent({ metaKey: true }))).toBe(false);
+    // The modifier key itself reports through event.key on its own keydown.
+    expect(matches(makeKeyEvent({ key: "Shift", metaKey: true, shiftKey: true }))).toBe(true);
+  });
+});
+
+describe("getModifiersFromActivationKey", () => {
+  it("parses an explicit string chord", () => {
+    expect(getModifiersFromActivationKey("ctrl+shift+k")).toEqual({
+      metaKey: false,
+      ctrlKey: true,
+      shiftKey: true,
+      altKey: false,
+      key: "k",
+    });
+  });
+
+  it("falls back to platform defaults for undefined and function keys", () => {
+    const forUndefined = getModifiersFromActivationKey(undefined);
+    expect(forUndefined.shiftKey).toBe(false);
+    expect(forUndefined.altKey).toBe(false);
+    expect(forUndefined.key).toBe(null);
+    // meta vs ctrl is platform-dependent, but exactly one is the primary chord.
+    expect(forUndefined.metaKey).not.toBe(forUndefined.ctrlKey);
+
+    const forFunction = getModifiersFromActivationKey(() => true);
+    expect(forFunction).toEqual(forUndefined);
+  });
+});

--- a/packages/react-grab/tests/parse-package-name.test.ts
+++ b/packages/react-grab/tests/parse-package-name.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vite-plus/test";
-import { parsePackageName } from "../src/utils/parse-package-name.js";
+import { parsePackageName, resolvePackageName } from "../src/utils/parse-package-name.js";
 
 describe("parsePackageName", () => {
+  it("returns null for empty input", () => {
+    expect(parsePackageName(null)).toBe(null);
+    expect(parsePackageName(undefined)).toBe(null);
+    expect(parsePackageName("")).toBe(null);
+  });
+
   it("reads packages from node_modules paths", () => {
     expect(parsePackageName("/app/node_modules/react-tabs/dist/index.js")).toBe("react-tabs");
     expect(parsePackageName("/app/node_modules/@radix-ui/react-tabs/dist/index.js")).toBe(
@@ -9,9 +15,25 @@ describe("parsePackageName", () => {
     );
   });
 
+  it("skips dotfile dependency folders like .pnpm and .bin", () => {
+    expect(parsePackageName("/app/node_modules/.pnpm/react@18/node_modules/.bin/x.js")).toBe(null);
+  });
+
   it("reads packages from Vite optimized dependency paths", () => {
     expect(parsePackageName("/app/node_modules/.vite/deps/@radix-ui_react-tabs.js")).toBe(
       "@radix-ui/react-tabs",
+    );
+    expect(parsePackageName("/app/node_modules/.vite/deps/react-dom.js")).toBe("react-dom");
+  });
+
+  it("ignores Vite internal chunk files", () => {
+    expect(parsePackageName("/app/node_modules/.vite/deps/chunk-ABC123XY.js")).toBe(null);
+  });
+
+  it("reads versioned packages from CDN URLs", () => {
+    expect(parsePackageName("https://esm.sh/react-tabs@1.2.3/dist/index.js")).toBe("react-tabs");
+    expect(parsePackageName("https://esm.sh/@radix-ui/react-dialog@1.0.0/dist/index.js")).toBe(
+      "@radix-ui/react-dialog",
     );
   });
 
@@ -25,5 +47,28 @@ describe("parsePackageName", () => {
     expect(parsePackageName("../@rippling/pebble/Tabs/Renderers.js")).toBe(null);
     expect(parsePackageName("./@company/web/src/tabs.tsx")).toBe(null);
     expect(parsePackageName("/@company/app/src/tabs.tsx")).toBe(null);
+  });
+});
+
+describe("resolvePackageName", () => {
+  it("returns null for empty input", () => {
+    expect(resolvePackageName(null)).toBe(null);
+    expect(resolvePackageName(undefined)).toBe(null);
+  });
+
+  it("falls back to scoped source paths that carry no node_modules marker", () => {
+    expect(resolvePackageName("@radix-ui/react-tabs/src/tabs.tsx")).toBe("@radix-ui/react-tabs");
+    expect(resolvePackageName("../@acme/ui/components/button.tsx")).toBe("@acme/ui");
+  });
+
+  it("still prefers the marker-based result when one exists", () => {
+    expect(resolvePackageName("/app/node_modules/react-tabs/dist/index.js")).toBe("react-tabs");
+  });
+
+  it("rejects alias scopes, app packages, and absolute scoped paths", () => {
+    expect(resolvePackageName("@components/forms/input.tsx")).toBe(null);
+    expect(resolvePackageName("@acme/app/src/index.ts")).toBe(null);
+    expect(resolvePackageName("/@fs/@radix-ui/react-tabs/src/tabs.tsx")).toBe(null);
+    expect(resolvePackageName("@radix-ui/react-tabs")).toBe(null);
   });
 });

--- a/packages/react-grab/tests/safe-decode-uri-component.test.ts
+++ b/packages/react-grab/tests/safe-decode-uri-component.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vite-plus/test";
+import { safeDecodeURIComponent } from "../src/utils/safe-decode-uri-component.js";
+
+describe("safeDecodeURIComponent", () => {
+  it("decodes percent-encoded input", () => {
+    expect(safeDecodeURIComponent("%40radix-ui%2Freact-tabs")).toBe("@radix-ui/react-tabs");
+    expect(safeDecodeURIComponent("a%20b")).toBe("a b");
+  });
+
+  it("returns the input unchanged when it is not valid encoding", () => {
+    // A lone `%` is a malformed escape sequence that throws in
+    // decodeURIComponent; the helper must fall back to the raw input.
+    expect(safeDecodeURIComponent("100%")).toBe("100%");
+    expect(safeDecodeURIComponent("%E0%A4%A")).toBe("%E0%A4%A");
+  });
+
+  it("passes through input with nothing to decode", () => {
+    expect(safeDecodeURIComponent("plain-text")).toBe("plain-text");
+  });
+});


### PR DESCRIPTION
## Summary
Closes the cheap, deterministic coverage gaps from the prioritized list — the ones the e2e suite can't reach because they're inlined by the bundler or never instantiated. All pure logic, so unit tests are the right tool.

- **errors.ts** (was 27%, no class ever instantiated): construct all five error classes, assert `name`/`message` and `SelectorTimeoutError.timeoutMs`.
- **clamp-to-range.ts** / **format-color-label.ts** (0% — inlined at call sites in the e2e build): direct unit coverage incl. transparent-hex labeling.
- **safe-decode-uri-component.ts**: covers the malformed-escape `catch` fallback.
- **parse-package-name.ts** (37% func): exercises `resolvePackageName` scoped fallback, CDN-URL parsing, vite internal-chunk rejection, and `.pnpm` skip — lifting the weakest axis (function coverage).
- **parse-activation-key.ts** (46% func): both matcher branches (single-key incl. `event.code` fallback, modifier chord, modifier-only chord) + `getModifiersFromActivationKey` defaults.

## Test plan
- [x] `pnpm test:unit` — 89 passed (was 69)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm format:check` — only flags pre-existing `core/index.tsx` (untouched, present on main)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code modifications.
> 
> **Overview**
> Adds **unit tests only** for `react-grab` helpers and errors that e2e coverage misses (inlined or rarely constructed). Unit count goes from 69 to 89 passing cases per the PR plan.
> 
> New Vitest files cover **`clampToRange`**, **`formatColorLabel`** (including transparent hex), **`safeDecodeURIComponent`** (malformed `%` fallback), all five **`errors`** classes, and **`parseActivationKey`** / **`getModifiersFromActivationKey`** (custom matcher passthrough, `code` fallback, modifier chords).
> 
> **`parse-package-name.test.ts`** is expanded with **`resolvePackageName`**, empty input, `.pnpm`/`.bin` skip, Vite chunk rejection, CDN URLs, and scoped-path fallback vs alias rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab88f45ce4ea9abf0cbfd6852bf449096fb9e212. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds unit tests for pure utils and error classes in `react-grab`, closing deterministic coverage gaps that e2e can’t hit. Covers error constructors (names/messages and timeout), `clampToRange`, `formatColorLabel` (transparent hex), safe URI decode fallback, `parsePackageName`/`resolvePackageName` across node_modules/Vite/CDN (skip `.pnpm`, reject internal chunks), and `parseActivationKey` including `getModifiersFromActivationKey` defaults.

<sup>Written for commit ab88f45ce4ea9abf0cbfd6852bf449096fb9e212. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

