### PR TITLE
test(react-grab): e2e cover the copy-failure error view

### DIFF
--- a/packages/react-grab/e2e/copy-failure.spec.ts
+++ b/packages/react-grab/e2e/copy-failure.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "./fixtures.js";
+import { ATTRIBUTE_NAME } from "./constants.js";
+
+interface ErrorViewSnapshot {
+  role: string | null;
+  text: string;
+  hasRetry: boolean;
+  hasOk: boolean;
+}
+
+test.describe("Copy failure feedback", () => {
+  test("renders the error view with the failure message when the synchronous copy fails", async ({
+    reactGrab,
+  }) => {
+    // copyContent() reports success/failure straight from execCommand("copy");
+    // forcing it to return false drives the grab into its error feedback path.
+    await reactGrab.page.evaluate(() => {
+      document.execCommand = () => false;
+    });
+
+    await reactGrab.activate();
+    await reactGrab.hoverUntilSelected("li");
+    await reactGrab.clickElement("li");
+
+    // Snapshot the error view the moment it mounts — the label auto-fades after
+    // ~1.5s, so capture state inside waitForFunction rather than in a later read.
+    const snapshotHandle = await reactGrab.page.waitForFunction(
+      (attrName): ErrorViewSnapshot | false => {
+        const host = document.querySelector(`[${attrName}]`);
+        const root = host?.shadowRoot?.querySelector(`[${attrName}]`);
+        const errorElement = root?.querySelector("[data-react-grab-error]");
+        if (!errorElement) return false;
+        return {
+          role: errorElement.getAttribute("role"),
+          text: errorElement.textContent?.trim() ?? "",
+          hasRetry: Boolean(root?.querySelector("[data-react-grab-retry]")),
+          hasOk: Boolean(root?.querySelector("[data-react-grab-error-ok]")),
+        };
+      },
+      ATTRIBUTE_NAME,
+      { timeout: 5000 },
+    );
+    const snapshot = (await snapshotHandle.jsonValue()) as ErrorViewSnapshot;
+
+    expect(snapshot.role).toBe("alert");
+    expect(snapshot.text).toContain("Failed to copy");
+    // The orchestrator never wires onRetry/onAcknowledgeError, so the action
+    // buttons stay hidden and only the message renders.
+    expect(snapshot.hasRetry).toBe(false);
+    expect(snapshot.hasOk).toBe(false);
+  });
+
+  test("marks a label instance as errored when the copy fails", async ({ reactGrab }) => {
+    await reactGrab.page.evaluate(() => {
+      document.execCommand = () => false;
+    });
+
+    await reactGrab.activate();
+    await reactGrab.hoverUntilSelected("li");
+    await reactGrab.clickElement("li");
+
+    await expect
+      .poll(
+        async () => {
+          const instances = await reactGrab.getLabelInstancesInfo();
+          return instances.some((instance) => instance.status === "error");
+        },
+        { timeout: 5000 },
+      )
+      .toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
`error-view.tsx` was the lowest-covered selection-label component (13%), and the **copy-failure feedback path** had no e2e coverage at all. This forces `execCommand("copy")` to return `false` so a normal grab degrades into its error path, then snapshots the error view the instant it mounts (via `waitForFunction`, before the ~1.5s auto-fade) and asserts:
- the `role="alert"` container renders, and
- the message contains `"Failed to copy"`.

A second test asserts a label instance flips to the `error` status.

### Note on the retry/acknowledge buttons
The Retry / Ok buttons and their Enter/Escape handlers in `error-view.tsx` are gated on `onRetry`/`onAcknowledgeError`, which **the orchestrator never wires** (no assignment exists anywhere in `src/`). They're effectively unreachable in the shipped app today, so they can't be exercised via e2e — the test documents this by asserting the buttons stay hidden. (If wiring those actions is intended, that's a separate follow-up.)

## Test plan
- [x] `playwright test e2e/copy-failure.spec.ts --project=chromium` — 2 pass
- [x] `--repeat-each=5 --workers=4` — 10/10 pass (no flake)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only addition; no runtime or production code changes.
> 
> **Overview**
> Adds **`e2e/copy-failure.spec.ts`** to cover the selection-label path when synchronous clipboard copy fails.
> 
> Tests stub **`document.execCommand`** to return `false`, run a normal grab on a `li`, then assert the shadow-DOM error view mounts with **`role="alert"`** and copy-failure copy (snapshot via **`waitForFunction`** before the ~1.5s fade). A second test polls **`getLabelInstancesInfo()`** until a label instance reports **`status: "error"`**.
> 
> The first test also documents current product behavior: **Retry** / **Ok** stay absent because **`onRetry`** / **`onAcknowledgeError`** are not wired from the orchestrator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41cf38e29f9786004e91a47f241d9c1e27249db7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Playwright e2e coverage for the copy-failure error view in `react-grab` by forcing `document.execCommand('copy')` to return `false` and triggering the error path. Verifies the `role="alert"` error message includes “Failed to copy”, a label instance flips to `error`, and Retry/Ok stay hidden since `onRetry`/`onAcknowledgeError` aren’t wired.

<sup>Written for commit 41cf38e29f9786004e91a47f241d9c1e27249db7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

