### PR TITLE
fix(react-grab): recover fiber-latched selection when the parent fiber is a host element

### DIFF
--- a/apps/e2e-app-vite/src/App.tsx
+++ b/apps/e2e-app-vite/src/App.tsx
@@ -650,10 +650,17 @@ const HiddenToggleSection = () => {
 // Renders the selection target as the sole host child of a component so a
 // `key` flip forces React to unmount the old DOM node and mount a fresh one
 // (new host fiber) under the same surviving parent fiber. react-grab should
-// latch the held selection back onto the new node via the fiber.
+// latch the held selection and post-copy label back onto the new node via the
+// fiber. The swapped variant is offset downward so an anchored label visibly
+// moves when it re-resolves.
 const FiberSwapTarget = ({ swapped }: { swapped: boolean }) => {
   return swapped ? (
-    <div key="swapped" className="p-4 bg-orange-100 rounded" data-testid="fiber-swap-target">
+    <div
+      key="swapped"
+      className="p-4 bg-orange-100 rounded"
+      style={{ marginTop: 150 }}
+      data-testid="fiber-swap-target"
+    >
       Swapped fiber node
     </div>
   ) : (

--- a/apps/e2e-app-vite/src/App.tsx
+++ b/apps/e2e-app-vite/src/App.tsx
@@ -1,6 +1,12 @@
 import { useState, useRef, useEffect } from "react";
 import { PerfGrid } from "./perf-grid";
 
+declare global {
+  interface Window {
+    __triggerFiberSwap?: () => void;
+  }
+}
+
 interface Todo {
   id: number;
   title: string;
@@ -661,10 +667,9 @@ const FiberSwapSection = () => {
   const [swapped, setSwapped] = useState(false);
 
   useEffect(() => {
-    (window as unknown as { __triggerFiberSwap?: () => void }).__triggerFiberSwap = () =>
-      setSwapped((previous) => !previous);
+    window.__triggerFiberSwap = () => setSwapped((previous) => !previous);
     return () => {
-      delete (window as unknown as { __triggerFiberSwap?: () => void }).__triggerFiberSwap;
+      delete window.__triggerFiberSwap;
     };
   }, []);
 

--- a/apps/e2e-app-vite/src/App.tsx
+++ b/apps/e2e-app-vite/src/App.tsx
@@ -4,6 +4,7 @@ import { PerfGrid } from "./perf-grid";
 declare global {
   interface Window {
     __triggerFiberSwap?: () => void;
+    __triggerInnerHtmlSwap?: () => void;
   }
 }
 
@@ -688,6 +689,35 @@ const FiberSwapSection = () => {
   );
 };
 
+// Mirrors the website's syntax-highlighted code blocks: the inner token nodes
+// are rendered via dangerouslySetInnerHTML, so they have no React fiber. A swap
+// replaces the whole subtree (new DOM nodes at the same path). react-grab should
+// re-find a selected token by anchoring to the fibered host div.
+const InnerHtmlSwapSection = () => {
+  const [variant, setVariant] = useState(0);
+
+  useEffect(() => {
+    window.__triggerInnerHtmlSwap = () => setVariant((previous) => previous + 1);
+    return () => {
+      delete window.__triggerInnerHtmlSwap;
+    };
+  }, []);
+
+  const tokenLabel = variant === 0 ? "token-initial" : "token-swapped";
+  const html = `<pre class="font-mono"><code><span class="inner-html-token">${tokenLabel}</span></code></pre>`;
+
+  return (
+    <section className="border rounded-lg p-4" data-testid="inner-html-swap-section">
+      <h2 className="text-lg font-bold mb-4">Inner HTML Swap</h2>
+      <div
+        className="p-4 bg-slate-100 rounded"
+        data-testid="inner-html-host"
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </section>
+  );
+};
+
 const usePerfGridConfig = (): { rowCount: number; columnCount: number } | null => {
   if (typeof window === "undefined") return null;
   const params = new URLSearchParams(window.location.search);
@@ -804,6 +834,8 @@ export default function App() {
       <HiddenToggleSection />
 
       <FiberSwapSection />
+
+      <InnerHtmlSwapSection />
 
       <div
         className="h-96 flex items-center justify-center bg-gray-100 rounded-lg"

--- a/apps/e2e-app-vite/src/App.tsx
+++ b/apps/e2e-app-vite/src/App.tsx
@@ -4,6 +4,7 @@ import { PerfGrid } from "./perf-grid";
 declare global {
   interface Window {
     __triggerFiberSwap?: () => void;
+    __triggerNestedFiberSwap?: () => void;
     __triggerInnerHtmlSwap?: () => void;
   }
 }
@@ -689,6 +690,45 @@ const FiberSwapSection = () => {
   );
 };
 
+// Like FiberSwapSection, but the keyed target is a host element nested directly
+// inside another host element within the SAME component, so the target fiber's
+// parent fiber is a host fiber (a `<div>`) rather than a component fiber. This
+// is the common shape of keyed lists (`<li>` inside `<ul>`). Fiber recovery has
+// to descend into the host parent's children to re-find the swapped node — using
+// the host parent directly compares its tag against the child's and never
+// matches, dropping the selection.
+const NestedFiberSwapSection = () => {
+  const [swapped, setSwapped] = useState(false);
+
+  useEffect(() => {
+    window.__triggerNestedFiberSwap = () => setSwapped((previous) => !previous);
+    return () => {
+      delete window.__triggerNestedFiberSwap;
+    };
+  }, []);
+
+  return (
+    <section className="border rounded-lg p-4" data-testid="nested-fiber-swap-section">
+      <h2 className="text-lg font-bold mb-4">Nested Fiber Swap</h2>
+      <div className="p-4 bg-purple-100 rounded">
+        {swapped ? (
+          <span
+            key="swapped"
+            data-testid="nested-fiber-swap-target"
+            style={{ display: "inline-block", marginTop: 150 }}
+          >
+            Swapped nested node
+          </span>
+        ) : (
+          <span key="initial" data-testid="nested-fiber-swap-target">
+            Initial nested node
+          </span>
+        )}
+      </div>
+    </section>
+  );
+};
+
 // Mirrors the website's syntax-highlighted code blocks: the inner token nodes
 // are rendered via dangerouslySetInnerHTML, so they have no React fiber. A swap
 // replaces the whole subtree (new DOM nodes at the same path). react-grab should
@@ -834,6 +874,8 @@ export default function App() {
       <HiddenToggleSection />
 
       <FiberSwapSection />
+
+      <NestedFiberSwapSection />
 
       <InnerHtmlSwapSection />
 

--- a/apps/e2e-app-vite/src/App.tsx
+++ b/apps/e2e-app-vite/src/App.tsx
@@ -641,6 +641,41 @@ const HiddenToggleSection = () => {
   );
 };
 
+// Renders the selection target as the sole host child of a component so a
+// `key` flip forces React to unmount the old DOM node and mount a fresh one
+// (new host fiber) under the same surviving parent fiber. react-grab should
+// latch the held selection back onto the new node via the fiber.
+const FiberSwapTarget = ({ swapped }: { swapped: boolean }) => {
+  return swapped ? (
+    <div key="swapped" className="p-4 bg-orange-100 rounded" data-testid="fiber-swap-target">
+      Swapped fiber node
+    </div>
+  ) : (
+    <div key="initial" className="p-4 bg-orange-100 rounded" data-testid="fiber-swap-target">
+      Initial fiber node
+    </div>
+  );
+};
+
+const FiberSwapSection = () => {
+  const [swapped, setSwapped] = useState(false);
+
+  useEffect(() => {
+    (window as unknown as { __triggerFiberSwap?: () => void }).__triggerFiberSwap = () =>
+      setSwapped((previous) => !previous);
+    return () => {
+      delete (window as unknown as { __triggerFiberSwap?: () => void }).__triggerFiberSwap;
+    };
+  }, []);
+
+  return (
+    <section className="border rounded-lg p-4" data-testid="fiber-swap-section">
+      <h2 className="text-lg font-bold mb-4">Fiber Swap</h2>
+      <FiberSwapTarget swapped={swapped} />
+    </section>
+  );
+};
+
 const usePerfGridConfig = (): { rowCount: number; columnCount: number } | null => {
   if (typeof window === "undefined") return null;
   const params = new URLSearchParams(window.location.search);
@@ -755,6 +790,8 @@ export default function App() {
       <PointerEventsModalSection />
 
       <HiddenToggleSection />
+
+      <FiberSwapSection />
 
       <div
         className="h-96 flex items-center justify-center bg-gray-100 rounded-lg"

--- a/packages/react-grab/e2e/fiber-relink.spec.ts
+++ b/packages/react-grab/e2e/fiber-relink.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from "./fixtures.js";
 
 interface FiberSwapWindow {
   __triggerFiberSwap?: () => void;
+  __triggerInnerHtmlSwap?: () => void;
   __REACT_GRAB__?: {
     getState: () => { targetElement: Element | null };
   };
@@ -66,5 +67,27 @@ test.describe("Fiber-latched selection", () => {
         { timeout: 1200 },
       )
       .toBeGreaterThan(40);
+  });
+
+  // Tokens rendered through dangerouslySetInnerHTML (syntax-highlighted code on
+  // the website) have no fiber of their own. Replacing the host's innerHTML
+  // detaches the selected token; recovery must anchor to the fibered host div
+  // and re-find the token by its DOM path.
+  test("re-resolves a selected innerHTML node with no fiber of its own", async ({
+    reactGrab,
+    page,
+  }) => {
+    await reactGrab.updateOptions({ freezeReactUpdates: false });
+
+    await reactGrab.activate();
+    await reactGrab.hoverUntilSelected(".inner-html-token");
+
+    await expect.poll(() => page.evaluate(getSelectionTargetText)).toBe("token-initial");
+
+    await page.evaluate(() => (window as unknown as FiberSwapWindow).__triggerInnerHtmlSwap?.());
+
+    await expect.poll(() => page.evaluate(getSelectionTargetText)).toBe("token-swapped");
+
+    expect(await reactGrab.isSelectionBoxVisible()).toBe(true);
   });
 });

--- a/packages/react-grab/e2e/fiber-relink.spec.ts
+++ b/packages/react-grab/e2e/fiber-relink.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from "./fixtures.js";
 
 interface FiberSwapWindow {
   __triggerFiberSwap?: () => void;
+  __triggerNestedFiberSwap?: () => void;
   __triggerInnerHtmlSwap?: () => void;
   __REACT_GRAB__?: {
     getState: () => { targetElement: Element | null };
@@ -67,6 +68,29 @@ test.describe("Fiber-latched selection", () => {
         { timeout: 1200 },
       )
       .toBeGreaterThan(40);
+  });
+
+  // The selected node is a host element nested directly inside another host
+  // element (a `<span>` inside a `<div>`) within the same component, so its
+  // parent fiber is a host fiber — the shape of keyed lists. Recovery has to
+  // descend into the host parent's children to re-find the swapped node; using
+  // the host parent itself compares the wrong tag and drops the selection.
+  test("re-resolves a swapped-out node whose parent fiber is a host element", async ({
+    reactGrab,
+    page,
+  }) => {
+    await reactGrab.updateOptions({ freezeReactUpdates: false });
+
+    await reactGrab.activate();
+    await reactGrab.hoverUntilSelected("[data-testid='nested-fiber-swap-target']");
+
+    await expect.poll(() => page.evaluate(getSelectionTargetText)).toBe("Initial nested node");
+
+    await page.evaluate(() => (window as unknown as FiberSwapWindow).__triggerNestedFiberSwap?.());
+
+    await expect.poll(() => page.evaluate(getSelectionTargetText)).toBe("Swapped nested node");
+
+    expect(await reactGrab.isSelectionBoxVisible()).toBe(true);
   });
 
   // Tokens rendered through dangerouslySetInnerHTML (syntax-highlighted code on

--- a/packages/react-grab/e2e/fiber-relink.spec.ts
+++ b/packages/react-grab/e2e/fiber-relink.spec.ts
@@ -36,4 +36,35 @@ test.describe("Fiber-latched selection", () => {
 
     expect(await reactGrab.isSelectionBoxVisible()).toBe(true);
   });
+
+  // The post-copy "Copied" label anchors to the grabbed element too, so it must
+  // follow the same fiber latching. The swapped node is offset downward, so a
+  // label that re-resolves onto it moves; a label stuck on the detached node
+  // stays put.
+  test("keeps the post-copy label anchored across a swapped-out DOM node", async ({
+    reactGrab,
+    page,
+  }) => {
+    await reactGrab.updateOptions({ freezeReactUpdates: false });
+
+    await reactGrab.activate();
+    await reactGrab.hoverUntilSelected("[data-testid='fiber-swap-target']");
+    await reactGrab.clickElement("[data-testid='fiber-swap-target']");
+    await expect.poll(() => reactGrab.getLabelStatusText(), { timeout: 2000 }).toBe("Copied");
+
+    const labelBefore = await reactGrab.getSelectionLabelBounds();
+    if (!labelBefore) throw new Error("Expected a post-copy label before the swap");
+
+    await page.evaluate(() => (window as unknown as FiberSwapWindow).__triggerFiberSwap?.());
+
+    await expect
+      .poll(
+        async () => {
+          const labelAfter = await reactGrab.getSelectionLabelBounds();
+          return labelAfter ? labelAfter.label.y - labelBefore.label.y : 0;
+        },
+        { timeout: 1200 },
+      )
+      .toBeGreaterThan(40);
+  });
 });

--- a/packages/react-grab/e2e/fiber-relink.spec.ts
+++ b/packages/react-grab/e2e/fiber-relink.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "./fixtures.js";
+
+interface FiberSwapWindow {
+  __triggerFiberSwap?: () => void;
+  __REACT_GRAB__?: {
+    getState: () => { targetElement: Element | null };
+  };
+}
+
+const getSelectionTargetText = () =>
+  (window as unknown as FiberSwapWindow).__REACT_GRAB__
+    ?.getState()
+    .targetElement?.textContent?.trim();
+
+test.describe("Fiber-latched selection", () => {
+  // When React swaps the DOM node backing a held selection (a keyed remount
+  // here), the originally captured Element detaches. Without fiber latching the
+  // selection drops; with it, react-grab re-resolves the live node from the
+  // fiber and keeps the selection on the freshly mounted node.
+  test("re-resolves the selection onto a swapped-out DOM node via its fiber", async ({
+    reactGrab,
+    page,
+  }) => {
+    // Let React commit the remount while react-grab holds the selection;
+    // otherwise the freeze buffers the update and no swap is observable.
+    await reactGrab.updateOptions({ freezeReactUpdates: false });
+
+    await reactGrab.activate();
+    await reactGrab.hoverUntilSelected("[data-testid='fiber-swap-target']");
+
+    await expect.poll(() => page.evaluate(getSelectionTargetText)).toBe("Initial fiber node");
+
+    await page.evaluate(() => (window as unknown as FiberSwapWindow).__triggerFiberSwap?.());
+
+    await expect.poll(() => page.evaluate(getSelectionTargetText)).toBe("Swapped fiber node");
+
+    expect(await reactGrab.isSelectionBoxVisible()).toBe(true);
+  });
+});

--- a/packages/react-grab/e2e/zoom-canvas.spec.ts
+++ b/packages/react-grab/e2e/zoom-canvas.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "./fixtures.js";
+import { ATTRIBUTE_NAME } from "./constants.js";
+
+// Browser zoom shrinks window.innerWidth/innerHeight (the visual viewport) while
+// getBoundingClientRect keeps returning full layout coordinates. The overlay
+// canvas must be sized to the layout viewport, or it draws the selection box
+// off-canvas for any element past the shrunken edge — the box vanishes entirely.
+const simulateBrowserZoom = (zoom: number) => {
+  const realWidth = window.innerWidth;
+  const realHeight = window.innerHeight;
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    get: () => Math.round(realWidth / zoom),
+  });
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    get: () => Math.round(realHeight / zoom),
+  });
+  window.dispatchEvent(new Event("resize"));
+};
+
+test.describe("Overlay canvas under browser zoom", () => {
+  test("draws the selection box for a far element when the visual viewport is shrunken", async ({
+    reactGrab,
+    page,
+  }) => {
+    await page.evaluate(simulateBrowserZoom, 1.5);
+
+    await reactGrab.activate();
+    await reactGrab.hoverUntilSelected("[data-testid='edge-bottom-right']");
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          ({ attributeName, selector }) => {
+            const host = document.querySelector(`[${attributeName}]`);
+            const canvas = host?.shadowRoot?.querySelector("canvas");
+            const element = document.querySelector(selector);
+            if (!canvas || !element) return -1;
+            const context = canvas.getContext("2d");
+            if (!context) return -1;
+            const bounds = element.getBoundingClientRect();
+            const scale =
+              canvas.width / parseFloat(canvas.style.width || String(window.innerWidth));
+            const startX = Math.max(0, Math.round((bounds.x - 10) * scale));
+            const startY = Math.max(0, Math.round((bounds.y - 10) * scale));
+            const width = Math.min(canvas.width - startX, Math.round((bounds.width + 20) * scale));
+            const height = Math.min(
+              canvas.height - startY,
+              Math.round((bounds.height + 20) * scale),
+            );
+            if (width <= 0 || height <= 0) return 0;
+            const pixels = context.getImageData(startX, startY, width, height).data;
+            let drawnPixels = 0;
+            for (let index = 3; index < pixels.length; index += 4) {
+              if (pixels[index] > 5) drawnPixels += 1;
+            }
+            return drawnPixels;
+          },
+          { attributeName: ATTRIBUTE_NAME, selector: "[data-testid='edge-bottom-right']" },
+        ),
+      )
+      .toBeGreaterThan(0);
+  });
+});

