### PR TITLE
feat(react-grab): add useReactGrab() hook + dials panel

### DIFF
--- a/.github/workflows/test-perf.yml
+++ b/.github/workflows/test-perf.yml
@@ -49,6 +49,10 @@ jobs:
         run: |
           git fetch origin "${{ github.base_ref }}" --depth=1
           if git cat-file -e "origin/${{ github.base_ref }}:packages/react-grab/src" 2>/dev/null; then
+            # Remove HEAD's src first so files this PR ADDS don't linger and import
+            # symbols the base ref never exported (a `checkout -- path` only updates
+            # files present in the base tree, leaving PR-only files behind).
+            git rm -r --quiet --ignore-unmatch packages/react-grab/src
             git checkout "origin/${{ github.base_ref }}" -- packages/react-grab/src
             echo "swapped=true" >> "$GITHUB_OUTPUT"
             echo "Swapped react-grab/src to origin/${{ github.base_ref }} ($(git rev-parse "origin/${{ github.base_ref }}"))"

--- a/.github/workflows/test-perf.yml
+++ b/.github/workflows/test-perf.yml
@@ -51,9 +51,11 @@ jobs:
           if git cat-file -e "origin/${{ github.base_ref }}:packages/react-grab/src" 2>/dev/null; then
             # Remove HEAD's src first so files this PR ADDS don't linger and import
             # symbols the base ref never exported (a `checkout -- path` only updates
-            # files present in the base tree, leaving PR-only files behind).
+            # files present in the base tree, leaving PR-only files behind). Swap the
+            # build config too so new entry points this PR adds (e.g. ./src/react.ts)
+            # don't leave the base build pointing at files the base ref lacks.
             git rm -r --quiet --ignore-unmatch packages/react-grab/src
-            git checkout "origin/${{ github.base_ref }}" -- packages/react-grab/src
+            git checkout "origin/${{ github.base_ref }}" -- packages/react-grab/src packages/react-grab/vite.config.ts
             echo "swapped=true" >> "$GITHUB_OUTPUT"
             echo "Swapped react-grab/src to origin/${{ github.base_ref }} ($(git rev-parse "origin/${{ github.base_ref }}"))"
           else
@@ -74,7 +76,7 @@ jobs:
 
       - name: Restore react-grab src to HEAD
         if: github.event_name == 'pull_request' && steps.swap-base.outputs.swapped == 'true'
-        run: git checkout HEAD -- packages/react-grab/src
+        run: git checkout HEAD -- packages/react-grab/src packages/react-grab/vite.config.ts
 
       # ─── HEAD run ──────────────────────────────────────────────────────
       - name: Run perf bench against HEAD src

--- a/apps/e2e-app-vite/src/App.tsx
+++ b/apps/e2e-app-vite/src/App.tsx
@@ -1,72 +1,11 @@
-import { useState, useRef, useEffect } from "react";
-import { useReactGrab } from "react-grab/react";
+import { lazy, Suspense, useState, useRef, useEffect } from "react";
 import { PerfGrid } from "./perf-grid";
 
-const DialKitCard = () => {
-  const params = useReactGrab("Card", {
-    blur: [0, 0, 40],
-    scale: 1.2,
-    radius: [24, 0, 80],
-    color: "#ff5500",
-    background: "#0b1020",
-    label: "React Grab",
-    visible: true,
-    layout: { type: "select", options: ["stack", "fan", "grid"], default: "stack" },
-    shadow: {
-      _collapsed: false,
-      blur: [24, 0, 80],
-      opacity: [0.4, 0, 1],
-    },
-    spring: { type: "spring", visualDuration: 0.5, bounce: 0.2 },
-  });
-
-  return (
-    <section className="border rounded-lg p-4" data-testid="dialkit-section">
-      <h2 className="text-lg font-bold mb-4">useReactGrab() Demo</h2>
-      <div className="flex items-center justify-center h-72">
-        <div
-          data-testid="dialkit-card"
-          style={{
-            opacity: params.visible ? 1 : 0,
-            filter: `blur(${params.blur}px)`,
-            transform: `scale(${params.scale})`,
-            borderRadius: `${params.radius}px`,
-            color: params.color,
-            background: params.background,
-            boxShadow: `0 8px ${params.shadow.blur}px rgba(0,0,0,${params.shadow.opacity})`,
-            transition: `transform ${params.spring.visualDuration}s, filter 0.2s, border-radius 0.2s`,
-            width: 220,
-            height: 140,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            fontWeight: 600,
-            fontSize: 18,
-          }}
-        >
-          {params.label} ({params.layout})
-        </div>
-      </div>
-    </section>
-  );
-};
-
-const SceneDials = () => {
-  const params = useReactGrab("Scene", {
-    fov: [50, 10, 120],
-    wireframe: false,
-    quality: { type: "select", options: ["low", "medium", "high"], default: "medium" },
-  });
-
-  return (
-    <section className="border rounded-lg p-4" data-testid="dialkit-section-2">
-      <h2 className="text-lg font-bold mb-4">Second useReactGrab() Hook</h2>
-      <div className="text-sm text-gray-600" data-testid="scene-readout">
-        FOV {params.fov} · {params.quality} · {params.wireframe ? "wireframe" : "solid"}
-      </div>
-    </section>
-  );
-};
+// Lazy + gated so the always-on dials demo never bundles into the default app:
+// it would otherwise statically import react-grab/react (a PR-only export the
+// perf baseline build cannot resolve) and overlap the selection prompt other
+// specs click. Open `/?dials` to preview the multi-hook layout.
+const DialsDemo = lazy(() => import("./dials-demo"));
 
 interface Todo {
   id: number;
@@ -725,6 +664,15 @@ const usePerfGridConfig = (): { rowCount: number; columnCount: number } | null =
   };
 };
 
+// The dials demo renders an always-on, toolbar-anchored panel that overlaps the
+// selection copy/discard prompt other specs click. Gate it behind `?dials` so the
+// default page (every existing spec) stays overlay-free; open `/?dials` to preview.
+const useDialsDemoEnabled = (): boolean => {
+  if (typeof window === "undefined") return false;
+  const value = new URLSearchParams(window.location.search).get("dials");
+  return value !== null && value !== "0" && value !== "false";
+};
+
 // Replicates the Radix/modal-library pattern of setting `body { pointer-events:
 // none }` while open (re-enabling it only on the popover). react-grab must still
 // hit-test page content outside the popover; this fixture guards that
