### PR TITLE
feat(react-grab): make copy failures recoverable via Retry/Ok

### DIFF
--- a/packages/react-grab/e2e/copy-failure.spec.ts
+++ b/packages/react-grab/e2e/copy-failure.spec.ts
@@ -95,6 +95,27 @@ test.describe("Copy failure feedback", () => {
     expect(instances.some((instance) => instance.status === "error")).toBe(false);
   });
 
+  test("Retry runs the full copy lifecycle so the overlay is not left stuck copying", async ({
+    reactGrab,
+  }) => {
+    await forceCopyResult(reactGrab, false);
+
+    await reactGrab.activate();
+    await reactGrab.hoverUntilSelected("li");
+    await reactGrab.clickElement("li");
+    await readErrorView(reactGrab);
+
+    await forceCopyResult(reactGrab, true);
+    await clickErrorButton(reactGrab, "data-react-grab-retry");
+
+    await expect.poll(() => isErrorViewGone(reactGrab), { timeout: 5000 }).toBe(true);
+    // A recovered copy must complete like a first-try success: the state
+    // machine leaves the copying state instead of stalling in it.
+    await expect
+      .poll(async () => (await reactGrab.getState()).isCopying, { timeout: 5000 })
+      .toBe(false);
+  });
+
   test("keeps the error label visible past the success-label fade window", async ({
     reactGrab,
   }) => {

--- a/packages/react-grab/e2e/copy-failure.spec.ts
+++ b/packages/react-grab/e2e/copy-failure.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from "./fixtures.js";
+import { ATTRIBUTE_NAME } from "./constants.js";
+
+interface ErrorViewSnapshot {
+  role: string | null;
+  text: string;
+  hasRetry: boolean;
+  hasOk: boolean;
+}
+
+const readErrorView = async (reactGrab: {
+  page: import("@playwright/test").Page;
+}): Promise<ErrorViewSnapshot | null> => {
+  const handle = await reactGrab.page.waitForFunction(
+    (attrName): ErrorViewSnapshot | false => {
+      const host = document.querySelector(`[${attrName}]`);
+      const root = host?.shadowRoot?.querySelector(`[${attrName}]`);
+      const errorElement = root?.querySelector("[data-react-grab-error]");
+      if (!errorElement) return false;
+      return {
+        role: errorElement.getAttribute("role"),
+        text: errorElement.textContent?.trim() ?? "",
+        hasRetry: Boolean(root?.querySelector("[data-react-grab-retry]")),
+        hasOk: Boolean(root?.querySelector("[data-react-grab-error-ok]")),
+      };
+    },
+    ATTRIBUTE_NAME,
+    { timeout: 5000 },
+  );
+  return handle.jsonValue() as Promise<ErrorViewSnapshot>;
+};
+
+const clickErrorButton = async (
+  reactGrab: { page: import("@playwright/test").Page },
+  buttonAttribute: string,
+): Promise<void> => {
+  await reactGrab.page.evaluate(
+    ({ attrName, target }) => {
+      const host = document.querySelector(`[${attrName}]`);
+      const root = host?.shadowRoot?.querySelector(`[${attrName}]`);
+      const button = root?.querySelector<HTMLButtonElement>(`[${target}]`);
+      if (!button) throw new Error(`Error button [${target}] not found`);
+      button.click();
+    },
+    { attrName: ATTRIBUTE_NAME, target: buttonAttribute },
+  );
+};
+
+const isErrorViewGone = (reactGrab: { page: import("@playwright/test").Page }) =>
+  reactGrab.page.evaluate((attrName) => {
+    const host = document.querySelector(`[${attrName}]`);
+    const root = host?.shadowRoot?.querySelector(`[${attrName}]`);
+    return !root?.querySelector("[data-react-grab-error]");
+  }, ATTRIBUTE_NAME);
+
+const forceCopyResult = (
+  reactGrab: { page: import("@playwright/test").Page },
+  shouldSucceed: boolean,
+) =>
+  reactGrab.page.evaluate((succeed) => {
+    document.execCommand = () => succeed;
+  }, shouldSucceed);
+
+test.describe("Copy failure feedback", () => {
+  test("renders the error view with the failure message and action buttons", async ({
+    reactGrab,
+  }) => {
+    await forceCopyResult(reactGrab, false);
+
+    await reactGrab.activate();
+    await reactGrab.hoverUntilSelected("li");
+    await reactGrab.clickElement("li");
+
+    const snapshot = await readErrorView(reactGrab);
+    expect(snapshot?.role).toBe("alert");
+    expect(snapshot?.text).toContain("Failed to copy");
+    expect(snapshot?.hasRetry).toBe(true);
+    expect(snapshot?.hasOk).toBe(true);
+  });
+
+  test("Retry re-runs the copy and clears the error once it succeeds", async ({ reactGrab }) => {
+    await forceCopyResult(reactGrab, false);
+
+    await reactGrab.activate();
+    await reactGrab.hoverUntilSelected("li");
+    await reactGrab.clickElement("li");
+    await readErrorView(reactGrab);
+
+    // The next copy attempt should succeed, so Retry clears the error.
+    await forceCopyResult(reactGrab, true);
+    await clickErrorButton(reactGrab, "data-react-grab-retry");
+
+    await expect.poll(() => isErrorViewGone(reactGrab), { timeout: 5000 }).toBe(true);
+    const instances = await reactGrab.getLabelInstancesInfo();
+    expect(instances.some((instance) => instance.status === "error")).toBe(false);
+  });
+
+  test("Ok dismisses the error label", async ({ reactGrab }) => {
+    await forceCopyResult(reactGrab, false);
+
+    await reactGrab.activate();
+    await reactGrab.hoverUntilSelected("li");
+    await reactGrab.clickElement("li");
+    await readErrorView(reactGrab);
+
+    await clickErrorButton(reactGrab, "data-react-grab-error-ok");
+
+    await expect.poll(() => isErrorViewGone(reactGrab), { timeout: 5000 }).toBe(true);
+    const instances = await reactGrab.getLabelInstancesInfo();
+    expect(instances.some((instance) => instance.status === "error")).toBe(false);
+  });
+});

--- a/packages/react-grab/e2e/copy-failure.spec.ts
+++ b/packages/react-grab/e2e/copy-failure.spec.ts
@@ -95,6 +95,24 @@ test.describe("Copy failure feedback", () => {
     expect(instances.some((instance) => instance.status === "error")).toBe(false);
   });
 
+  test("keeps the error label visible past the success-label fade window", async ({
+    reactGrab,
+  }) => {
+    await forceCopyResult(reactGrab, false);
+
+    await reactGrab.activate();
+    await reactGrab.hoverUntilSelected("li");
+    await reactGrab.clickElement("li");
+    await readErrorView(reactGrab);
+
+    // A copied label fades after ~1.5s; an actionable error must outlast it.
+    await reactGrab.page.waitForTimeout(2000);
+
+    expect(await isErrorViewGone(reactGrab)).toBe(false);
+    const instances = await reactGrab.getLabelInstancesInfo();
+    expect(instances.some((instance) => instance.status === "error")).toBe(true);
+  });
+
   test("Ok dismisses the error label", async ({ reactGrab }) => {
     await forceCopyResult(reactGrab, false);
 

--- a/packages/react-grab/src/components/renderer.tsx
+++ b/packages/react-grab/src/components/renderer.tsx
@@ -108,6 +108,8 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
               }
               return () => props.onShowContextMenuInstance?.(currentInstance.id);
             })()}
