### PR TITLE
test(react-grab): unit-test Next runtime detection + base path

### DIFF
--- a/packages/react-grab/tests/get-next-base-path.test.ts
+++ b/packages/react-grab/tests/get-next-base-path.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const globalWithDocument = globalThis as { document?: unknown };
+let originalDocument: unknown;
+
+const stubScriptSource = (source: string | null): void => {
+  globalWithDocument.document = {
+    querySelector: () => (source === null ? null : { src: source }),
+  };
+};
+
+// getNextBasePath memoizes at module scope with no reset hook, so each branch
+// needs a freshly imported module to act as its "first call".
+const loadGetNextBasePath = async (): Promise<() => string> => {
+  vi.resetModules();
+  return (await import("../src/utils/get-next-base-path.js")).getNextBasePath;
+};
+
+beforeEach(() => {
+  originalDocument = globalWithDocument.document;
+});
+
+afterEach(() => {
+  globalWithDocument.document = originalDocument;
+  vi.resetModules();
+});
+
+describe("getNextBasePath", () => {
+  it("returns the prefix before /_next/ when a basePath is configured", async () => {
+    stubScriptSource("http://localhost:3000/app/_next/static/chunks/main.js");
+    const getNextBasePath = await loadGetNextBasePath();
+    expect(getNextBasePath()).toBe("/app");
+  });
+
+  it("returns an empty string when scripts load from the root /_next/", async () => {
+    stubScriptSource("http://localhost:3000/_next/static/chunks/main.js");
+    const getNextBasePath = await loadGetNextBasePath();
+    expect(getNextBasePath()).toBe("");
+  });
+
+  it("returns an empty string when no /_next/ script is present", async () => {
+    stubScriptSource(null);
+    const getNextBasePath = await loadGetNextBasePath();
+    expect(getNextBasePath()).toBe("");
+  });
+
+  it("memoizes the first computed base path", async () => {
+    stubScriptSource("http://localhost:3000/app/_next/static/chunks/main.js");
+    const getNextBasePath = await loadGetNextBasePath();
+    expect(getNextBasePath()).toBe("/app");
+
+    stubScriptSource("http://localhost:3000/other/_next/static/chunks/main.js");
+    expect(getNextBasePath()).toBe("/app");
+  });
+});

--- a/packages/react-grab/tests/is-next-project-runtime.test.ts
+++ b/packages/react-grab/tests/is-next-project-runtime.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { isNextProjectRuntime } from "../src/utils/is-next-project-runtime.js";
+
+interface DocumentStub {
+  getElementById: (id: string) => unknown;
+  querySelector: (selector: string) => unknown;
+}
+
+const globalWithDocument = globalThis as { document?: unknown };
+let originalDocument: unknown;
+
+const stubDocument = (stub: DocumentStub | undefined): void => {
+  globalWithDocument.document = stub;
+};
+
+beforeEach(() => {
+  originalDocument = globalWithDocument.document;
+});
+
+afterEach(() => {
+  globalWithDocument.document = originalDocument;
+});
+
+describe("isNextProjectRuntime", () => {
+  it("is false when there is no document (e.g. server runtime)", () => {
+    stubDocument(undefined);
+    expect(isNextProjectRuntime(true)).toBe(false);
+  });
+
+  it("detects the __NEXT_DATA__ script (Pages Router)", () => {
+    stubDocument({
+      getElementById: (id) => (id === "__NEXT_DATA__" ? {} : null),
+      querySelector: () => null,
+    });
+    expect(isNextProjectRuntime(true)).toBe(true);
+  });
+
+  it("detects the nextjs-portal element (App Router dev overlay)", () => {
+    stubDocument({
+      getElementById: () => null,
+      querySelector: (selector) => (selector === "nextjs-portal" ? {} : null),
+    });
+    expect(isNextProjectRuntime(true)).toBe(true);
+  });
+
+  it("is false when neither Next marker is present", () => {
+    stubDocument({ getElementById: () => null, querySelector: () => null });
+    expect(isNextProjectRuntime(true)).toBe(false);
+  });
+
+  it("memoizes the result until revalidation is requested", () => {
+    stubDocument({
+      getElementById: (id) => (id === "__NEXT_DATA__" ? {} : null),
+      querySelector: () => null,
+    });
+    expect(isNextProjectRuntime(true)).toBe(true);
+
+    // The cached value holds even though the markers are now gone...
+    stubDocument({ getElementById: () => null, querySelector: () => null });
+    expect(isNextProjectRuntime()).toBe(true);
+
+    // ...until a revalidate pass re-reads the DOM.
+    expect(isNextProjectRuntime(true)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
The e2e coverage run skips the Next fixture, leaving these `document`-driven helpers structurally untested (`is-next-project-runtime.ts` ~20%, `get-next-base-path.ts` via the `next-server-frames` path always hit the empty branch). Tested in isolation in node with a stubbed `document`.

- **is-next-project-runtime.ts**: `__NEXT_DATA__` (Pages Router) and `nextjs-portal` (App Router dev overlay) detection, the no-document and no-marker negatives, and the memoize/`shouldRevalidate` cache contract.
- **get-next-base-path.ts**: the configured-`basePath` prefix (`/app/_next/…` → `/app`), the root `/_next/` and missing-script empty cases, and first-call memoization. Each branch re-imports a fresh module via `vi.resetModules()` since the module-level cache has no reset hook.

## Test plan
- [x] `pnpm test:unit` — 98 passed (was 89)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm format:check` — only flags pre-existing `core/index.tsx` (untouched)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code modifications.
> 
> **Overview**
> Adds **unit tests only** for two DOM-dependent Next.js helpers that were lightly covered because e2e skips the Next fixture.
> 
> **`is-next-project-runtime`**: stubs `document` to assert Pages Router (`__NEXT_DATA__`) and App Router dev overlay (`nextjs-portal`) detection, no-document/no-marker negatives, and memoization until `shouldRevalidate` clears the cache.
> 
> **`get-next-base-path`**: stubs a `/_next/` script `src` to assert configured `basePath` prefix extraction, root and missing-script empty results, and first-call memoization. Tests use `vi.resetModules()` and fresh dynamic imports because the module cache has no reset hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ddaa05f2570b326c4165ee678b9c4393e64d068. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `is-next-project-runtime` and `get-next-base-path` in `react-grab`, using a stubbed `document` to run in Node. Covers Pages/App Router markers, no-document/no-marker and missing-script cases, basePath extraction (including root `/_next/`), and memoization/revalidation behavior.

<sup>Written for commit 5ddaa05f2570b326c4165ee678b9c4393e64d068. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