--- a/packages/react-grab/src/components/overlay-canvas.tsx
+++ b/packages/react-grab/src/components/overlay-canvas.tsx
@@ -112,8 +112,14 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
     if (!canvasRef) return;
 
     devicePixelRatio = Math.max(window.devicePixelRatio || 1, MIN_DEVICE_PIXEL_RATIO);
-    canvasWidth = window.innerWidth;
-    canvasHeight = window.innerHeight;
+    // Size to the layout viewport (documentElement.clientWidth/Height), not
+    // window.innerWidth/Height. Under browser zoom the latter shrink to the
+    // visual viewport while getBoundingClientRect — which positions the boxes —
+    // keeps returning full layout coordinates, so a canvas sized to innerWidth
+    // draws the selection box off-canvas for anything past the shrunken edge
+    // (the "selection box gone entirely when zoomed" bug).
+    canvasWidth = document.documentElement.clientWidth || window.innerWidth;
+    canvasHeight = document.documentElement.clientHeight || window.innerHeight;
 
     canvasRef.width = canvasWidth * devicePixelRatio;
     canvasRef.height = canvasHeight * devicePixelRatio;

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -55,11 +55,6 @@ export const BOUNDS_CACHE_TTL_MS = 16;
 export const BORDER_RADIUS_CACHE_TTL_MS = 200;
 export const BOUNDS_RECALC_INTERVAL_MS = 100;
 