+            onRetry={() => props.onRetryInstance?.(instance().id)}
+            onAcknowledgeError={() => props.onAcknowledgeErrorInstance?.(instance().id)}
             onHoverChange={(isHovered) =>
               props.onLabelInstanceHoverChange?.(instance().id, isHovered)
             }

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -656,16 +656,14 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
     const labelController = createLabelController(actions, () => store.labelInstances);
 
-    const executeCopyOperation = async (
+    // Per-label retry closures, registered when a copy fails so the error
+    // view's Retry button (and Enter key) can re-run the exact same operation.
+    const retryCopyByInstanceId = new Map<string, () => void>();
+
+    const attemptClipboardAndLabel = async (
       clipboardOperation: () => Promise<boolean>,
       labelInstanceIds: string[] | null,
-      shouldDeactivateAfter?: boolean,
-    ) => {
-      clearCopyFeedbackCooldown();
-      if (current().state !== "copying") {
-        actions.startCopy();
-      }
-
+    ): Promise<boolean> => {
       let didSucceed = false;
       let errorMessage: string | undefined;
 
@@ -680,6 +678,62 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         for (const labelInstanceId of labelInstanceIds) {
           labelController.updateAfterCopy(labelInstanceId, didSucceed, errorMessage);
         }
+      }
+
+      return didSucceed;
+    };
+
+    const registerCopyRetry = (
+      didSucceed: boolean,
+      clipboardOperation: () => Promise<boolean>,
+      labelInstanceIds: string[],
+    ) => {
+      if (didSucceed) {
+        for (const labelInstanceId of labelInstanceIds) {
+          retryCopyByInstanceId.delete(labelInstanceId);
+        }
+        return;
+      }
+
+      const retry = () => {
+        for (const labelInstanceId of labelInstanceIds) {
+          labelController.markRetrying(labelInstanceId);
+          retryCopyByInstanceId.delete(labelInstanceId);
+        }
+        void attemptClipboardAndLabel(clipboardOperation, labelInstanceIds).then(
+          (didRetrySucceed) =>
+            registerCopyRetry(didRetrySucceed, clipboardOperation, labelInstanceIds),
+        );
+      };
+
+      for (const labelInstanceId of labelInstanceIds) {
+        retryCopyByInstanceId.set(labelInstanceId, retry);
+      }
+    };
+
+    const handleRetryInstance = (instanceId: string) => {
+      retryCopyByInstanceId.get(instanceId)?.();
+    };
+
+    const handleAcknowledgeErrorInstance = (instanceId: string) => {
+      retryCopyByInstanceId.delete(instanceId);
+      labelController.dismissInstance(instanceId);
+    };
+
+    const executeCopyOperation = async (
+      clipboardOperation: () => Promise<boolean>,
+      labelInstanceIds: string[] | null,
+      shouldDeactivateAfter?: boolean,
+    ) => {
+      clearCopyFeedbackCooldown();
+      if (current().state !== "copying") {
+        actions.startCopy();
+      }
+
+      const didSucceed = await attemptClipboardAndLabel(clipboardOperation, labelInstanceIds);
+
+      if (labelInstanceIds) {
+        registerCopyRetry(didSucceed, clipboardOperation, labelInstanceIds);
       }
 
       if (current().state !== "copying") return;
@@ -778,6 +832,13 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           const normalizedMessage = normalizeErrorMessage(error, "Action failed");
           for (const labelInstanceId of copy.labelInstanceIds) {
             labelController.updateAfterCopy(labelInstanceId, false, normalizedMessage);
+          }
+          if (copy.labelInstanceIds.length > 0) {
+            registerCopyRetry(
+              false,
+              () => copyElementsToClipboard(copy.targetElements, copy.extraPrompt, undefined),
+              copy.labelInstanceIds,
+            );
           }
           if (current().state === "copying") {
             actions.unfreeze();
@@ -3825,6 +3886,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
                 inputValue={store.inputText}
                 isPromptMode={isPromptMode()}
                 onShowContextMenuInstance={handleShowContextMenuInstance}
+                onRetryInstance={handleRetryInstance}
+                onAcknowledgeErrorInstance={handleAcknowledgeErrorInstance}
                 onLabelInstanceHoverChange={labelController.handleHoverChange}
                 onInputChange={actions.setInputText}
                 onInputSubmit={() => void handleInputSubmit()}

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -197,6 +197,7 @@ interface LabeledCopyOptions {
 interface CopyRetryEntry {
   operation: () => Promise<boolean>;
   siblingIds: Set<string>;
+  shouldDeactivateAfter: boolean;
 }
 
 let hasInited = false;
@@ -699,6 +700,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       didSucceed: boolean,
       clipboardOperation: () => Promise<boolean>,
       labelInstanceIds: string[],
+      shouldDeactivateAfter: boolean,
     ) => {
       if (didSucceed) {
         for (const labelInstanceId of labelInstanceIds) {
@@ -710,29 +712,11 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       const entry: CopyRetryEntry = {
         operation: clipboardOperation,
         siblingIds: new Set(labelInstanceIds),
+        shouldDeactivateAfter,
       };
       for (const labelInstanceId of labelInstanceIds) {
         retryCopyByInstanceId.set(labelInstanceId, entry);
       }
-    };
-
-    const handleRetryInstance = (instanceId: string) => {
-      const entry = retryCopyByInstanceId.get(instanceId);
-      if (!entry) return;
-      const idsToRetry = [...entry.siblingIds];
-      for (const labelInstanceId of idsToRetry) {
-        labelController.markRetrying(labelInstanceId);
-        retryCopyByInstanceId.delete(labelInstanceId);
-      }
-      void attemptClipboardAndLabel(entry.operation, idsToRetry).then((didRetrySucceed) =>
-        registerCopyRetry(didRetrySucceed, entry.operation, idsToRetry),
-      );
-    };
-
-    const handleAcknowledgeErrorInstance = (instanceId: string) => {
-      retryCopyByInstanceId.get(instanceId)?.siblingIds.delete(instanceId);
-      retryCopyByInstanceId.delete(instanceId);
-      labelController.dismissInstance(instanceId);
     };
 
     const executeCopyOperation = async (
@@ -748,7 +732,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       const didSucceed = await attemptClipboardAndLabel(clipboardOperation, labelInstanceIds);
 
       if (labelInstanceIds) {
-        registerCopyRetry(didSucceed, clipboardOperation, labelInstanceIds);
+        registerCopyRetry(
+          didSucceed,
+          clipboardOperation,
+          labelInstanceIds,
+          Boolean(shouldDeactivateAfter),
+        );
       }
 
       if (current().state !== "copying") return;
@@ -765,6 +754,26 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       } else {
         actions.unfreeze();
       }
+    };
+
+    const handleRetryInstance = (instanceId: string) => {
+      const entry = retryCopyByInstanceId.get(instanceId);
+      if (!entry) return;
+      const idsToRetry = [...entry.siblingIds];
+      for (const labelInstanceId of idsToRetry) {
+        labelController.markRetrying(labelInstanceId);
+        retryCopyByInstanceId.delete(labelInstanceId);
+      }
+      // Route through the full copy path (not just the clipboard attempt) so a
+      // recovered copy runs the same completion side effects as a first-try
+      // success: completeCopy, re-activate or deactivate, and feedback cooldown.
+      void executeCopyOperation(entry.operation, idsToRetry, entry.shouldDeactivateAfter);
+    };
+
+    const handleAcknowledgeErrorInstance = (instanceId: string) => {
+      retryCopyByInstanceId.get(instanceId)?.siblingIds.delete(instanceId);
+      retryCopyByInstanceId.delete(instanceId);
+      labelController.dismissInstance(instanceId);
     };
 
     const copyResolvedElements = (
@@ -860,6 +869,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
                   ),
                 ),
               copy.labelInstanceIds,
+              Boolean(copy.shouldDeactivateAfter),
             );
           }
           if (current().state === "copying") {

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -194,6 +194,11 @@ interface LabeledCopyOptions {
   onComplete?: () => void;
 }
 
+interface CopyRetryEntry {
+  operation: () => Promise<boolean>;
+  siblingIds: Set<string>;
+}
+
 let hasInited = false;
 const toolbarStateChangeCallbacks = new Set<(state: ToolbarState) => void>();
 
@@ -654,11 +659,18 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       );
     };
 
