### PR TITLE
test(react-grab): cover enrichServerFrameLocations owner-stack merge

### DIFF
--- a/packages/react-grab/tests/next-server-frames.test.ts
+++ b/packages/react-grab/tests/next-server-frames.test.ts
@@ -1,6 +1,34 @@
-import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { StackFrame } from "bippy/source";
-import { symbolicateServerFrames } from "../src/core/next-server-frames.js";
+import type { Fiber } from "bippy";
+import {
+  enrichServerFrameLocations,
+  symbolicateServerFrames,
+} from "../src/core/next-server-frames.js";
+
+// enrichServerFrameLocations walks the fiber tree via bippy to recover server
+// frame file locations from React's owner debug stacks. Stub bippy so the merge
+// logic is exercised deterministically without a real fiber tree. The runtime
+// helpers below are unused by symbolicateServerFrames, so its tests are
+// unaffected.
+interface DebugFiber {
+  _debugStack?: { stack: string };
+}
+interface DebugRoot {
+  fibers: DebugFiber[];
+}
+
+vi.mock("bippy", () => ({
+  traverseFiber: (root: DebugRoot, selector: (fiber: DebugFiber) => boolean) => {
+    for (const fiber of root.fibers) selector(fiber);
+  },
+}));
+
+vi.mock("bippy/source", () => ({
+  hasDebugStack: (fiber: DebugFiber) => Boolean(fiber._debugStack),
+  formatOwnerStack: (stack: string) => stack,
+  parseStack: (ownerStack: string) => JSON.parse(ownerStack) as StackFrame[],
+}));
 
 // symbolicateServerFrames touches only `document` (for the Next base path) and
 // the global `fetch`, both stubbed here so the POST behavior can be asserted in
@@ -242,5 +270,103 @@ describe("symbolicateServerFrames — success path", () => {
     expect(result[1].fileName).not.toBe("app/ignored.tsx");
     expect(result[2].isSymbolicated).toBeFalsy();
     expect(result[3]).toMatchObject({ fileName: "app/ok.tsx", isSymbolicated: true });
+  });
+
+  it("falls back to <unknown> and null positions for a server frame missing that metadata", async () => {
+    let captured: CapturedRequest | undefined;
+    globalThis.fetch = respondWith([fulfilled("app/z.tsx", 1, 1)], (request) => {
+      captured = request;
+    });
+
+    const bareFrame = {
+      fileName: "rsc://React/Server/webpack-internal:///./app/z.tsx?1",
+      isServer: true,
+    } as StackFrame;
+
+    await symbolicateServerFrames([bareFrame]);
+
+    expect(captured?.body.frames[0].methodName).toBe("<unknown>");
+    expect(captured?.body.frames[0].line1).toBe(null);
+    expect(captured?.body.frames[0].column1).toBe(null);
+  });
+});
+
+const makeUnresolvedServerFrame = (functionName: string): StackFrame =>
+  ({ functionName, fileName: undefined, isServer: true }) as StackFrame;
+
+const makeDebugRoot = (fibers: DebugFiber[]): Fiber => ({ fibers }) as unknown as Fiber;
+
+const debugFiber = (frames: Array<Partial<StackFrame>>): DebugFiber => ({
+  _debugStack: { stack: JSON.stringify(frames) },
+});
+
+describe("enrichServerFrameLocations", () => {
+  it("returns the frames untouched when none are unresolved server frames", () => {
+    const frames = [makeClientFrame(), makeServerFrame()];
+    const root = makeDebugRoot([]);
+    expect(enrichServerFrameLocations(root, frames)).toBe(frames);
+  });
+
+  it("returns the frames untouched when the debug stack yields no server frames", () => {
+    const frames = [makeUnresolvedServerFrame("ServerComponent")];
+    // A fiber whose owner stack holds only client URLs contributes nothing.
+    const root = makeDebugRoot([
+      debugFiber([{ functionName: "ClientThing", fileName: "/src/widget.tsx" }]),
+    ]);
+    expect(enrichServerFrameLocations(root, frames)).toBe(frames);
+  });
+
+  it("fills file/line/column from the first matching owner-stack frame by name", () => {
+    const unresolved = makeUnresolvedServerFrame("Page");
+    const resolvedClient = makeClientFrame();
+    const frames = [resolvedClient, unresolved];
+
+    const root = makeDebugRoot([
+      debugFiber([
+        {
+          functionName: "Page",
+          fileName: "rsc://React/Server/webpack-internal:///./app/page.tsx?9",
+          lineNumber: 42,
+          columnNumber: 7,
+        },
+        // A later duplicate by name must be ignored (first match wins).
+        {
+          functionName: "Page",
+          fileName: "rsc://React/Server/webpack-internal:///./app/other.tsx?9",
+          lineNumber: 99,
+          columnNumber: 99,
+        },
+        // Frames without a server URL or without a name are skipped.
+        { functionName: "Client", fileName: "/src/x.tsx", lineNumber: 1, columnNumber: 1 },
+        { fileName: "rsc://React/Server/webpack-internal:///./app/noname.tsx", lineNumber: 2 },
+      ]),
+    ]);
+
+    const result = enrichServerFrameLocations(root, frames);
+
+    expect(result[0]).toBe(resolvedClient);
+    expect(result[1]).toMatchObject({
+      functionName: "Page",
+      fileName: "rsc://React/Server/webpack-internal:///./app/page.tsx?9",
+      lineNumber: 42,
+      columnNumber: 7,
+    });
+  });
+
+  it("leaves an unresolved server frame alone when no owner-stack name matches", () => {
+    const unresolved = makeUnresolvedServerFrame("Missing");
+    const root = makeDebugRoot([
+      debugFiber([
+        {
+          functionName: "SomethingElse",
+          fileName: "rsc://React/Server/webpack-internal:///./app/else.tsx?1",
+          lineNumber: 5,
+          columnNumber: 5,
+        },
+      ]),
+    ]);
+
+    const result = enrichServerFrameLocations(root, [unresolved]);
+    expect(result[0].fileName).toBeFalsy();
   });
 });