-// How many fiber ancestors to walk when re-resolving a selected element whose
-// DOM node was swapped out. Bounded so recovery never climbs to the root and
-// latches onto an unrelated, much larger ancestor.
-export const MAX_FIBER_RELINK_DEPTH = 8;
-
 export const AUTO_SCROLL_EDGE_THRESHOLD_PX = 25;
 export const AUTO_SCROLL_SPEED_PX = 10;
 

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -55,6 +55,11 @@ export const BOUNDS_CACHE_TTL_MS = 16;
 export const BORDER_RADIUS_CACHE_TTL_MS = 200;
 export const BOUNDS_RECALC_INTERVAL_MS = 100;
 
+// How many fiber ancestors to walk when re-resolving a selected element whose
+// DOM node was swapped out. Bounded so recovery never climbs to the root and
+// latches onto an unrelated, much larger ancestor.
+export const MAX_FIBER_RELINK_DEPTH = 8;
+
 export const AUTO_SCROLL_EDGE_THRESHOLD_PX = 25;
 export const AUTO_SCROLL_SPEED_PX = 10;
 

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -841,7 +841,9 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       if (!element) return;
 
       const intervalId = setInterval(() => {
-        if (!isElementConnected(element)) {
+        if (isElementConnected(store.detectedElement)) return;
+        actions.relinkLiveElements();
+        if (!isElementConnected(store.detectedElement)) {
           actions.setDetectedElement(null);
         }
       }, BOUNDS_RECALC_INTERVAL_MS);
@@ -2447,7 +2449,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       const targetElement = target instanceof HTMLElement ? target : null;
       return Boolean(
         targetElement?.closest("[data-react-grab-discard-copy]") ||
-          targetElement?.closest("[data-react-grab-discard-yes]"),
+        targetElement?.closest("[data-react-grab-discard-yes]"),
       );
     };
 