-    const labelController = createLabelController(actions, () => store.labelInstances);
+    // Per-label retry entries, registered when a copy fails so the error view's
+    // Retry button (and Enter key) can re-run the exact same operation. Grouped
+    // instances (a multi-element grab) share one entry whose siblingIds set is
+    // the live membership: acknowledging one instance drops it from the set so a
+    // later Retry never resurrects a dismissed label.
+    const retryCopyByInstanceId = new Map<string, CopyRetryEntry>();
 
-    // Per-label retry closures, registered when a copy fails so the error
-    // view's Retry button (and Enter key) can re-run the exact same operation.
-    const retryCopyByInstanceId = new Map<string, () => void>();
+    const labelController = createLabelController(
+      actions,
+      () => store.labelInstances,
+      () => retryCopyByInstanceId.clear(),
+    );
 
     const attemptClipboardAndLabel = async (
       clipboardOperation: () => Promise<boolean>,
@@ -695,27 +707,30 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         return;
       }
 
-      const retry = () => {
-        for (const labelInstanceId of labelInstanceIds) {
-          labelController.markRetrying(labelInstanceId);
-          retryCopyByInstanceId.delete(labelInstanceId);
-        }
-        void attemptClipboardAndLabel(clipboardOperation, labelInstanceIds).then(
-          (didRetrySucceed) =>
-            registerCopyRetry(didRetrySucceed, clipboardOperation, labelInstanceIds),
-        );
+      const entry: CopyRetryEntry = {
+        operation: clipboardOperation,
+        siblingIds: new Set(labelInstanceIds),
       };
-
       for (const labelInstanceId of labelInstanceIds) {
-        retryCopyByInstanceId.set(labelInstanceId, retry);
+        retryCopyByInstanceId.set(labelInstanceId, entry);
       }
     };
 
     const handleRetryInstance = (instanceId: string) => {
-      retryCopyByInstanceId.get(instanceId)?.();
+      const entry = retryCopyByInstanceId.get(instanceId);
+      if (!entry) return;
+      const idsToRetry = [...entry.siblingIds];
+      for (const labelInstanceId of idsToRetry) {
+        labelController.markRetrying(labelInstanceId);
+        retryCopyByInstanceId.delete(labelInstanceId);
+      }
+      void attemptClipboardAndLabel(entry.operation, idsToRetry).then((didRetrySucceed) =>
+        registerCopyRetry(didRetrySucceed, entry.operation, idsToRetry),
+      );
     };
 
     const handleAcknowledgeErrorInstance = (instanceId: string) => {
+      retryCopyByInstanceId.get(instanceId)?.siblingIds.delete(instanceId);
       retryCopyByInstanceId.delete(instanceId);
       labelController.dismissInstance(instanceId);
     };