### PR DESCRIPTION
## Summary
- `enrichServerFrameLocations` and its owner-stack extraction (the fiber debug-stack recovery path used to recover Next.js server-component file locations) had **zero** unit coverage — the report flagged `next-server-frames.ts` at 41% lines / 5% branches, and the e2e suite skips Next.
- Stubs bippy's `traverseFiber`/`hasDebugStack`/`formatOwnerStack`/`parseStack` so the merge logic runs deterministically in node (no real fiber tree), covering:
  - the two early exits (no unresolved server frames; debug stack yields no server frames),
  - the name-matched file/line/column merge — including **first-match-wins** dedup and server-URL-only / named-frame filtering,
  - the no-match passthrough.
- Also adds the cheap `symbolicateServerFrames` `<unknown>` `methodName` + `null` line/column fallbacks for a bare server frame missing that metadata.

These extend the existing `next-server-frames.test.ts`; the bippy mock is scoped to this file and does not affect `symbolicateServerFrames` (which uses no bippy runtime exports).

## Test plan
- [x] `vp test run tests` — 63 unit tests pass (13 in this file)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code modifications.
> 
> **Overview**
> Adds unit tests in `next-server-frames.test.ts` for **`enrichServerFrameLocations`** (Next server-component location recovery from React owner debug stacks) and one extra **`symbolicateServerFrames`** case.
> 
> **`enrichServerFrameLocations`:** Mocks `bippy` / `bippy/source` so fiber traversal and stack parsing are deterministic in Node. Covers early returns when there are no unresolved server frames or no server URLs in the debug stack; merging file/line/column by **function name** with **first-match-wins**; filtering non-server URLs and unnamed frames; and passthrough when names do not match.
> 
> **`symbolicateServerFrames`:** Asserts the POST body uses `<unknown>` for `methodName` and `null` for line/column when a server frame omits that metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dee96ce3da497ebac201dc299196c709919ef3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `enrichServerFrameLocations` owner-stack merge and `symbolicateServerFrames` fallbacks to validate Next.js server-component frame recovery. Stub `bippy` traversal so tests run deterministically and cover early exits, first-match-wins name merge with server-URL filtering, no-match passthrough, and `<unknown>`/null fallbacks for bare server frames.

<sup>Written for commit 5dee96ce3da497ebac201dc299196c709919ef3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