@@ -2951,6 +2953,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
     const handleViewportChange = () => {
       invalidateInteractionCaches();
+      actions.relinkLiveElements();
       redetectElementUnderPointer();
       actions.incrementViewportVersion();
       actions.updateContextMenuPosition();
@@ -3019,6 +3022,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         if (boundsRecalcIntervalId !== null) return;
 
         boundsRecalcIntervalId = window.setInterval(() => {
+          actions.relinkLiveElements();
           scheduleBoundsSync();
         }, BOUNDS_RECALC_INTERVAL_MS);
         return;

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -841,7 +841,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       if (!element) return;
 
       const intervalId = setInterval(() => {
-        if (isElementConnected(store.detectedElement)) return;
         actions.relinkLiveElements();
         if (!isElementConnected(store.detectedElement)) {
           actions.setDetectedElement(null);

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -2952,7 +2952,6 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
     const handleViewportChange = () => {
       invalidateInteractionCaches();
-      actions.relinkLiveElements();
       redetectElementUnderPointer();
       actions.incrementViewportVersion();
       actions.updateContextMenuPosition();
@@ -3217,7 +3216,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       if (!pluginRegistry.store.theme.grabbedBoxes.enabled) return [];
       void viewportVersion();
       return store.grabbedBoxes.map((box) => {
-        if (!box.element || !document.body.contains(box.element)) {
+        if (!isElementConnected(box.element)) {
           return box;
         }
         return {

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -842,8 +842,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
       const intervalId = setInterval(() => {
         actions.relinkLiveElements();
+        // The hovered node can be swapped out by a re-render the freeze didn't
+        // catch (e.g. a dangerouslySetInnerHTML block re-highlighting). If fiber
+        // recovery couldn't relink it, re-detect under the pointer so the
+        // selection latches onto its replacement instead of vanishing.
         if (!isElementConnected(store.detectedElement)) {
-          actions.setDetectedElement(null);
+          redetectElementUnderPointer();
         }
       }, BOUNDS_RECALC_INTERVAL_MS);
 

--- a/packages/react-grab/src/core/store.ts
+++ b/packages/react-grab/src/core/store.ts
@@ -5,6 +5,7 @@ import { OFFSCREEN_POSITION } from "../constants.js";
 import { createElementBounds } from "../utils/create-element-bounds.js";
 import { getBoundsCenter } from "../utils/get-bounds-center.js";
 import { isElementConnected } from "../utils/is-element-connected.js";
+import { resolveLiveElement } from "../utils/resolve-live-element.js";
 
 interface FrozenDragRect {
   pageX: number;
@@ -131,6 +132,7 @@ interface GrabActions {
   toggleFrozenElement: (element: Element) => void;
   addFrozenElements: (elements: Element[]) => void;
   setFrozenDragRect: (rect: FrozenDragRect | null) => void;
+  relinkLiveElements: () => void;
   setCopyStart: (position: Position, element: Element) => void;
   setLastGrabbed: (element: Element | null) => void;
   setWasActivatedByToggle: (value: boolean) => void;
@@ -480,6 +482,42 @@ const createGrabStore = (input: GrabStoreInput) => {
 
     setFrozenDragRect: (rect: FrozenDragRect | null) => {
       setStore("frozenDragRect", rect);
+    },
+
+    // Re-resolve any tracked element whose DOM node was swapped out by latching
+    // onto its fiber. Cheap when nothing detached: the isConnected guard skips
+    // the fiber lookup for every still-attached element.
+    relinkLiveElements: () => {
+      const relink = (element: Element | null): Element | null =>
+        element && !element.isConnected ? resolveLiveElement(element) : element;
+
+      setStore(
+        produce((draft) => {
+          let didRelinkFrozen = false;
+          for (let index = 0; index < draft.frozenElements.length; index += 1) {
+            const element = draft.frozenElements[index];
+            if (element.isConnected) continue;
+            const liveElement = resolveLiveElement(element);
+            if (liveElement && liveElement !== element) {
+              draft.frozenElements[index] = liveElement;
+              didRelinkFrozen = true;
+            }
+          }
+
+          if (didRelinkFrozen) {
+            draft.frozenElement = draft.frozenElements.length > 0 ? draft.frozenElements[0] : null;
+          } else {
+            const liveFrozen = relink(draft.frozenElement);
+            if (liveFrozen) draft.frozenElement = liveFrozen;
+          }
+
+          const liveDetected = relink(draft.detectedElement);
+          if (liveDetected) draft.detectedElement = liveDetected;
+
+          const liveContextMenu = relink(draft.contextMenuElement);
+          if (liveContextMenu) draft.contextMenuElement = liveContextMenu;
+        }),
+      );
     },
 
     setCopyStart: (position: Position, element: Element) => {

--- a/packages/react-grab/src/core/store.ts
+++ b/packages/react-grab/src/core/store.ts
@@ -67,6 +67,22 @@ interface GrabStoreInput {
   keyHoldDuration: number;
 }
 
+// Returns the live element to use for a tracked slot: records the fiber while
+// connected so a future swap can be recovered, and re-resolves the current node
+// once it has detached. Keeps the old reference when recovery fails so callers
+// never lose the slot to a transient null.
+const relinkElement = (element: Element | null): Element | null => {
+  if (!element) return null;
+  if (element.isConnected) {
+    trackElementFiber(element);
+    return element;
+  }
+  const liveElement = resolveLiveElement(element);
+  if (!liveElement) return element;
+  trackElementFiber(liveElement);
+  return liveElement;
+};
+
 const createInitialStore = (input: GrabStoreInput): GrabStore => ({
   selectionInteractionLockDepth: 0,
 
@@ -484,48 +500,42 @@ const createGrabStore = (input: GrabStoreInput) => {
       setStore("frozenDragRect", rect);
     },
 
-    // Keep tracked elements latched onto their fiber across DOM swaps: record a
-    // surviving ancestor fiber while an element is connected, and re-resolve the
-    // live node once it detaches. Cheap when nothing detached — the isConnected
-    // guard skips the recovery work for every still-attached element.
+    // Keep tracked elements latched onto their fiber across DOM swaps. The
+    // pre-pass records each connected element's fiber (so a later swap can be
+    // recovered) and notes whether anything detached; tracking must run every
+    // tick while elements are alive. The store is only mutated through the far
+    // costlier produce when something actually needs recovery, so the common
+    // (nothing-detached) path — including per-frame scroll — stays allocation-light.
     relinkLiveElements: () => {
+      let hasDetachedElement = false;
+      const trackOrFlagDetached = (element: Element | null) => {
+        if (!element) return;
+        if (element.isConnected) trackElementFiber(element);
+        else hasDetachedElement = true;
+      };
+
+      for (const frozenElement of store.frozenElements) trackOrFlagDetached(frozenElement);
+      trackOrFlagDetached(store.frozenElement);
+      trackOrFlagDetached(store.detectedElement);
+      trackOrFlagDetached(store.contextMenuElement);
+
+      if (!hasDetachedElement) return;
+
       setStore(
         produce((draft) => {
-          const relinkSingle = (
-            key: "frozenElement" | "detectedElement" | "contextMenuElement",
-          ) => {
-            const element = draft[key];
-            if (!element) return;
-            if (element.isConnected) {
-              trackElementFiber(element);
-              return;
-            }
-            const liveElement = resolveLiveElement(element);
-            if (liveElement) draft[key] = liveElement;
-          };
-
-          let didRelinkFrozen = false;
           for (let index = 0; index < draft.frozenElements.length; index += 1) {
-            const element = draft.frozenElements[index];
-            if (element.isConnected) {
-              trackElementFiber(element);
-              continue;
-            }
-            const liveElement = resolveLiveElement(element);
-            if (liveElement && liveElement !== element) {
-              draft.frozenElements[index] = liveElement;
-              trackElementFiber(liveElement);
-              didRelinkFrozen = true;
-            }
+            const liveElement = relinkElement(draft.frozenElements[index]);
+            if (liveElement) draft.frozenElements[index] = liveElement;
           }
-
-          if (didRelinkFrozen) {
-            draft.frozenElement = draft.frozenElements.length > 0 ? draft.frozenElements[0] : null;
-          } else {
-            relinkSingle("frozenElement");
-          }
-          relinkSingle("detectedElement");
-          relinkSingle("contextMenuElement");
+          // frozenElement mirrors frozenElements[0] when the array is populated
+          // (see updateFrozenElements); it only stands alone in freeze / prompt
+          // mode, where it is recovered on its own.
+          draft.frozenElement =
+            draft.frozenElements.length > 0
+              ? draft.frozenElements[0]
+              : relinkElement(draft.frozenElement);
+          draft.detectedElement = relinkElement(draft.detectedElement);
+          draft.contextMenuElement = relinkElement(draft.contextMenuElement);
         }),
       );
     },

--- a/packages/react-grab/src/core/store.ts
+++ b/packages/react-grab/src/core/store.ts
@@ -67,12 +67,11 @@ interface GrabStoreInput {
   keyHoldDuration: number;
 }
 
-// Returns the live element to use for a tracked slot: records the fiber while
+// Returns the live element for a tracked slot: records the fiber while
 // connected so a future swap can be recovered, and re-resolves the current node
 // once it has detached. Keeps the old reference when recovery fails so callers
 // never lose the slot to a transient null.
-const relinkElement = (element: Element | null): Element | null => {
-  if (!element) return null;
+const relinkElement = (element: Element): Element => {
   if (element.isConnected) {
     trackElementFiber(element);
     return element;
@@ -81,6 +80,38 @@ const relinkElement = (element: Element | null): Element | null => {
   if (!liveElement) return element;
   trackElementFiber(liveElement);
   return liveElement;
+};
+
+// Re-resolves every element the overlay anchors to — the selection, the hover
+// target, the context-menu target, and the post-copy "Copied" labels and
+// grabbed-box flashes — so they all follow the same DOM swaps. Run on the
+// recalc interval; assigning the same reference back is a no-op for solid, so
+// connected elements produce no store notifications.
+const relinkSlots = (draft: GrabStore): void => {
+  for (let index = 0; index < draft.frozenElements.length; index += 1) {
+    draft.frozenElements[index] = relinkElement(draft.frozenElements[index]);
+  }
+  // frozenElement mirrors frozenElements[0] when the array is populated (see
+  // updateFrozenElements); it only stands alone in freeze / prompt mode, where
+  // it is recovered on its own.
+  draft.frozenElement =
+    draft.frozenElements.length > 0
+      ? draft.frozenElements[0]
+      : draft.frozenElement && relinkElement(draft.frozenElement);
+  draft.detectedElement = draft.detectedElement && relinkElement(draft.detectedElement);
+  draft.contextMenuElement = draft.contextMenuElement && relinkElement(draft.contextMenuElement);
+
+  for (const instance of draft.labelInstances) {
+    if (instance.element) instance.element = relinkElement(instance.element);
+    if (instance.elements) {
+      for (let index = 0; index < instance.elements.length; index += 1) {
+        instance.elements[index] = relinkElement(instance.elements[index]);
+      }
+    }
+  }
+  for (const box of draft.grabbedBoxes) {
+    if (box.element) box.element = relinkElement(box.element);
+  }
 };
 
 const createInitialStore = (input: GrabStoreInput): GrabStore => ({
@@ -500,64 +531,8 @@ const createGrabStore = (input: GrabStoreInput) => {
       setStore("frozenDragRect", rect);
     },
 
-    // Keep every element the overlay anchors to — the selection, the detected
-    // hover target, the context-menu target, and the post-copy "Copied" labels
-    // and grabbed-box flashes — latched onto its fiber across DOM swaps. The
-    // pre-pass records each connected element's fiber (so a later swap can be
-    // recovered) and notes whether anything detached; tracking must run every
-    // tick while elements are alive. The store is only mutated through the far
-    // costlier produce when something actually needs recovery, so the common
-    // (nothing-detached) path — including per-frame scroll — stays allocation-light.
     relinkLiveElements: () => {
-      let hasDetachedElement = false;
-      const trackOrFlagDetached = (element: Element | null | undefined) => {
-        if (!element) return;
-        if (element.isConnected) trackElementFiber(element);
-        else hasDetachedElement = true;
-      };
-
-      for (const frozenElement of store.frozenElements) trackOrFlagDetached(frozenElement);
-      trackOrFlagDetached(store.frozenElement);
-      trackOrFlagDetached(store.detectedElement);
-      trackOrFlagDetached(store.contextMenuElement);
-      for (const instance of store.labelInstances) {
-        trackOrFlagDetached(instance.element);
-        instance.elements?.forEach(trackOrFlagDetached);
-      }
-      for (const box of store.grabbedBoxes) trackOrFlagDetached(box.element);
-
-      if (!hasDetachedElement) return;
-
-      setStore(
-        produce((draft) => {
-          for (let index = 0; index < draft.frozenElements.length; index += 1) {
-            const liveElement = relinkElement(draft.frozenElements[index]);
-            if (liveElement) draft.frozenElements[index] = liveElement;
-          }
-          // frozenElement mirrors frozenElements[0] when the array is populated
-          // (see updateFrozenElements); it only stands alone in freeze / prompt
-          // mode, where it is recovered on its own.
-          draft.frozenElement =
-            draft.frozenElements.length > 0
-              ? draft.frozenElements[0]
-              : relinkElement(draft.frozenElement);
-          draft.detectedElement = relinkElement(draft.detectedElement);
-          draft.contextMenuElement = relinkElement(draft.contextMenuElement);
-
-          for (const instance of draft.labelInstances) {
-            if (instance.element) instance.element = relinkElement(instance.element) ?? undefined;
-            if (instance.elements) {
-              for (let index = 0; index < instance.elements.length; index += 1) {
-                const liveElement = relinkElement(instance.elements[index]);
-                if (liveElement) instance.elements[index] = liveElement;
-              }
-            }
-          }
-          for (const box of draft.grabbedBoxes) {
-            if (box.element) box.element = relinkElement(box.element) ?? undefined;
-          }
-        }),
-      );
+      setStore(produce(relinkSlots));
     },
 
     setCopyStart: (position: Position, element: Element) => {

--- a/packages/react-grab/src/core/store.ts
+++ b/packages/react-grab/src/core/store.ts
@@ -500,7 +500,9 @@ const createGrabStore = (input: GrabStoreInput) => {
       setStore("frozenDragRect", rect);
     },
 
-    // Keep tracked elements latched onto their fiber across DOM swaps. The
+    // Keep every element the overlay anchors to — the selection, the detected
+    // hover target, the context-menu target, and the post-copy "Copied" labels
+    // and grabbed-box flashes — latched onto its fiber across DOM swaps. The
     // pre-pass records each connected element's fiber (so a later swap can be
     // recovered) and notes whether anything detached; tracking must run every
     // tick while elements are alive. The store is only mutated through the far
@@ -508,7 +510,7 @@ const createGrabStore = (input: GrabStoreInput) => {
     // (nothing-detached) path — including per-frame scroll — stays allocation-light.
     relinkLiveElements: () => {
       let hasDetachedElement = false;
-      const trackOrFlagDetached = (element: Element | null) => {
+      const trackOrFlagDetached = (element: Element | null | undefined) => {
         if (!element) return;
         if (element.isConnected) trackElementFiber(element);
         else hasDetachedElement = true;
@@ -518,6 +520,11 @@ const createGrabStore = (input: GrabStoreInput) => {
       trackOrFlagDetached(store.frozenElement);
       trackOrFlagDetached(store.detectedElement);
       trackOrFlagDetached(store.contextMenuElement);
+      for (const instance of store.labelInstances) {
+        trackOrFlagDetached(instance.element);
+        instance.elements?.forEach(trackOrFlagDetached);
+      }
+      for (const box of store.grabbedBoxes) trackOrFlagDetached(box.element);
 
       if (!hasDetachedElement) return;
 
@@ -536,6 +543,19 @@ const createGrabStore = (input: GrabStoreInput) => {
               : relinkElement(draft.frozenElement);
           draft.detectedElement = relinkElement(draft.detectedElement);
           draft.contextMenuElement = relinkElement(draft.contextMenuElement);
+
+          for (const instance of draft.labelInstances) {
+            if (instance.element) instance.element = relinkElement(instance.element) ?? undefined;
+            if (instance.elements) {
+              for (let index = 0; index < instance.elements.length; index += 1) {
+                const liveElement = relinkElement(instance.elements[index]);
+                if (liveElement) instance.elements[index] = liveElement;
+              }
+            }
+          }
+          for (const box of draft.grabbedBoxes) {
+            if (box.element) box.element = relinkElement(box.element) ?? undefined;
+          }
         }),
       );
     },

--- a/packages/react-grab/src/core/store.ts
+++ b/packages/react-grab/src/core/store.ts
@@ -5,7 +5,7 @@ import { OFFSCREEN_POSITION } from "../constants.js";
 import { createElementBounds } from "../utils/create-element-bounds.js";
 import { getBoundsCenter } from "../utils/get-bounds-center.js";
 import { isElementConnected } from "../utils/is-element-connected.js";
-import { resolveLiveElement } from "../utils/resolve-live-element.js";
+import { resolveLiveElement, trackElementFiber } from "../utils/resolve-live-element.js";
 
 interface FrozenDragRect {
   pageX: number;
@@ -484,22 +484,37 @@ const createGrabStore = (input: GrabStoreInput) => {
       setStore("frozenDragRect", rect);
     },
 
-    // Re-resolve any tracked element whose DOM node was swapped out by latching
-    // onto its fiber. Cheap when nothing detached: the isConnected guard skips
-    // the fiber lookup for every still-attached element.
+    // Keep tracked elements latched onto their fiber across DOM swaps: record a
+    // surviving ancestor fiber while an element is connected, and re-resolve the
+    // live node once it detaches. Cheap when nothing detached — the isConnected
+    // guard skips the recovery work for every still-attached element.
     relinkLiveElements: () => {
-      const relink = (element: Element | null): Element | null =>
-        element && !element.isConnected ? resolveLiveElement(element) : element;
-
       setStore(
         produce((draft) => {
+          const relinkSingle = (
+            key: "frozenElement" | "detectedElement" | "contextMenuElement",
+          ) => {
+            const element = draft[key];
+            if (!element) return;
+            if (element.isConnected) {
+              trackElementFiber(element);
+              return;
+            }
+            const liveElement = resolveLiveElement(element);
+            if (liveElement) draft[key] = liveElement;
+          };
+
           let didRelinkFrozen = false;
           for (let index = 0; index < draft.frozenElements.length; index += 1) {
             const element = draft.frozenElements[index];
-            if (element.isConnected) continue;
+            if (element.isConnected) {
+              trackElementFiber(element);
+              continue;
+            }
             const liveElement = resolveLiveElement(element);
             if (liveElement && liveElement !== element) {
               draft.frozenElements[index] = liveElement;
+              trackElementFiber(liveElement);
               didRelinkFrozen = true;
             }
           }
@@ -507,15 +522,10 @@ const createGrabStore = (input: GrabStoreInput) => {
           if (didRelinkFrozen) {
             draft.frozenElement = draft.frozenElements.length > 0 ? draft.frozenElements[0] : null;
           } else {
-            const liveFrozen = relink(draft.frozenElement);
-            if (liveFrozen) draft.frozenElement = liveFrozen;
+            relinkSingle("frozenElement");
           }
-
-          const liveDetected = relink(draft.detectedElement);
-          if (liveDetected) draft.detectedElement = liveDetected;
-
-          const liveContextMenu = relink(draft.contextMenuElement);
-          if (liveContextMenu) draft.contextMenuElement = liveContextMenu;
+          relinkSingle("detectedElement");
+          relinkSingle("contextMenuElement");
         }),
       );
     },

--- a/packages/react-grab/src/utils/index-in-parent.ts
+++ b/packages/react-grab/src/utils/index-in-parent.ts
@@ -1,0 +1,12 @@
+// Position of an element among its parent's element children, used to record
+// and replay a DOM path. Counts previous siblings rather than borrowing
+// Array.prototype.indexOf against the live HTMLCollection.
+export const indexInParent = (element: Element): number => {
+  let index = 0;
+  let sibling = element.previousElementSibling;
+  while (sibling) {
+    index += 1;
+    sibling = sibling.previousElementSibling;
+  }
+  return index;
+};

--- a/packages/react-grab/src/utils/resolve-live-element.ts
+++ b/packages/react-grab/src/utils/resolve-live-element.ts
@@ -5,6 +5,7 @@ import {
   isHostFiber,
   type Fiber,
 } from "bippy";
+import { indexInParent } from "./index-in-parent.js";
 
 interface ElementAnchor {
   // Nearest ancestor (or the element itself) that React manages via a fiber.
@@ -60,10 +61,8 @@ const findAnchor = (element: Element): ElementAnchor | null => {
   let anchorElement: Element | null = element;
   let anchorFiber = getFiberFromHostInstance(anchorElement);
   while (anchorElement && !anchorFiber) {
-    const parent: Element | null = anchorElement.parentElement;
-    if (!parent) return null;
-    domPath.unshift(Array.prototype.indexOf.call(parent.children, anchorElement));
-    anchorElement = parent;
+    domPath.unshift(indexInParent(anchorElement));
+    anchorElement = anchorElement.parentElement;
     anchorFiber = getFiberFromHostInstance(anchorElement);
   }
   const anchorParentFiber = anchorFiber?.return;

--- a/packages/react-grab/src/utils/resolve-live-element.ts
+++ b/packages/react-grab/src/utils/resolve-live-element.ts
@@ -5,22 +5,36 @@ import {
   isHostFiber,
   type Fiber,
 } from "bippy";
-import { MAX_FIBER_RELINK_DEPTH } from "../constants.js";
 
-const connectedHostElement = (fiber: Fiber): Element | null => {
-  const node = fiber.stateNode;
-  return node instanceof Element && node.isConnected ? node : null;
-};
+// Parent fiber of each tracked element, captured while it was still mounted.
+// React mutates a fiber's `return`/`alternate` to null when it unmounts, so the
+// only link from a swapped-out node back to the live tree is an ancestor fiber
+// recorded before the unmount. The parent survives the child's remount.
+const ancestorFiberByElement = new WeakMap<Element, Fiber>();
 
-const liveHostElementsFromFiber = (fiber: Fiber): Element[] => {
+const liveHostElementFromFiber = (fiber: Fiber, tagName: string): Element | null => {
   const latest = getLatestFiber(fiber);
   const hostFibers = isHostFiber(latest) ? [latest] : getNearestHostFibers(latest);
-  const elements: Element[] = [];
+  let fallback: Element | null = null;
   for (const hostFiber of hostFibers) {
-    const element = connectedHostElement(hostFiber);
-    if (element) elements.push(element);
+    const node = hostFiber.stateNode;
+    if (!(node instanceof Element) || !node.isConnected) continue;
+    // Prefer a recovered node whose tag matches the original so we latch onto
+    // the swapped element rather than an unrelated sibling host.
+    if (node.tagName === tagName) return node;
+    fallback ??= node;
   }
-  return elements;
+  return fallback;
+};
+
+// Records the parent fiber of a still-connected element so its replacement can
+// be recovered later. Cheap and idempotent: skips disconnected elements and
+// anything already tracked.
+export const trackElementFiber = (element: Element): void => {
+  if (!element.isConnected) return;
+  if (ancestorFiberByElement.has(element)) return;
+  const parentFiber = getFiberFromHostInstance(element)?.return;
+  if (parentFiber) ancestorFiberByElement.set(element, parentFiber);
 };
 
 // When React swaps the DOM node backing a selected element — a conditional
@@ -30,28 +44,25 @@ const liveHostElementsFromFiber = (fiber: Fiber): Element[] => {
 // stable identity that survives the swap, so we re-resolve the current host
 // node from it and latch the selection onto the new DOM node.
 //
-// A detached node still carries its `__reactFiber$` back-reference, so we can
-// reach the captured fiber and walk its (now stale) `return` chain. For each
-// ancestor we map back to the live, double-buffered fiber via getLatestFiber
-// and read its connected host node. We start at the captured fiber and climb
-// only a bounded number of ancestors so recovery never jumps to the root, and
-// prefer a recovered node whose tag matches the original to avoid latching
-// onto a sibling.
+// First we try the element's own fiber in case React kept it and only swapped
+// its host instance. Otherwise we fall back to the ancestor fiber captured by
+// trackElementFiber while the element was alive and read its current host
+// descendant.
 export const resolveLiveElement = (element: Element): Element | null => {
   if (element.isConnected) return element;
 
-  let fiber: Fiber | null = getFiberFromHostInstance(element);
-  if (!fiber) return null;
-
   const tagName = element.tagName;
-  let depth = 0;
-  while (fiber && depth <= MAX_FIBER_RELINK_DEPTH) {
-    const liveElements = liveHostElementsFromFiber(fiber);
-    if (liveElements.length > 0) {
-      return liveElements.find((live) => live.tagName === tagName) ?? liveElements[0];
-    }
-    fiber = fiber.return;
-    depth += 1;
+
+  const ownFiber = getFiberFromHostInstance(element);
+  if (ownFiber) {
+    const liveFromOwn = liveHostElementFromFiber(ownFiber, tagName);
+    if (liveFromOwn) return liveFromOwn;
+  }
+
+  const ancestorFiber = ancestorFiberByElement.get(element);
+  if (ancestorFiber) {
+    const liveFromAncestor = liveHostElementFromFiber(ancestorFiber, tagName);
+    if (liveFromAncestor) return liveFromAncestor;
   }
 
   return null;

--- a/packages/react-grab/src/utils/resolve-live-element.ts
+++ b/packages/react-grab/src/utils/resolve-live-element.ts
@@ -6,22 +6,36 @@ import {
   type Fiber,
 } from "bippy";
 
-// Parent fiber of each tracked element, captured while it was still mounted.
-// React mutates a fiber's `return`/`alternate` to null when it unmounts, so the
-// only link from a swapped-out node back to the live tree is an ancestor fiber
-// recorded before the unmount. The parent survives the child's remount.
-const ancestorFiberByElement = new WeakMap<Element, Fiber>();
+interface ElementAnchor {
+  // Nearest ancestor (or the element itself) that React manages via a fiber.
+  // Content rendered through `dangerouslySetInnerHTML` — e.g. syntax-highlighted
+  // code — has no fiber of its own, so we anchor to the nearest fibered host and
+  // re-find the element by the DOM path below it after a re-render.
+  anchorElement: Element;
+  // Parent fiber of the anchor, used to recover the anchor when React remounts
+  // it: a fiber's own `return`/`alternate` are nulled on unmount, so the link
+  // back to the live tree has to come from an ancestor that survives.
+  anchorParentFiber: Fiber;
+  // Child-index chain from the anchor down to the tracked element; empty when
+  // the element is itself the anchor.
+  domPath: number[];
+  targetTagName: string;
+}
 
-// Resolves the fiber's current host node whose tag matches the original. The
-// tag match keeps recovery from latching onto an unrelated host when the
-// original element type is gone; same-tag siblings under a shared ancestor
-// can't be told apart and resolve to the first match, which still leaves the
-// selection on a valid node instead of dropping it.
+// Recovery metadata for each tracked element, captured while it was still
+// mounted (React nulls the fiber pointers on unmount, so this must be recorded
+// before the swap).
+const anchorByElement = new WeakMap<Element, ElementAnchor>();
+
 const liveHostElementFromFiber = (fiber: Fiber, tagName: string): Element | null => {
   const latest = getLatestFiber(fiber);
   const hostFibers = isHostFiber(latest) ? [latest] : getNearestHostFibers(latest);
   for (const hostFiber of hostFibers) {
     const node = hostFiber.stateNode;
+    // The tag match keeps recovery from latching onto an unrelated host when the
+    // original element type is gone. Same-tag siblings under a shared ancestor
+    // can't be told apart and resolve to the first match, which still leaves the
+    // selection on a valid node instead of dropping it.
     if (node instanceof Element && node.isConnected && node.tagName === tagName) {
       return node;
     }
@@ -29,43 +43,64 @@ const liveHostElementFromFiber = (fiber: Fiber, tagName: string): Element | null
   return null;
 };
 
-// Records the parent fiber of a still-connected element so its replacement can
-// be recovered later. Cheap and idempotent: skips disconnected elements and
-// anything already tracked.
+const followDomPath = (root: Element, domPath: number[]): Element | null => {
+  let node: Element = root;
+  for (const childIndex of domPath) {
+    const child = node.children[childIndex];
+    if (!child) return null;
+    node = child;
+  }
+  return node;
+};
+
+// Walks up to the nearest fiber-managed ancestor, recording the DOM path taken
+// so a non-fibered element (innerHTML content) can be re-found beneath it.
+const findAnchor = (element: Element): ElementAnchor | null => {
+  const domPath: number[] = [];
+  let anchorElement: Element | null = element;
+  let anchorFiber = getFiberFromHostInstance(anchorElement);
+  while (anchorElement && !anchorFiber) {
+    const parent: Element | null = anchorElement.parentElement;
+    if (!parent) return null;
+    domPath.unshift(Array.prototype.indexOf.call(parent.children, anchorElement));
+    anchorElement = parent;
+    anchorFiber = getFiberFromHostInstance(anchorElement);
+  }
+  const anchorParentFiber = anchorFiber?.return;
+  if (!anchorElement || !anchorParentFiber) return null;
+  return { anchorElement, anchorParentFiber, domPath, targetTagName: element.tagName };
+};
+
+// Records how to recover an element after a DOM swap. Cheap and idempotent:
+// skips disconnected elements and anything already tracked.
 export const trackElementFiber = (element: Element): void => {
   if (!element.isConnected) return;
-  if (ancestorFiberByElement.has(element)) return;
-  const parentFiber = getFiberFromHostInstance(element)?.return;
-  if (parentFiber) ancestorFiberByElement.set(element, parentFiber);
+  if (anchorByElement.has(element)) return;
+  const anchor = findAnchor(element);
+  if (anchor) anchorByElement.set(element, anchor);
 };
 
 // When React swaps the DOM node backing a selected element — a conditional
-// remount (`cond ? <a/> : <button/>`), a route/view transition, or an
-// animation library reparenting nodes — the originally captured Element
-// detaches and the selection box plus copied context break. The fiber is the
-// stable identity that survives the swap, so we re-resolve the current host
-// node from it and latch the selection onto the new DOM node.
-//
-// First we try the element's own fiber in case React kept it and only swapped
-// its host instance. Otherwise we fall back to the ancestor fiber captured by
-// trackElementFiber while the element was alive and read its current host
-// descendant.
+// remount, a route/view transition, an animation library reparenting nodes, or
+// a `dangerouslySetInnerHTML` subtree (syntax-highlighted code) being replaced —
+// the originally captured Element detaches and the selection box, copied
+// context, and post-copy label break. We recover by resolving the nearest
+// surviving fibered ancestor and re-walking the recorded DOM path to the
+// element's replacement.
 export const resolveLiveElement = (element: Element): Element | null => {
   if (element.isConnected) return element;
 
-  const tagName = element.tagName;
+  const anchor = anchorByElement.get(element);
+  if (!anchor) return null;
 
-  const ownFiber = getFiberFromHostInstance(element);
-  if (ownFiber) {
-    const liveFromOwn = liveHostElementFromFiber(ownFiber, tagName);
-    if (liveFromOwn) return liveFromOwn;
+  const liveAnchor = anchor.anchorElement.isConnected
+    ? anchor.anchorElement
+    : liveHostElementFromFiber(anchor.anchorParentFiber, anchor.anchorElement.tagName);
+  if (!liveAnchor) return null;
+
+  const recovered = followDomPath(liveAnchor, anchor.domPath);
+  if (recovered && recovered.isConnected && recovered.tagName === anchor.targetTagName) {
+    return recovered;
   }
-
-  const ancestorFiber = ancestorFiberByElement.get(element);
-  if (ancestorFiber) {
-    const liveFromAncestor = liveHostElementFromFiber(ancestorFiber, tagName);
-    if (liveFromAncestor) return liveFromAncestor;
-  }
-
   return null;
 };

--- a/packages/react-grab/src/utils/resolve-live-element.ts
+++ b/packages/react-grab/src/utils/resolve-live-element.ts
@@ -12,19 +12,21 @@ import {
 // recorded before the unmount. The parent survives the child's remount.
 const ancestorFiberByElement = new WeakMap<Element, Fiber>();
 
+// Resolves the fiber's current host node whose tag matches the original. The
+// tag match keeps recovery from latching onto an unrelated host when the
+// original element type is gone; same-tag siblings under a shared ancestor
+// can't be told apart and resolve to the first match, which still leaves the
+// selection on a valid node instead of dropping it.
 const liveHostElementFromFiber = (fiber: Fiber, tagName: string): Element | null => {
   const latest = getLatestFiber(fiber);
   const hostFibers = isHostFiber(latest) ? [latest] : getNearestHostFibers(latest);
-  let fallback: Element | null = null;
   for (const hostFiber of hostFibers) {
     const node = hostFiber.stateNode;
-    if (!(node instanceof Element) || !node.isConnected) continue;
-    // Prefer a recovered node whose tag matches the original so we latch onto
-    // the swapped element rather than an unrelated sibling host.
-    if (node.tagName === tagName) return node;
-    fallback ??= node;
+    if (node instanceof Element && node.isConnected && node.tagName === tagName) {
+      return node;
+    }
   }
-  return fallback;
+  return null;
 };
 
 // Records the parent fiber of a still-connected element so its replacement can

--- a/packages/react-grab/src/utils/resolve-live-element.ts
+++ b/packages/react-grab/src/utils/resolve-live-element.ts
@@ -28,10 +28,31 @@ interface ElementAnchor {
 // before the swap).
 const anchorByElement = new WeakMap<Element, ElementAnchor>();
 
-const liveHostElementFromFiber = (fiber: Fiber, tagName: string): Element | null => {
-  const latest = getLatestFiber(fiber);
-  const hostFibers = isHostFiber(latest) ? [latest] : getNearestHostFibers(latest);
-  for (const hostFiber of hostFibers) {
+// Host fibers rendered as children of the anchor's parent fiber — the level
+// where the swapped-out anchor lived. When the parent is a component fiber,
+// getNearestHostFibers already returns its host children. When the parent is
+// itself a host fiber (the common case of one host element nested inside
+// another within the same component, e.g. a keyed `<li>` inside a `<ul>`),
+// getNearestHostFibers returns that parent host itself rather than descending,
+// so we step one level down and collect the host fibers under each child. Using
+// the parent host directly would compare its tag against the child's and never
+// match, dropping the selection.
+const candidateHostFibers = (parentFiber: Fiber): Fiber[] => {
+  const latest = getLatestFiber(parentFiber);
+  if (!isHostFiber(latest)) return getNearestHostFibers(latest);
+
+  const hostFibers: Fiber[] = [];
+  let child: Fiber | null = latest.child;
+  while (child) {
+    if (isHostFiber(child)) hostFibers.push(child);
+    else hostFibers.push(...getNearestHostFibers(child));
+    child = child.sibling;
+  }
+  return hostFibers;
+};
+
+const liveHostElementFromFiber = (parentFiber: Fiber, tagName: string): Element | null => {
+  for (const hostFiber of candidateHostFibers(parentFiber)) {
     const node = hostFiber.stateNode;
     // The tag match keeps recovery from latching onto an unrelated host when the
     // original element type is gone. Same-tag siblings under a shared ancestor

--- a/packages/react-grab/src/utils/resolve-live-element.ts
+++ b/packages/react-grab/src/utils/resolve-live-element.ts
@@ -1,0 +1,58 @@
+import {
+  getFiberFromHostInstance,
+  getLatestFiber,
+  getNearestHostFibers,
+  isHostFiber,
+  type Fiber,
+} from "bippy";
+import { MAX_FIBER_RELINK_DEPTH } from "../constants.js";
+
+const connectedHostElement = (fiber: Fiber): Element | null => {
+  const node = fiber.stateNode;
+  return node instanceof Element && node.isConnected ? node : null;
+};
+
+const liveHostElementsFromFiber = (fiber: Fiber): Element[] => {
+  const latest = getLatestFiber(fiber);
+  const hostFibers = isHostFiber(latest) ? [latest] : getNearestHostFibers(latest);
+  const elements: Element[] = [];
+  for (const hostFiber of hostFibers) {
+    const element = connectedHostElement(hostFiber);
+    if (element) elements.push(element);
+  }
+  return elements;
+};
+
+// When React swaps the DOM node backing a selected element — a conditional
+// remount (`cond ? <a/> : <button/>`), a route/view transition, or an
+// animation library reparenting nodes — the originally captured Element
+// detaches and the selection box plus copied context break. The fiber is the
+// stable identity that survives the swap, so we re-resolve the current host
+// node from it and latch the selection onto the new DOM node.
+//
+// A detached node still carries its `__reactFiber$` back-reference, so we can
+// reach the captured fiber and walk its (now stale) `return` chain. For each
+// ancestor we map back to the live, double-buffered fiber via getLatestFiber
+// and read its connected host node. We start at the captured fiber and climb
+// only a bounded number of ancestors so recovery never jumps to the root, and
+// prefer a recovered node whose tag matches the original to avoid latching
+// onto a sibling.
+export const resolveLiveElement = (element: Element): Element | null => {
+  if (element.isConnected) return element;
+
+  let fiber: Fiber | null = getFiberFromHostInstance(element);
+  if (!fiber) return null;
+
+  const tagName = element.tagName;
+  let depth = 0;
+  while (fiber && depth <= MAX_FIBER_RELINK_DEPTH) {
+    const liveElements = liveHostElementsFromFiber(fiber);
+    if (liveElements.length > 0) {
+      return liveElements.find((live) => live.tagName === tagName) ?? liveElements[0];
+    }
+    fiber = fiber.return;
+    depth += 1;
+  }
+
+  return null;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this fixes

While investigating the latest fiber-latched selection work (#498), I found a bug in `resolve-live-element.ts` that breaks recovery for one of the most common DOM shapes the feature targets.

`liveHostElementFromFiber` recovers a swapped-out element by asking bippy for the host fibers of the anchor's **parent fiber**:

```ts
const hostFibers = isHostFiber(latest) ? [latest] : getNearestHostFibers(latest);
```

The problem is the `isHostFiber(latest) ? [latest]` branch. `getNearestHostFibers` does **not descend** when given a host fiber — it returns that fiber itself (confirmed from bippy's source: `s(e) ? t.push(e) : e.child && n.push(e.child)`). So when the anchor's parent fiber is itself a **host** fiber, recovery compares the *parent host's* tag against the *child's* tag, never matches, and returns `null` — the held selection drops on a keyed remount.

The parent fiber is a host fiber whenever the selected element is a host element nested directly inside another host element **within the same component** — e.g. a keyed `<li>` inside a `<ul>`, a `<span>` inside a `<p>`, an icon inside a `<button>`. This is exactly the keyed-list scenario the feature is meant to handle. The existing test only covered the case where the parent fiber is a *component* fiber (`FiberSwapTarget` returns the target directly), so the gap slipped through.

## The fix

When the parent fiber is itself a host fiber, descend one level and collect the host fibers of its children — the level where the swapped-out anchor actually lived:

```ts
const candidateHostFibers = (parentFiber: Fiber): Fiber[] => {
  const latest = getLatestFiber(parentFiber);
  if (!isHostFiber(latest)) return getNearestHostFibers(latest);

  const hostFibers: Fiber[] = [];
  let child: Fiber | null = latest.child;
  while (child) {
    if (isHostFiber(child)) hostFibers.push(child);
    else hostFibers.push(...getNearestHostFibers(child));
    child = child.sibling;
  }
  return hostFibers;
};
```

The component-parent path is unchanged (`getNearestHostFibers(latest)`), so there's no regression for the cases #498 already covered.

## Testing

- Added `NestedFiberSwapSection` to the e2e app (a keyed `<span>` nested directly inside a host `<div>` in the same component) and a regression test: **re-resolves a swapped-out node whose parent fiber is a host element**.
- The new test **fails on the pre-fix code** (selection target stays `Initial nested node`) and **passes with the fix** (`Swapped nested node`).
- Full `fiber-relink.spec.ts` (4 tests) passes; `pnpm --filter react-grab build`, `typecheck`, `lint`, and `format` are clean.

### Demo

Recorded run of the regression scenario: react-grab selects the nested `<span>`, then a keyed remount swaps the DOM node (the replacement is offset downward). The selection box re-latches onto the freshly mounted node via its fiber — instead of dropping, which is what happens without this fix.

[fiber-recovery-demo.mp4](https://cursor.com/agents/bc-019f1621-3340-7b36-8f0a-4ab9f60fa525/artifacts?path=%2Ftmp%2Frg-artifacts%2Ffiber-recovery-demo.mp4)

> Targets the #498 branch since the affected code only exists there.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1621-3340-7b36-8f0a-4ab9f60fa525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1621-3340-7b36-8f0a-4ab9f60fa525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes recovery of fiber-latched selection when the parent fiber is a host element. We now descend into the host parent’s children to find the swapped node, preventing selection drop on keyed remounts.

- **Bug Fixes**
  - Update `resolve-live-element.ts`: when the parent is a host fiber, collect host children (descend one level) instead of using `getNearestHostFibers` on the parent, which compared the wrong tag and returned null.
  - Add e2e scenario `NestedFiberSwapSection` and a regression test that re-resolves a swapped node with a host parent; fails before the fix and passes now.
  - Component-parent path is unchanged; no regressions expected.

<sup>Written for commit 5927b73d3e23831e36b7448f225dc93695372a93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