@@ -836,7 +851,14 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           if (copy.labelInstanceIds.length > 0) {
             registerCopyRetry(
               false,
-              () => copyElementsToClipboard(copy.targetElements, copy.extraPrompt, undefined),
+              () =>
+                getNearestComponentName(copy.primaryElement).then((componentName) =>
+                  copyElementsToClipboard(
+                    copy.targetElements,
+                    copy.extraPrompt,
+                    componentName ?? undefined,
+                  ),
+                ),
               copy.labelInstanceIds,
             );
           }

--- a/packages/react-grab/src/core/label-controller.ts
+++ b/packages/react-grab/src/core/label-controller.ts
@@ -54,6 +54,8 @@ interface LabelController {
     status: SelectionLabelInstance["status"],
   ) => string[];
   updateAfterCopy: (instanceId: string, didSucceed: boolean, errorMessage?: string) => void;
+  markRetrying: (instanceId: string) => void;
+  dismissInstance: (instanceId: string) => void;
   cancelAllFades: () => void;
   clearAll: () => void;
   handleHoverChange: (instanceId: string, isHovered: boolean) => void;
@@ -175,6 +177,16 @@ export const createLabelController = (
     scheduleFade(instanceId);
   };
 
+  const markRetrying = (instanceId: string) => {
+    cancelFade(instanceId);
+    store.updateLabelInstance(instanceId, "copying");
+  };
+
+  const dismissInstance = (instanceId: string) => {
+    cancelFade(instanceId);
+    store.removeLabelInstance(instanceId);
+  };
+
   const handleHoverChange = (instanceId: string, isHovered: boolean) => {
     if (isHovered) {
       cancelFade(instanceId);
@@ -195,6 +207,8 @@ export const createLabelController = (
     createInstance,
     createPerElementInstances,
     updateAfterCopy,
+    markRetrying,
+    dismissInstance,
     cancelAllFades,
     clearAll,
     handleHoverChange,

--- a/packages/react-grab/src/core/label-controller.ts
+++ b/packages/react-grab/src/core/label-controller.ts
@@ -88,6 +88,7 @@ const buildLabelInstance = (options: BuildLabelInstanceOptions): SelectionLabelI
 export const createLabelController = (
   store: LabelStoreBridge,
   getLabelInstances: () => readonly SelectionLabelInstance[],
+  onClearAll?: () => void,
 ): LabelController => {
   const fadeTimeouts = new Map<string, number>();
 
@@ -109,6 +110,7 @@ export const createLabelController = (
   const clearAll = () => {
     cancelAllFades();
     store.clearLabelInstances();
+    onClearAll?.();
   };
 
   const scheduleFade = (instanceId: string) => {

--- a/packages/react-grab/src/core/label-controller.ts
+++ b/packages/react-grab/src/core/label-controller.ts
@@ -171,10 +171,13 @@ export const createLabelController = (
   const updateAfterCopy = (instanceId: string, didSucceed: boolean, errorMessage?: string) => {
     if (didSucceed) {
       store.updateLabelInstance(instanceId, "copied");
+      scheduleFade(instanceId);
     } else {
+      // Errors are actionable (Retry/Ok), so the label persists until it is
+      // acknowledged or superseded by the next grab instead of auto-fading.
+      cancelFade(instanceId);
       store.updateLabelInstance(instanceId, "error", errorMessage || "Unknown error");
     }
-    scheduleFade(instanceId);
   };
 
   const markRetrying = (instanceId: string) => {
@@ -194,11 +197,9 @@ export const createLabelController = (
     }
     const instance = getLabelInstances().find((labelInstance) => labelInstance.id === instanceId);
     if (!instance) return;
-    if (
-      instance.status === "copied" ||
-      instance.status === "error" ||
-      instance.status === "fading"
-    ) {
+    // Error labels are dismissed explicitly (Retry/Ok), so unhovering must not
+    // start a fade; only the transient copied/fading labels fade on hover-out.
+    if (instance.status === "copied" || instance.status === "fading") {
       scheduleFade(instanceId);
     }
   };

--- a/packages/react-grab/src/core/store.ts
+++ b/packages/react-grab/src/core/store.ts
@@ -553,6 +553,11 @@ const createGrabStore = (input: GrabStoreInput) => {
           setStore("labelInstances", index, "status", status);
           if (errorMessage !== undefined) {
             setStore("labelInstances", index, "errorMessage", errorMessage);
+          } else if (status !== "error") {
+            // errorMessage is only meaningful in the error state; leaving it set
+            // after a retry (copying) or success (copied) keeps the Retry/Ok
+            // panel visible, since the view renders on the message, not status.
+            setStore("labelInstances", index, "errorMessage", undefined);
           }
         });
       }

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -556,6 +556,8 @@ export interface ReactGrabRendererProps {
   inputValue?: string;
   isPromptMode?: boolean;
   onShowContextMenuInstance?: (instanceId: string) => void;
+  onRetryInstance?: (instanceId: string) => void;
+  onAcknowledgeErrorInstance?: (instanceId: string) => void;
   onLabelInstanceHoverChange?: (instanceId: string, isHovered: boolean) => void;
   onInputChange?: (value: string) => void;
   onInputSubmit?: () => void;


### PR DESCRIPTION
## Summary
`error-view.tsx` already rendered **Retry** and **Ok** buttons (plus Enter/Escape handlers), but the orchestrator never wired `onRetry`/`onAcknowledgeError` — so a copy failure surfaced only a message that auto-faded with no way to recover. This wires both, per label instance:

- **Retry** re-runs the *exact* failed clipboard operation. The op is captured in a per-instance closure when the copy fails (covering both the `execCommand("copy") === false` path and the thrown-error path in `runLabeledCopy`), flips the label back to `copying`, re-attempts, and updates the same label in place. It re-registers on a repeat failure so it stays retryable.
- **Ok / acknowledge** dismisses the error label and drops its retry closure.

Implementation:
- Refactors `executeCopyOperation` to share an `attemptClipboardAndLabel` core with the retry path (no duplicated try/catch).
- Adds `markRetrying` / `dismissInstance` to the label controller.
- Adds `onRetryInstance` / `onAcknowledgeErrorInstance` renderer props, wired to the per-instance `SelectionLabel`.

## Test plan
- [x] New `e2e/copy-failure.spec.ts`: error view renders alert + message + Retry/Ok buttons; Retry clears the error once the copy succeeds; Ok dismisses it — `--repeat-each=4 --workers=4` → 12/12, no flake
- [x] No regression: `hold-activation` + `copy-feedback` + `api-methods` (53 tests) pass
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm format`

## Note
Supersedes #508 (which documented the buttons as dead code). That PR can be closed in favor of this one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the copy state machine, label lifecycle, and clipboard failure paths in the main grab orchestrator; behavior is covered by new e2e tests but regressions could affect normal copy success flows.
> 
> **Overview**
> Copy failures in **react-grab** now surface a persistent error label with working **Retry** and **Ok** actions, instead of auto-fading away with no recovery path.
> 
> The core orchestrator registers a per-label (or shared multi-select) retry closure on failed copies, routes **Retry** through the full `executeCopyOperation` path so the copying state machine completes correctly, and clears stale `errorMessage` when status leaves `error`. Error labels no longer auto-fade or fade on hover-out; only success labels do. **Ok** dismisses the label and removes that instance from grouped retry sets so dismissed siblings are not resurrected.
> 
> Renderer props `onRetryInstance` / `onAcknowledgeErrorInstance` connect per-instance labels to these handlers; label reset clears the retry map. New Playwright coverage asserts the alert UI, retry success, Ok dismiss, persistence past the success fade window, and that retry does not leave `isCopying` stuck.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b74e5f73d47ebbd9a2b011dbce3e1665cff6bf26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make copy failures recoverable in `react-grab` with per-label Retry/Ok. Retry runs the exact failed operation through the full copy lifecycle and stays retryable; Ok dismisses the error. Error labels stay visible until acknowledged.

- **New Features**
  - Wire per-instance `onRetry`/`onAcknowledgeError` from the renderer to the error view.
  - Re-run the exact failed operation through the full copy lifecycle; re-register on repeat failures.
  - Keep error labels visible until Retry succeeds or Ok; add e2e for UI, Retry success and lifecycle completion (no stuck copying), Ok, and persistence.

- **Bug Fixes**
  - Clear retry closures when labels reset (new grab/deactivate) to avoid retaining stale DOM captures.
  - Group multi-label retries under a shared sibling set; acknowledging one removes it so Retry won’t resurrect dismissed labels.
  - Re-resolve copy metadata on retry and clear stale `errorMessage` on non-error transitions to prevent the Retry/Ok panel from sticking.

<sup>Written for commit b74e5f73d47ebbd9a2b011dbce3e1665cff6bf26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

