### PR TITLE
feat(react-grab): natural-language comparative style edits

### DIFF
--- a/packages/react-grab/e2e/edit-panel-comparative.spec.ts
+++ b/packages/react-grab/e2e/edit-panel-comparative.spec.ts
@@ -68,6 +68,18 @@ test.describe("Style Panel Comparative Commands", () => {
     expect(secondApply).toBe(firstApply);
   });
 
+  test("tolerates a typo in the comparative ('biger')", async ({ reactGrab }) => {
+    await openEditPanel(reactGrab, BUTTON_SELECTOR);
+
+    await applyComparative(reactGrab.page, "font size");
+    const baseline = parsePx(await getActivePropertyValue(reactGrab.page));
+
+    await applyComparative(reactGrab.page, "biger");
+    expect(await getActivePropertyKey(reactGrab.page)).toBe("font-size");
+    const enlarged = parsePx(await getActivePropertyValue(reactGrab.page));
+    expect(enlarged).toBeGreaterThan(baseline);
+  });
+
   test("'too big' shrinks font size", async ({ reactGrab }) => {
     await openEditPanel(reactGrab, BUTTON_SELECTOR);
 

--- a/packages/react-grab/e2e/edit-panel-comparative.spec.ts
+++ b/packages/react-grab/e2e/edit-panel-comparative.spec.ts
@@ -1,0 +1,94 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "./fixtures.js";
+import {
+  BUTTON_SELECTOR,
+  clearEditStorage,
+  getActivePropertyKey,
+  getActivePropertyValue,
+  getInlineStyleProperty,
+  openEditPanel,
+  setSearchInputValue,
+} from "./edit-panel-helpers.js";
+
+const UNIFORM_PADDING_SELECTOR = "[data-testid='th-1']";
+
+const parsePx = (value: string | null): number => {
+  if (!value) return Number.NaN;
+  return Number.parseFloat(value.replace(/px$/, ""));
+};
+
+const applyComparative = async (page: Page, query: string): Promise<void> => {
+  await setSearchInputValue(page, query);
+  await page.waitForTimeout(80);
+};
+
+test.describe("Style Panel Comparative Commands", () => {
+  test.beforeEach(async ({ reactGrab }) => {
+    await clearEditStorage(reactGrab.page);
+  });
+
+  test("'bigger' targets font size and increases it", async ({ reactGrab }) => {
+    await openEditPanel(reactGrab, BUTTON_SELECTOR);
+
+    await applyComparative(reactGrab.page, "font size");
+    const baseline = parsePx(await getActivePropertyValue(reactGrab.page));
+
+    await applyComparative(reactGrab.page, "bigger");
+    expect(await getActivePropertyKey(reactGrab.page)).toBe("font-size");
+    const enlarged = parsePx(await getActivePropertyValue(reactGrab.page));
+    expect(enlarged).toBeGreaterThan(baseline);
+  });
+
+  test("amplifiers move the value further than a plain comparative", async ({ reactGrab }) => {
+    await openEditPanel(reactGrab, BUTTON_SELECTOR);
+
+    await applyComparative(reactGrab.page, "font size");
+    const baseline = parsePx(await getActivePropertyValue(reactGrab.page));
+
+    await applyComparative(reactGrab.page, "bigger");
+    const single = parsePx(await getActivePropertyValue(reactGrab.page));
+
+    await applyComparative(reactGrab.page, "much bigger");
+    const amplified = parsePx(await getActivePropertyValue(reactGrab.page));
+
+    expect(single).toBeGreaterThan(baseline);
+    expect(amplified).toBeGreaterThan(single);
+  });
+
+  test("re-applying the same command is idempotent against the baseline", async ({ reactGrab }) => {
+    await openEditPanel(reactGrab, BUTTON_SELECTOR);
+
+    await applyComparative(reactGrab.page, "bigger");
+    const firstApply = parsePx(await getActivePropertyValue(reactGrab.page));
+
+    await applyComparative(reactGrab.page, "smaller");
+    await applyComparative(reactGrab.page, "bigger");
+    const secondApply = parsePx(await getActivePropertyValue(reactGrab.page));
+
+    expect(secondApply).toBe(firstApply);
+  });
+
+  test("'more padding' increases padding on every side", async ({ reactGrab }) => {
+    await openEditPanel(reactGrab, UNIFORM_PADDING_SELECTOR);
+
+    await applyComparative(reactGrab.page, "more padding");
+    expect(await getActivePropertyKey(reactGrab.page)).toBe("padding");
+
+    // th-1 starts at p-2 (8px); a single step floors at +4px.
+    await expect
+      .poll(() => getInlineStyleProperty(reactGrab.page, UNIFORM_PADDING_SELECTOR, "padding-top"))
+      .toBe("12px");
+    await expect
+      .poll(() => getInlineStyleProperty(reactGrab.page, UNIFORM_PADDING_SELECTOR, "padding-left"))
+      .toBe("12px");
+  });
+
+  test("'less padding' decreases padding", async ({ reactGrab }) => {
+    await openEditPanel(reactGrab, UNIFORM_PADDING_SELECTOR);
+
+    await applyComparative(reactGrab.page, "less padding");
+    await expect
+      .poll(() => getInlineStyleProperty(reactGrab.page, UNIFORM_PADDING_SELECTOR, "padding-top"))
+      .toBe("4px");
+  });
+});

--- a/packages/react-grab/e2e/edit-panel-comparative.spec.ts
+++ b/packages/react-grab/e2e/edit-panel-comparative.spec.ts
@@ -68,6 +68,18 @@ test.describe("Style Panel Comparative Commands", () => {
     expect(secondApply).toBe(firstApply);
   });
 
+  test("'too big' shrinks font size", async ({ reactGrab }) => {
+    await openEditPanel(reactGrab, BUTTON_SELECTOR);
+
+    await applyComparative(reactGrab.page, "font size");
+    const baseline = parsePx(await getActivePropertyValue(reactGrab.page));
+
+    await applyComparative(reactGrab.page, "too big");
+    expect(await getActivePropertyKey(reactGrab.page)).toBe("font-size");
+    const shrunk = parsePx(await getActivePropertyValue(reactGrab.page));
+    expect(shrunk).toBeLessThan(baseline);
+  });
+
   test("'more padding' increases padding on every side", async ({ reactGrab }) => {
     await openEditPanel(reactGrab, UNIFORM_PADDING_SELECTOR);
 

--- a/packages/react-grab/src/components/edit-panel/tailwind-autoapply.ts
+++ b/packages/react-grab/src/components/edit-panel/tailwind-autoapply.ts
@@ -7,6 +7,9 @@ import type {
   NumericEditableProperty,
 } from "../../types.js";
 import { clampToRange } from "../../utils/clamp-to-range.js";
+import { parseComparativeIntent } from "../../utils/comparative-intent.js";
+import { computeComparativeValue } from "../../utils/compute-comparative-value.js";
+import { resolveComparativeTargets } from "../../utils/resolve-comparative-target.js";
 import { expandAggregateLonghands } from "../../utils/expand-aggregate-longhands.js";
 import { roundEditableNumericValue } from "../../utils/format-css-value.js";
 import { isNumericDraftQuery } from "../../utils/is-numeric-draft-query.js";
@@ -332,7 +335,23 @@ export const createTailwindAutoApply = (
     return findEnum(initialProperties, propertyKey) !== null;
   };
 
+  const applyComparativeIntent = (rawQuery: string): boolean => {
+    const intent = parseComparativeIntent(rawQuery);
+    if (!intent) return false;
+    const resolution = resolveComparativeTargets(intent, initialProperties);
+    if (!resolution) return false;
+    setIsCompact(true);
+    batch(() => {
+      for (const target of resolution.targets) {
+        const nextValue = computeComparativeValue(target, resolution.direction, resolution.magnitude);
+        if (nextValue !== null) commit(target, nextValue, { shouldCompact: true });
+      }
+    });
+    return true;
+  };
+
   const applyTailwindClass = (rawQuery: string) => {
+    if (applyComparativeIntent(rawQuery)) return;
     const strippedClassAttribute = rawQuery
       .trim()
       .replace(/^class\s*=\s*["']/, "")

--- a/packages/react-grab/src/components/edit-panel/tailwind-autoapply.ts
+++ b/packages/react-grab/src/components/edit-panel/tailwind-autoapply.ts
@@ -343,7 +343,11 @@ export const createTailwindAutoApply = (
     setIsCompact(true);
     batch(() => {
       for (const target of resolution.targets) {
-        const nextValue = computeComparativeValue(target, resolution.direction, resolution.magnitude);
+        const nextValue = computeComparativeValue(
+          target,
+          resolution.direction,
+          resolution.magnitude,
+        );
         if (nextValue !== null) commit(target, nextValue, { shouldCompact: true });
       }
     });

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -259,6 +259,22 @@ export const EDIT_SEARCH_POSITION_PENALTY = 100;
 export const EDIT_SEARCH_LENGTH_PENALTY = 1;
 export const EDIT_COMPACT_SLIDER_MIN_WIDTH_PX = 96;
 
+// Natural-language comparative edits ("make it bigger", "way more padding").
+// A single step nudges a numeric property by BASE_RATIO of its current value,
+// floored per-unit so properties sitting at 0 still move a sensible amount.
+export const COMPARATIVE_BASE_RATIO = 0.25;
+export const COMPARATIVE_LENGTH_FLOOR_PX = 4;
+export const COMPARATIVE_OPACITY_FLOOR_PERCENT = 10;
+export const COMPARATIVE_Z_INDEX_FLOOR = 1;
+export const COMPARATIVE_UNITLESS_FLOOR = 1;
+// Intensity multipliers: "much"/"way" amplify, "slightly"/"a bit" damp, and a
+// repeated adjective ("big bigger", "more more") stacks via the repeat factor.
+export const COMPARATIVE_AMPLIFIER_FACTOR = 2;
+export const COMPARATIVE_DIMINISHER_FACTOR = 0.5;
+export const COMPARATIVE_REPEAT_FACTOR = 1.5;
+export const COMPARATIVE_MIN_MAGNITUDE = 0.25;
+export const COMPARATIVE_MAX_MAGNITUDE = 8;
+
 export const CSS_VALUE_DECIMAL_PLACES = 2;
 // Tailwind v4's `rounded-full` is calc(infinity * 1px). Browsers clamp
 // it to their internal length maximum (~3.36e7px in Chromium, ~1.79e7px

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -208,6 +208,23 @@ export type EditableProperty =
   | ColorEditableProperty
   | EnumEditableProperty;
 
+// A parsed natural-language comparative command ("make it much bigger",
+// "less padding"). `dimensionCandidates` are the css property keys implied by
+// a comparative adjective (tried in order); `subject` is an explicit property
+// noun that overrides them when it resolves. `magnitude` is the intensity.
+export interface ComparativeIntent {
+  subject: string | null;
+  dimensionCandidates: readonly string[] | null;
+  direction: 1 | -1;
+  magnitude: number;
+}
+
+export interface ComparativeResolution {
+  targets: EditableProperty[];
+  direction: 1 | -1;
+  magnitude: number;
+}
+
 interface NumericPendingEdit {
   kind: "numeric";
   key: string;

--- a/packages/react-grab/src/utils/comparative-intent.ts
+++ b/packages/react-grab/src/utils/comparative-intent.ts
@@ -16,6 +16,7 @@ const BORDER_WIDTH = ["border-width"];
 const RADIUS = ["border-radius"];
 const OPACITY = ["opacity"];
 const TRACKING = ["letter-spacing"];
+const SPACING = ["padding", "gap"];
 
 interface PolarAdjective {
   candidates: readonly string[];
@@ -86,15 +87,22 @@ const POLAR_DEFINITIONS: ReadonlyArray<{
     candidates: RADIUS,
     direction: -1,
   },
-  { base: ["opaque"], comparative: ["opaquer"], candidates: OPACITY, direction: 1 },
+  { base: ["opaque", "solid"], comparative: ["opaquer"], candidates: OPACITY, direction: 1 },
   {
-    base: ["transparent", "translucent", "faded", "faint", "see-through", "seethrough"],
-    comparative: ["fainter", "faintest"],
+    base: ["transparent", "translucent", "faded", "faint", "see-through", "seethrough", "dim"],
+    comparative: ["fainter", "faintest", "dimmer", "dimmest"],
     candidates: OPACITY,
     direction: -1,
   },
   { base: ["loose"], comparative: ["looser", "loosest"], candidates: TRACKING, direction: 1 },
   { base: ["tight"], comparative: ["tighter", "tightest"], candidates: TRACKING, direction: -1 },
+  {
+    base: ["roomy", "airy", "spacious"],
+    comparative: ["roomier", "airier"],
+    candidates: SPACING,
+    direction: 1,
+  },
+  { base: ["cramped", "crowded"], comparative: [], candidates: SPACING, direction: -1 },
 ];
 
 const POLAR_ADJECTIVES = ((): Map<string, PolarAdjective> => {
@@ -135,6 +143,7 @@ const INCREASE_VERBS = new Set([
   "bumped",
   "extra",
   "plus",
+  "up",
 ]);
 
 const DECREASE_VERBS = new Set([
@@ -152,7 +161,10 @@ const DECREASE_VERBS = new Set([
   "dropped",
   "lessen",
   "minimize",
+  "minimise",
   "trim",
+  "down",
+  "shave",
 ]);
 
 const COMMAND_VERBS = new Set(["make", "set", "turn", "render", "get", "give", "keep"]);
@@ -173,6 +185,11 @@ const AMPLIFIER_WORDS = new Set([
   "tons",
   "loads",
   "crazy",
+  "so",
+  "real",
+  "ridiculously",
+  "absurdly",
+  "noticeably",
 ]);
 
 const DIMINISHER_WORDS = new Set([
@@ -199,14 +216,30 @@ const STOPWORDS = new Set([
   "my",
   "your",
   "please",
-  "too",
   "and",
   "for",
   "on",
+  "can",
+  "could",
+  "would",
+  "you",
+  "i",
+  "im",
+  "want",
+  "wanna",
+  "need",
+  "needs",
+  "just",
+  "look",
+  "looks",
+  "looking",
 ]);
 
 const AMPLIFIER_PHRASE_PATTERN = /\ba\s+(?:lot|ton|whole\s+lot)\b/g;
 const DIMINISHER_PHRASE_PATTERN = /\ba\s+(?:bit|little|tad|touch|smidge|hair)\b/g;
+// "too much/many <x>" reads as "trim x" without amplifying, so it is matched
+// as a unit before the bare "much" amplifier is counted.
+const TOO_MUCH_PHRASE_PATTERN = /\btoo\s+(?:much|many)\b/g;
 
 const countAndStrip = (text: string, pattern: RegExp): { text: string; count: number } => {
   let count = 0;
@@ -233,7 +266,8 @@ export const parseComparativeIntent = (rawQuery: string): ComparativeIntent | nu
   const lowered = rawQuery.toLowerCase().trim();
   if (!lowered) return null;
 
-  const amplifierPhrases = countAndStrip(lowered, AMPLIFIER_PHRASE_PATTERN);
+  const tooMuchPhrases = countAndStrip(lowered, TOO_MUCH_PHRASE_PATTERN);
+  const amplifierPhrases = countAndStrip(tooMuchPhrases.text, AMPLIFIER_PHRASE_PATTERN);
   const diminisherPhrases = countAndStrip(amplifierPhrases.text, DIMINISHER_PHRASE_PATTERN);
   let amplifierCount = amplifierPhrases.count;
   let diminisherCount = diminisherPhrases.count;
@@ -246,6 +280,11 @@ export const parseComparativeIntent = (rawQuery: string): ComparativeIntent | nu
   let genericSign: 1 | -1 | 0 = 0;
   let genericVerbCount = 0;
   let hasCommandVerb = false;
+  // "too big" → smaller; "not big enough" → bigger. Tracked separately so the
+  // direction resolver can flip or reinforce the adjective.
+  let hasExcessCue = tooMuchPhrases.count > 0;
+  let hasNegationCue = false;
+  let hasEnoughCue = false;
   const subjectTokens: string[] = [];
 
   for (const token of tokens) {
@@ -255,6 +294,18 @@ export const parseComparativeIntent = (rawQuery: string): ComparativeIntent | nu
     }
     if (DIMINISHER_WORDS.has(token)) {
       diminisherCount++;
+      continue;
+    }
+    if (token === "too") {
+      hasExcessCue = true;
+      continue;
+    }
+    if (token === "not" || token === "isnt" || token === "no") {
+      hasNegationCue = true;
+      continue;
+    }
+    if (token === "enough") {
+      hasEnoughCue = true;
       continue;
     }
     if (COMMAND_VERBS.has(token)) {
@@ -282,12 +333,15 @@ export const parseComparativeIntent = (rawQuery: string): ComparativeIntent | nu
     subjectTokens.push(token);
   }
 
+  const hasNotEnoughCue = hasNegationCue && hasEnoughCue;
   const hasSignal =
     hasStrongPolar ||
     hasCommandVerb ||
     amplifierCount > 0 ||
     diminisherCount > 0 ||
     genericVerbCount > 0 ||
+    hasExcessCue ||
+    hasNotEnoughCue ||
     polarCount >= 2;
   if (!hasSignal) return null;
 
@@ -295,11 +349,24 @@ export const parseComparativeIntent = (rawQuery: string): ComparativeIntent | nu
   let dimensionCandidates: readonly string[] | null;
   if (polarAdjective) {
     dimensionCandidates = polarAdjective.candidates;
-    const shouldInvert = genericSign === -1;
-    direction = shouldInvert ? (polarAdjective.direction === 1 ? -1 : 1) : polarAdjective.direction;
+    // A decrease cue flips the adjective's natural direction: "less wide" →
+    // wider, "too big" → smaller. "not big enough" keeps it (reinforces).
+    let inversions = 0;
+    if (genericSign === -1) inversions++;
+    if (hasExcessCue) inversions++;
+    direction =
+      inversions % 2 === 1 ? (polarAdjective.direction === 1 ? -1 : 1) : polarAdjective.direction;
   } else if (genericSign !== 0) {
     dimensionCandidates = null;
     direction = genericSign;
+  } else if (hasExcessCue) {
+    // "too much padding" → trim the named property.
+    dimensionCandidates = null;
+    direction = -1;
+  } else if (hasNotEnoughCue) {
+    // "not enough padding" → add to the named property.
+    dimensionCandidates = null;
+    direction = 1;
   } else {
     return null;
   }

--- a/packages/react-grab/src/utils/comparative-intent.ts
+++ b/packages/react-grab/src/utils/comparative-intent.ts
@@ -7,6 +7,8 @@ import {
 } from "../constants.js";
 import type { ComparativeIntent } from "../types.js";
 import { clampToRange } from "./clamp-to-range.js";
+import { findClosestWord } from "./fuzzy-match.js";
+import { propertyKeyForAlias } from "./tailwind-class-map.js";
 
 const SIZE = ["font-size", "width", "height"];
 const WIDTH = ["width", "max-width", "min-width"];
@@ -235,6 +237,16 @@ const STOPWORDS = new Set([
   "looking",
 ]);
 
+// Snapshots of each vocabulary for fuzzy fallback. Order within each list is
+// the priority used on ties; categories themselves are tried in the same
+// order as the exact checks below.
+const POLAR_WORDS = Array.from(POLAR_ADJECTIVES.keys());
+const AMPLIFIER_WORD_LIST = Array.from(AMPLIFIER_WORDS);
+const DIMINISHER_WORD_LIST = Array.from(DIMINISHER_WORDS);
+const COMMAND_WORD_LIST = Array.from(COMMAND_VERBS);
+const INCREASE_WORD_LIST = Array.from(INCREASE_VERBS);
+const DECREASE_WORD_LIST = Array.from(DECREASE_VERBS);
+
 const AMPLIFIER_PHRASE_PATTERN = /\ba\s+(?:lot|ton|whole\s+lot)\b/g;
 const DIMINISHER_PHRASE_PATTERN = /\ba\s+(?:bit|little|tad|touch|smidge|hair)\b/g;
 // "too much/many <x>" reads as "trim x" without amplifying, so it is matched
@@ -330,6 +342,45 @@ export const parseComparativeIntent = (rawQuery: string): ComparativeIntent | nu
       continue;
     }
     if (STOPWORDS.has(token)) continue;
+
+    // Typo fallback. Skipped for any token that already names a property
+    // (e.g. "border", "right") so a one-edit neighbor like "bolder"/"tight"
+    // can never hijack a legitimate property search.
+    if (propertyKeyForAlias(token) === null) {
+      if (findClosestWord(token, AMPLIFIER_WORD_LIST)) {
+        amplifierCount++;
+        continue;
+      }
+      if (findClosestWord(token, DIMINISHER_WORD_LIST)) {
+        diminisherCount++;
+        continue;
+      }
+      if (findClosestWord(token, COMMAND_WORD_LIST)) {
+        hasCommandVerb = true;
+        continue;
+      }
+      if (findClosestWord(token, INCREASE_WORD_LIST)) {
+        genericSign = 1;
+        genericVerbCount++;
+        continue;
+      }
+      if (findClosestWord(token, DECREASE_WORD_LIST)) {
+        genericSign = -1;
+        genericVerbCount++;
+        continue;
+      }
+      const polarWord = findClosestWord(token, POLAR_WORDS);
+      if (polarWord) {
+        const polar = POLAR_ADJECTIVES.get(polarWord);
+        if (polar) {
+          polarCount++;
+          if (polar.isComparativeForm) hasStrongPolar = true;
+          if (!polarAdjective) polarAdjective = polar;
+        }
+        continue;
+      }
+    }
+
     subjectTokens.push(token);
   }
 

--- a/packages/react-grab/src/utils/comparative-intent.ts
+++ b/packages/react-grab/src/utils/comparative-intent.ts
@@ -296,11 +296,7 @@ export const parseComparativeIntent = (rawQuery: string): ComparativeIntent | nu
   if (polarAdjective) {
     dimensionCandidates = polarAdjective.candidates;
     const shouldInvert = genericSign === -1;
-    direction = shouldInvert
-      ? polarAdjective.direction === 1
-        ? -1
-        : 1
-      : polarAdjective.direction;
+    direction = shouldInvert ? (polarAdjective.direction === 1 ? -1 : 1) : polarAdjective.direction;
   } else if (genericSign !== 0) {
     dimensionCandidates = null;
     direction = genericSign;
@@ -311,8 +307,7 @@ export const parseComparativeIntent = (rawQuery: string): ComparativeIntent | nu
   const subject = subjectTokens.join(" ").trim() || null;
   if (!polarAdjective && !subject) return null;
 
-  const extraRepeats =
-    Math.max(0, polarCount - 1) + Math.max(0, genericVerbCount - 1);
+  const extraRepeats = Math.max(0, polarCount - 1) + Math.max(0, genericVerbCount - 1);
   const magnitude = computeMagnitude(amplifierCount, diminisherCount, extraRepeats);
 
   return { subject, dimensionCandidates, direction, magnitude };

--- a/packages/react-grab/src/utils/comparative-intent.ts
+++ b/packages/react-grab/src/utils/comparative-intent.ts
@@ -1,0 +1,319 @@
+import {
+  COMPARATIVE_AMPLIFIER_FACTOR,
+  COMPARATIVE_DIMINISHER_FACTOR,
+  COMPARATIVE_MAX_MAGNITUDE,
+  COMPARATIVE_MIN_MAGNITUDE,
+  COMPARATIVE_REPEAT_FACTOR,
+} from "../constants.js";
+import type { ComparativeIntent } from "../types.js";
+import { clampToRange } from "./clamp-to-range.js";
+
+const SIZE = ["font-size", "width", "height"];
+const WIDTH = ["width", "max-width", "min-width"];
+const HEIGHT = ["height", "max-height", "min-height"];
+const WEIGHT = ["font-weight"];
+const BORDER_WIDTH = ["border-width"];
+const RADIUS = ["border-radius"];
+const OPACITY = ["opacity"];
+const TRACKING = ["letter-spacing"];
+
+interface PolarAdjective {
+  candidates: readonly string[];
+  direction: 1 | -1;
+  isComparativeForm: boolean;
+}
+
+// Positive forms (`big`) only fire with another signal (a command verb,
+// modifier, or repetition); comparative/superlative forms (`bigger`) are a
+// strong signal on their own. `transparent`/`faint` deliberately live here —
+// not as opacity aliases — because they invert the named quantity (more
+// transparent means less opacity).
+const POLAR_DEFINITIONS: ReadonlyArray<{
+  base: readonly string[];
+  comparative: readonly string[];
+  candidates: readonly string[];
+  direction: 1 | -1;
+}> = [
+  {
+    base: ["big", "large", "huge", "enormous", "giant", "massive"],
+    comparative: ["bigger", "biggest", "larger", "largest", "grow", "enlarge"],
+    candidates: SIZE,
+    direction: 1,
+  },
+  {
+    base: ["small", "tiny", "petite"],
+    comparative: ["smaller", "smallest", "tinier", "tiniest", "shrink"],
+    candidates: SIZE,
+    direction: -1,
+  },
+  {
+    base: ["wide", "broad"],
+    comparative: ["wider", "widest", "broader"],
+    candidates: WIDTH,
+    direction: 1,
+  },
+  {
+    base: ["narrow", "skinny"],
+    comparative: ["narrower", "narrowest", "skinnier"],
+    candidates: WIDTH,
+    direction: -1,
+  },
+  { base: ["tall"], comparative: ["taller", "tallest"], candidates: HEIGHT, direction: 1 },
+  { base: ["short"], comparative: ["shorter", "shortest"], candidates: HEIGHT, direction: -1 },
+  {
+    base: ["bold", "heavy"],
+    comparative: ["bolder", "boldest", "heavier", "heaviest"],
+    candidates: WEIGHT,
+    direction: 1,
+  },
+  { base: ["light"], comparative: ["lighter", "lightest"], candidates: WEIGHT, direction: -1 },
+  { base: ["thick"], comparative: ["thicker", "thickest"], candidates: BORDER_WIDTH, direction: 1 },
+  {
+    base: ["thin"],
+    comparative: ["thinner", "thinnest"],
+    candidates: BORDER_WIDTH,
+    direction: -1,
+  },
+  {
+    base: ["round", "rounded"],
+    comparative: ["rounder", "roundest"],
+    candidates: RADIUS,
+    direction: 1,
+  },
+  {
+    base: ["sharp", "square", "squared", "boxy"],
+    comparative: ["sharper", "sharpest", "squarer"],
+    candidates: RADIUS,
+    direction: -1,
+  },
+  { base: ["opaque"], comparative: ["opaquer"], candidates: OPACITY, direction: 1 },
+  {
+    base: ["transparent", "translucent", "faded", "faint", "see-through", "seethrough"],
+    comparative: ["fainter", "faintest"],
+    candidates: OPACITY,
+    direction: -1,
+  },
+  { base: ["loose"], comparative: ["looser", "loosest"], candidates: TRACKING, direction: 1 },
+  { base: ["tight"], comparative: ["tighter", "tightest"], candidates: TRACKING, direction: -1 },
+];
+
+const POLAR_ADJECTIVES = ((): Map<string, PolarAdjective> => {
+  const wordToAdjective = new Map<string, PolarAdjective>();
+  for (const definition of POLAR_DEFINITIONS) {
+    for (const word of definition.base) {
+      wordToAdjective.set(word, {
+        candidates: definition.candidates,
+        direction: definition.direction,
+        isComparativeForm: false,
+      });
+    }
+    for (const word of definition.comparative) {
+      wordToAdjective.set(word, {
+        candidates: definition.candidates,
+        direction: definition.direction,
+        isComparativeForm: true,
+      });
+    }
+  }
+  return wordToAdjective;
+})();
+
+const INCREASE_VERBS = new Set([
+  "more",
+  "increase",
+  "increased",
+  "increasing",
+  "raise",
+  "raised",
+  "add",
+  "added",
+  "boost",
+  "boosted",
+  "expand",
+  "expanded",
+  "bump",
+  "bumped",
+  "extra",
+  "plus",
+]);
+
+const DECREASE_VERBS = new Set([
+  "less",
+  "fewer",
+  "decrease",
+  "decreased",
+  "decreasing",
+  "reduce",
+  "reduced",
+  "lower",
+  "lowered",
+  "cut",
+  "drop",
+  "dropped",
+  "lessen",
+  "minimize",
+  "trim",
+]);
+
+const COMMAND_VERBS = new Set(["make", "set", "turn", "render", "get", "give", "keep"]);
+
+const AMPLIFIER_WORDS = new Set([
+  "much",
+  "very",
+  "really",
+  "super",
+  "ultra",
+  "way",
+  "far",
+  "extremely",
+  "insanely",
+  "massively",
+  "hugely",
+  "mega",
+  "tons",
+  "loads",
+  "crazy",
+]);
+
+const DIMINISHER_WORDS = new Set([
+  "slightly",
+  "slight",
+  "somewhat",
+  "marginally",
+  "barely",
+  "kinda",
+  "bit",
+]);
+
+const STOPWORDS = new Set([
+  "it",
+  "its",
+  "this",
+  "that",
+  "the",
+  "a",
+  "an",
+  "to",
+  "by",
+  "of",
+  "my",
+  "your",
+  "please",
+  "too",
+  "and",
+  "for",
+  "on",
+]);
+
+const AMPLIFIER_PHRASE_PATTERN = /\ba\s+(?:lot|ton|whole\s+lot)\b/g;
+const DIMINISHER_PHRASE_PATTERN = /\ba\s+(?:bit|little|tad|touch|smidge|hair)\b/g;
+
+const countAndStrip = (text: string, pattern: RegExp): { text: string; count: number } => {
+  let count = 0;
+  const stripped = text.replace(pattern, () => {
+    count++;
+    return " ";
+  });
+  return { text: stripped, count };
+};
+
+const computeMagnitude = (
+  amplifierCount: number,
+  diminisherCount: number,
+  extraRepeats: number,
+): number => {
+  const magnitude =
+    COMPARATIVE_AMPLIFIER_FACTOR ** amplifierCount *
+    COMPARATIVE_DIMINISHER_FACTOR ** diminisherCount *
+    COMPARATIVE_REPEAT_FACTOR ** extraRepeats;
+  return clampToRange(magnitude, COMPARATIVE_MIN_MAGNITUDE, COMPARATIVE_MAX_MAGNITUDE);
+};
+
+export const parseComparativeIntent = (rawQuery: string): ComparativeIntent | null => {
+  const lowered = rawQuery.toLowerCase().trim();
+  if (!lowered) return null;
+
+  const amplifierPhrases = countAndStrip(lowered, AMPLIFIER_PHRASE_PATTERN);
+  const diminisherPhrases = countAndStrip(amplifierPhrases.text, DIMINISHER_PHRASE_PATTERN);
+  let amplifierCount = amplifierPhrases.count;
+  let diminisherCount = diminisherPhrases.count;
+
+  const tokens = diminisherPhrases.text.split(/\s+/).filter(Boolean);
+
+  let polarAdjective: PolarAdjective | null = null;
+  let polarCount = 0;
+  let hasStrongPolar = false;
+  let genericSign: 1 | -1 | 0 = 0;
+  let genericVerbCount = 0;
+  let hasCommandVerb = false;
+  const subjectTokens: string[] = [];
+
+  for (const token of tokens) {
+    if (AMPLIFIER_WORDS.has(token)) {
+      amplifierCount++;
+      continue;
+    }
+    if (DIMINISHER_WORDS.has(token)) {
+      diminisherCount++;
+      continue;
+    }
+    if (COMMAND_VERBS.has(token)) {
+      hasCommandVerb = true;
+      continue;
+    }
+    if (INCREASE_VERBS.has(token)) {
+      genericSign = 1;
+      genericVerbCount++;
+      continue;
+    }
+    if (DECREASE_VERBS.has(token)) {
+      genericSign = -1;
+      genericVerbCount++;
+      continue;
+    }
+    const polar = POLAR_ADJECTIVES.get(token);
+    if (polar) {
+      polarCount++;
+      if (polar.isComparativeForm) hasStrongPolar = true;
+      if (!polarAdjective) polarAdjective = polar;
+      continue;
+    }
+    if (STOPWORDS.has(token)) continue;
+    subjectTokens.push(token);
+  }
+
+  const hasSignal =
+    hasStrongPolar ||
+    hasCommandVerb ||
+    amplifierCount > 0 ||
+    diminisherCount > 0 ||
+    genericVerbCount > 0 ||
+    polarCount >= 2;
+  if (!hasSignal) return null;
+
+  let direction: 1 | -1;
+  let dimensionCandidates: readonly string[] | null;
+  if (polarAdjective) {
+    dimensionCandidates = polarAdjective.candidates;
+    const shouldInvert = genericSign === -1;
+    direction = shouldInvert
+      ? polarAdjective.direction === 1
+        ? -1
+        : 1
+      : polarAdjective.direction;
+  } else if (genericSign !== 0) {
+    dimensionCandidates = null;
+    direction = genericSign;
+  } else {
+    return null;
+  }
+
+  const subject = subjectTokens.join(" ").trim() || null;
+  if (!polarAdjective && !subject) return null;
+
+  const extraRepeats =
+    Math.max(0, polarCount - 1) + Math.max(0, genericVerbCount - 1);
+  const magnitude = computeMagnitude(amplifierCount, diminisherCount, extraRepeats);
+
+  return { subject, dimensionCandidates, direction, magnitude };
+};

--- a/packages/react-grab/src/utils/compute-comparative-value.ts
+++ b/packages/react-grab/src/utils/compute-comparative-value.ts
@@ -1,0 +1,47 @@
+import {
+  COMPARATIVE_BASE_RATIO,
+  COMPARATIVE_LENGTH_FLOOR_PX,
+  COMPARATIVE_OPACITY_FLOOR_PERCENT,
+  COMPARATIVE_UNITLESS_FLOOR,
+  COMPARATIVE_Z_INDEX_FLOOR,
+} from "../constants.js";
+import type { EditableProperty, NumericEditableProperty } from "../types.js";
+import { clampToRange } from "./clamp-to-range.js";
+import { roundEditableNumericValue } from "./format-css-value.js";
+
+const floorStep = (property: NumericEditableProperty): number => {
+  if (property.key === "opacity") return COMPARATIVE_OPACITY_FLOOR_PERCENT;
+  if (property.key === "z-index") return COMPARATIVE_Z_INDEX_FLOOR;
+  if (property.unit === "px") return COMPARATIVE_LENGTH_FLOOR_PX;
+  return COMPARATIVE_UNITLESS_FLOOR;
+};
+
+// Comparative edits are computed from the property's panel-open baseline so
+// re-typing the same phrase converges instead of compounding. Ordinal enums
+// (font-weight) step through their options; numeric rows move by the larger of
+// a proportional nudge and a per-unit floor, scaled by intensity.
+export const computeComparativeValue = (
+  property: EditableProperty,
+  direction: 1 | -1,
+  magnitude: number,
+): number | string | null => {
+  if (property.kind === "enum") {
+    const currentIndex = property.options.findIndex((option) => option.value === property.value);
+    if (currentIndex === -1) return null;
+    const steps = Math.max(1, Math.round(magnitude));
+    const targetIndex = clampToRange(
+      currentIndex + direction * steps,
+      0,
+      property.options.length - 1,
+    );
+    const nextValue = property.options[targetIndex].value;
+    return nextValue === property.value ? null : nextValue;
+  }
+  if (property.kind !== "numeric") return null;
+
+  const proportionalDelta = Math.abs(property.value) * COMPARATIVE_BASE_RATIO;
+  const unitDelta = Math.max(proportionalDelta, floorStep(property)) * magnitude;
+  const candidate = property.value + direction * unitDelta;
+  const nextValue = roundEditableNumericValue(clampToRange(candidate, property.min, property.max));
+  return nextValue === property.value ? null : nextValue;
+};

--- a/packages/react-grab/src/utils/fuzzy-match.ts
+++ b/packages/react-grab/src/utils/fuzzy-match.ts
@@ -1,0 +1,66 @@
+// Allowed typo budget grows with the candidate length: short words demand an
+// exact hit (too easy to collide), medium words tolerate one edit, long words
+// two. Tuned so comparative forms ("bigger", "smaller", "increase") forgive a
+// single slip without coercing unrelated 4-letter words.
+const allowedEditDistance = (length: number): number => (length <= 4 ? 0 : length <= 7 ? 1 : 2);
+
+const MIN_FUZZY_TOKEN_LENGTH = 4;
+
+// Bounded Levenshtein: bails out early (returning maxDistance + 1) once a row's
+// best is already over budget, so most non-matches cost a few comparisons.
+const editDistance = (source: string, target: string, maxDistance: number): number => {
+  const sourceLength = source.length;
+  const targetLength = target.length;
+  if (Math.abs(sourceLength - targetLength) > maxDistance) return maxDistance + 1;
+
+  let previousRow = new Array<number>(targetLength + 1);
+  let currentRow = new Array<number>(targetLength + 1);
+  for (let column = 0; column <= targetLength; column++) previousRow[column] = column;
+
+  for (let row = 1; row <= sourceLength; row++) {
+    currentRow[0] = row;
+    let rowMinimum = currentRow[0];
+    const sourceCharCode = source.charCodeAt(row - 1);
+    for (let column = 1; column <= targetLength; column++) {
+      const substitutionCost = sourceCharCode === target.charCodeAt(column - 1) ? 0 : 1;
+      const deletion = previousRow[column] + 1;
+      const insertion = currentRow[column - 1] + 1;
+      const substitution = previousRow[column - 1] + substitutionCost;
+      let best = deletion < insertion ? deletion : insertion;
+      if (substitution < best) best = substitution;
+      currentRow[column] = best;
+      if (best < rowMinimum) rowMinimum = best;
+    }
+    if (rowMinimum > maxDistance) return maxDistance + 1;
+    const swap = previousRow;
+    previousRow = currentRow;
+    currentRow = swap;
+  }
+  return previousRow[targetLength];
+};
+
+export const isTypoMatch = (token: string, candidate: string): boolean => {
+  if (token.length < MIN_FUZZY_TOKEN_LENGTH) return false;
+  const allowed = allowedEditDistance(candidate.length);
+  if (allowed === 0) return false;
+  return editDistance(token, candidate, allowed) <= allowed;
+};
+
+// Returns the first candidate (in supplied priority order) within typo budget,
+// or null. Stops at the first single-edit hit since nothing can beat it.
+export const findClosestWord = (token: string, candidates: readonly string[]): string | null => {
+  if (token.length < MIN_FUZZY_TOKEN_LENGTH) return null;
+  let best: string | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (const candidate of candidates) {
+    const allowed = allowedEditDistance(candidate.length);
+    if (allowed === 0) continue;
+    const distance = editDistance(token, candidate, allowed);
+    if (distance <= allowed && distance < bestDistance) {
+      best = candidate;
+      bestDistance = distance;
+      if (distance === 1) break;
+    }
+  }
+  return best;
+};

--- a/packages/react-grab/src/utils/property-search-index.ts
+++ b/packages/react-grab/src/utils/property-search-index.ts
@@ -9,6 +9,8 @@ import {
   EDIT_SEARCH_TAILWIND_PREFIX_SCORE,
 } from "../constants.js";
 import type { EditableProperty } from "../types.js";
+import { parseComparativeIntent } from "./comparative-intent.js";
+import { resolveComparativeTargets } from "./resolve-comparative-target.js";
 import { isNumericQuery } from "./is-numeric-query.js";
 import {
   getTailwindPrefixPropertyKeysForSearchQuery,
@@ -136,6 +138,19 @@ export const createPropertySearchIndex = (properties: EditableProperty[]): Prope
   };
 
   const search = (query: string): EditableProperty[] => {
+    // A natural-language comparative ("make it bigger", "less padding")
+    // surfaces its resolved target(s) first so the panel highlights the row
+    // the same edit will mutate, with the remaining rows kept underneath.
+    const comparativeIntent = parseComparativeIntent(query);
+    if (comparativeIntent) {
+      const resolution = resolveComparativeTargets(comparativeIntent, properties);
+      if (resolution) {
+        const targetKeys = new Set(resolution.targets.map((target) => target.key));
+        const remaining = properties.filter((property) => !targetKeys.has(property.key));
+        return [...resolution.targets, ...remaining];
+      }
+    }
+
     const normalized = normalizeSearchText(query);
     if (!normalized || isNumericQuery(normalized)) return properties;
 

--- a/packages/react-grab/src/utils/resolve-comparative-target.ts
+++ b/packages/react-grab/src/utils/resolve-comparative-target.ts
@@ -1,0 +1,100 @@
+import type { ComparativeIntent, ComparativeResolution, EditableProperty } from "../types.js";
+import { expandAggregateLonghands } from "./expand-aggregate-longhands.js";
+import { AGGREGATE_GROUPS } from "./property-definitions.js";
+import { propertyKeyForAlias } from "./tailwind-class-map.js";
+
+const ORDINAL_ENUM_KEYS = new Set(["font-weight"]);
+
+// Maps each side longhand of the box aggregates (padding/margin/radius/
+// border-width/inset) back to its all-sides key so an unaligned subject like
+// "padding" resolves to the same fan-out target on every keystroke. The size
+// group is excluded so "width"/"height" stay independent rows.
+const CANONICAL_AGGREGATE_KEY_BY_LONGHAND = ((): Map<string, string> => {
+  const longhandToKey = new Map<string, string>();
+  for (const group of AGGREGATE_GROUPS) {
+    const topLevel = group[0];
+    if (topLevel.key === "width,height") continue;
+    for (const longhand of topLevel.longhands) longhandToKey.set(longhand, topLevel.key);
+  }
+  return longhandToKey;
+})();
+
+const normalizeSubject = (value: string): string => value.toLowerCase().replace(/[^a-z0-9]+/g, "");
+
+const isComparable = (property: EditableProperty): boolean =>
+  property.kind === "numeric" || (property.kind === "enum" && ORDINAL_ENUM_KEYS.has(property.key));
+
+const canonicalizeKey = (key: string): string => {
+  if (key.includes(",")) return key;
+  return CANONICAL_AGGREGATE_KEY_BY_LONGHAND.get(key) ?? key;
+};
+
+const matchSubjectProperty = (
+  subject: string,
+  properties: readonly EditableProperty[],
+): EditableProperty | null => {
+  const normalizedSubject = normalizeSubject(subject);
+  if (!normalizedSubject) return null;
+  let prefixMatch: EditableProperty | null = null;
+  for (const property of properties) {
+    const terms = [property.key, property.label, ...property.tailwindAliases];
+    for (const term of terms) {
+      const normalizedTerm = normalizeSubject(term);
+      if (!normalizedTerm) continue;
+      if (normalizedTerm === normalizedSubject) return property;
+      if (
+        !prefixMatch &&
+        (normalizedTerm.startsWith(normalizedSubject) ||
+          normalizedSubject.startsWith(normalizedTerm))
+      ) {
+        prefixMatch = property;
+      }
+    }
+  }
+  return prefixMatch;
+};
+
+const findPropertiesForKey = (
+  key: string,
+  properties: readonly EditableProperty[],
+): EditableProperty[] => {
+  const direct = properties.find((property) => property.key === key && isComparable(property));
+  if (direct) return [direct];
+  const longhands = expandAggregateLonghands(key);
+  return properties.filter(
+    (property) =>
+      property.kind === "numeric" &&
+      property.cssProperties.length === 1 &&
+      longhands.includes(property.cssProperties[0]),
+  );
+};
+
+const resolveSubjectKey = (
+  subject: string,
+  properties: readonly EditableProperty[],
+): string | null => {
+  const aliasKey = propertyKeyForAlias(subject);
+  if (aliasKey) return canonicalizeKey(aliasKey);
+  const matched = matchSubjectProperty(subject, properties);
+  return matched ? canonicalizeKey(matched.key) : null;
+};
+
+export const resolveComparativeTargets = (
+  intent: ComparativeIntent,
+  properties: readonly EditableProperty[],
+): ComparativeResolution | null => {
+  const candidateKeys: string[] = [];
+  if (intent.subject) {
+    const subjectKey = resolveSubjectKey(intent.subject, properties);
+    if (subjectKey) candidateKeys.push(subjectKey);
+  }
+  if (intent.dimensionCandidates) candidateKeys.push(...intent.dimensionCandidates);
+
+  for (const key of candidateKeys) {
+    const targets = findPropertiesForKey(key, properties);
+    if (targets.length > 0) {
+      return { targets, direction: intent.direction, magnitude: intent.magnitude };
+    }
+  }
+  return null;
+};

--- a/packages/react-grab/src/utils/resolve-comparative-target.ts
+++ b/packages/react-grab/src/utils/resolve-comparative-target.ts
@@ -1,5 +1,6 @@
 import type { ComparativeIntent, ComparativeResolution, EditableProperty } from "../types.js";
 import { expandAggregateLonghands } from "./expand-aggregate-longhands.js";
+import { isTypoMatch } from "./fuzzy-match.js";
 import { AGGREGATE_GROUPS } from "./property-definitions.js";
 import { propertyKeyForAlias } from "./tailwind-class-map.js";
 
@@ -36,6 +37,7 @@ const matchSubjectProperty = (
   const normalizedSubject = normalizeSubject(subject);
   if (!normalizedSubject) return null;
   let prefixMatch: EditableProperty | null = null;
+  let typoMatch: EditableProperty | null = null;
   for (const property of properties) {
     const terms = [property.key, property.label, ...property.tailwindAliases];
     for (const term of terms) {
@@ -49,9 +51,12 @@ const matchSubjectProperty = (
       ) {
         prefixMatch = property;
       }
+      if (!prefixMatch && !typoMatch && isTypoMatch(normalizedSubject, normalizedTerm)) {
+        typoMatch = property;
+      }
     }
   }
-  return prefixMatch;
+  return prefixMatch ?? typoMatch;
 };
 
 const findPropertiesForKey = (

--- a/packages/react-grab/src/utils/tailwind-class-map.ts
+++ b/packages/react-grab/src/utils/tailwind-class-map.ts
@@ -75,6 +75,21 @@ const TAILWIND_PREFIX_TO_PROPERTY: Partial<Record<string, string>> = {
 };
 
 const EXTRA_PROPERTY_ALIASES: Record<string, string[]> = {
+  // Spelled-out nouns for natural-language comparatives ("more padding",
+  // "less line height"). Tailwind prefixes (p, m, w, …) are already folded in
+  // below; these add the words users actually type.
+  padding: ["padding", "pad"],
+  margin: ["margin"],
+  gap: ["gap", "gutter"],
+  width: ["width"],
+  height: ["height"],
+  "border-radius": ["radius", "border radius", "rounding", "roundness", "corners"],
+  "border-width": ["border", "border width", "border thickness"],
+  "letter-spacing": ["letter spacing", "tracking"],
+  "line-height": ["line height", "leading"],
+  "z-index": ["z index", "depth"],
+  "font-weight": ["weight", "font weight", "boldness"],
+  opacity: ["opacity"],
   "font-size": ["font-size", "font size", "text-size", "text size"],
   color: ["color", "text-color", "text color", "text-colour", "text colour", "foreground", "fg"],
   "background-color": [
@@ -460,6 +475,32 @@ export const getElementTailwindProperties = (element: Element): Set<string> => {
 
 export const getTailwindAliasesForProperty = (property: string): string[] =>
   PROPERTY_ALIASES[property] ?? [];
+
+const normalizeAliasText = (value: string): string =>
+  value.toLowerCase().replace(/[^a-z0-9]+/g, "");
+
+// Reverse of PROPERTY_ALIASES: a spelled-out noun or tailwind prefix back to
+// its css property key. First spelling wins on collision so prefix-derived
+// keys (set up before EXTRA_PROPERTY_ALIASES) take precedence.
+const PROPERTY_KEY_BY_ALIAS = ((): Map<string, string> => {
+  const aliasToKey = new Map<string, string>();
+  for (const [property, aliases] of Object.entries(PROPERTY_ALIASES)) {
+    if (!aliases) continue;
+    for (const alias of aliases) {
+      const normalizedAlias = normalizeAliasText(alias);
+      if (normalizedAlias && !aliasToKey.has(normalizedAlias)) {
+        aliasToKey.set(normalizedAlias, property);
+      }
+    }
+  }
+  return aliasToKey;
+})();
+
+export const propertyKeyForAlias = (text: string): string | null => {
+  const normalized = normalizeAliasText(text);
+  if (!normalized) return null;
+  return PROPERTY_KEY_BY_ALIAS.get(normalized) ?? null;
+};
 
 export const tailwindPrefixToProperty = (prefix: string): string | null => {
   const propertyKey = TAILWIND_PREFIX_TO_PROPERTY[prefix];

--- a/packages/react-grab/src/utils/tailwind-class-map.ts
+++ b/packages/react-grab/src/utils/tailwind-class-map.ts
@@ -83,7 +83,7 @@ const EXTRA_PROPERTY_ALIASES: Record<string, string[]> = {
   gap: ["gap", "gutter"],
   width: ["width"],
   height: ["height"],
-  "border-radius": ["radius", "border radius", "rounding", "roundness", "corners"],
+  "border-radius": ["radius", "border radius", "rounding", "roundness", "corner", "corners"],
   "border-width": ["border", "border width", "border thickness"],
   "letter-spacing": ["letter spacing", "tracking"],
   "line-height": ["line height", "leading"],

--- a/packages/react-grab/tests/comparative-intent.test.ts
+++ b/packages/react-grab/tests/comparative-intent.test.ts
@@ -73,6 +73,60 @@ describe("parseComparativeIntent", () => {
     expect(intent?.dimensionCandidates).toContain("font-size");
   });
 
+  it("inverts the direction for 'too X' and reinforces for 'not X enough'", () => {
+    const tooBig = parseComparativeIntent("too big");
+    expect(tooBig?.dimensionCandidates).toContain("font-size");
+    expect(tooBig?.direction).toBe(-1);
+
+    expect(parseComparativeIntent("too small")?.direction).toBe(1);
+    expect(parseComparativeIntent("way too wide")?.direction).toBe(-1);
+    expect(parseComparativeIntent("way too wide")?.magnitude).toBe(2);
+
+    const notBigEnough = parseComparativeIntent("not big enough");
+    expect(notBigEnough?.dimensionCandidates).toContain("font-size");
+    expect(notBigEnough?.direction).toBe(1);
+  });
+
+  it("treats 'too much X' / 'not enough X' as subject commands", () => {
+    const tooMuch = parseComparativeIntent("too much padding");
+    expect(tooMuch?.subject).toBe("padding");
+    expect(tooMuch?.direction).toBe(-1);
+    expect(tooMuch?.magnitude).toBe(1);
+
+    const notEnough = parseComparativeIntent("not enough margin");
+    expect(notEnough?.subject).toBe("margin");
+    expect(notEnough?.direction).toBe(1);
+  });
+
+  it("inverts a comparative adjective under less", () => {
+    expect(parseComparativeIntent("less wide")?.direction).toBe(-1);
+    expect(parseComparativeIntent("less narrow")?.direction).toBe(1);
+  });
+
+  it("recognizes up/down directional verbs and extra synonyms", () => {
+    const up = parseComparativeIntent("bump up the padding");
+    expect(up?.subject).toBe("padding");
+    expect(up?.direction).toBe(1);
+
+    const down = parseComparativeIntent("shave down the border");
+    expect(down?.subject).toBe("border");
+    expect(down?.direction).toBe(-1);
+  });
+
+  it("understands extra opacity and spacing adjectives", () => {
+    expect(parseComparativeIntent("dimmer")?.dimensionCandidates).toContain("opacity");
+    expect(parseComparativeIntent("dimmer")?.direction).toBe(-1);
+    expect(parseComparativeIntent("roomier")?.dimensionCandidates).toContain("padding");
+    expect(parseComparativeIntent("roomier")?.direction).toBe(1);
+  });
+
+  it("ignores conversational filler around the command", () => {
+    const intent = parseComparativeIntent("can you make this a little bigger please");
+    expect(intent?.dimensionCandidates).toContain("font-size");
+    expect(intent?.direction).toBe(1);
+    expect(intent?.subject).toBeNull();
+  });
+
   it("handles inverse opacity adjectives independent of more/less", () => {
     const moreTransparent = parseComparativeIntent("more transparent");
     expect(moreTransparent?.dimensionCandidates).toContain("opacity");

--- a/packages/react-grab/tests/comparative-intent.test.ts
+++ b/packages/react-grab/tests/comparative-intent.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vite-plus/test";
+import { parseComparativeIntent } from "../src/utils/comparative-intent.js";
+
+describe("parseComparativeIntent", () => {
+  it("returns null for plain property searches and tailwind classes", () => {
+    for (const query of ["", "padding", "color", "p-4", "text-sm", "rounded-lg", "bg-red-500"]) {
+      expect(parseComparativeIntent(query), query).toBeNull();
+    }
+  });
+
+  it("ignores bare positive adjectives without another signal", () => {
+    for (const query of ["big", "bold", "round", "tight"]) {
+      expect(parseComparativeIntent(query), query).toBeNull();
+    }
+  });
+
+  it("ignores a generic verb with no subject", () => {
+    expect(parseComparativeIntent("more")).toBeNull();
+    expect(parseComparativeIntent("less")).toBeNull();
+  });
+
+  it("parses comparative adjectives into a dimension and direction", () => {
+    const bigger = parseComparativeIntent("bigger");
+    expect(bigger?.dimensionCandidates).toContain("font-size");
+    expect(bigger?.direction).toBe(1);
+    expect(bigger?.magnitude).toBe(1);
+
+    expect(parseComparativeIntent("smaller")?.direction).toBe(-1);
+    expect(parseComparativeIntent("wider")?.dimensionCandidates).toContain("width");
+    expect(parseComparativeIntent("taller")?.dimensionCandidates).toContain("height");
+    expect(parseComparativeIntent("bolder")?.dimensionCandidates).toContain("font-weight");
+    expect(parseComparativeIntent("rounder")?.dimensionCandidates).toContain("border-radius");
+  });
+
+  it("treats a command verb as a signal for positive adjectives", () => {
+    const intent = parseComparativeIntent("make it big");
+    expect(intent?.dimensionCandidates).toContain("font-size");
+    expect(intent?.direction).toBe(1);
+  });
+
+  it("scales magnitude with amplifiers, diminishers, and repetition", () => {
+    expect(parseComparativeIntent("much bigger")?.magnitude).toBe(2);
+    expect(parseComparativeIntent("a lot bigger")?.magnitude).toBe(2);
+    expect(parseComparativeIntent("way way bigger")?.magnitude).toBe(4);
+    expect(parseComparativeIntent("slightly bigger")?.magnitude).toBe(0.5);
+    expect(parseComparativeIntent("a bit smaller")?.magnitude).toBe(0.5);
+    // "big bigger" stacks the repeated adjective.
+    expect(parseComparativeIntent("big bigger")?.magnitude).toBe(1.5);
+    expect(parseComparativeIntent("make it big big bigger")?.magnitude).toBeCloseTo(1.5 ** 2, 5);
+  });
+
+  it("parses more/less commands with an explicit subject", () => {
+    const more = parseComparativeIntent("more padding");
+    expect(more?.subject).toBe("padding");
+    expect(more?.direction).toBe(1);
+
+    const less = parseComparativeIntent("less margin");
+    expect(less?.subject).toBe("margin");
+    expect(less?.direction).toBe(-1);
+
+    const reduce = parseComparativeIntent("reduce the font size a lot");
+    expect(reduce?.subject).toBe("font size");
+    expect(reduce?.direction).toBe(-1);
+    expect(reduce?.magnitude).toBe(2);
+  });
+
+  it("keeps the adjective's direction and exposes the subject override", () => {
+    const intent = parseComparativeIntent("make the border radius bigger");
+    // The adjective fixes the direction; the subject noun is carried
+    // separately so resolution can override the dimension default.
+    expect(intent?.subject).toBe("border radius");
+    expect(intent?.direction).toBe(1);
+    expect(intent?.dimensionCandidates).toContain("font-size");
+  });
+
+  it("handles inverse opacity adjectives independent of more/less", () => {
+    const moreTransparent = parseComparativeIntent("more transparent");
+    expect(moreTransparent?.dimensionCandidates).toContain("opacity");
+    expect(moreTransparent?.direction).toBe(-1);
+
+    const lessTransparent = parseComparativeIntent("less transparent");
+    expect(lessTransparent?.dimensionCandidates).toContain("opacity");
+    expect(lessTransparent?.direction).toBe(1);
+
+    expect(parseComparativeIntent("make it more opaque")?.direction).toBe(1);
+  });
+});

--- a/packages/react-grab/tests/comparative-intent.test.ts
+++ b/packages/react-grab/tests/comparative-intent.test.ts
@@ -127,6 +127,27 @@ describe("parseComparativeIntent", () => {
     expect(intent?.subject).toBeNull();
   });
 
+  it("tolerates single-character typos in adjectives and verbs", () => {
+    expect(parseComparativeIntent("biger")?.dimensionCandidates).toContain("font-size");
+    expect(parseComparativeIntent("biger")?.direction).toBe(1);
+    expect(parseComparativeIntent("smaler")?.direction).toBe(-1);
+    expect(parseComparativeIntent("widder")?.dimensionCandidates).toContain("width");
+
+    const increase = parseComparativeIntent("incrase the padding");
+    expect(increase?.subject).toBe("padding");
+    expect(increase?.direction).toBe(1);
+
+    expect(parseComparativeIntent("slighty bigger")?.magnitude).toBe(0.5);
+  });
+
+  it("never coerces a real property word into a typo'd adjective", () => {
+    // "border" is one edit from "bolder", "right" from "tight" — both must
+    // stay plain property searches, not comparative commands.
+    expect(parseComparativeIntent("border")).toBeNull();
+    expect(parseComparativeIntent("right")).toBeNull();
+    expect(parseComparativeIntent("color")).toBeNull();
+  });
+
   it("handles inverse opacity adjectives independent of more/less", () => {
     const moreTransparent = parseComparativeIntent("more transparent");
     expect(moreTransparent?.dimensionCandidates).toContain("opacity");

--- a/packages/react-grab/tests/compute-comparative-value.test.ts
+++ b/packages/react-grab/tests/compute-comparative-value.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { EnumEditableProperty, NumericEditableProperty } from "../src/types.js";
+import { computeComparativeValue } from "../src/utils/compute-comparative-value.js";
+
+const numeric = (
+  key: string,
+  value: number,
+  unit: string,
+  min = 0,
+  max = 1000,
+): NumericEditableProperty => ({
+  kind: "numeric",
+  key,
+  label: key,
+  cssProperties: [key],
+  min,
+  max,
+  value,
+  original: value,
+  unit,
+  tailwindAliases: [],
+  isPrioritized: false,
+  isDefault: false,
+  isCanonical: true,
+});
+
+const fontWeight = (value: string): EnumEditableProperty => ({
+  kind: "enum",
+  key: "font-weight",
+  label: "font weight",
+  cssProperties: ["font-weight"],
+  value,
+  original: value,
+  options: [
+    { value: "100", label: "thin" },
+    { value: "400", label: "normal" },
+    { value: "700", label: "bold" },
+    { value: "900", label: "black" },
+  ],
+  tailwindAliases: [],
+  isPrioritized: false,
+  isDefault: false,
+  isCanonical: true,
+});
+
+describe("computeComparativeValue", () => {
+  it("nudges a length by the larger of a proportional step and the floor", () => {
+    expect(computeComparativeValue(numeric("font-size", 16, "px"), 1, 1)).toBe(20);
+    expect(computeComparativeValue(numeric("font-size", 16, "px"), -1, 1)).toBe(12);
+    expect(computeComparativeValue(numeric("width", 200, "px"), 1, 2)).toBe(300);
+  });
+
+  it("moves a zero-valued property by the floor so it still changes", () => {
+    expect(computeComparativeValue(numeric("padding", 0, "px"), 1, 1)).toBe(4);
+  });
+
+  it("uses a percent floor for opacity", () => {
+    expect(computeComparativeValue(numeric("opacity", 100, "%"), -1, 1)).toBe(75);
+  });
+
+  it("clamps to the property bounds", () => {
+    expect(computeComparativeValue(numeric("font-size", 96, "px", 8, 96), 1, 1)).toBeNull();
+  });
+
+  it("steps ordinal enum options without wrapping", () => {
+    expect(computeComparativeValue(fontWeight("400"), 1, 1)).toBe("700");
+    expect(computeComparativeValue(fontWeight("400"), 1, 2)).toBe("900");
+    expect(computeComparativeValue(fontWeight("400"), -1, 1)).toBe("100");
+    expect(computeComparativeValue(fontWeight("900"), 1, 1)).toBeNull();
+  });
+});

--- a/packages/react-grab/tests/fuzzy-match.test.ts
+++ b/packages/react-grab/tests/fuzzy-match.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vite-plus/test";
+import { findClosestWord, isTypoMatch } from "../src/utils/fuzzy-match.js";
+
+describe("isTypoMatch", () => {
+  it("accepts single edits on medium and long words", () => {
+    expect(isTypoMatch("paddng", "padding")).toBe(true);
+    expect(isTypoMatch("incrase", "increase")).toBe(true);
+    expect(isTypoMatch("opacty", "opacity")).toBe(true);
+  });
+
+  it("requires exact matches for short words", () => {
+    expect(isTypoMatch("gap", "tap")).toBe(false);
+    expect(isTypoMatch("bold", "cold")).toBe(false);
+  });
+
+  it("rejects tokens that are too short or too far off", () => {
+    expect(isTypoMatch("pad", "padding")).toBe(false);
+    expect(isTypoMatch("paddxyz", "padding")).toBe(false);
+  });
+});
+
+describe("findClosestWord", () => {
+  const candidates = ["bigger", "smaller", "increase", "padding"];
+
+  it("returns the closest candidate within budget", () => {
+    expect(findClosestWord("biger", candidates)).toBe("bigger");
+    expect(findClosestWord("smaler", candidates)).toBe("smaller");
+    expect(findClosestWord("incrase", candidates)).toBe("increase");
+  });
+
+  it("returns null when nothing is close enough", () => {
+    expect(findClosestWord("color", candidates)).toBeNull();
+    expect(findClosestWord("xyz", candidates)).toBeNull();
+  });
+});

--- a/packages/react-grab/tests/resolve-comparative-target.test.ts
+++ b/packages/react-grab/tests/resolve-comparative-target.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vite-plus/test";
+import type {
+  ColorEditableProperty,
+  ComparativeIntent,
+  EnumEditableProperty,
+  NumericEditableProperty,
+} from "../src/types.js";
+import { parseComparativeIntent } from "../src/utils/comparative-intent.js";
+import { resolveComparativeTargets } from "../src/utils/resolve-comparative-target.js";
+
+const numeric = (
+  key: string,
+  value: number,
+  unit: string,
+  cssProperties: string[] = [key],
+): NumericEditableProperty => ({
+  kind: "numeric",
+  key,
+  label: key.replace(/-/g, " "),
+  cssProperties,
+  min: 0,
+  max: 1000,
+  value,
+  original: value,
+  unit,
+  tailwindAliases: [],
+  isPrioritized: false,
+  isDefault: false,
+  isCanonical: true,
+});
+
+const fontWeight = (): EnumEditableProperty => ({
+  kind: "enum",
+  key: "font-weight",
+  label: "font weight",
+  cssProperties: ["font-weight"],
+  value: "400",
+  original: "400",
+  options: [
+    { value: "100", label: "thin" },
+    { value: "400", label: "normal" },
+    { value: "700", label: "bold" },
+    { value: "900", label: "black" },
+  ],
+  tailwindAliases: [],
+  isPrioritized: false,
+  isDefault: false,
+  isCanonical: true,
+});
+
+const color: ColorEditableProperty = {
+  kind: "color",
+  key: "color",
+  label: "text color",
+  cssProperties: ["color"],
+  value: "#000000",
+  original: "#000000",
+  tailwindAliases: ["color"],
+  isPrioritized: false,
+  isDefault: false,
+  isCanonical: true,
+};
+
+const properties = [
+  numeric("font-size", 16, "px"),
+  numeric("width", 200, "px"),
+  numeric("padding", 0, "px", ["padding-top", "padding-right", "padding-bottom", "padding-left"]),
+  numeric("opacity", 100, "%"),
+  numeric("border-radius", 8, "px", [
+    "border-top-left-radius",
+    "border-top-right-radius",
+    "border-bottom-right-radius",
+    "border-bottom-left-radius",
+  ]),
+  fontWeight(),
+  color,
+];
+
+const resolve = (query: string) => {
+  const intent = parseComparativeIntent(query) as ComparativeIntent;
+  return resolveComparativeTargets(intent, properties);
+};
+
+describe("resolveComparativeTargets", () => {
+  it("resolves comparative adjectives to their dimension property", () => {
+    expect(resolve("bigger")?.targets.map((target) => target.key)).toEqual(["font-size"]);
+    expect(resolve("wider")?.targets.map((target) => target.key)).toEqual(["width"]);
+    expect(resolve("bolder")?.targets.map((target) => target.key)).toEqual(["font-weight"]);
+  });
+
+  it("resolves more/less subjects through the alias map", () => {
+    expect(resolve("more padding")?.targets.map((target) => target.key)).toEqual(["padding"]);
+    expect(resolve("less opacity")?.targets.map((target) => target.key)).toEqual(["opacity"]);
+  });
+
+  it("fans out to side rows when no aligned aggregate row exists", () => {
+    const sideRows = [
+      numeric("padding-top", 4, "px", ["padding-top"]),
+      numeric("padding-left", 8, "px", ["padding-left"]),
+    ];
+    const intent = parseComparativeIntent("more padding") as ComparativeIntent;
+    const resolution = resolveComparativeTargets(intent, sideRows);
+    expect(resolution?.targets.map((target) => target.key)).toEqual([
+      "padding-top",
+      "padding-left",
+    ]);
+  });
+
+  it("lets an explicit subject override the adjective's default dimension", () => {
+    const resolution = resolve("make the border radius bigger");
+    expect(resolution?.targets.map((target) => target.key)).toEqual(["border-radius"]);
+    expect(resolution?.direction).toBe(1);
+  });
+
+  it("does not target color or non-ordinal rows", () => {
+    expect(resolve("more color")).toBeNull();
+  });
+
+  it("carries direction and magnitude through resolution", () => {
+    const resolution = resolve("much smaller");
+    expect(resolution?.direction).toBe(-1);
+    expect(resolution?.magnitude).toBe(2);
+  });
+});

--- a/packages/react-grab/tests/resolve-comparative-target.test.ts
+++ b/packages/react-grab/tests/resolve-comparative-target.test.ts
@@ -121,4 +121,19 @@ describe("resolveComparativeTargets", () => {
     expect(resolution?.direction).toBe(-1);
     expect(resolution?.magnitude).toBe(2);
   });
+
+  it("resolves excess and shortage commands", () => {
+    const tooMuch = resolve("too much padding");
+    expect(tooMuch?.targets.map((target) => target.key)).toEqual(["padding"]);
+    expect(tooMuch?.direction).toBe(-1);
+
+    const notEnough = resolve("not enough opacity");
+    expect(notEnough?.targets.map((target) => target.key)).toEqual(["opacity"]);
+    expect(notEnough?.direction).toBe(1);
+  });
+
+  it("resolves extra opacity and spacing adjectives", () => {
+    expect(resolve("dimmer")?.targets.map((target) => target.key)).toEqual(["opacity"]);
+    expect(resolve("roomier")?.targets.map((target) => target.key)).toEqual(["padding"]);
+  });
 });

--- a/packages/react-grab/tests/resolve-comparative-target.test.ts
+++ b/packages/react-grab/tests/resolve-comparative-target.test.ts
@@ -136,4 +136,9 @@ describe("resolveComparativeTargets", () => {
     expect(resolve("dimmer")?.targets.map((target) => target.key)).toEqual(["opacity"]);
     expect(resolve("roomier")?.targets.map((target) => target.key)).toEqual(["padding"]);
   });
+
+  it("resolves a misspelled subject via fuzzy matching", () => {
+    expect(resolve("more paddng")?.targets.map((target) => target.key)).toEqual(["padding"]);
+    expect(resolve("less opacty")?.targets.map((target) => target.key)).toEqual(["opacity"]);
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Teaches the Style panel search box to understand natural-language comparative commands so you can type intent instead of exact tailwind classes or numbers:

- `bigger` / `smaller`, `wider` / `narrower`, `taller` / `shorter`, `bolder` / `lighter`, `thicker` / `thinner`, `rounder` / `sharper`, `more opaque` / `more transparent`, `looser` / `tighter`, plus `dimmer`, `roomier`/`airier`, `cramped`.
- `more padding`, `less margin`, `reduce the font size`, `make the border radius bigger`, `bump up the padding`, `shave down the border`, … — the `more`/`less`/`up`/`down` (+ verb) form resolves an explicit property noun, so it works for **all** properties via the alias/label map.
- Excess / shortage phrasing: `too big` → smaller, `too wide` → narrower, `too much padding` → less padding, `not big enough` → bigger, `not enough margin` → more margin.
- Intensity stacking via regex + heuristics: `much bigger`, `way way bigger`, `a lot smaller`, `slightly bigger`, `a bit smaller`, `so big`, and the requested **`big bigger`** (repeated adjective stacks the magnitude).
- Tolerant of conversational filler: `can you make this a little bigger please` still resolves cleanly.

## How

A query is parsed into a `ComparativeIntent` (subject, dimension candidates, direction, magnitude), resolved against the element's editable properties, and applied through the existing commit/preview pipeline.

- `utils/comparative-intent.ts` — pure regex/heuristic parser. Polar adjectives (with comparative/superlative forms) map to a dimension + direction; positive forms only fire alongside another signal (a command verb, intensity modifier, excess cue, or repetition) so bare property searches like `rounded` or tailwind classes like `rounded-lg` are never hijacked. Decrease cues (`less`, `too`) flip the adjective's direction; `not … enough` reinforces it. Inverse adjectives (`transparent`, `faint`, `dim`) are handled as opacity-down rather than opacity aliases so `more transparent` / `less transparent` both do the right thing.
- `utils/resolve-comparative-target.ts` — maps the intent to concrete numeric/ordinal-enum target rows, canonicalizing box-aggregate longhands so an unaligned `padding` fans out consistently across keystrokes.
- `utils/compute-comparative-value.ts` — each step moves a numeric row by the larger of a proportional nudge (25% of value) and a per-unit floor, scaled by magnitude and computed from the panel-open baseline so re-typing the same phrase **converges instead of compounding**. Ordinal enums (`font-weight`) step through their options without wrapping.
- `tailwind-autoapply.ts` applies the intent (taking precedence over class parsing); `property-search-index.ts` surfaces the resolved target row so the panel highlights exactly what the command mutates.
- `tailwind-class-map.ts` gains a forward `propertyKeyForAlias` resolver plus spelled-out noun aliases (`padding`, `radius`, `line height`, `weight`, …).

All new magic numbers live in `constants.ts`.

## Tests

- Unit: `comparative-intent`, `resolve-comparative-target`, `compute-comparative-value` (parsing, direction/magnitude, subject override, too/not-enough inversion, up/down verbs, fan-out, clamping, enum stepping).
- E2E: `edit-panel-comparative.spec.ts` — `bigger` targets font-size, amplifiers move further, idempotency, `too big` shrinks, `more`/`less padding`.
- Full existing edit-panel + autocomplete suites pass unchanged; lint, format, typecheck clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce9209c8-dc94-4fb3-9614-87072ab21e95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce9209c8-dc94-4fb3-9614-87072ab21e95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds natural-language comparative commands to the Style panel in `react-grab`, so you can type things like “bigger”, “less padding”, “too big”, or “bump up the padding” to change styles. Edits are consistent, support intensity, highlight the exact row, and now tolerate small typos.

- New Features
  - Broader language: “too X” / “not X enough”, “too much/many X”, up/down verbs, ignores filler.
  - More adjectives: opacity (“dim/dimmer”), spacing (“roomy/roomier/airy/spacious”), plus size/weight/radius/border/spacing comparatives.
  - Intensity: “much/way” amplify, “slightly/a bit” dampen, repeated adjectives stack; idempotent against the panel-open baseline; numeric steps are proportional with sensible floors; enums step without wrapping.
  - Typo tolerance: bounded fuzzy match forgives small mistakes (e.g. “biger”, “incrase”, “paddng”); won’t hijack real property searches.
  - Resolution/UX: subject aliases (“border radius”, “line height”); padding/margin fan out consistently; search surfaces the resolved target row; comparative intent applies before Tailwind class parsing.

- Tests
  - Unit and E2E cover typos, excess/shortage cues, up/down verbs, new adjectives, intensity, idempotency, fan-out, and enum stepping.

<sup>Written for commit d162ca0ca67a75a0e9819b811088077925b0003f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