@@ -771,6 +719,7 @@ const PointerEventsModalSection = () => {
 
 export default function App() {
   const perfConfig = usePerfGridConfig();
+  const dialsDemoEnabled = useDialsDemoEnabled();
 
   if (perfConfig) {
     return <PerfGrid rowCount={perfConfig.rowCount} columnCount={perfConfig.columnCount} />;
@@ -795,9 +744,11 @@ export default function App() {
         </p>
       </header>
 
-      <DialKitCard />
-
-      <SceneDials />
+      {dialsDemoEnabled && (
+        <Suspense fallback={null}>
+          <DialsDemo />
+        </Suspense>
+      )}
 
       <TodoList />
 

--- a/apps/e2e-app-vite/src/App.tsx
+++ b/apps/e2e-app-vite/src/App.tsx
@@ -1,5 +1,72 @@
 import { useState, useRef, useEffect } from "react";
+import { useReactGrab } from "react-grab/react";
 import { PerfGrid } from "./perf-grid";
+
+const DialKitCard = () => {
+  const params = useReactGrab("Card", {
+    blur: [0, 0, 40],
+    scale: 1.2,
+    radius: [24, 0, 80],
+    color: "#ff5500",
+    background: "#0b1020",
+    label: "React Grab",
+    visible: true,
+    layout: { type: "select", options: ["stack", "fan", "grid"], default: "stack" },
+    shadow: {
+      _collapsed: false,
+      blur: [24, 0, 80],
+      opacity: [0.4, 0, 1],
+    },
+    spring: { type: "spring", visualDuration: 0.5, bounce: 0.2 },
+  });
+
+  return (
+    <section className="border rounded-lg p-4" data-testid="dialkit-section">
+      <h2 className="text-lg font-bold mb-4">useReactGrab() Demo</h2>
+      <div className="flex items-center justify-center h-72">
+        <div
+          data-testid="dialkit-card"
+          style={{
+            opacity: params.visible ? 1 : 0,
+            filter: `blur(${params.blur}px)`,
+            transform: `scale(${params.scale})`,
+            borderRadius: `${params.radius}px`,
+            color: params.color,
+            background: params.background,
+            boxShadow: `0 8px ${params.shadow.blur}px rgba(0,0,0,${params.shadow.opacity})`,
+            transition: `transform ${params.spring.visualDuration}s, filter 0.2s, border-radius 0.2s`,
+            width: 220,
+            height: 140,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontWeight: 600,
+            fontSize: 18,
+          }}
+        >
+          {params.label} ({params.layout})
+        </div>
+      </div>
+    </section>
+  );
+};
+
+const SceneDials = () => {
+  const params = useReactGrab("Scene", {
+    fov: [50, 10, 120],
+    wireframe: false,
+    quality: { type: "select", options: ["low", "medium", "high"], default: "medium" },
+  });
+
+  return (
+    <section className="border rounded-lg p-4" data-testid="dialkit-section-2">
+      <h2 className="text-lg font-bold mb-4">Second useReactGrab() Hook</h2>
+      <div className="text-sm text-gray-600" data-testid="scene-readout">
+        FOV {params.fov} · {params.quality} · {params.wireframe ? "wireframe" : "solid"}
+      </div>
+    </section>
+  );
+};
 
 interface Todo {
   id: number;
@@ -727,6 +794,10 @@ export default function App() {
           Comprehensive test page for E2E testing
         </p>
       </header>
+
+      <DialKitCard />
+
+      <SceneDials />
 
       <TodoList />
 

--- a/apps/e2e-app-vite/src/dials-demo.tsx
+++ b/apps/e2e-app-vite/src/dials-demo.tsx
@@ -1,0 +1,105 @@
+import { useReactGrab } from "react-grab/react";
+
+const DialKitCard = () => {
+  const params = useReactGrab("Card", {
+    blur: [0, 0, 40],
+    scale: 1.2,
+    radius: [24, 0, 80],
+    color: "#ff5500",
+    background: "#0b1020",
+    label: "React Grab",
+    visible: true,
+    layout: { type: "select", options: ["stack", "fan", "grid"], default: "stack" },
+    shadow: {
+      _collapsed: false,
+      blur: [24, 0, 80],
+      opacity: [0.4, 0, 1],
+    },
+    spring: { type: "spring", visualDuration: 0.5, bounce: 0.2 },
+  });
+
+  return (
+    <section className="border rounded-lg p-4" data-testid="dialkit-section">
+      <h2 className="text-lg font-bold mb-4">useReactGrab() Demo</h2>
+      <div className="flex items-center justify-center h-72">
+        <div
+          data-testid="dialkit-card"
+          style={{
+            opacity: params.visible ? 1 : 0,
+            filter: `blur(${params.blur}px)`,
+            transform: `scale(${params.scale})`,
+            borderRadius: `${params.radius}px`,
+            color: params.color,
+            background: params.background,
+            boxShadow: `0 8px ${params.shadow.blur}px rgba(0,0,0,${params.shadow.opacity})`,
+            transition: `transform ${params.spring.visualDuration}s, filter 0.2s, border-radius 0.2s`,
+            width: 220,
+            height: 140,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontWeight: 600,
+            fontSize: 18,
+          }}
+        >
+          {params.label} ({params.layout})
+        </div>
+      </div>
+    </section>
+  );
+};
+
+const SceneDials = () => {
+  const params = useReactGrab("Scene", {
+    fov: [50, 10, 120],
+    wireframe: false,
+    quality: { type: "select", options: ["low", "medium", "high"], default: "medium" },
+  });
+
+  return (
+    <section className="border rounded-lg p-4" data-testid="dialkit-section-2">
+      <h2 className="text-lg font-bold mb-4">Second useReactGrab() Hook</h2>
+      <div className="text-sm text-gray-600" data-testid="scene-readout">
+        FOV {params.fov} · {params.quality} · {params.wireframe ? "wireframe" : "solid"}
+      </div>
+    </section>
+  );
+};
+
+const TypographyDials = () => {
+  const params = useReactGrab("Typography", {
+    fontSize: [16, 8, 72],
+    lineHeight: [1.5, 0.8, 3],
+    weight: { type: "select", options: ["regular", "medium", "bold"], default: "regular" },
+    italic: false,
+  });
+
+  return (
+    <section className="border rounded-lg p-4" data-testid="dialkit-section-3">
+      <h2 className="text-lg font-bold mb-4">Third useReactGrab() Hook</h2>
+      <p
+        data-testid="typography-readout"
+        style={{
+          fontSize: `${params.fontSize}px`,
+          lineHeight: params.lineHeight,
+          fontWeight: params.weight === "bold" ? 700 : params.weight === "medium" ? 500 : 400,
+          fontStyle: params.italic ? "italic" : "normal",
+        }}
+      >
+        The quick brown fox
+      </p>
+    </section>
+  );
+};
+
+const DialsDemo = () => (
+  <>
+    <DialKitCard />
+
+    <SceneDials />
+
+    <TypographyDials />
+  </>
+);
+
+export default DialsDemo;

--- a/packages/react-grab/package.json
+++ b/packages/react-grab/package.json
@@ -69,6 +69,16 @@
         "default": "./dist/primitives.cjs"
       }
     },
+    "./react": {
+      "import": {
+        "types": "./dist/react.d.ts",
+        "default": "./dist/react.js"
+      },
+      "require": {
+        "types": "./dist/react.d.cts",
+        "default": "./dist/react.cjs"
+      }
+    },
     "./src/*": "./src/*",
     "./styles.css": "./dist/styles.css",
     "./dist/styles.css": "./dist/styles.css",

--- a/packages/react-grab/package.json
+++ b/packages/react-grab/package.json
@@ -110,7 +110,8 @@
   },
   "dependencies": {
     "@react-grab/cli": "workspace:*",
-    "bippy": "^0.5.42"
+    "bippy": "^0.5.42",
+    "use-sync-external-store": "^1.6.0"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",
@@ -121,6 +122,7 @@
     "@types/babel__core": "^7.20.5",
     "@types/node": "^25.6.2",
     "@types/react": "^19.2.14",
+    "@types/use-sync-external-store": "^1.5.0",
     "babel-preset-solid": "^1.9.12",
     "concurrently": "^9.2.1",
     "expect-sdk": "^0.1.2",

--- a/packages/react-grab/src/components/dials-panel/action-control.tsx
+++ b/packages/react-grab/src/components/dials-panel/action-control.tsx
@@ -1,0 +1,24 @@
+import { type Component } from "solid-js";
+
+interface ActionControlProps {
+  label: string;
+  onTrigger: () => void;
+}
+
+export const ActionControl: Component<ActionControlProps> = (props) => (
+  <div class="flex items-center w-full px-2">
+    <button
+      type="button"
+      data-react-grab-ignore-events
+      class="w-full flex items-center justify-center h-[20px] rounded-[6px] bg-[var(--rg-surface-hover)] [border-width:0.5px] border-solid border-[var(--rg-border-button)] cursor-pointer transition-colors hover:bg-[var(--rg-surface-active)] press-scale text-[12px] leading-4 font-medium text-[var(--rg-text-primary)]"
+      onPointerDown={(event) => event.stopPropagation()}
+      onClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        props.onTrigger();
+      }}
+    >
+      {props.label}
+    </button>
+  </div>
+);

--- a/packages/react-grab/src/components/dials-panel/controls-tree.tsx
+++ b/packages/react-grab/src/components/dials-panel/controls-tree.tsx
@@ -1,7 +1,7 @@
-import { createEffect, For, Match, Show, Switch, type Component } from "solid-js";
+import { For, Match, Show, Switch, type Component } from "solid-js";
 import type { DialValue } from "../../types.js";
 import { cn } from "../../utils/cn.js";
-import { createMenuHighlight } from "../../utils/create-menu-highlight.js";
+import { createMenuList } from "../../utils/create-menu-list.js";
 import { EDIT_LABEL_CLASS } from "../edit-panel/constants.js";
 import { IconChevron } from "../icons/icon-chevron.jsx";
 import { ActionControl } from "./action-control.js";
@@ -29,72 +29,28 @@ interface DialRowsProps {
 const INDENT_PER_DEPTH_PX = 10;
 
 export const DialRows: Component<DialRowsProps> = (props) => {
-  const rowElements: (HTMLElement | undefined)[] = [];
-  let listRef: HTMLElement | undefined;
-  let didPointerMove = false;
-  let lastPointerX = Number.NaN;
-  let lastPointerY = Number.NaN;
+  const navCount = () =>
+    props.rows.reduce((max, row) => ("navIndex" in row ? Math.max(max, row.navIndex) : max), -1) +
+    1;
 
-  // Keyboard navigation swaps the active row's content under a stationary
-  // cursor, which fires phantom pointerenter/pointermove on whatever row sits
-  // beneath the pointer and would yank the active row back. Only react to
-  // genuine pointer movement (coordinates actually changed) so synthetic
-  // events at the same position are ignored.
-  const activateFromPointer = (navIndex: number, event: PointerEvent, source: "move" | "enter") => {
-    const isSamePosition = event.clientX === lastPointerX && event.clientY === lastPointerY;
-    if (source === "move") {
-      if (isSamePosition) return;
-      didPointerMove = true;
-    } else if (!didPointerMove || isSamePosition) {
-      return;
-    }
-    lastPointerX = event.clientX;
-    lastPointerY = event.clientY;
-    props.onActivate(navIndex);
-  };
-
-  const { containerRef, highlightRef, updateHighlight, clearHighlight } = createMenuHighlight({});
-
-  createEffect(() => {
-    const activeIndex = props.activeIndex;
-    const element = activeIndex < 0 ? undefined : rowElements[activeIndex];
-    if (!element) {
-      clearHighlight();
-      return;
-    }
-    updateHighlight(element);
-    if (!listRef) return;
-    const containerRect = listRef.getBoundingClientRect();
-    const targetRect = element.getBoundingClientRect();
-    if (targetRect.top < containerRect.top || targetRect.bottom > containerRect.bottom) {
-      element.scrollIntoView({ block: "nearest" });
-    }
+  const menu = createMenuList({
+    activeIndex: () => props.activeIndex,
+    itemCount: navCount,
+    onHoverIndex: (index) => props.onActivate(index),
   });
 
   const indentStyle = (depth: number) => ({ "padding-left": `${depth * INDENT_PER_DEPTH_PX}px` });
 
-  const registerRow = (navIndex: number, element: HTMLElement | undefined) => {
-    rowElements[navIndex] = element;
-  };
-
   return (
     <div
-      ref={(element) => {
-        listRef = element;
-        containerRef(element);
-      }}
+      ref={menu.containerRef}
       role="menu"
       aria-orientation="vertical"
-      class="relative flex flex-col"
-      onPointerMove={(event) => {
-        if (event.clientX === lastPointerX && event.clientY === lastPointerY) return;
-        didPointerMove = true;
-        lastPointerX = event.clientX;
-        lastPointerY = event.clientY;
-      }}
+      class="relative flex flex-col min-h-0 overflow-y-auto overflow-x-hidden no-scrollbar"
+      onPointerMove={menu.handleListPointerMove}
     >
       <div
-        ref={highlightRef}
+        ref={menu.highlightRef}
         aria-hidden="true"
         class="pointer-events-none absolute opacity-0 rounded-[6px] transition-[top,left,width,height,opacity] duration-75 ease-out bg-[var(--rg-surface-hover)]"
       />
@@ -103,17 +59,54 @@ export const DialRows: Component<DialRowsProps> = (props) => {
           <Switch>
             <Match when={row.type === "title" && row}>
               {(titleRow) => (
-                <div
-                  class={cn(
-                    "px-2 pt-1.5 pb-1",
-                    titleRow().showDivider &&
-                      "mt-1.5 pt-2.5 [border-top-width:0.5px] border-solid border-[var(--rg-border-subtle)]",
-                  )}
+                <Show
+                  when={titleRow().collapsible}
+                  fallback={
+                    <div
+                      class={cn(
+                        "flex items-center w-full pl-1.5 pr-2 py-1",
+                        titleRow().showDivider &&
+                          "mt-1 [border-top-width:0.5px] border-solid border-[var(--rg-border-subtle)] pt-2",
+                      )}
+                    >
+                      <span class="text-[var(--rg-text-primary)] text-[13px] leading-4 font-semibold truncate min-w-0">
+                        {titleRow().name}
+                      </span>
+                    </div>
+                  }
                 >
-                  <span class="text-[var(--rg-text-primary)] text-[13px] leading-4 font-semibold">
-                    {titleRow().name}
-                  </span>
-                </div>
+                  <button
+                    type="button"
+                    data-react-grab-ignore-events
+                    ref={(element) => menu.registerItem(titleRow().navIndex, element)}
+                    aria-expanded={!titleRow().collapsed}
+                    tabindex={-1}
+                    class={cn(
+                      "relative z-1 contain-layout flex items-center gap-1 w-full pl-1.5 pr-2 py-1 cursor-pointer border-none bg-transparent text-left",
+                      titleRow().showDivider &&
+                        "mt-1 [border-top-width:0.5px] border-solid border-[var(--rg-border-subtle)] pt-2",
+                    )}
+                    {...menu.rowHoverHandlers(titleRow().navIndex)}
+                    onPointerDown={(event) => event.stopPropagation()}
+                    onMouseDown={menu.handleRowMouseDown}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      props.onToggleFolder(titleRow().navIndex);
+                    }}
+                  >
+                    <IconChevron
+                      size={14}
+                      class={cn(
+                        "text-[var(--rg-text-secondary)] transition-transform duration-150 ease-drawer -ml-0.5 shrink-0",
+                        titleRow().collapsed ? "rotate-0" : "rotate-90",
+                      )}
+                    />
+                    <span class="text-[var(--rg-text-primary)] text-[13px] leading-4 font-semibold truncate min-w-0">
+                      {titleRow().name}
+                    </span>
+                  </button>
+                </Show>
               )}
             </Match>
 
@@ -122,20 +115,16 @@ export const DialRows: Component<DialRowsProps> = (props) => {
                 <button
                   type="button"
                   data-react-grab-ignore-events
-                  ref={(element) => registerRow(folderRow().navIndex, element)}
+                  ref={(element) => menu.registerItem(folderRow().navIndex, element)}
                   aria-expanded={!folderRow().collapsed}
                   tabindex={-1}
-                  class="relative z-1 flex items-center gap-1 w-full h-[24px] pr-2 cursor-pointer border-none bg-transparent text-left"
+                  class="relative z-1 contain-layout flex items-center gap-1 w-full h-[24px] pr-2 cursor-pointer border-none bg-transparent text-left"
                   style={{
                     "padding-left": `${4 + folderRow().depth * INDENT_PER_DEPTH_PX}px`,
                   }}
-                  onPointerMove={(event) =>
-                    activateFromPointer(folderRow().navIndex, event, "move")
-                  }
-                  onPointerEnter={(event) =>
-                    activateFromPointer(folderRow().navIndex, event, "enter")
-                  }
+                  {...menu.rowHoverHandlers(folderRow().navIndex)}
                   onPointerDown={(event) => event.stopPropagation()}
+                  onMouseDown={menu.handleRowMouseDown}
                   onClick={(event) => {
                     event.preventDefault();
                     event.stopPropagation();
@@ -178,17 +167,13 @@ export const DialRows: Component<DialRowsProps> = (props) => {
                   <button
                     type="button"
                     data-react-grab-ignore-events
-                    ref={(element) => registerRow(fieldRow().navIndex, element)}
+                    ref={(element) => menu.registerItem(fieldRow().navIndex, element)}
                     tabindex={-1}
-                    class="relative z-1 block w-full h-[24px] px-0 py-0 cursor-pointer border-none bg-transparent text-left"
+                    class="relative z-1 contain-layout block w-full h-[24px] px-0 py-0 cursor-pointer border-none bg-transparent text-left"
                     style={indentStyle(fieldRow().depth)}
-                    onPointerMove={(event) =>
-                      activateFromPointer(fieldRow().navIndex, event, "move")
-                    }
-                    onPointerEnter={(event) =>
-                      activateFromPointer(fieldRow().navIndex, event, "enter")
-                    }
+                    {...menu.rowHoverHandlers(fieldRow().navIndex)}
                     onPointerDown={(event) => event.stopPropagation()}
+                    onMouseDown={menu.handleRowMouseDown}
                     onClick={(event) => {
                       event.stopPropagation();
                       props.onActivate(fieldRow().navIndex);
@@ -241,18 +226,14 @@ export const DialRows: Component<DialRowsProps> = (props) => {
                   <button
                     type="button"
                     data-react-grab-ignore-events
-                    ref={(element) => registerRow(leafRow().navIndex, element)}
+                    ref={(element) => menu.registerItem(leafRow().navIndex, element)}
                     aria-current={isActive() ? "true" : undefined}
                     tabindex={-1}
-                    class="relative z-1 block w-full h-[24px] px-0 py-0 cursor-pointer border-none bg-transparent text-left"
+                    class="relative z-1 contain-layout block w-full h-[24px] px-0 py-0 cursor-pointer border-none bg-transparent text-left"
                     style={indentStyle(leafRow().depth)}
-                    onPointerMove={(event) =>
-                      activateFromPointer(leafRow().navIndex, event, "move")
-                    }
-                    onPointerEnter={(event) =>
-                      activateFromPointer(leafRow().navIndex, event, "enter")
-                    }
+                    {...menu.rowHoverHandlers(leafRow().navIndex)}
                     onPointerDown={(event) => event.stopPropagation()}
+                    onMouseDown={menu.handleRowMouseDown}
                     onClick={(event) => {
                       event.stopPropagation();
                       if (isAction()) {

--- a/packages/react-grab/src/components/dials-panel/controls-tree.tsx
+++ b/packages/react-grab/src/components/dials-panel/controls-tree.tsx
@@ -1,0 +1,314 @@
+import { createEffect, For, Match, Show, Switch, type Component } from "solid-js";
+import type { DialValue } from "../../types.js";
+import { cn } from "../../utils/cn.js";
+import { createMenuHighlight } from "../../utils/create-menu-highlight.js";
+import { EDIT_LABEL_CLASS } from "../edit-panel/constants.js";
+import { IconChevron } from "../icons/icon-chevron.jsx";
+import { ActionControl } from "./action-control.js";
+import {
+  DialActiveControl,
+  DialNumberActive,
+  DialNumberSummary,
+  DialValueSummary,
+} from "./dial-control.js";
+import { SpringVisualization } from "./spring-visualization.js";
+import { readSpring, type DialViewRow } from "./view-rows.js";
+
+interface DialRowsProps {
+  rows: DialViewRow[];
+  activeIndex: number;
+  activeKey: "left" | "right" | null;
+  getValue: (panelId: string, path: string) => DialValue;
+  onToggleFolder: (navIndex: number) => void;
+  onActivate: (navIndex: number) => void;
+  onCommit: (panelId: string, path: string, value: DialValue) => void;
+  onTriggerAction: (panelId: string, path: string) => void;
+  onInteract: () => void;
+}
+
+const INDENT_PER_DEPTH_PX = 10;
+
+export const DialRows: Component<DialRowsProps> = (props) => {
+  const rowElements: (HTMLElement | undefined)[] = [];
+  let listRef: HTMLElement | undefined;
+  let didPointerMove = false;
+  let lastPointerX = Number.NaN;
+  let lastPointerY = Number.NaN;
+
+  // Keyboard navigation swaps the active row's content under a stationary
+  // cursor, which fires phantom pointerenter/pointermove on whatever row sits
+  // beneath the pointer and would yank the active row back. Only react to
+  // genuine pointer movement (coordinates actually changed) so synthetic
+  // events at the same position are ignored.
+  const activateFromPointer = (navIndex: number, event: PointerEvent, source: "move" | "enter") => {
+    const isSamePosition = event.clientX === lastPointerX && event.clientY === lastPointerY;
+    if (source === "move") {
+      if (isSamePosition) return;
+      didPointerMove = true;
+    } else if (!didPointerMove || isSamePosition) {
+      return;
+    }
+    lastPointerX = event.clientX;
+    lastPointerY = event.clientY;
+    props.onActivate(navIndex);
+  };
+
+  const { containerRef, highlightRef, updateHighlight, clearHighlight } = createMenuHighlight({});
+
+  createEffect(() => {
+    const activeIndex = props.activeIndex;
+    const element = activeIndex < 0 ? undefined : rowElements[activeIndex];
+    if (!element) {
+      clearHighlight();
+      return;
+    }
+    updateHighlight(element);
+    if (!listRef) return;
+    const containerRect = listRef.getBoundingClientRect();
+    const targetRect = element.getBoundingClientRect();
+    if (targetRect.top < containerRect.top || targetRect.bottom > containerRect.bottom) {
+      element.scrollIntoView({ block: "nearest" });
+    }
+  });
+
+  const indentStyle = (depth: number) => ({ "padding-left": `${depth * INDENT_PER_DEPTH_PX}px` });
+
+  const registerRow = (navIndex: number, element: HTMLElement | undefined) => {
+    rowElements[navIndex] = element;
+  };
+
+  return (
+    <div
+      ref={(element) => {
+        listRef = element;
+        containerRef(element);
+      }}
+      role="menu"
+      aria-orientation="vertical"
+      class="relative flex flex-col"
+      onPointerMove={(event) => {
+        if (event.clientX === lastPointerX && event.clientY === lastPointerY) return;
+        didPointerMove = true;
+        lastPointerX = event.clientX;
+        lastPointerY = event.clientY;
+      }}
+    >
+      <div
+        ref={highlightRef}
+        aria-hidden="true"
+        class="pointer-events-none absolute opacity-0 rounded-[6px] transition-[top,left,width,height,opacity] duration-75 ease-out bg-[var(--rg-surface-hover)]"
+      />
+      <For each={props.rows}>
+        {(row) => (
+          <Switch>
+            <Match when={row.type === "title" && row}>
+              {(titleRow) => (
+                <div
+                  class={cn(
+                    "px-2 pt-1.5 pb-1",
+                    titleRow().showDivider &&
+                      "mt-1.5 pt-2.5 [border-top-width:0.5px] border-solid border-[var(--rg-border-subtle)]",
+                  )}
+                >
+                  <span class="text-[var(--rg-text-primary)] text-[13px] leading-4 font-semibold">
+                    {titleRow().name}
+                  </span>
+                </div>
+              )}
+            </Match>
+
+            <Match when={row.type === "folder" && row}>
+              {(folderRow) => (
+                <button
+                  type="button"
+                  data-react-grab-ignore-events
+                  ref={(element) => registerRow(folderRow().navIndex, element)}
+                  aria-expanded={!folderRow().collapsed}
+                  tabindex={-1}
+                  class="relative z-1 flex items-center gap-1 w-full h-[24px] pr-2 cursor-pointer border-none bg-transparent text-left"
+                  style={{
+                    "padding-left": `${4 + folderRow().depth * INDENT_PER_DEPTH_PX}px`,
+                  }}
+                  onPointerMove={(event) =>
+                    activateFromPointer(folderRow().navIndex, event, "move")
+                  }
+                  onPointerEnter={(event) =>
+                    activateFromPointer(folderRow().navIndex, event, "enter")
+                  }
+                  onPointerDown={(event) => event.stopPropagation()}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    props.onToggleFolder(folderRow().navIndex);
+                  }}
+                >
+                  <IconChevron
+                    size={14}
+                    class={cn(
+                      "text-[var(--rg-text-secondary)] transition-transform duration-150 ease-drawer -ml-0.5 shrink-0",
+                      folderRow().collapsed ? "rotate-0" : "rotate-90",
+                    )}
+                  />
+                  <span
+                    class={`${EDIT_LABEL_CLASS} text-[var(--rg-text-primary)] font-semibold truncate min-w-0`}
+                  >
+                    {folderRow().label}
+                  </span>
+                </button>
+              )}
+            </Match>
+
+            <Match when={row.type === "spring-viz" && row}>
+              {(vizRow) => (
+                <div class="w-full px-2" style={indentStyle(vizRow().depth)}>
+                  <SpringVisualization
+                    value={readSpring(props.getValue(vizRow().panelId, vizRow().springPath))}
+                  />
+                </div>
+              )}
+            </Match>
+
+            <Match when={row.type === "spring-field" && row}>
+              {(fieldRow) => {
+                const spring = () =>
+                  readSpring(props.getValue(fieldRow().panelId, fieldRow().springPath));
+                const isActive = () => props.activeIndex === fieldRow().navIndex;
+                const unit = () => (fieldRow().field === "visualDuration" ? "s" : "");
+                return (
+                  <button
+                    type="button"
+                    data-react-grab-ignore-events
+                    ref={(element) => registerRow(fieldRow().navIndex, element)}
+                    tabindex={-1}
+                    class="relative z-1 block w-full h-[24px] px-0 py-0 cursor-pointer border-none bg-transparent text-left"
+                    style={indentStyle(fieldRow().depth)}
+                    onPointerMove={(event) =>
+                      activateFromPointer(fieldRow().navIndex, event, "move")
+                    }
+                    onPointerEnter={(event) =>
+                      activateFromPointer(fieldRow().navIndex, event, "enter")
+                    }
+                    onPointerDown={(event) => event.stopPropagation()}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      props.onActivate(fieldRow().navIndex);
+                    }}
+                  >
+                    <Show
+                      when={isActive()}
+                      fallback={
+                        <div class="flex items-center justify-between w-full h-[24px] px-2 gap-2">
+                          <span
+                            class={`${EDIT_LABEL_CLASS} text-[var(--rg-text-primary)] truncate min-w-0`}
+                          >
+                            {fieldRow().label}
+                          </span>
+                          <DialNumberSummary value={spring()[fieldRow().field]} unit={unit()} />
+                        </div>
+                      }
+                    >
+                      <div class="flex items-center w-full h-[24px]">
+                        <DialNumberActive
+                          label={fieldRow().label}
+                          value={spring()[fieldRow().field]}
+                          min={fieldRow().min}
+                          max={fieldRow().max}
+                          step={fieldRow().step}
+                          unit={unit()}
+                          activeKey={props.activeKey}
+                          onCommit={(value) =>
+                            props.onCommit(fieldRow().panelId, fieldRow().springPath, {
+                              ...spring(),
+                              [fieldRow().field]: value,
+                            })
+                          }
+                          onInteract={props.onInteract}
+                        />
+                      </div>
+                    </Show>
+                  </button>
+                );
+              }}
+            </Match>
+
+            <Match when={row.type === "leaf" && row}>
+              {(leafRow) => {
+                const control = () => leafRow().control;
+                const value = () => props.getValue(leafRow().panelId, control().path);
+                const isActive = () => props.activeIndex === leafRow().navIndex;
+                const isAction = () => control().kind === "action";
+                return (
+                  <button
+                    type="button"
+                    data-react-grab-ignore-events
+                    ref={(element) => registerRow(leafRow().navIndex, element)}
+                    aria-current={isActive() ? "true" : undefined}
+                    tabindex={-1}
+                    class="relative z-1 block w-full h-[24px] px-0 py-0 cursor-pointer border-none bg-transparent text-left"
+                    style={indentStyle(leafRow().depth)}
+                    onPointerMove={(event) =>
+                      activateFromPointer(leafRow().navIndex, event, "move")
+                    }
+                    onPointerEnter={(event) =>
+                      activateFromPointer(leafRow().navIndex, event, "enter")
+                    }
+                    onPointerDown={(event) => event.stopPropagation()}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      if (isAction()) {
+                        props.onTriggerAction(leafRow().panelId, control().path);
+                        return;
+                      }
+                      props.onActivate(leafRow().navIndex);
+                    }}
+                  >
+                    <Show
+                      when={isAction()}
+                      fallback={
+                        <Show
+                          when={isActive()}
+                          fallback={
+                            <div class="flex items-center justify-between w-full h-[24px] px-2 gap-2">
+                              <span
+                                class={`${EDIT_LABEL_CLASS} text-[var(--rg-text-primary)] truncate min-w-0`}
+                              >
+                                {control().label}
+                              </span>
+                              <DialValueSummary control={control()} value={value()} />
+                            </div>
+                          }
+                        >
+                          <div class="flex items-center w-full h-[24px]">
+                            <DialActiveControl
+                              control={control()}
+                              value={value()}
+                              activeKey={props.activeKey}
+                              onCommit={(path, nextValue) =>
+                                props.onCommit(leafRow().panelId, path, nextValue)
+                              }
+                              onTriggerAction={(path) =>
+                                props.onTriggerAction(leafRow().panelId, path)
+                              }
+                              onInteract={props.onInteract}
+                            />
+                          </div>
+                        </Show>
+                      }
+                    >
+                      <div class="flex items-center w-full h-[24px]">
+                        <ActionControl
+                          label={control().label}
+                          onTrigger={() => props.onTriggerAction(leafRow().panelId, control().path)}
+                        />
+                      </div>
+                    </Show>
+                  </button>
+                );
+              }}
+            </Match>
+          </Switch>
+        )}
+      </For>
+    </div>
+  );
+};

--- a/packages/react-grab/src/components/dials-panel/dial-control.tsx
+++ b/packages/react-grab/src/components/dials-panel/dial-control.tsx
@@ -1,0 +1,204 @@
+import { Match, Show, Switch, type Component } from "solid-js";
+import type { DialControl, DialValue } from "../../types.js";
+import { clampToRange } from "../../utils/clamp-to-range.js";
+import { ColorPicker } from "../edit-panel/color-picker.js";
+import { CycleControl } from "../edit-panel/cycle-control.js";
+import { ValueStepper } from "../edit-panel/value-stepper.js";
+import { ActionControl } from "./action-control.js";
+import { TextControl } from "./text-control.js";
+import { ToggleControl } from "./toggle-control.js";
+
+interface DialActiveControlProps {
+  control: DialControl;
+  value: DialValue;
+  activeKey: "left" | "right" | null;
+  onCommit: (path: string, value: DialValue) => void;
+  onTriggerAction: (path: string) => void;
+  onInteract: () => void;
+}
+
+interface DialValueSummaryProps {
+  control: DialControl;
+  value: DialValue;
+}
+
+interface DialNumberActiveProps {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  unit: string;
+  activeKey: "left" | "right" | null;
+  onCommit: (value: number) => void;
+  onInteract: () => void;
+}
+
+const stepDecimals = (step: number): number => {
+  if (step >= 1) return 0;
+  const fraction = String(step).split(".")[1];
+  return fraction ? Math.min(6, fraction.length) : 2;
+};
+
+const snapNumber = (value: number, min: number, max: number, step: number): number =>
+  Number(clampToRange(value, min, max).toFixed(stepDecimals(step)));
+
+const SUMMARY_VALUE_CLASS = "text-[11px] font-sans text-[var(--rg-text-secondary)] shrink-0";
+
+export const DialNumberActive: Component<DialNumberActiveProps> = (props) => {
+  const commit = (rawValue: number) => {
+    const snapped = snapNumber(rawValue, props.min, props.max, props.step);
+    if (snapped !== props.value) props.onCommit(snapped);
+  };
+  return (
+    <ValueStepper
+      label={props.label}
+      value={props.value}
+      min={props.min}
+      max={props.max}
+      unit={props.unit}
+      activeKey={props.activeKey}
+      onStep={(direction) => commit(props.value + direction * props.step)}
+      onCommitValue={(nextValue) => commit(nextValue)}
+      onInteract={props.onInteract}
+    />
+  );
+};
+
+export const DialNumberSummary: Component<{ value: number; unit: string }> = (props) => (
+  <span class="font-sans text-[var(--rg-text-secondary)] tabular-nums shrink-0">
+    <span class="text-[11px]">{props.value}</span>
+    <Show when={props.unit}>
+      <span class="text-[9px] ml-px">{props.unit}</span>
+    </Show>
+  </span>
+);
+
+export const DialActiveControl: Component<DialActiveControlProps> = (props) => (
+  <Switch>
+    <Match when={props.control.kind === "number" && props.control}>
+      {(control) => (
+        <DialNumberActive
+          label={control().label}
+          value={typeof props.value === "number" ? props.value : control().default}
+          min={control().min}
+          max={control().max}
+          step={control().step}
+          unit=""
+          activeKey={props.activeKey}
+          onCommit={(value) => props.onCommit(control().path, value)}
+          onInteract={props.onInteract}
+        />
+      )}
+    </Match>
+    <Match when={props.control.kind === "color" && props.control}>
+      {(control) => (
+        <ColorPicker
+          label={control().label}
+          value={typeof props.value === "string" ? props.value : control().default}
+          onCommit={(nextValue) => props.onCommit(control().path, nextValue)}
+          onInteract={props.onInteract}
+        />
+      )}
+    </Match>
+    <Match when={props.control.kind === "select" && props.control}>
+      {(control) => {
+        const select = control();
+        const currentValue = () => (typeof props.value === "string" ? props.value : select.default);
+        const cycle = (direction: 1 | -1) => {
+          const currentIndex = select.options.findIndex(
+            (option) => option.value === currentValue(),
+          );
+          const nextIndex =
+            (currentIndex + direction + select.options.length) % select.options.length;
+          props.onCommit(select.path, select.options[nextIndex].value);
+        };
+        return (
+          <CycleControl
+            label={select.label}
+            value={currentValue()}
+            options={select.options}
+            activeKey={props.activeKey}
+            onStep={cycle}
+          />
+        );
+      }}
+    </Match>
+    <Match when={props.control.kind === "toggle" && props.control}>
+      {(control) => (
+        <ToggleControl
+          label={control().label}
+          value={typeof props.value === "boolean" ? props.value : control().default}
+          onCommit={(nextValue) => {
+            props.onCommit(control().path, nextValue);
+            props.onInteract();
+          }}
+        />
+      )}
+    </Match>
+    <Match when={props.control.kind === "text" && props.control}>
+      {(control) => (
+        <TextControl
+          label={control().label}
+          value={typeof props.value === "string" ? props.value : control().default}
+          placeholder={control().placeholder}
+          onCommit={(nextValue) => props.onCommit(control().path, nextValue)}
+        />
+      )}
+    </Match>
+    <Match when={props.control.kind === "action" && props.control}>
+      {(control) => (
+        <ActionControl
+          label={control().label}
+          onTrigger={() => props.onTriggerAction(control().path)}
+        />
+      )}
+    </Match>
+  </Switch>
+);
+
+export const DialValueSummary: Component<DialValueSummaryProps> = (props) => (
+  <Switch>
+    <Match when={props.control.kind === "number" && props.control}>
+      {(control) => (
+        <DialNumberSummary
+          value={typeof props.value === "number" ? props.value : control().default}
+          unit=""
+        />
+      )}
+    </Match>
+    <Match when={props.control.kind === "color" && props.control}>
+      {(control) => (
+        <span
+          aria-hidden="true"
+          class="size-[12px] rounded-[3px] border-[var(--rg-border-button)] [border-width:0.5px] border-solid shrink-0"
+          style={{
+            "background-color": typeof props.value === "string" ? props.value : control().default,
+          }}
+        />
+      )}
+    </Match>
+    <Match when={props.control.kind === "select" && props.control}>
+      {(control) => {
+        const select = control();
+        const value = typeof props.value === "string" ? props.value : select.default;
+        const label = select.options.find((option) => option.value === value)?.label ?? value;
+        return <span class={SUMMARY_VALUE_CLASS}>{label}</span>;
+      }}
+    </Match>
+    <Match when={props.control.kind === "toggle" && props.control}>
+      {(control) => (
+        <span class={SUMMARY_VALUE_CLASS}>
+          {(typeof props.value === "boolean" ? props.value : control().default) ? "On" : "Off"}
+        </span>
+      )}
+    </Match>
+    <Match when={props.control.kind === "text" && props.control}>
+      {(control) => (
+        <span class={`${SUMMARY_VALUE_CLASS} truncate max-w-[140px]`}>
+          {typeof props.value === "string" ? props.value : control().default}
+        </span>
+      )}
+    </Match>
+  </Switch>
+);

--- a/packages/react-grab/src/components/dials-panel/dial-control.tsx
+++ b/packages/react-grab/src/components/dials-panel/dial-control.tsx
@@ -106,6 +106,7 @@ export const DialActiveControl: Component<DialActiveControlProps> = (props) => (
         const select = control();
         const currentValue = () => (typeof props.value === "string" ? props.value : select.default);
         const cycle = (direction: 1 | -1) => {
+          if (select.options.length === 0) return;
           const currentIndex = select.options.findIndex(
             (option) => option.value === currentValue(),
           );

--- a/packages/react-grab/src/components/dials-panel/index.tsx
+++ b/packages/react-grab/src/components/dials-panel/index.tsx
@@ -146,7 +146,7 @@ export const DialsPanel: Component<DialsPanelProps> = (props) => {
       isPanelEngaged = isWithinPanel(event);
     };
     const handleWindowKeyDown = (event: KeyboardEvent) => {
-      if (!isPanelEngaged) return;
+      if (!isPanelEngaged || !props.position) return;
       const target = event.composedPath()[0];
       if (target instanceof HTMLElement && target.closest("input, textarea")) return;
       handleKeyDown(event);

--- a/packages/react-grab/src/components/dials-panel/index.tsx
+++ b/packages/react-grab/src/components/dials-panel/index.tsx
@@ -131,6 +131,11 @@ export const DialsPanel: Component<DialsPanelProps> = (props) => {
   };
 
   let isPanelEngaged = false;
+  // Dismissing (anchor → null) must also drop engagement; otherwise a reopened
+  // panel would treat keys as engaged without a fresh click inside it.
+  createEffect(() => {
+    if (!props.position) isPanelEngaged = false;
+  });
 
   const isWithinPanel = (event: Event): boolean => {
     const target = event.composedPath()[0];

--- a/packages/react-grab/src/components/dials-panel/index.tsx
+++ b/packages/react-grab/src/components/dials-panel/index.tsx
@@ -39,6 +39,7 @@ export const DialsPanel: Component<DialsPanelProps> = (props) => {
   const [collapsedOverrides, setCollapsedOverrides] = createSignal(new Map<string, boolean>());
   const [activeIndex, setActiveIndex] = createSignal(-1);
   const [activeKey, setActiveKey] = createSignal<"left" | "right" | null>(null);
+  const [searchQuery, setSearchQuery] = createSignal("");
 
   const flashActiveKey = (key: "left" | "right") => {
     setActiveKey(key);
@@ -70,13 +71,17 @@ export const DialsPanel: Component<DialsPanelProps> = (props) => {
   };
 
   const viewModel = createMemo(() =>
-    buildDialViewModel(props.panels, {
-      getValue,
-      commit: props.onCommit,
-      triggerAction: props.onTriggerAction,
-      isCollapsed,
-      setCollapsed,
-    }),
+    buildDialViewModel(
+      props.panels,
+      {
+        getValue,
+        commit: props.onCommit,
+        triggerAction: props.onTriggerAction,
+        isCollapsed,
+        setCollapsed,
+      },
+      searchQuery(),
+    ),
   );
 
   createEffect(() => {
@@ -201,6 +206,25 @@ export const DialsPanel: Component<DialsPanelProps> = (props) => {
             "scrollbar-width": "none",
           }}
         >
+          <div class="shrink-0 px-2 pb-1.5 mb-1 [border-bottom-width:0.5px] border-solid border-[var(--rg-border-subtle)]">
+            <input
+              type="text"
+              data-react-grab-ignore-events
+              data-react-grab-input
+              aria-label="Search dials"
+              autocapitalize="none"
+              autocorrect="off"
+              autocomplete="off"
+              spellcheck={false}
+              class="w-full p-0 m-0 bg-transparent border-none outline-none text-[var(--rg-text-primary)] placeholder:text-[var(--rg-text-secondary)] text-[13px] leading-4 font-medium"
+              value={searchQuery()}
+              onInput={(event) => {
+                setSearchQuery(event.currentTarget.value);
+                setActiveIndex(-1);
+              }}
+              placeholder="Search"
+            />
+          </div>
           <DialRows
             rows={viewModel().rows}
             activeIndex={activeIndex()}

--- a/packages/react-grab/src/components/dials-panel/index.tsx
+++ b/packages/react-grab/src/components/dials-panel/index.tsx
@@ -198,12 +198,11 @@ export const DialsPanel: Component<DialsPanelProps> = (props) => {
         onContextMenu={suppressMenuEvent}
       >
         <Surface
-          class="flex flex-col overflow-y-auto overflow-x-hidden w-fit py-1.5"
+          class="flex flex-col overflow-hidden w-fit py-1.5"
           style={{
             "min-width": `${DIAL_PANEL_MIN_WIDTH_PX}px`,
             "max-width": `${DIAL_PANEL_MAX_WIDTH_PX}px`,
             "max-height": `${DIAL_PANEL_MAX_HEIGHT_PX}px`,
-            "scrollbar-width": "none",
           }}
         >
           <div class="shrink-0 px-2 pb-1.5 mb-1 [border-bottom-width:0.5px] border-solid border-[var(--rg-border-subtle)]">

--- a/packages/react-grab/src/components/dials-panel/index.tsx
+++ b/packages/react-grab/src/components/dials-panel/index.tsx
@@ -1,0 +1,219 @@
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  onCleanup,
+  onMount,
+  Show,
+  type Component,
+} from "solid-js";
+import {
+  DIAL_PANEL_MAX_HEIGHT_PX,
+  DIAL_PANEL_MAX_WIDTH_PX,
+  DIAL_PANEL_MIN_WIDTH_PX,
+  DROPDOWN_EDGE_TRANSFORM_ORIGIN,
+  EDIT_PANEL_ACTIVE_KEY_FLASH_MS,
+  Z_INDEX_OVERLAY,
+} from "../../constants.js";
+import type { DropdownAnchor, DialPanelRuntime, DialValue } from "../../types.js";
+import { cn } from "../../utils/cn.js";
+import { createAnchoredDropdown } from "../../utils/create-anchored-dropdown.js";
+import { registerOverlayDismiss } from "../../utils/register-overlay-dismiss.js";
+import { suppressMenuEvent } from "../../utils/suppress-menu-event.js";
+import { Surface } from "../ui/surface.js";
+import { DialRows } from "./controls-tree.js";
+import { buildDialViewModel } from "./view-rows.js";
+
+interface DialsPanelProps {
+  panels: DialPanelRuntime[];
+  position: DropdownAnchor | null;
+  onCommit: (id: string, path: string, value: DialValue) => void;
+  onTriggerAction: (id: string, path: string) => void;
+  onInteract: () => void;
+  onDismiss: () => void;
+}
+
+export const DialsPanel: Component<DialsPanelProps> = (props) => {
+  let containerRef: HTMLDivElement | undefined;
+  let activeKeyTimeout: ReturnType<typeof setTimeout> | undefined;
+  const [collapsedOverrides, setCollapsedOverrides] = createSignal(new Map<string, boolean>());
+  const [activeIndex, setActiveIndex] = createSignal(-1);
+  const [activeKey, setActiveKey] = createSignal<"left" | "right" | null>(null);
+
+  const flashActiveKey = (key: "left" | "right") => {
+    setActiveKey(key);
+    clearTimeout(activeKeyTimeout);
+    activeKeyTimeout = setTimeout(() => setActiveKey(null), EDIT_PANEL_ACTIVE_KEY_FLASH_MS);
+  };
+
+  const dropdown = createAnchoredDropdown(
+    () => containerRef,
+    () => props.position,
+  );
+
+  const getValue = (panelId: string, path: string): DialValue => {
+    const panel = props.panels.find((candidate) => candidate.id === panelId);
+    return panel ? panel.valuesByPath[path] : 0;
+  };
+
+  const isCollapsed = (key: string, defaultCollapsed: boolean): boolean => {
+    const overrides = collapsedOverrides();
+    return overrides.has(key) ? Boolean(overrides.get(key)) : defaultCollapsed;
+  };
+
+  const setCollapsed = (key: string, collapsed: boolean) => {
+    setCollapsedOverrides((previous) => {
+      const next = new Map(previous);
+      next.set(key, collapsed);
+      return next;
+    });
+  };
+
+  const viewModel = createMemo(() =>
+    buildDialViewModel(props.panels, {
+      getValue,
+      commit: props.onCommit,
+      triggerAction: props.onTriggerAction,
+      isCollapsed,
+      setCollapsed,
+    }),
+  );
+
+  createEffect(() => {
+    const count = viewModel().navEntries.length;
+    setActiveIndex((previous) => (previous >= count ? count - 1 : previous));
+  });
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    const entries = viewModel().navEntries;
+    if (entries.length === 0) return;
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      event.stopPropagation();
+      setActiveIndex((previous) => (previous < 0 ? 0 : Math.min(previous + 1, entries.length - 1)));
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      event.stopPropagation();
+      setActiveIndex((previous) => (previous < 0 ? entries.length - 1 : Math.max(previous - 1, 0)));
+      return;
+    }
+    const activeEntry = entries[activeIndex()];
+    if (!activeEntry) return;
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      event.stopPropagation();
+      flashActiveKey("right");
+      activeEntry.adjust(1, event.shiftKey);
+    } else if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      event.stopPropagation();
+      flashActiveKey("left");
+      activeEntry.adjust(-1, event.shiftKey);
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      event.stopPropagation();
+      activeEntry.activate();
+    }
+  };
+
+  const handlePointerDown = (event: PointerEvent) => {
+    suppressMenuEvent(event);
+    const target = event.target;
+    if (target instanceof HTMLElement && target.closest("input, textarea")) return;
+    containerRef?.focus({ preventScroll: true });
+  };
+
+  let isPanelEngaged = false;
+
+  const isWithinPanel = (event: Event): boolean => {
+    const target = event.composedPath()[0];
+    return target instanceof Node && Boolean(containerRef?.contains(target));
+  };
+
+  onMount(() => {
+    dropdown.measure();
+    // Keyboard navigation is gated on engagement (a click inside the panel)
+    // rather than DOM focus, since clicks land on inner tabindex=-1 controls
+    // and focus tracking across the shadow boundary is unreliable.
+    const handleWindowPointerDown = (event: PointerEvent) => {
+      isPanelEngaged = isWithinPanel(event);
+    };
+    const handleWindowKeyDown = (event: KeyboardEvent) => {
+      if (!isPanelEngaged) return;
+      const target = event.composedPath()[0];
+      if (target instanceof HTMLElement && target.closest("input, textarea")) return;
+      handleKeyDown(event);
+    };
+    window.addEventListener("pointerdown", handleWindowPointerDown, { capture: true });
+    window.addEventListener("keydown", handleWindowKeyDown, { capture: true });
+    const unregisterDismiss = registerOverlayDismiss({
+      isOpen: () => Boolean(props.position),
+      onDismiss: props.onDismiss,
+      shouldIgnoreRightClick: true,
+      shouldIgnoreInputEvents: true,
+    });
+    onCleanup(() => {
+      window.removeEventListener("pointerdown", handleWindowPointerDown, { capture: true });
+      window.removeEventListener("keydown", handleWindowKeyDown, { capture: true });
+      dropdown.clearAnimationHandles();
+      unregisterDismiss();
+      clearTimeout(activeKeyTimeout);
+    });
+  });
+
+  return (
+    <Show when={dropdown.shouldMount()}>
+      <div
+        ref={containerRef}
+        role="dialog"
+        aria-label="React Grab dials"
+        data-react-grab-ignore-events
+        data-react-grab-dials-panel
+        tabindex={0}
+        class={cn(
+          "fixed font-sans text-[13px] antialiased outline-none [filter:var(--rg-drop-shadow)] select-none",
+          dropdown.isAnimatedIn()
+            ? "transition-[opacity,transform] duration-220 ease-spring"
+            : "transition-[opacity,transform] duration-120 ease-drawer",
+        )}
+        style={{
+          top: `${dropdown.displayPosition().top}px`,
+          left: `${dropdown.displayPosition().left}px`,
+          "z-index": `${Z_INDEX_OVERLAY}`,
+          "pointer-events": dropdown.isAnimatedIn() ? "auto" : "none",
+          "transform-origin": DROPDOWN_EDGE_TRANSFORM_ORIGIN[dropdown.lastAnchorEdge()],
+          opacity: dropdown.isAnimatedIn() ? "1" : "0",
+          transform: dropdown.isAnimatedIn() ? "scale(1)" : "scale(0.92)",
+        }}
+        onPointerDown={handlePointerDown}
+        onMouseDown={suppressMenuEvent}
+        onClick={suppressMenuEvent}
+        onContextMenu={suppressMenuEvent}
+      >
+        <Surface
+          class="flex flex-col overflow-y-auto overflow-x-hidden w-fit py-1.5"
+          style={{
+            "min-width": `${DIAL_PANEL_MIN_WIDTH_PX}px`,
+            "max-width": `${DIAL_PANEL_MAX_WIDTH_PX}px`,
+            "max-height": `${DIAL_PANEL_MAX_HEIGHT_PX}px`,
+            "scrollbar-width": "none",
+          }}
+        >
+          <DialRows
+            rows={viewModel().rows}
+            activeIndex={activeIndex()}
+            activeKey={activeKey()}
+            getValue={getValue}
+            onToggleFolder={(navIndex) => viewModel().navEntries[navIndex]?.activate()}
+            onActivate={setActiveIndex}
+            onCommit={props.onCommit}
+            onTriggerAction={props.onTriggerAction}
+            onInteract={props.onInteract}
+          />
+        </Surface>
+      </div>
+    </Show>
+  );
+};

--- a/packages/react-grab/src/components/dials-panel/spring-visualization.tsx
+++ b/packages/react-grab/src/components/dials-panel/spring-visualization.tsx
@@ -1,0 +1,86 @@
+import { createMemo, type Component } from "solid-js";
+import type { SpringValue } from "../../types.js";
+import { clampToRange } from "../../utils/clamp-to-range.js";
+
+interface SpringVisualizationProps {
+  value: SpringValue;
+}
+
+const VIEW_WIDTH = 100;
+const VIEW_HEIGHT = 100;
+const SAMPLE_COUNT = 60;
+const VALUE_MIN = -0.3;
+const VALUE_MAX = 1.55;
+
+// Underdamped spring step response normalized to a target of 1. `bounce`
+// maps to the damping ratio (0 = no overshoot, 1 = very springy) and
+// `visualDuration` sets how quickly the curve rises and settles.
+const springPosition = (timeSeconds: number, visualDuration: number, bounce: number): number => {
+  const dampingRatio = clampToRange(1 - bounce * 0.85, 0.12, 1);
+  const naturalFrequency = 6 / Math.max(visualDuration, 0.05);
+  const decay = Math.exp(-dampingRatio * naturalFrequency * timeSeconds);
+  if (dampingRatio >= 1) {
+    return 1 - decay * (1 + naturalFrequency * timeSeconds);
+  }
+  const dampedFrequency = naturalFrequency * Math.sqrt(1 - dampingRatio * dampingRatio);
+  return (
+    1 -
+    decay *
+      (Math.cos(dampedFrequency * timeSeconds) +
+        ((dampingRatio * naturalFrequency) / dampedFrequency) *
+          Math.sin(dampedFrequency * timeSeconds))
+  );
+};
+
+const toSvgY = (value: number): number =>
+  VIEW_HEIGHT - ((value - VALUE_MIN) / (VALUE_MAX - VALUE_MIN)) * VIEW_HEIGHT;
+
+export const SpringVisualization: Component<SpringVisualizationProps> = (props) => {
+  const curvePath = createMemo(() => {
+    const windowSeconds = Math.max(props.value.visualDuration * 1.8, 0.45);
+    let path = "";
+    for (let sampleIndex = 0; sampleIndex <= SAMPLE_COUNT; sampleIndex += 1) {
+      const progress = sampleIndex / SAMPLE_COUNT;
+      const value = springPosition(
+        progress * windowSeconds,
+        props.value.visualDuration,
+        props.value.bounce,
+      );
+      const x = progress * VIEW_WIDTH;
+      const y = toSvgY(value);
+      path += `${sampleIndex === 0 ? "M" : "L"}${x.toFixed(2)} ${y.toFixed(2)} `;
+    }
+    return path.trim();
+  });
+
+  return (
+    <div class="relative w-full h-[52px] rounded-[6px] overflow-hidden bg-[var(--rg-surface-hover)]">
+      <svg
+        aria-hidden="true"
+        class="absolute inset-0 w-full h-full"
+        viewBox={`0 0 ${VIEW_WIDTH} ${VIEW_HEIGHT}`}
+        preserveAspectRatio="none"
+      >
+        <line
+          x1="0"
+          x2={VIEW_WIDTH}
+          y1={toSvgY(1)}
+          y2={toSvgY(1)}
+          stroke="var(--rg-border-subtle)"
+          stroke-width="1"
+          stroke-dasharray="3 3"
+          vector-effect="non-scaling-stroke"
+        />
+        <path
+          d={curvePath()}
+          fill="none"
+          stroke="var(--rg-text-primary)"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          vector-effect="non-scaling-stroke"
+        />
+      </svg>
+    </div>
+  );
+};

--- a/packages/react-grab/src/components/dials-panel/text-control.tsx
+++ b/packages/react-grab/src/components/dials-panel/text-control.tsx
@@ -1,0 +1,32 @@
+import { type Component } from "solid-js";
+import { EDIT_LABEL_CLASS } from "../edit-panel/constants.js";
+import { Input } from "../ui/input.js";
+
+interface TextControlProps {
+  label?: string;
+  value: string;
+  placeholder?: string;
+  onCommit: (value: string) => void;
+}
+
+export const TextControl: Component<TextControlProps> = (props) => (
+  <div class="flex items-center gap-2 w-full px-2 h-[20px]">
+    {props.label && (
+      <span class={`${EDIT_LABEL_CLASS} text-[var(--rg-text-primary)] truncate min-w-0`}>
+        {props.label}
+      </span>
+    )}
+    <Input
+      aria-label={props.label ?? "Text value"}
+      placeholder={props.placeholder}
+      class="ml-auto text-[12px] leading-4 font-medium text-right min-w-0 flex-1"
+      style={{ "max-width": "140px" }}
+      value={props.value}
+      onInput={(event) => props.onCommit(event.currentTarget.value)}
+      onKeyDown={(event) => event.stopImmediatePropagation()}
+      onPointerDown={(event) => event.stopPropagation()}
+      onMouseDown={(event) => event.stopPropagation()}
+      onClick={(event) => event.stopPropagation()}
+    />
+  </div>
+);

--- a/packages/react-grab/src/components/dials-panel/toggle-control.tsx
+++ b/packages/react-grab/src/components/dials-panel/toggle-control.tsx
@@ -1,0 +1,49 @@
+import { For, type Component } from "solid-js";
+import { cn } from "../../utils/cn.js";
+import { EDIT_LABEL_CLASS } from "../edit-panel/constants.js";
+
+interface ToggleControlProps {
+  label?: string;
+  value: boolean;
+  onCommit: (value: boolean) => void;
+}
+
+const SEGMENTS: ReadonlyArray<{ value: boolean; label: string }> = [
+  { value: false, label: "Off" },
+  { value: true, label: "On" },
+];
+
+export const ToggleControl: Component<ToggleControlProps> = (props) => (
+  <div class="flex items-center gap-2 w-full px-2 h-[20px]">
+    {props.label && (
+      <span class={`${EDIT_LABEL_CLASS} text-[var(--rg-text-primary)] truncate min-w-0`}>
+        {props.label}
+      </span>
+    )}
+    <div class="ml-auto shrink-0 flex items-center gap-0.5 rounded-[6px] bg-[var(--rg-surface-hover)] p-0.5">
+      <For each={SEGMENTS}>
+        {(segment) => (
+          <button
+            type="button"
+            data-react-grab-ignore-events
+            aria-pressed={props.value === segment.value}
+            class={cn(
+              "px-1.5 py-px rounded-[4px] text-[11px] leading-4 font-medium cursor-pointer transition-colors press-scale",
+              props.value === segment.value
+                ? "bg-[var(--rg-surface-active)] text-[var(--rg-text-primary)]"
+                : "text-[var(--rg-text-secondary)] hover:text-[var(--rg-text-primary)]",
+            )}
+            onPointerDown={(event) => event.stopPropagation()}
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              props.onCommit(segment.value);
+            }}
+          >
+            {segment.label}
+          </button>
+        )}
+      </For>
+    </div>
+  </div>
+);

--- a/packages/react-grab/src/components/dials-panel/view-rows.ts
+++ b/packages/react-grab/src/components/dials-panel/view-rows.ts
@@ -1,0 +1,282 @@
+import {
+  DIAL_SPRING_BOUNCE_MAX,
+  DIAL_SPRING_BOUNCE_MIN,
+  DIAL_SPRING_DEFAULT_BOUNCE,
+  DIAL_SPRING_DEFAULT_VISUAL_DURATION_S,
+  DIAL_SPRING_VISUAL_DURATION_MAX_S,
+  DIAL_SPRING_VISUAL_DURATION_MIN_S,
+} from "../../constants.js";
+import type { DialControl, DialPanelRuntime, DialValue, SpringValue } from "../../types.js";
+import { clampToRange } from "../../utils/clamp-to-range.js";
+
+interface DialViewHandlers {
+  getValue: (panelId: string, path: string) => DialValue;
+  commit: (panelId: string, path: string, value: DialValue) => void;
+  triggerAction: (panelId: string, path: string) => void;
+  isCollapsed: (key: string, defaultCollapsed: boolean) => boolean;
+  setCollapsed: (key: string, collapsed: boolean) => void;
+}
+
+interface DialNavEntry {
+  adjust: (direction: 1 | -1, large: boolean) => void;
+  activate: () => void;
+}
+
+interface DialTitleRow {
+  type: "title";
+  key: string;
+  name: string;
+  showDivider: boolean;
+}
+
+interface DialFolderRow {
+  type: "folder";
+  key: string;
+  navIndex: number;
+  depth: number;
+  label: string;
+  collapsed: boolean;
+}
+
+interface DialLeafRow {
+  type: "leaf";
+  key: string;
+  navIndex: number;
+  depth: number;
+  panelId: string;
+  control: DialControl;
+}
+
+interface DialSpringVizRow {
+  type: "spring-viz";
+  key: string;
+  depth: number;
+  panelId: string;
+  springPath: string;
+}
+
+interface DialSpringFieldRow {
+  type: "spring-field";
+  key: string;
+  navIndex: number;
+  depth: number;
+  panelId: string;
+  springPath: string;
+  field: "visualDuration" | "bounce";
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+}
+
+type DialViewRow =
+  | DialTitleRow
+  | DialFolderRow
+  | DialLeafRow
+  | DialSpringVizRow
+  | DialSpringFieldRow;
+
+interface DialViewModel {
+  rows: DialViewRow[];
+  navEntries: DialNavEntry[];
+}
+
+const SPRING_FIELD_STEP = 0.05;
+const SPRING_FIELDS: ReadonlyArray<{
+  field: "visualDuration" | "bounce";
+  label: string;
+  min: number;
+  max: number;
+}> = [
+  {
+    field: "visualDuration",
+    label: "Duration",
+    min: DIAL_SPRING_VISUAL_DURATION_MIN_S,
+    max: DIAL_SPRING_VISUAL_DURATION_MAX_S,
+  },
+  { field: "bounce", label: "Bounce", min: DIAL_SPRING_BOUNCE_MIN, max: DIAL_SPRING_BOUNCE_MAX },
+];
+
+const stepDecimals = (step: number): number => {
+  if (step >= 1) return 0;
+  const fraction = String(step).split(".")[1];
+  return fraction ? Math.min(6, fraction.length) : 2;
+};
+
+export const readSpring = (raw: DialValue): SpringValue =>
+  typeof raw === "object"
+    ? raw
+    : {
+        type: "spring",
+        visualDuration: DIAL_SPRING_DEFAULT_VISUAL_DURATION_S,
+        bounce: DIAL_SPRING_DEFAULT_BOUNCE,
+      };
+
+export const buildDialViewModel = (
+  panels: DialPanelRuntime[],
+  handlers: DialViewHandlers,
+): DialViewModel => {
+  const rows: DialViewRow[] = [];
+  const navEntries: DialNavEntry[] = [];
+
+  const pushNav = (entry: DialNavEntry): number => {
+    navEntries.push(entry);
+    return navEntries.length - 1;
+  };
+
+  const pushCollapsibleHeader = (
+    panelId: string,
+    path: string,
+    label: string,
+    depth: number,
+    defaultCollapsed: boolean,
+  ): boolean => {
+    const key = `${panelId}::${path}`;
+    const collapsed = handlers.isCollapsed(key, defaultCollapsed);
+    rows.push({
+      type: "folder",
+      key,
+      navIndex: pushNav({
+        adjust: (direction) => handlers.setCollapsed(key, direction < 0),
+        activate: () => handlers.setCollapsed(key, !collapsed),
+      }),
+      depth,
+      label,
+      collapsed,
+    });
+    return collapsed;
+  };
+
+  const walk = (panelId: string, controls: DialControl[], depth: number) => {
+    for (const control of controls) {
+      if (control.kind === "folder") {
+        const collapsed = pushCollapsibleHeader(
+          panelId,
+          control.path,
+          control.label,
+          depth,
+          control.collapsed,
+        );
+        if (!collapsed) walk(panelId, control.children, depth + 1);
+        continue;
+      }
+
+      if (control.kind === "spring") {
+        const collapsed = pushCollapsibleHeader(panelId, control.path, control.label, depth, false);
+        if (collapsed) continue;
+        const springPath = control.path;
+        rows.push({
+          type: "spring-viz",
+          key: `${panelId}::${springPath}::viz`,
+          depth: depth + 1,
+          panelId,
+          springPath,
+        });
+        for (const fieldConfig of SPRING_FIELDS) {
+          rows.push({
+            type: "spring-field",
+            key: `${panelId}::${springPath}::${fieldConfig.field}`,
+            navIndex: pushNav({
+              adjust: (direction, large) => {
+                const spring = readSpring(handlers.getValue(panelId, springPath));
+                const stepAmount = SPRING_FIELD_STEP * (large ? 4 : 1);
+                const next = Number(
+                  clampToRange(
+                    spring[fieldConfig.field] + direction * stepAmount,
+                    fieldConfig.min,
+                    fieldConfig.max,
+                  ).toFixed(stepDecimals(SPRING_FIELD_STEP)),
+                );
+                if (next !== spring[fieldConfig.field]) {
+                  handlers.commit(panelId, springPath, { ...spring, [fieldConfig.field]: next });
+                }
+              },
+              activate: () => {},
+            }),
+            depth: depth + 1,
+            panelId,
+            springPath,
+            field: fieldConfig.field,
+            label: fieldConfig.label,
+            min: fieldConfig.min,
+            max: fieldConfig.max,
+            step: SPRING_FIELD_STEP,
+          });
+        }
+        continue;
+      }
+
+      rows.push({
+        type: "leaf",
+        key: `${panelId}::${control.path}`,
+        navIndex: pushNav(buildLeafNavEntry(panelId, control, handlers)),
+        depth,
+        panelId,
+        control,
+      });
+    }
+  };
+
+  panels.forEach((panel, panelIndex) => {
+    rows.push({
+      type: "title",
+      key: `${panel.id}::title`,
+      name: panel.name,
+      showDivider: panelIndex > 0,
+    });
+    walk(panel.id, panel.controls, 0);
+  });
+
+  return { rows, navEntries };
+};
+
+const buildLeafNavEntry = (
+  panelId: string,
+  control: DialControl,
+  handlers: DialViewHandlers,
+): DialNavEntry => {
+  const path = control.path;
+  if (control.kind === "number") {
+    return {
+      adjust: (direction, large) => {
+        const current = handlers.getValue(panelId, path);
+        const value = typeof current === "number" ? current : control.default;
+        const stepAmount = control.step * (large ? 10 : 1);
+        const next = Number(
+          clampToRange(value + direction * stepAmount, control.min, control.max).toFixed(
+            stepDecimals(control.step),
+          ),
+        );
+        if (next !== value) handlers.commit(panelId, path, next);
+      },
+      activate: () => {},
+    };
+  }
+  if (control.kind === "select") {
+    const cycle = (direction: 1 | -1) => {
+      const current = handlers.getValue(panelId, path);
+      const value = typeof current === "string" ? current : control.default;
+      const currentIndex = control.options.findIndex((option) => option.value === value);
+      const nextIndex =
+        (currentIndex + direction + control.options.length) % control.options.length;
+      handlers.commit(panelId, path, control.options[nextIndex].value);
+    };
+    return { adjust: (direction) => cycle(direction), activate: () => cycle(1) };
+  }
+  if (control.kind === "toggle") {
+    return {
+      adjust: (direction) => handlers.commit(panelId, path, direction > 0),
+      activate: () => {
+        const current = handlers.getValue(panelId, path);
+        const value = typeof current === "boolean" ? current : control.default;
+        handlers.commit(panelId, path, !value);
+      },
+    };
+  }
+  if (control.kind === "action") {
+    return { adjust: () => {}, activate: () => handlers.triggerAction(panelId, path) };
+  }
+  return { adjust: () => {}, activate: () => {} };
+};
+
+export type { DialNavEntry, DialViewRow };

--- a/packages/react-grab/src/components/dials-panel/view-rows.ts
+++ b/packages/react-grab/src/components/dials-panel/view-rows.ts
@@ -106,14 +106,19 @@ const stepDecimals = (step: number): number => {
   return fraction ? Math.min(6, fraction.length) : 2;
 };
 
+const DEFAULT_SPRING: SpringValue = {
+  type: "spring",
+  visualDuration: DIAL_SPRING_DEFAULT_VISUAL_DURATION_S,
+  bounce: DIAL_SPRING_DEFAULT_BOUNCE,
+};
+
 export const readSpring = (raw: DialValue): SpringValue =>
-  typeof raw === "object"
+  typeof raw === "object" &&
+  raw !== null &&
+  typeof raw.visualDuration === "number" &&
+  typeof raw.bounce === "number"
     ? raw
-    : {
-        type: "spring",
-        visualDuration: DIAL_SPRING_DEFAULT_VISUAL_DURATION_S,
-        bounce: DIAL_SPRING_DEFAULT_BOUNCE,
-      };
+    : DEFAULT_SPRING;
 
 export const buildDialViewModel = (
   panels: DialPanelRuntime[],

--- a/packages/react-grab/src/components/dials-panel/view-rows.ts
+++ b/packages/react-grab/src/components/dials-panel/view-rows.ts
@@ -27,6 +27,9 @@ interface DialTitleRow {
   key: string;
   name: string;
   showDivider: boolean;
+  collapsible: boolean;
+  collapsed: boolean;
+  navIndex: number;
 }
 
 interface DialFolderRow {
@@ -235,29 +238,51 @@ export const buildDialViewModel = (
     }
   };
 
+  // A single panel needs no name - the whole panel IS that one set of dials.
+  // With multiple panels, each name becomes a collapsible group header so the
+  // sources stay visually distinct and individually foldable.
+  const showPanelHeaders = panels.length > 1;
+
+  const pushPanelHeader = (panel: DialPanelRuntime, showDivider: boolean, collapsible: boolean) => {
+    const key = `${panel.id}::group`;
+    const collapsed = collapsible && handlers.isCollapsed(key, false);
+    rows.push({
+      type: "title",
+      key,
+      name: panel.name,
+      showDivider,
+      collapsible,
+      collapsed,
+      navIndex: collapsible
+        ? pushNav({
+            adjust: (direction) => handlers.setCollapsed(key, direction < 0),
+            activate: () => handlers.setCollapsed(key, !collapsed),
+          })
+        : -1,
+    });
+    return collapsed;
+  };
+
   let renderedPanelCount = 0;
   for (const panel of panels) {
     if (normalizedQuery) {
       const matched: DialControl[] = [];
       collectMatching(panel.controls, matched);
       if (matched.length === 0) continue;
-      rows.push({
-        type: "title",
-        key: `${panel.id}::title`,
-        name: panel.name,
-        showDivider: renderedPanelCount > 0,
-      });
+      if (showPanelHeaders) pushPanelHeader(panel, renderedPanelCount > 0, false);
       for (const control of matched) {
-        if (control.kind === "spring") emitSpringRows(panel.id, control.path, 0);
-        else emitLeaf(panel.id, control, 0);
+        if (control.kind === "spring") {
+          const collapsed = pushCollapsibleHeader(panel.id, control.path, control.label, 0, false);
+          if (!collapsed) emitSpringRows(panel.id, control.path, 0);
+        } else {
+          emitLeaf(panel.id, control, 0);
+        }
       }
     } else {
-      rows.push({
-        type: "title",
-        key: `${panel.id}::title`,
-        name: panel.name,
-        showDivider: renderedPanelCount > 0,
-      });
+      if (showPanelHeaders && pushPanelHeader(panel, renderedPanelCount > 0, true)) {
+        renderedPanelCount += 1;
+        continue;
+      }
       walk(panel.id, panel.controls, 0);
     }
     renderedPanelCount += 1;
@@ -290,6 +315,7 @@ const buildLeafNavEntry = (
   }
   if (control.kind === "select") {
     const cycle = (direction: 1 | -1) => {
+      if (control.options.length === 0) return;
       const current = handlers.getValue(panelId, path);
       const value = typeof current === "string" ? current : control.default;
       const currentIndex = control.options.findIndex((option) => option.value === value);

--- a/packages/react-grab/src/components/dials-panel/view-rows.ts
+++ b/packages/react-grab/src/components/dials-panel/view-rows.ts
@@ -115,7 +115,9 @@ export const readSpring = (raw: DialValue): SpringValue =>
 export const buildDialViewModel = (
   panels: DialPanelRuntime[],
   handlers: DialViewHandlers,
+  query = "",
 ): DialViewModel => {
+  const normalizedQuery = query.trim().toLowerCase();
   const rows: DialViewRow[] = [];
   const navEntries: DialNavEntry[] = [];
 
@@ -147,6 +149,58 @@ export const buildDialViewModel = (
     return collapsed;
   };
 
+  const emitSpringRows = (panelId: string, springPath: string, depth: number) => {
+    rows.push({
+      type: "spring-viz",
+      key: `${panelId}::${springPath}::viz`,
+      depth,
+      panelId,
+      springPath,
+    });
+    for (const fieldConfig of SPRING_FIELDS) {
+      rows.push({
+        type: "spring-field",
+        key: `${panelId}::${springPath}::${fieldConfig.field}`,
+        navIndex: pushNav({
+          adjust: (direction, large) => {
+            const spring = readSpring(handlers.getValue(panelId, springPath));
+            const stepAmount = SPRING_FIELD_STEP * (large ? 4 : 1);
+            const next = Number(
+              clampToRange(
+                spring[fieldConfig.field] + direction * stepAmount,
+                fieldConfig.min,
+                fieldConfig.max,
+              ).toFixed(stepDecimals(SPRING_FIELD_STEP)),
+            );
+            if (next !== spring[fieldConfig.field]) {
+              handlers.commit(panelId, springPath, { ...spring, [fieldConfig.field]: next });
+            }
+          },
+          activate: () => {},
+        }),
+        depth,
+        panelId,
+        springPath,
+        field: fieldConfig.field,
+        label: fieldConfig.label,
+        min: fieldConfig.min,
+        max: fieldConfig.max,
+        step: SPRING_FIELD_STEP,
+      });
+    }
+  };
+
+  const emitLeaf = (panelId: string, control: DialControl, depth: number) => {
+    rows.push({
+      type: "leaf",
+      key: `${panelId}::${control.path}`,
+      navIndex: pushNav(buildLeafNavEntry(panelId, control, handlers)),
+      depth,
+      panelId,
+      control,
+    });
+  };
+
   const walk = (panelId: string, controls: DialControl[], depth: number) => {
     for (const control of controls) {
       if (control.kind === "folder") {
@@ -163,69 +217,51 @@ export const buildDialViewModel = (
 
       if (control.kind === "spring") {
         const collapsed = pushCollapsibleHeader(panelId, control.path, control.label, depth, false);
-        if (collapsed) continue;
-        const springPath = control.path;
-        rows.push({
-          type: "spring-viz",
-          key: `${panelId}::${springPath}::viz`,
-          depth: depth + 1,
-          panelId,
-          springPath,
-        });
-        for (const fieldConfig of SPRING_FIELDS) {
-          rows.push({
-            type: "spring-field",
-            key: `${panelId}::${springPath}::${fieldConfig.field}`,
-            navIndex: pushNav({
-              adjust: (direction, large) => {
-                const spring = readSpring(handlers.getValue(panelId, springPath));
-                const stepAmount = SPRING_FIELD_STEP * (large ? 4 : 1);
-                const next = Number(
-                  clampToRange(
-                    spring[fieldConfig.field] + direction * stepAmount,
-                    fieldConfig.min,
-                    fieldConfig.max,
-                  ).toFixed(stepDecimals(SPRING_FIELD_STEP)),
-                );
-                if (next !== spring[fieldConfig.field]) {
-                  handlers.commit(panelId, springPath, { ...spring, [fieldConfig.field]: next });
-                }
-              },
-              activate: () => {},
-            }),
-            depth: depth + 1,
-            panelId,
-            springPath,
-            field: fieldConfig.field,
-            label: fieldConfig.label,
-            min: fieldConfig.min,
-            max: fieldConfig.max,
-            step: SPRING_FIELD_STEP,
-          });
-        }
+        if (!collapsed) emitSpringRows(panelId, control.path, depth + 1);
         continue;
       }
 
-      rows.push({
-        type: "leaf",
-        key: `${panelId}::${control.path}`,
-        navIndex: pushNav(buildLeafNavEntry(panelId, control, handlers)),
-        depth,
-        panelId,
-        control,
-      });
+      emitLeaf(panelId, control, depth);
     }
   };
 
-  panels.forEach((panel, panelIndex) => {
-    rows.push({
-      type: "title",
-      key: `${panel.id}::title`,
-      name: panel.name,
-      showDivider: panelIndex > 0,
-    });
-    walk(panel.id, panel.controls, 0);
-  });
+  const collectMatching = (controls: DialControl[], out: DialControl[]) => {
+    for (const control of controls) {
+      if (control.kind === "folder") {
+        collectMatching(control.children, out);
+        continue;
+      }
+      if (control.label.toLowerCase().includes(normalizedQuery)) out.push(control);
+    }
+  };
+
+  let renderedPanelCount = 0;
+  for (const panel of panels) {
+    if (normalizedQuery) {
+      const matched: DialControl[] = [];
+      collectMatching(panel.controls, matched);
+      if (matched.length === 0) continue;
+      rows.push({
+        type: "title",
+        key: `${panel.id}::title`,
+        name: panel.name,
+        showDivider: renderedPanelCount > 0,
+      });
+      for (const control of matched) {
+        if (control.kind === "spring") emitSpringRows(panel.id, control.path, 0);
+        else emitLeaf(panel.id, control, 0);
+      }
+    } else {
+      rows.push({
+        type: "title",
+        key: `${panel.id}::title`,
+        name: panel.name,
+        showDivider: renderedPanelCount > 0,
+      });
+      walk(panel.id, panel.controls, 0);
+    }
+    renderedPanelCount += 1;
+  }
 
   return { rows, navEntries };
 };

--- a/packages/react-grab/src/components/edit-panel/property-list.tsx
+++ b/packages/react-grab/src/components/edit-panel/property-list.tsx
@@ -1,7 +1,6 @@
-import { createEffect, Index, Match, onCleanup, Show, Switch, type Component } from "solid-js";
+import { Index, Match, onCleanup, Show, Switch, type Component } from "solid-js";
 import type { EditableProperty } from "../../types.js";
-import { createMenuHighlight } from "../../utils/create-menu-highlight.js";
-import { getShadowActiveElement } from "../../utils/get-shadow-active-element.js";
+import { createMenuList } from "../../utils/create-menu-list.js";
 import { formatDisplayValue } from "../../utils/format-css-value.js";
 import { ActivePropertyControl } from "./active-property-control.js";
 import { narrowColor, narrowEnum, narrowNumeric } from "./narrow-property.js";
@@ -32,123 +31,36 @@ interface PropertyListProps {
 }
 
 export const PropertyList: Component<PropertyListProps> = (props) => {
-  const itemElements: (HTMLButtonElement | undefined)[] = [];
-  let listRef: HTMLDivElement | undefined;
-  // Mount-time gate: a stationary cursor + the initial reflow can fire
-  // phantom pointerenter on whatever row the mouse happens to be sitting
-  // on, yanking the active row before the user has demonstrated intent
-  // to use the mouse. Once any real pointer movement is observed, the
-  // gate is permanently open for this panel mount.
-  let didPointerMove = false;
-  let pendingHoverIndex: number | null = null;
-
-  const isHoverOwnedByFocusedInlineInput = (): boolean => {
-    if (!listRef) return false;
-    const focusedElement = getShadowActiveElement(listRef);
-    return (
-      focusedElement instanceof HTMLElement &&
-      focusedElement.matches("input[data-react-grab-input]")
-    );
-  };
-
-  const maybeActivateHoveredIndex = (propertyIndex: number, source: "enter" | "move") => {
-    if (source === "move") didPointerMove = true;
-    const isFocusLocked = isHoverOwnedByFocusedInlineInput();
-    if (!didPointerMove) return;
-    if (isFocusLocked) return;
-    if (props.isAdjusting()) {
-      pendingHoverIndex = propertyIndex;
-      return;
-    }
-    pendingHoverIndex = null;
-    if (propertyIndex === props.activeIndex) return;
-    props.onHoverIndex(propertyIndex);
-  };
-
-  createEffect(() => {
-    if (props.isAdjusting()) return;
-    const propertyIndex = pendingHoverIndex;
-    if (propertyIndex === null) return;
-    pendingHoverIndex = null;
-    const element = itemElements[propertyIndex];
-    const isFocusLocked = isHoverOwnedByFocusedInlineInput();
-    if (!didPointerMove) return;
-    if (isFocusLocked) return;
-    if (!element?.matches(":hover")) return;
-    if (propertyIndex === props.activeIndex) return;
-    props.onHoverIndex(propertyIndex);
-  });
-
-  const {
-    containerRef: highlightContainerRef,
-    highlightRef,
-    updateHighlight,
-    clearHighlight,
-  } = createMenuHighlight({});
-
-  createEffect(() => {
-    itemElements.length = props.properties.length;
-  });
-
-  let pendingHighlightFrame: number | undefined;
-  createEffect(() => {
-    const activeIndex = props.activeIndex;
-    const element = itemElements[activeIndex];
-    if (!element || activeIndex < 0) {
-      clearHighlight();
-      return;
-    }
-    updateHighlight(element);
-    if (pendingHighlightFrame !== undefined) {
-      cancelAnimationFrame(pendingHighlightFrame);
-    }
-    pendingHighlightFrame = requestAnimationFrame(() => {
-      pendingHighlightFrame = undefined;
-      const refreshed = itemElements[activeIndex];
-      if (refreshed) updateHighlight(refreshed);
-    });
-    if (!listRef) return;
-    const containerRect = listRef.getBoundingClientRect();
-    const targetRect = element.getBoundingClientRect();
-    if (targetRect.top < containerRect.top || targetRect.bottom > containerRect.bottom) {
-      element.scrollIntoView({ block: "nearest" });
-    }
-  });
-  onCleanup(() => {
-    if (pendingHighlightFrame !== undefined) cancelAnimationFrame(pendingHighlightFrame);
+  const menu = createMenuList({
+    activeIndex: () => props.activeIndex,
+    itemCount: () => props.properties.length,
+    onHoverIndex: (index) => props.onHoverIndex(index),
+    isAdjusting: () => props.isAdjusting(),
   });
 
   return (
     <div
-      ref={(element) => {
-        listRef = element;
-        highlightContainerRef(element);
-      }}
+      ref={menu.containerRef}
       role="menu"
       aria-orientation="vertical"
       aria-label="Editable properties"
       class="relative flex flex-col w-full max-h-[var(--rg-edit-list-max-h)] overflow-y-auto outline-none no-scrollbar"
-      onPointerMove={() => {
-        didPointerMove = true;
-      }}
+      onPointerMove={menu.handleListPointerMove}
     >
       <div
-        ref={highlightRef}
+        ref={menu.highlightRef}
         aria-hidden="true"
         class="pointer-events-none absolute opacity-0 transition-[top,left,width,height,opacity,border-radius] duration-75 ease-out bg-[var(--rg-surface-hover)]"
       />
       <Index each={props.properties}>
         {(property, propertyIndex) => {
           const isActive = () => propertyIndex === props.activeIndex;
+          const hover = menu.rowHoverHandlers(propertyIndex);
           return (
             <button
               ref={(element) => {
-                itemElements[propertyIndex] = element;
-                onCleanup(() => {
-                  if (itemElements[propertyIndex] === element) {
-                    itemElements[propertyIndex] = undefined;
-                  }
-                });
+                menu.registerItem(propertyIndex, element);
+                onCleanup(() => menu.registerItem(propertyIndex, undefined));
               }}
               data-react-grab-ignore-events
               data-react-grab-edit-property={property().key}
@@ -157,31 +69,10 @@ export const PropertyList: Component<PropertyListProps> = (props) => {
               role="menuitem"
               tabindex={-1}
               class="relative z-1 contain-layout block w-full h-[24px] px-0 py-0 cursor-pointer text-left border-none bg-transparent"
-              onPointerEnter={() => {
-                maybeActivateHoveredIndex(propertyIndex, "enter");
-              }}
-              onPointerMove={() => {
-                maybeActivateHoveredIndex(propertyIndex, "move");
-              }}
-              onPointerLeave={() => {
-                if (pendingHoverIndex === propertyIndex) pendingHoverIndex = null;
-              }}
-              onMouseDown={(event) => {
-                // Default focus on the clicked button would steal it from
-                // EditPanel's search input and break arrow-key tweaking.
-                // Blur any in-progress inline value input FIRST so its
-                // onBlur=>commit fires before the subsequent onClick
-                // changes activeIndex and unmounts the input (otherwise
-                // the typed draft is silently lost).
-                const focusedElement = listRef ? getShadowActiveElement(listRef) : null;
-                if (
-                  focusedElement instanceof HTMLElement &&
-                  focusedElement.matches("input[data-react-grab-input]")
-                ) {
-                  focusedElement.blur();
-                }
-                event.preventDefault();
-              }}
+              onPointerEnter={hover.onPointerEnter}
+              onPointerMove={hover.onPointerMove}
+              onPointerLeave={hover.onPointerLeave}
+              onMouseDown={menu.handleRowMouseDown}
               onClick={(event) => {
                 event.stopPropagation();
                 props.onSelect(propertyIndex);

--- a/packages/react-grab/src/components/edit-panel/value-stepper.tsx
+++ b/packages/react-grab/src/components/edit-panel/value-stepper.tsx
@@ -29,6 +29,7 @@ interface ValueStepperProps {
   onInvalidCommit?: () => void;
   onInteract?: () => void;
   emphasized?: boolean;
+  baseTrack?: boolean;
   tailwindLabel?: string | null;
 }
 
@@ -246,7 +247,7 @@ export const ValueStepper: Component<ValueStepperProps> = (props) => {
         onPointerCancel={releaseDrag}
         onLostPointerCapture={releaseDrag}
       >
-        <Show when={props.emphasized}>
+        <Show when={props.emphasized || props.baseTrack}>
           <div
             data-react-grab-slider-base
             aria-hidden="true"

--- a/packages/react-grab/src/components/renderer.tsx
+++ b/packages/react-grab/src/components/renderer.tsx
@@ -14,6 +14,7 @@ import { SelectionLabel } from "./selection-label/index.js";
 import { Toolbar } from "./toolbar/index.js";
 import { ContextMenu } from "./context-menu.js";
 import { EditPanel } from "./edit-panel/index.js";
+import { DialsPanel } from "./dials-panel/index.js";
 import { ToolbarMenu } from "./toolbar/toolbar-menu.js";
 
 export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
@@ -153,6 +154,7 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
           onSelectHoverChange={props.onToolbarSelectHoverChange}
           onContainerRef={props.onToolbarRef}
           onToggleToolbarMenu={props.onToggleToolbarMenu}
+          onFadeInComplete={props.onToolbarFadeInComplete}
         />
       </Show>
       <ContextMenu
@@ -180,6 +182,14 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
         onSubmit={props.onEditPanelSubmit ?? (() => {})}
         onPendingEditsChange={props.onEditPanelPendingEditsChange}
         onInteractingChange={props.onEditPanelInteractingChange}
+      />
+      <DialsPanel
+        panels={props.dialsPanels ?? []}
+        position={props.dialsPanelPosition ?? null}
+        onCommit={props.onDialCommit ?? (() => {})}
+        onTriggerAction={props.onDialTriggerAction ?? (() => {})}
+        onInteract={() => {}}
+        onDismiss={props.onDialsPanelDismiss ?? (() => {})}
       />
     </>
   );

--- a/packages/react-grab/src/components/toolbar/index.tsx
+++ b/packages/react-grab/src/components/toolbar/index.tsx
@@ -9,6 +9,7 @@ import { ToolbarActionButton } from "./toolbar-action-button.jsx";
 import {
   TOOLBAR_SNAP_MARGIN_PX,
   TOOLBAR_FADE_IN_DELAY_MS,
+  TOOLBAR_FADE_IN_TRANSITION_MS,
   TOOLBAR_COLLAPSE_ANIMATION_DURATION_MS,
   TOOLBAR_DEFAULT_WIDTH_PX,
   TOOLBAR_DEFAULT_HEIGHT_PX,
@@ -49,6 +50,7 @@ interface ToolbarProps {
   onSelectHoverChange?: (isHovered: boolean) => void;
   onContainerRef?: (element: HTMLDivElement) => void;
   onToggleToolbarMenu?: () => void;
+  onFadeInComplete?: () => void;
 }
 
 interface FreezeHandlersOptions {
@@ -548,12 +550,17 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
       onCleanup(() => observer.disconnect());
     }
 
+    let fadeCompleteTimeout: ReturnType<typeof setTimeout> | undefined;
     const fadeInTimeout = setTimeout(() => {
       setIsVisible(true);
+      fadeCompleteTimeout = setTimeout(() => {
+        props.onFadeInComplete?.();
+      }, TOOLBAR_FADE_IN_TRANSITION_MS);
     }, TOOLBAR_FADE_IN_DELAY_MS);
 
     onCleanup(() => {
       clearTimeout(fadeInTimeout);
+      clearTimeout(fadeCompleteTimeout);
     });
   });
 

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -142,6 +142,10 @@ export const DEV_TOOLS_OVERLAY_Z_INDEX_THRESHOLD = 2147483600;
 
 export const TOOLBAR_SNAP_MARGIN_PX = 16;
 export const TOOLBAR_FADE_IN_DELAY_MS = 500;
+// Must match the `duration-400` opacity transition in the toolbar's default
+// getTransitionClass(): consumers (e.g. the dials panel) wait this long after
+// the fade-in starts before treating the toolbar as fully visible.
+export const TOOLBAR_FADE_IN_TRANSITION_MS = 400;
 export const TOOLBAR_SNAP_ANIMATION_DURATION_MS = 300;
 export const TOOLBAR_DRAG_THRESHOLD_PX = 5;
 export const TOOLBAR_VELOCITY_MULTIPLIER_MS = 150;
@@ -219,6 +223,16 @@ export const EDIT_TRANSPARENT_COLOR_LABEL = "transparent";
 export const EDIT_ROOT_FONT_SIZE_PX = 16;
 export const EDIT_PANEL_MIN_WIDTH_PX = 200;
 export const EDIT_PANEL_MAX_WIDTH_PX = 320;
+
+export const DIAL_PANEL_MIN_WIDTH_PX = 220;
+export const DIAL_PANEL_MAX_WIDTH_PX = 300;
+export const DIAL_PANEL_MAX_HEIGHT_PX = 420;
+export const DIAL_SPRING_DEFAULT_VISUAL_DURATION_S = 0.5;
+export const DIAL_SPRING_DEFAULT_BOUNCE = 0.2;
+export const DIAL_SPRING_VISUAL_DURATION_MIN_S = 0.1;
+export const DIAL_SPRING_VISUAL_DURATION_MAX_S = 1;
+export const DIAL_SPRING_BOUNCE_MIN = 0;
+export const DIAL_SPRING_BOUNCE_MAX = 1;
 export const EDIT_SHIFT_STEP_MULTIPLIER = 10;
 // Idle window after the last control-interact pulse before the
 // transient-interaction signal clears. Must comfortably exceed the

--- a/packages/react-grab/src/core/dials-registry.ts
+++ b/packages/react-grab/src/core/dials-registry.ts
@@ -114,7 +114,10 @@ export const createDialsRegistry = (): DialsRegistry => {
     }
     listeners.add(callback);
     return () => {
-      listeners?.delete(callback);
+      const current = listenersById.get(id);
+      if (!current) return;
+      current.delete(callback);
+      if (current.size === 0) listenersById.delete(id);
     };
   };
 

--- a/packages/react-grab/src/core/dials-registry.ts
+++ b/packages/react-grab/src/core/dials-registry.ts
@@ -79,6 +79,7 @@ export const createDialsRegistry = (): DialsRegistry => {
     setStore("panels", (panels) => panels.filter((panel) => panel.id !== id));
     snapshotById.delete(id);
     defaultsById.delete(id);
+    listenersById.delete(id);
   };
 
   const setValue = (id: string, path: string, value: DialValue) => {

--- a/packages/react-grab/src/core/dials-registry.ts
+++ b/packages/react-grab/src/core/dials-registry.ts
@@ -1,0 +1,136 @@
+import { createStore } from "solid-js/store";
+import type { DialPanelInput, DialPanelRuntime, DialValue } from "../types.js";
+import { collectDialDefaults } from "../utils/resolve-dial-values.js";
+
+interface DialsStoreState {
+  panels: DialPanelRuntime[];
+}
+
+export interface DialsRegistry {
+  store: DialsStoreState;
+  register: (panel: DialPanelInput) => () => void;
+  unregister: (id: string) => void;
+  setValue: (id: string, path: string, value: DialValue) => void;
+  setValues: (id: string, values: Record<string, DialValue>) => void;
+  reset: (id: string) => void;
+  getValues: (id: string) => Record<string, DialValue> | null;
+  subscribe: (id: string, callback: () => void) => () => void;
+  triggerAction: (id: string, path: string) => void;
+}
+
+export const createDialsRegistry = (): DialsRegistry => {
+  const [store, setStore] = createStore<DialsStoreState>({ panels: [] });
+  // React reads these immutable snapshots via useSyncExternalStore. The Solid
+  // store mutates valuesByPath in place (so its proxy keeps a stable identity
+  // for fine-grained UI reactivity), which would never trip React's snapshot
+  // equality - so a fresh plain object is published here on every change.
+  const snapshotById = new Map<string, Record<string, DialValue>>();
+  const listenersById = new Map<string, Set<() => void>>();
+  const defaultsById = new Map<string, Record<string, DialValue>>();
+
+  const indexOf = (id: string): number => store.panels.findIndex((panel) => panel.id === id);
+
+  const notify = (id: string) => {
+    const listeners = listenersById.get(id);
+    if (!listeners) return;
+    for (const listener of listeners) listener();
+  };
+
+  const publishSnapshot = (id: string, values: Record<string, DialValue>) => {
+    snapshotById.set(id, { ...values });
+    notify(id);
+  };
+
+  const register = (panel: DialPanelInput): (() => void) => {
+    const defaults = collectDialDefaults(panel.controls);
+    defaultsById.set(panel.id, defaults);
+    const existingIndex = indexOf(panel.id);
+    const previousValues =
+      existingIndex >= 0 ? store.panels[existingIndex].valuesByPath : undefined;
+
+    // Config merge: keep current values for paths that survive, drop removed.
+    const mergedValues: Record<string, DialValue> = {};
+    for (const path of Object.keys(defaults)) {
+      mergedValues[path] =
+        previousValues && path in previousValues ? previousValues[path] : defaults[path];
+    }
+
+    const runtime: DialPanelRuntime = {
+      id: panel.id,
+      name: panel.name,
+      controls: panel.controls,
+      valuesByPath: mergedValues,
+      onAction: panel.onAction,
+    };
+
+    if (existingIndex >= 0) {
+      setStore("panels", existingIndex, runtime);
+    } else {
+      setStore("panels", store.panels.length, runtime);
+    }
+    publishSnapshot(panel.id, mergedValues);
+
+    return () => unregister(panel.id);
+  };
+
+  const unregister = (id: string) => {
+    const existingIndex = indexOf(id);
+    if (existingIndex < 0) return;
+    setStore("panels", (panels) => panels.filter((panel) => panel.id !== id));
+    snapshotById.delete(id);
+    defaultsById.delete(id);
+  };
+
+  const setValue = (id: string, path: string, value: DialValue) => {
+    const existingIndex = indexOf(id);
+    if (existingIndex < 0) return;
+    setStore("panels", existingIndex, "valuesByPath", path, value);
+    publishSnapshot(id, store.panels[existingIndex].valuesByPath);
+  };
+
+  const setValues = (id: string, values: Record<string, DialValue>) => {
+    const existingIndex = indexOf(id);
+    if (existingIndex < 0) return;
+    for (const path of Object.keys(values)) {
+      setStore("panels", existingIndex, "valuesByPath", path, values[path]);
+    }
+    publishSnapshot(id, store.panels[existingIndex].valuesByPath);
+  };
+
+  const reset = (id: string) => {
+    const defaults = defaultsById.get(id);
+    if (!defaults) return;
+    setValues(id, defaults);
+  };
+
+  const getValues = (id: string): Record<string, DialValue> | null => snapshotById.get(id) ?? null;
+
+  const subscribe = (id: string, callback: () => void): (() => void) => {
+    let listeners = listenersById.get(id);
+    if (!listeners) {
+      listeners = new Set();
+      listenersById.set(id, listeners);
+    }
+    listeners.add(callback);
+    return () => {
+      listeners?.delete(callback);
+    };
+  };
+
+  const triggerAction = (id: string, path: string) => {
+    const panel = store.panels[indexOf(id)];
+    panel?.onAction?.(path);
+  };
+
+  return {
+    store,
+    register,
+    unregister,
+    setValue,
+    setValues,
+    reset,
+    getValues,
+    subscribe,
+    triggerAction,
+  };
+};

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -112,6 +112,7 @@ import type {
   ElementLabelVariant,
 } from "../types.js";
 import { createEditModeController, type EditModeOverrides } from "./edit-mode.js";
+import { createDialsRegistry } from "./dials-registry.js";
 import { createPluginRegistry } from "./plugin-registry.js";
 import { createLabelController } from "./label-controller.js";
 import { createArrowNavigator } from "./arrow-navigation.js";
@@ -305,6 +306,11 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     const [isToolbarSelectHovered, setIsToolbarSelectHovered] = createSignal(false);
     const [toolbarMenuPosition, setToolbarMenuPosition] = createSignal<DropdownAnchor | null>(null);
     const [editPanelPosition, setEditPanelPosition] = createSignal<DropdownAnchor | null>(null);
+    const [dialsPanelPosition, setDialsPanelPosition] = createSignal<DropdownAnchor | null>(null);
+    const [isDialsPanelOpen, setIsDialsPanelOpen] = createSignal(true);
+    const [isToolbarFadedIn, setIsToolbarFadedIn] = createSignal(false);
+    const dialsRegistry = createDialsRegistry();
+    let stopDialsPanelTracking: (() => void) | null = null;
     // Forward-ref wrappers because activateRenderer / deactivateRenderer /
     // performCopyWithLabel are declared later in this scope. The wrappers
     // are captured by the controller; the underlying lookups happen at
@@ -1548,6 +1554,13 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
 
     const handleActivateAction = (actionId: string) => {
+      // The Style button doubles as the dials panel toggle whenever a
+      // useReactGrab() panel is registered, so the dials live under the
+      // same affordance as element styling.
+      if (actionId === EDIT_ACTION_ID && dialsRegistry.store.panels.length > 0) {
+        setIsDialsPanelOpen((open) => !open);
+        return;
+      }
       if (isActivated()) {
         // While still choosing an element, clicking a different action switches
         // the pending action in place instead of tearing down selection mode;
@@ -2447,7 +2460,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       const targetElement = target instanceof HTMLElement ? target : null;
       return Boolean(
         targetElement?.closest("[data-react-grab-discard-copy]") ||
-          targetElement?.closest("[data-react-grab-discard-yes]"),
+        targetElement?.closest("[data-react-grab-discard-yes]"),
       );
     };
 
@@ -3597,6 +3610,40 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       updateToolbarState({ defaultAction: actionId });
     };
 
+    const handleDialsPanelDismiss = () => {
+      setIsDialsPanelOpen(false);
+    };
+
+    // The dials panel is non-modal and anchors to the toolbar like the other
+    // dropdowns, but it stays open on load instead of being triggered by a
+    // grab. It yields whenever a modal popover (edit/context/toolbar menu)
+    // takes over the same anchor.
+    const shouldShowDialsPanel = createMemo(
+      () =>
+        isDialsPanelOpen() &&
+        isToolbarFadedIn() &&
+        dialsRegistry.store.panels.length > 0 &&
+        isEnabled() &&
+        !editMode.isOpen() &&
+        store.contextMenuPosition === null &&
+        toolbarMenuPosition() === null,
+    );
+
+    createEffect(() => {
+      if (shouldShowDialsPanel()) {
+        if (!stopDialsPanelTracking) {
+          stopDialsPanelTracking = trackDropdownPosition(
+            computeDropdownAnchor,
+            setDialsPanelPosition,
+          );
+        }
+      } else {
+        stopDialsPanelTracking?.();
+        stopDialsPanelTracking = null;
+        setDialsPanelPosition(null);
+      }
+    });
+
     const handleShowContextMenuInstance = (instanceId: string) => {
       const instance = store.labelInstances.find(
         (labelInstance) => labelInstance.id === instanceId,
@@ -3747,6 +3794,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
                 defaultActionId={currentToolbarState()?.defaultAction ?? DEFAULT_ACTION_ID}
                 onSetDefaultAction={handleSetDefaultAction}
                 onToggleToolbarMenu={handleToggleToolbarMenu}
+                onToolbarFadeInComplete={() => setIsToolbarFadedIn(true)}
                 onToolbarMenuDismiss={dismissToolbarMenu}
                 editPanelState={editMode.state()}
                 editPanelPosition={editPanelPosition()}
@@ -3754,6 +3802,11 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
                 onEditPanelSubmit={editMode.submit}
                 onEditPanelPendingEditsChange={editMode.setPendingEdits}
                 onEditPanelInteractingChange={editMode.setInteracting}
+                dialsPanels={dialsRegistry.store.panels}
+                dialsPanelPosition={dialsPanelPosition()}
+                onDialCommit={dialsRegistry.setValue}
+                onDialTriggerAction={dialsRegistry.triggerAction}
+                onDialsPanelDismiss={handleDialsPanelDismiss}
               />
             );
           }, rendererRoot);
@@ -3876,6 +3929,16 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       },
       getPlugins: () => pluginRegistry.getPluginNames(),
       getDisplayName: getComponentDisplayName,
+      registerDials: (panel) => {
+        const dispose = dialsRegistry.register(panel);
+        setIsDialsPanelOpen(true);
+        return dispose;
+      },
+      updateDialValue: dialsRegistry.setValue,
+      updateDialValues: dialsRegistry.setValues,
+      resetDials: dialsRegistry.reset,
+      getDialValues: dialsRegistry.getValues,
+      subscribeDials: dialsRegistry.subscribe,
     };
 
     for (const plugin of builtInPlugins) {

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -3643,6 +3643,10 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         setDialsPanelPosition(null);
       }
     });
+    onCleanup(() => {
+      stopDialsPanelTracking?.();
+      stopDialsPanelTracking = null;
+    });
 
     const handleShowContextMenuInstance = (instanceId: string) => {
       const instance = store.labelInstances.find(

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -3930,8 +3930,11 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       getPlugins: () => pluginRegistry.getPluginNames(),
       getDisplayName: getComponentDisplayName,
       registerDials: (panel) => {
+        const isNewPanel = dialsRegistry.getValues(panel.id) === null;
         const dispose = dialsRegistry.register(panel);
-        setIsDialsPanelOpen(true);
+        // Only auto-open on first registration; a config/name change re-registers
+        // the same panel and must not reopen one the user explicitly dismissed.
+        if (isNewPanel) setIsDialsPanelOpen(true);
         return dispose;
       },
       updateDialValue: dialsRegistry.setValue,

--- a/packages/react-grab/src/core/noop-api.ts
+++ b/packages/react-grab/src/core/noop-api.ts
@@ -36,4 +36,10 @@ export const createNoopApi = (): ReactGrabAPI => ({
   unregisterPlugin: NOOP,
   getPlugins: () => [],
   getDisplayName: () => null,
+  registerDials: () => NOOP,
+  updateDialValue: NOOP,
+  updateDialValues: NOOP,
+  resetDials: NOOP,
+  getDialValues: () => null,
+  subscribeDials: () => NOOP,
 });

--- a/packages/react-grab/src/react.ts
+++ b/packages/react-grab/src/react.ts
@@ -58,13 +58,20 @@ const useDials = <C extends DialConfig>(
 
   const onActionRef = useRef(options?.onAction);
   onActionRef.current = options?.onAction;
+  const nameRef = useRef(name);
+  nameRef.current = name;
+  const controlsRef = useRef(controls);
+  controlsRef.current = controls;
 
+  // Register on mount, unregister on unmount. Keyed on the stable id alone so a
+  // name/config change never tears the panel down - the registry merges and
+  // preserves existing values only when the panel is still registered.
   useEffect(() => {
     const register = (api: ReactGrabAPI): (() => void) =>
       api.registerDials({
         id,
-        name,
-        controls,
+        name: nameRef.current,
+        controls: controlsRef.current,
         onAction: (path) => onActionRef.current?.(path),
       });
 
@@ -86,14 +93,44 @@ const useDials = <C extends DialConfig>(
       window.removeEventListener("react-grab:init", handleInit);
       dispose?.();
     };
+  }, [id]);
+
+  // Sync name/controls changes by re-registering (merge-preserving) without
+  // unregistering first, so values survive and a dismissed panel stays closed.
+  const didMountRef = useRef(false);
+  useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
+    getApi()?.registerDials({
+      id,
+      name,
+      controls,
+      onAction: (path) => onActionRef.current?.(path),
+    });
   }, [id, name, controls]);
 
   const subscribe = useCallback(
     (onStoreChange: () => void): (() => void) => {
       const api = getApi();
       if (api) return api.subscribeDials(id, onStoreChange);
-      window.addEventListener("react-grab:init", onStoreChange);
-      return () => window.removeEventListener("react-grab:init", onStoreChange);
+
+      // Mounted before react-grab booted: bridge to the live store once it is
+      // ready (and notify), otherwise post-init value changes never re-render.
+      let unsubscribe: (() => void) | undefined;
+      const handleInit = () => {
+        const readyApi = getApi();
+        if (!readyApi) return;
+        window.removeEventListener("react-grab:init", handleInit);
+        unsubscribe = readyApi.subscribeDials(id, onStoreChange);
+        onStoreChange();
+      };
+      window.addEventListener("react-grab:init", handleInit);
+      return () => {
+        window.removeEventListener("react-grab:init", handleInit);
+        unsubscribe?.();
+      };
     },
     [id],
   );

--- a/packages/react-grab/src/react.ts
+++ b/packages/react-grab/src/react.ts
@@ -1,4 +1,7 @@
-import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+// Shim resolves to React's built-in on 18+ and a userland impl on 17, keeping
+// the `react-grab/react` entry safe for the package's `react >=17` peer range.
+import { useSyncExternalStore } from "use-sync-external-store/shim";
 import type {
   DialConfig,
   DialControl,

--- a/packages/react-grab/src/react.ts
+++ b/packages/react-grab/src/react.ts
@@ -1,0 +1,168 @@
+import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from "react";
+import type {
+  DialConfig,
+  DialControl,
+  DialValue,
+  ReactGrabAPI,
+  ResolvedDialValues,
+} from "./types.js";
+import { resolveDialConfig } from "./utils/resolve-dial-config.js";
+import { collectDialDefaults, resolveDialValues } from "./utils/resolve-dial-values.js";
+
+declare global {
+  interface Window {
+    __REACT_GRAB__?: ReactGrabAPI;
+  }
+}
+
+export interface UseReactGrabOptions {
+  id?: string;
+  onAction?: (path: string) => void;
+}
+
+export interface ReactGrabController<C extends DialConfig> {
+  values: ResolvedDialValues<C>;
+  setValue: (path: string, value: DialValue) => void;
+  setValues: (partial: Record<string, DialValue>) => void;
+  resetValues: () => void;
+  getValues: () => ResolvedDialValues<C>;
+}
+
+let autoIdCounter = 0;
+
+const getApi = (): ReactGrabAPI | null => {
+  if (typeof window === "undefined") return null;
+  return window.__REACT_GRAB__ ?? null;
+};
+
+interface DialsHandle<C extends DialConfig> {
+  id: string;
+  controls: DialControl[];
+  values: ResolvedDialValues<C>;
+}
+
+const useDials = <C extends DialConfig>(
+  name: string,
+  config: C,
+  options?: UseReactGrabOptions,
+): DialsHandle<C> => {
+  const idRef = useRef<string | null>(null);
+  if (idRef.current === null) {
+    idRef.current = options?.id ?? `${name}-${++autoIdCounter}`;
+  }
+  const id = idRef.current;
+
+  const signature = useMemo(() => JSON.stringify(config), [config]);
+  const controls = useMemo(() => resolveDialConfig(config), [signature]);
+  const defaultSnapshot = useMemo(() => collectDialDefaults(controls), [controls]);
+
+  const onActionRef = useRef(options?.onAction);
+  onActionRef.current = options?.onAction;
+
+  useEffect(() => {
+    const register = (api: ReactGrabAPI): (() => void) =>
+      api.registerDials({
+        id,
+        name,
+        controls,
+        onAction: (path) => onActionRef.current?.(path),
+      });
+
+    const api = getApi();
+    if (api) return register(api);
+
+    // react-grab can finish booting after this component mounts.
+    let disposed = false;
+    let dispose: (() => void) | undefined;
+    const handleInit = () => {
+      const readyApi = getApi();
+      if (!readyApi || disposed) return;
+      dispose = register(readyApi);
+      window.removeEventListener("react-grab:init", handleInit);
+    };
+    window.addEventListener("react-grab:init", handleInit);
+    return () => {
+      disposed = true;
+      window.removeEventListener("react-grab:init", handleInit);
+      dispose?.();
+    };
+  }, [id, name, controls]);
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void): (() => void) => {
+      const api = getApi();
+      if (api) return api.subscribeDials(id, onStoreChange);
+      window.addEventListener("react-grab:init", onStoreChange);
+      return () => window.removeEventListener("react-grab:init", onStoreChange);
+    },
+    [id],
+  );
+
+  const getSnapshot = useCallback(
+    (): Record<string, DialValue> => getApi()?.getDialValues(id) ?? defaultSnapshot,
+    [id, defaultSnapshot],
+  );
+
+  const flatValues = useSyncExternalStore(subscribe, getSnapshot, () => defaultSnapshot);
+
+  const values = useMemo(
+    () => resolveDialValues(controls, flatValues) as ResolvedDialValues<C>,
+    [controls, flatValues],
+  );
+
+  return { id, controls, values };
+};
+
+export const useReactGrab = <C extends DialConfig>(
+  name: string,
+  config: C,
+  options?: UseReactGrabOptions,
+): ResolvedDialValues<C> => useDials(name, config, options).values;
+
+const flattenPartial = (
+  controls: DialControl[],
+  partial: Record<string, unknown>,
+): Record<string, DialValue> => {
+  const flat: Record<string, DialValue> = {};
+  for (const control of controls) {
+    if (!(control.key in partial)) continue;
+    const next = partial[control.key];
+    if (control.kind === "folder") {
+      if (next && typeof next === "object") {
+        Object.assign(flat, flattenPartial(control.children, next as Record<string, unknown>));
+      }
+    } else if (control.kind !== "action") {
+      flat[control.path] = next as DialValue;
+    }
+  }
+  return flat;
+};
+
+export const useReactGrabController = <C extends DialConfig>(
+  name: string,
+  config: C,
+  options?: UseReactGrabOptions,
+): ReactGrabController<C> => {
+  const { id, controls, values } = useDials(name, config, options);
+
+  const setValue = useCallback(
+    (path: string, value: DialValue) => getApi()?.updateDialValue(id, path, value),
+    [id],
+  );
+  const setValues = useCallback(
+    (partial: Record<string, DialValue>) =>
+      getApi()?.updateDialValues(id, flattenPartial(controls, partial)),
+    [id, controls],
+  );
+  const resetValues = useCallback(() => getApi()?.resetDials(id), [id]);
+  const getValues = useCallback(
+    () =>
+      resolveDialValues(
+        controls,
+        getApi()?.getDialValues(id) ?? collectDialDefaults(controls),
+      ) as ResolvedDialValues<C>,
+    [id, controls],
+  );
+
+  return { values, setValue, setValues, resetValues, getValues };
+};

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -438,6 +438,192 @@ export interface ReactGrabAPI {
   unregisterPlugin: (name: string) => void;
   getPlugins: () => string[];
   getDisplayName: (element: Element) => string | null;
+  registerDials: (panel: DialPanelInput) => () => void;
+  updateDialValue: (id: string, path: string, value: DialValue) => void;
+  updateDialValues: (id: string, values: Record<string, DialValue>) => void;
+  resetDials: (id: string) => void;
+  getDialValues: (id: string) => Record<string, DialValue> | null;
+  subscribeDials: (id: string, callback: () => void) => () => void;
+}
+
+export interface SpringValue {
+  type: "spring";
+  visualDuration: number;
+  bounce: number;
+}
+
+export type DialValue = number | string | boolean | SpringValue;
+
+export interface DialNumberConfig {
+  type: "number";
+  default: number;
+  min?: number;
+  max?: number;
+  step?: number;
+}
+
+export interface DialColorConfig {
+  type: "color";
+  default: string;
+}
+
+export interface DialToggleConfig {
+  type: "toggle";
+  default: boolean;
+}
+
+export interface DialTextConfig {
+  type: "text";
+  default?: string;
+  placeholder?: string;
+}
+
+export interface DialSelectConfig {
+  type: "select";
+  options: ReadonlyArray<string | { value: string; label: string }>;
+  default?: string;
+}
+
+export interface DialSpringConfig {
+  type: "spring";
+  visualDuration?: number;
+  bounce?: number;
+}
+
+export interface DialActionConfig {
+  type: "action";
+  label?: string;
+}
+
+export type DialControlConfig =
+  | number
+  | readonly [number, number, number]
+  | readonly [number, number, number, number]
+  | boolean
+  | string
+  | DialNumberConfig
+  | DialColorConfig
+  | DialToggleConfig
+  | DialTextConfig
+  | DialSelectConfig
+  | DialSpringConfig
+  | DialActionConfig
+  | DialConfig;
+
+export interface DialConfig {
+  [key: string]: DialControlConfig | boolean | undefined;
+  _collapsed?: boolean;
+}
+
+export type ResolvedDialValue<T> = T extends number
+  ? number
+  : T extends readonly number[]
+    ? number
+    : T extends boolean
+      ? boolean
+      : T extends DialNumberConfig
+        ? number
+        : T extends DialToggleConfig
+          ? boolean
+          : T extends DialColorConfig | DialTextConfig | DialSelectConfig
+            ? string
+            : T extends DialSpringConfig
+              ? SpringValue
+              : T extends DialActionConfig
+                ? never
+                : T extends string
+                  ? string
+                  : T extends DialConfig
+                    ? ResolvedDialValues<T>
+                    : never;
+
+export type ResolvedDialValues<C> = {
+  [K in keyof C as C[K] extends DialActionConfig
+    ? never
+    : K extends "_collapsed"
+      ? never
+      : K]: ResolvedDialValue<C[K]>;
+};
+
+export interface DialEnumOption {
+  value: string;
+  label: string;
+}
+
+interface DialControlBase {
+  key: string;
+  path: string;
+  label: string;
+}
+
+export interface DialNumberControl extends DialControlBase {
+  kind: "number";
+  default: number;
+  min: number;
+  max: number;
+  step: number;
+}
+
+export interface DialColorControl extends DialControlBase {
+  kind: "color";
+  default: string;
+}
+
+export interface DialSelectControl extends DialControlBase {
+  kind: "select";
+  default: string;
+  options: DialEnumOption[];
+}
+
+export interface DialToggleControl extends DialControlBase {
+  kind: "toggle";
+  default: boolean;
+}
+
+export interface DialTextControl extends DialControlBase {
+  kind: "text";
+  default: string;
+  placeholder?: string;
+}
+
+export interface DialSpringControl extends DialControlBase {
+  kind: "spring";
+  default: SpringValue;
+}
+
+export interface DialActionControl extends DialControlBase {
+  kind: "action";
+}
+
+export interface DialFolderControl extends DialControlBase {
+  kind: "folder";
+  collapsed: boolean;
+  children: DialControl[];
+}
+
+export type DialControl =
+  | DialNumberControl
+  | DialColorControl
+  | DialSelectControl
+  | DialToggleControl
+  | DialTextControl
+  | DialSpringControl
+  | DialActionControl
+  | DialFolderControl;
+
+export interface DialPanelInput {
+  id: string;
+  name: string;
+  controls: DialControl[];
+  onAction?: (path: string) => void;
+}
+
+export interface DialPanelRuntime {
+  id: string;
+  name: string;
+  controls: DialControl[];
+  valuesByPath: Record<string, DialValue>;
+  onAction?: (path: string) => void;
 }
 
 export interface OverlayBounds {
@@ -539,6 +725,7 @@ export interface ReactGrabRendererProps {
   defaultActionId?: string;
   onSetDefaultAction?: (actionId: string) => void;
   onToggleToolbarMenu?: () => void;
+  onToolbarFadeInComplete?: () => void;
   onToolbarMenuDismiss?: () => void;
   editPanelState?: EditPanelState | null;
   editPanelPosition?: DropdownAnchor | null;
@@ -546,6 +733,11 @@ export interface ReactGrabRendererProps {
   onEditPanelSubmit?: (pendingEdits: PendingEdits) => void;
   onEditPanelPendingEditsChange?: (pendingEdits: PendingEdits) => void;
   onEditPanelInteractingChange?: (interacting: boolean) => void;
+  dialsPanels?: DialPanelRuntime[];
+  dialsPanelPosition?: DropdownAnchor | null;
+  onDialCommit?: (id: string, path: string, value: DialValue) => void;
+  onDialTriggerAction?: (id: string, path: string) => void;
+  onDialsPanelDismiss?: () => void;
 }
 
 export interface GrabbedBox {

--- a/packages/react-grab/src/utils/create-menu-list.ts
+++ b/packages/react-grab/src/utils/create-menu-list.ts
@@ -1,0 +1,167 @@
+import { createEffect, onCleanup } from "solid-js";
+import { createMenuHighlight } from "./create-menu-highlight.js";
+import { getShadowActiveElement } from "./get-shadow-active-element.js";
+
+interface MenuListOptions {
+  activeIndex: () => number;
+  itemCount: () => number;
+  onHoverIndex: (index: number) => void;
+  isAdjusting?: () => boolean;
+}
+
+interface MenuRowHoverHandlers {
+  onPointerEnter: (event: PointerEvent) => void;
+  onPointerMove: (event: PointerEvent) => void;
+  onPointerLeave: () => void;
+}
+
+interface MenuListController {
+  containerRef: (element: HTMLElement | undefined) => void;
+  highlightRef: (element: HTMLElement) => void;
+  registerItem: (index: number, element: HTMLElement | undefined) => void;
+  rowHoverHandlers: (index: number) => MenuRowHoverHandlers;
+  handleListPointerMove: (event: PointerEvent) => void;
+  handleRowMouseDown: (event: MouseEvent) => void;
+}
+
+// Shared vertical menu navigation for the dials and style panels: the active
+// row highlight follower, scroll-into-view, and pointer-hover activation. A
+// stationary cursor lies about intent in two ways: (1) the mount-time reflow
+// fires a phantom pointerenter on whatever row sits under the mouse before any
+// real movement, and (2) keyboard navigation swapping the active row's content
+// fires a phantom pointerenter on the row under the cursor, yanking the
+// selection back. We track the cursor position seen on REAL pointermove events
+// and ignore any enter/move whose coordinates have not changed since — the
+// only events at the settled position are synthetic. The position is recorded
+// on `move` only (never `enter`) so a genuine single mouse-move, which fires
+// `enter` then `move` at the same coordinates, still activates via its `move`.
+export const createMenuList = (options: MenuListOptions): MenuListController => {
+  const itemElements: (HTMLElement | undefined)[] = [];
+  let listRef: HTMLElement | undefined;
+  let didPointerMove = false;
+  let pendingHoverIndex: number | null = null;
+  let lastPointerX = Number.NaN;
+  let lastPointerY = Number.NaN;
+
+  const isHoverOwnedByFocusedInlineInput = (): boolean => {
+    if (!listRef) return false;
+    const focusedElement = getShadowActiveElement(listRef);
+    return (
+      focusedElement instanceof HTMLElement &&
+      focusedElement.matches("input[data-react-grab-input]")
+    );
+  };
+
+  const isSettledPosition = (event: PointerEvent): boolean =>
+    event.clientX === lastPointerX && event.clientY === lastPointerY;
+
+  const maybeActivateHoveredIndex = (
+    index: number,
+    source: "enter" | "move",
+    event: PointerEvent,
+  ) => {
+    if (source === "move") {
+      if (isSettledPosition(event)) return;
+      didPointerMove = true;
+    } else if (!didPointerMove || isSettledPosition(event)) {
+      // Enter only counts once the user has actually moved, and never at the
+      // settled position — a content swap re-firing enter under the cursor is
+      // exactly that phantom we must drop, or it yanks back keyboard nav.
+      return;
+    }
+    lastPointerX = event.clientX;
+    lastPointerY = event.clientY;
+    if (isHoverOwnedByFocusedInlineInput()) return;
+    if (options.isAdjusting?.()) {
+      pendingHoverIndex = index;
+      return;
+    }
+    pendingHoverIndex = null;
+    if (index === options.activeIndex()) return;
+    options.onHoverIndex(index);
+  };
+
+  createEffect(() => {
+    if (options.isAdjusting?.()) return;
+    const index = pendingHoverIndex;
+    if (index === null) return;
+    pendingHoverIndex = null;
+    const element = itemElements[index];
+    if (!didPointerMove) return;
+    if (isHoverOwnedByFocusedInlineInput()) return;
+    if (!element?.matches(":hover")) return;
+    if (index === options.activeIndex()) return;
+    options.onHoverIndex(index);
+  });
+
+  const {
+    containerRef: highlightContainerRef,
+    highlightRef,
+    updateHighlight,
+    clearHighlight,
+  } = createMenuHighlight({});
+
+  createEffect(() => {
+    itemElements.length = options.itemCount();
+  });
+
+  let pendingHighlightFrame: number | undefined;
+  createEffect(() => {
+    const activeIndex = options.activeIndex();
+    const element = activeIndex < 0 ? undefined : itemElements[activeIndex];
+    if (!element) {
+      clearHighlight();
+      return;
+    }
+    updateHighlight(element);
+    if (pendingHighlightFrame !== undefined) cancelAnimationFrame(pendingHighlightFrame);
+    pendingHighlightFrame = requestAnimationFrame(() => {
+      pendingHighlightFrame = undefined;
+      const refreshed = itemElements[activeIndex];
+      if (refreshed) updateHighlight(refreshed);
+    });
+    if (!listRef) return;
+    const containerRect = listRef.getBoundingClientRect();
+    const targetRect = element.getBoundingClientRect();
+    if (targetRect.top < containerRect.top || targetRect.bottom > containerRect.bottom) {
+      element.scrollIntoView({ block: "nearest" });
+    }
+  });
+  onCleanup(() => {
+    if (pendingHighlightFrame !== undefined) cancelAnimationFrame(pendingHighlightFrame);
+  });
+
+  return {
+    containerRef: (element) => {
+      listRef = element;
+      if (element) highlightContainerRef(element);
+    },
+    highlightRef,
+    registerItem: (index, element) => {
+      itemElements[index] = element;
+    },
+    rowHoverHandlers: (index) => ({
+      onPointerEnter: (event) => maybeActivateHoveredIndex(index, "enter", event),
+      onPointerMove: (event) => maybeActivateHoveredIndex(index, "move", event),
+      onPointerLeave: () => {
+        if (pendingHoverIndex === index) pendingHoverIndex = null;
+      },
+    }),
+    handleListPointerMove: (event) => {
+      if (isSettledPosition(event)) return;
+      lastPointerX = event.clientX;
+      lastPointerY = event.clientY;
+      didPointerMove = true;
+    },
+    handleRowMouseDown: (event) => {
+      const focusedElement = listRef ? getShadowActiveElement(listRef) : null;
+      if (
+        focusedElement instanceof HTMLElement &&
+        focusedElement.matches("input[data-react-grab-input]")
+      ) {
+        focusedElement.blur();
+      }
+      event.preventDefault();
+    },
+  };
+};

--- a/packages/react-grab/src/utils/resolve-dial-config.ts
+++ b/packages/react-grab/src/utils/resolve-dial-config.ts
@@ -1,0 +1,192 @@
+import type {
+  DialActionConfig,
+  DialColorConfig,
+  DialConfig,
+  DialControl,
+  DialControlConfig,
+  DialEnumOption,
+  DialNumberConfig,
+  DialSelectConfig,
+  DialSpringConfig,
+  DialTextConfig,
+} from "../types.js";
+import { DIAL_SPRING_DEFAULT_BOUNCE, DIAL_SPRING_DEFAULT_VISUAL_DURATION_S } from "../constants.js";
+
+const HEX_COLOR_PATTERN = /^#(?:[0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+
+const toTitleCase = (key: string): string => {
+  const spaced = key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .trim();
+  if (spaced.length === 0) return key;
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+};
+
+interface InferredRange {
+  min: number;
+  max: number;
+  step: number;
+}
+
+const inferNumberRange = (value: number): InferredRange => {
+  const magnitude = Math.abs(value);
+  if (magnitude <= 1) return { min: 0, max: 1, step: 0.01 };
+  if (magnitude <= 10) return { min: 0, max: value * 3, step: 0.1 };
+  if (magnitude <= 100) return { min: 0, max: value * 3, step: 1 };
+  return { min: 0, max: value * 3, step: 10 };
+};
+
+const isHexColor = (value: string): boolean => HEX_COLOR_PATTERN.test(value);
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const normalizeSelectOptions = (options: DialSelectConfig["options"]): DialEnumOption[] =>
+  options.map((option) => (typeof option === "string" ? { value: option, label: option } : option));
+
+const joinPath = (parentPath: string, key: string): string =>
+  parentPath ? `${parentPath}.${key}` : key;
+
+const resolveControl = (
+  key: string,
+  parentPath: string,
+  config: DialControlConfig,
+): DialControl | null => {
+  const path = joinPath(parentPath, key);
+  const label = toTitleCase(key);
+
+  if (typeof config === "number") {
+    const range = inferNumberRange(config);
+    return { kind: "number", key, path, label, default: config, ...range };
+  }
+
+  if (typeof config === "boolean") {
+    return { kind: "toggle", key, path, label, default: config };
+  }
+
+  if (typeof config === "string") {
+    if (isHexColor(config)) {
+      return { kind: "color", key, path, label, default: config };
+    }
+    return { kind: "text", key, path, label, default: config };
+  }
+
+  if (Array.isArray(config)) {
+    const [defaultValue, min, max, step] = config;
+    return {
+      kind: "number",
+      key,
+      path,
+      label,
+      default: defaultValue,
+      min,
+      max,
+      step: step ?? inferNumberRange(defaultValue).step,
+    };
+  }
+
+  if (isPlainObject(config) && typeof config.type === "string") {
+    return resolveTypedControl(key, path, label, config);
+  }
+
+  if (isPlainObject(config)) {
+    const folderConfig = config as DialConfig;
+    return {
+      kind: "folder",
+      key,
+      path,
+      label,
+      collapsed: folderConfig._collapsed === true,
+      children: resolveDialConfig(folderConfig, path),
+    };
+  }
+
+  return null;
+};
+
+const resolveTypedControl = (
+  key: string,
+  path: string,
+  label: string,
+  config: Record<string, unknown>,
+): DialControl | null => {
+  switch (config.type) {
+    case "number": {
+      const numberConfig = config as unknown as DialNumberConfig;
+      const range = inferNumberRange(numberConfig.default);
+      return {
+        kind: "number",
+        key,
+        path,
+        label,
+        default: numberConfig.default,
+        min: numberConfig.min ?? range.min,
+        max: numberConfig.max ?? range.max,
+        step: numberConfig.step ?? range.step,
+      };
+    }
+    case "color": {
+      const colorConfig = config as unknown as DialColorConfig;
+      return { kind: "color", key, path, label, default: colorConfig.default };
+    }
+    case "toggle": {
+      return { kind: "toggle", key, path, label, default: Boolean(config.default) };
+    }
+    case "text": {
+      const textConfig = config as unknown as DialTextConfig;
+      return {
+        kind: "text",
+        key,
+        path,
+        label,
+        default: textConfig.default ?? "",
+        placeholder: textConfig.placeholder,
+      };
+    }
+    case "select": {
+      const selectConfig = config as unknown as DialSelectConfig;
+      const options = normalizeSelectOptions(selectConfig.options);
+      return {
+        kind: "select",
+        key,
+        path,
+        label,
+        default: selectConfig.default ?? options[0]?.value ?? "",
+        options,
+      };
+    }
+    case "spring": {
+      const springConfig = config as unknown as DialSpringConfig;
+      return {
+        kind: "spring",
+        key,
+        path,
+        label,
+        default: {
+          type: "spring",
+          visualDuration: springConfig.visualDuration ?? DIAL_SPRING_DEFAULT_VISUAL_DURATION_S,
+          bounce: springConfig.bounce ?? DIAL_SPRING_DEFAULT_BOUNCE,
+        },
+      };
+    }
+    case "action": {
+      const actionConfig = config as unknown as DialActionConfig;
+      return { kind: "action", key, path, label: actionConfig.label ?? label };
+    }
+    default:
+      return null;
+  }
+};
+
+export const resolveDialConfig = (config: DialConfig, parentPath = ""): DialControl[] => {
+  const controls: DialControl[] = [];
+  for (const key of Object.keys(config)) {
+    if (key === "_collapsed") continue;
+    const entry = config[key];
+    if (entry === undefined) continue;
+    const control = resolveControl(key, parentPath, entry as DialControlConfig);
+    if (control) controls.push(control);
+  }
+  return controls;
+};

--- a/packages/react-grab/src/utils/resolve-dial-config.ts
+++ b/packages/react-grab/src/utils/resolve-dial-config.ts
@@ -31,10 +31,11 @@ interface InferredRange {
 
 const inferNumberRange = (value: number): InferredRange => {
   const magnitude = Math.abs(value);
-  if (magnitude <= 1) return { min: 0, max: 1, step: 0.01 };
-  if (magnitude <= 10) return { min: 0, max: value * 3, step: 0.1 };
-  if (magnitude <= 100) return { min: 0, max: value * 3, step: 1 };
-  return { min: 0, max: value * 3, step: 10 };
+  const step = magnitude <= 1 ? 0.01 : magnitude <= 10 ? 0.1 : magnitude <= 100 ? 1 : 10;
+  const bound = magnitude <= 1 ? 1 : magnitude * 3;
+  // Bracket toward the sign of the default so a negative default isn't clamped
+  // to 0 by an inverted (min > max) range.
+  return value < 0 ? { min: -bound, max: 0, step } : { min: 0, max: bound, step };
 };
 
 const isHexColor = (value: string): boolean => HEX_COLOR_PATTERN.test(value);

--- a/packages/react-grab/src/utils/resolve-dial-values.ts
+++ b/packages/react-grab/src/utils/resolve-dial-values.ts
@@ -1,0 +1,32 @@
+import type { DialControl, DialValue } from "../types.js";
+
+export const collectDialDefaults = (controls: DialControl[]): Record<string, DialValue> => {
+  const defaults: Record<string, DialValue> = {};
+  const walk = (nodes: DialControl[]) => {
+    for (const node of nodes) {
+      if (node.kind === "folder") {
+        walk(node.children);
+      } else if (node.kind !== "action") {
+        defaults[node.path] = node.default;
+      }
+    }
+  };
+  walk(controls);
+  return defaults;
+};
+
+export const resolveDialValues = (
+  controls: DialControl[],
+  valuesByPath: Record<string, DialValue>,
+): Record<string, unknown> => {
+  const resolved: Record<string, unknown> = {};
+  for (const node of controls) {
+    if (node.kind === "action") continue;
+    if (node.kind === "folder") {
+      resolved[node.key] = resolveDialValues(node.children, valuesByPath);
+      continue;
+    }
+    resolved[node.key] = valuesByPath[node.path] ?? node.default;
+  }
+  return resolved;
+};

--- a/packages/react-grab/vite.config.ts
+++ b/packages/react-grab/vite.config.ts
@@ -56,7 +56,7 @@ export default defineConfig({
       plugins: [solidWebBrowserPlugin(), cssTextPlugin(), solidBabelPlugin()],
     },
     {
-      entry: ["./src/index.ts", "./src/core/index.tsx", "./src/primitives.ts"],
+      entry: ["./src/index.ts", "./src/core/index.tsx", "./src/primitives.ts", "./src/react.ts"],
       format: ["cjs", "esm"],
       dts: true,
       clean: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,6 +390,9 @@ importers:
       react:
         specifier: 19.2.6
         version: 19.2.6
+      use-sync-external-store:
+        specifier: ^1.6.0
+        version: 1.6.0(react@19.2.6)
     devDependencies:
       '@babel/core':
         specifier: ^7.29.0
@@ -415,6 +418,9 @@ importers:
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
+      '@types/use-sync-external-store':
+        specifier: ^1.5.0
+        version: 1.5.0
       babel-preset-solid:
         specifier: ^1.9.12
         version: 1.9.12(@babel/core@7.29.0)(solid-js@1.9.12)
@@ -3549,6 +3555,9 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
+
+  '@types/use-sync-external-store@1.5.0':
+    resolution: {integrity: sha512-5dyB8nLC/qogMrlCizZnYWQTA4lnb/v+It+sqNl5YnSRAPMlIqY/X0Xn+gZw8vOL+TgTTr28VEbn3uf8fUtAkw==}
 
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
@@ -8983,7 +8992,7 @@ snapshots:
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
       zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -10847,6 +10856,8 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
+
+  '@types/use-sync-external-store@1.5.0': {}
 
   '@types/validate-npm-package-name@4.0.2': {}
 
@@ -15254,10 +15265,6 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
-
-  zod-to-json-schema@3.25.2(zod@4.4.3):
-    dependencies:
-      zod: 4.4.3
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## Summary

Adds a dialkit-style `useReactGrab()` React hook for defining tweakable component parameters, surfaced through a SolidJS **dials panel** overlay. The panel reuses react-grab's existing edit-panel controls and anchors to the toolbar under the same affordance as style editing.

- **`useReactGrab(name, config)`** (`react-grab/react`): declare tweakable params and read live values back. `useReactGrabController()` additionally exposes `setValue`/`setValues`/`resetValues`/`getValues`. Bridged from the SolidJS overlay via `useSyncExternalStore`.
- **Dials registry** merges values on re-register (keeps current values for surviving paths, drops removed ones) and supports **multiple hooks combined into one panel**, with a divider between sections.
- **Full control parity**: numbers, colors, selects, toggles, text, springs (with step-response curve visualization), actions, and nested/collapsible folders.
- **Keyboard navigation**: engagement-gated window keydown handler — click into the panel to engage, then up/down to move rows (across panel boundaries), left/right to tweak (shift = large step), Enter to activate. Pointer activation only fires on genuine cursor movement, avoiding phantom re-activation when the active row's content swaps under a stationary cursor.
- Exposes a new `./react` package export (esm/cjs + types) and wires `src/react.ts` into the build.

## Test plan

- [ ] `pnpm build && pnpm typecheck && pnpm lint && pnpm format` all pass
- [ ] In `apps/e2e-app-vite`, the `Card` and `Scene` hooks render as one combined panel with a section divider
- [ ] Click a control row, then up/down navigates rows (including across the two panels), left/right tweaks values, Enter toggles/activates
- [ ] Spring folder shows the curve viz with Duration/Bounce sub-fields
- [ ] Color picker, cycle/select, toggle, and text controls all commit values and reflect live in the demo card
- [ ] Arrow keys do not hijack the host page when the panel isn't engaged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new overlay surface (global key handlers, toolbar integration, React↔Solid state bridge) touches core UX; mitigations include engagement gating and merge-on-reregister, but regressions in selection/edit flows are plausible.
> 
> **Overview**
> Introduces a **dialkit-style dev workflow**: React apps declare tweakable params with **`useReactGrab()`** / **`useReactGrabController()`** on the new **`react-grab/react`** export, backed by a Solid **`dials-registry`** and **`useSyncExternalStore`** (with a React 17 shim).
> 
> The overlay **dials panel** anchors to the toolbar (auto-opens after fade-in; **Style** toggles it when panels exist), merges multiple hook registrations into one searchable UI, and supports numbers, colors, selects, toggles, text, springs (with curve viz), actions, and nested folders. Shared **`createMenuList`** refactors edit-panel row navigation for both panels.
> 
> **E2E/CI:** the Vite dials demo is **lazy-loaded** and gated behind **`/?dials`** so default specs and perf baselines avoid the PR-only export and toolbar overlap. Perf workflow **fully swaps** `react-grab/src` and **`vite.config.ts`** on baseline runs so PR-only files and build entries do not leak.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b19f1bb737cb3435329dd9a3bc06f03261bfec29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dialkit-style `useReactGrab()` React hook and a SolidJS dials panel with a search bar to tweak component params live. The panel anchors to the toolbar under the Style button and merges multiple hooks into one view.

- **New Features**
  - Exported `useReactGrab()` and `useReactGrabController()` from `react-grab/react` (ESM/CJS + types) via new `./react` entry; React bridge via `useSyncExternalStore` (shim for React 17).
  - Dials panel overlay anchored to the toolbar; multiple hooks combine into one panel with section dividers.
  - Search filters by label across all panels; folders flatten in results; clearing restores the nested view.
  - Full control set: numbers, colors, selects, toggles, text, springs (with curve), actions, nested folders.
  - Keyboard UX: click to engage; Up/Down move; Left/Right tweak (Shift = larger); Enter activates; guards phantom pointer events.
  - Dials registry with merge-on-reregister and stable values across config changes.
  - Demo: `apps/e2e-app-vite` shows “Card” and “Scene” hooks in a combined panel; lazy-loaded and gated behind `/?dials`.

- **Bug Fixes**
  - Preserve dial values and keep dismissed panels closed across re-registration; bridge pre-init subscriptions.
  - Fix number range inference for negative defaults; guard select cycling on empty options.
  - Keep spring control labels in search; reject non-spring objects in `readSpring`.
  - Share menu-list interactions with the style panel via `createMenuList`; clip dials overscroll.
  - Tear down dials panel position tracking on root disposal (fix RAF leak).
  - Drop empty listener sets so transient hook IDs don’t accumulate listeners.
  - Reset keyboard engagement on dismiss so reopened panels don’t hijack arrow/enter; ignore global keys while dismissed.
  - CI/perf: baseline swap removes PR-added `react-grab/src` and reverts `packages/react-grab/vite.config.ts` to base to avoid unresolved entries.

<sup>Written for commit b19f1bb737cb3435329dd9a3bc06f03261bfec29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

