### PR TITLE
feat(react-grab): time-travel render-history plugin

### DIFF
--- a/.changeset/time-travel-history-panel.md
+++ b/.changeset/time-travel-history-panel.md
@@ -1,0 +1,5 @@
+---
+"react-grab": minor
+---
+
+Add a time-travel render-history plugin. React Grab now records what changed on every React commit (props and `useState`/`useReducer` state, resolved through bippy's commit instrumentation) into a bounded ring buffer. Selecting an element and choosing **History** (toolbar menu, right-click menu, or the `H` shortcut) opens a compact panel that scrubs that component's timeline: ←/→ (or the on-screen arrows) step back and forward through every recorded re-render, showing each `prev → next` change, and Enter/Copy hands the current moment to a coding agent.

--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Analytics } from "@vercel/analytics/react";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
+import Script from "next/script";
 import { Caveat, Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
@@ -62,7 +63,11 @@ const RootLayout = ({
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${caveat.variable} antialiased`}
       >
-        <script src="/script.js" defer />
+        {/* beforeInteractive (not defer) so bippy's devtools hook installs
+            before React initializes. React only emits commit events to a hook
+            present at init, and the render-history recorder relies on those
+            commits — a deferred script loads too late and records nothing. */}
+        <Script src="/script.js" strategy="beforeInteractive" />
         <NuqsAdapter>{children}</NuqsAdapter>
         <Analytics />
       </body>

--- a/packages/react-grab/e2e/history-panel.spec.ts
+++ b/packages/react-grab/e2e/history-panel.spec.ts
@@ -1,0 +1,67 @@
+import type { Page } from "@playwright/test";
+import { ATTRIBUTE_NAME } from "./constants.js";
+import { expect, test } from "./fixtures.js";
+
+const HISTORY_PANEL_ATTR = "data-react-grab-history-panel";
+const ADD_BUTTON_SELECTOR = "[data-testid='add-element-button']";
+
+const isHistoryPanelVisible = async (page: Page): Promise<boolean> =>
+  page.evaluate(
+    ({ attrName, panelAttr }) => {
+      const shadowRoot = document.querySelector(`[${attrName}]`)?.shadowRoot;
+      return Boolean(shadowRoot?.querySelector(`[${panelAttr}]`));
+    },
+    { attrName: ATTRIBUTE_NAME, panelAttr: HISTORY_PANEL_ATTR },
+  );
+
+// Reads the "<cursor> / <total>" position label from the panel footer.
+const readHistoryPosition = async (page: Page): Promise<{ cursor: number; total: number } | null> =>
+  page.evaluate(
+    ({ attrName, panelAttr }) => {
+      const shadowRoot = document.querySelector(`[${attrName}]`)?.shadowRoot;
+      const panel = shadowRoot?.querySelector(`[${panelAttr}]`);
+      const match = panel?.textContent?.match(/(\d+)\s*\/\s*(\d+)/);
+      if (!match) return null;
+      return { cursor: Number(match[1]), total: Number(match[2]) };
+    },
+    { attrName: ATTRIBUTE_NAME, panelAttr: HISTORY_PANEL_ATTR },
+  );
+
+test.describe("Render history panel", () => {
+  test("records commits and scrubs a component's timeline", async ({ reactGrab }) => {
+    const page = reactGrab.page;
+
+    // Generate history while grab is inactive: each click re-renders
+    // DynamicElements with a new `elements` array (a tracked state change).
+    for (let clickIndex = 0; clickIndex < 3; clickIndex++) {
+      await page.click(ADD_BUTTON_SELECTOR);
+      await page.waitForTimeout(50);
+    }
+
+    await reactGrab.activate();
+    await reactGrab.hoverUntilSelected(ADD_BUTTON_SELECTOR);
+    await reactGrab.rightClickElement(ADD_BUTTON_SELECTOR);
+    await reactGrab.clickContextMenuItem("History");
+
+    await expect.poll(() => isHistoryPanelVisible(page)).toBe(true);
+
+    const initialPosition = await readHistoryPosition(page);
+    expect(initialPosition).not.toBeNull();
+    expect(initialPosition!.total).toBeGreaterThanOrEqual(2);
+    // Opens focused on the most recent moment.
+    expect(initialPosition!.cursor).toBe(initialPosition!.total);
+
+    await page.keyboard.press("ArrowLeft");
+    await expect
+      .poll(async () => (await readHistoryPosition(page))?.cursor)
+      .toBe(initialPosition!.total - 1);
+
+    await page.keyboard.press("ArrowRight");
+    await expect
+      .poll(async () => (await readHistoryPosition(page))?.cursor)
+      .toBe(initialPosition!.total);
+
+    await page.keyboard.press("Escape");
+    await expect.poll(() => isHistoryPanelVisible(page)).toBe(false);
+  });
+});

--- a/packages/react-grab/src/components/history-panel/index.tsx
+++ b/packages/react-grab/src/components/history-panel/index.tsx
@@ -1,0 +1,239 @@
+import { createMemo, For, onCleanup, onMount, Show, type Accessor, type Component } from "solid-js";
+import {
+  DROPDOWN_EDGE_TRANSFORM_ORIGIN,
+  HISTORY_PANEL_MAX_WIDTH_PX,
+  HISTORY_PANEL_MIN_WIDTH_PX,
+  Z_INDEX_OVERLAY,
+} from "../../constants.js";
+import type { DropdownAnchor, HistoryMoment, HistoryPanelState } from "../../types.js";
+import { cn } from "../../utils/cn.js";
+import { createAnchoredDropdown } from "../../utils/create-anchored-dropdown.js";
+import { formatRelativeTime } from "../../utils/format-relative-time.js";
+import { getTagDisplay } from "../../utils/get-tag-display.js";
+import { isEventFromOverlay } from "../../utils/is-event-from-overlay.js";
+import { registerOverlayDismiss } from "../../utils/register-overlay-dismiss.js";
+import { suppressMenuEvent } from "../../utils/suppress-menu-event.js";
+import { EditPanelCopyButton } from "../edit-panel/copy-button.js";
+import { StepArrow } from "../edit-panel/step-arrow.js";
+import { TagBadge } from "../selection-label/tag-badge.js";
+import { Surface } from "../ui/surface.js";
+
+interface HistoryPanelProps {
+  state: HistoryPanelState | null;
+  position: DropdownAnchor | null;
+  onDismiss: () => void;
+  onStep: (direction: 1 | -1) => void;
+  onSubmit: () => void;
+}
+
+export const HistoryPanel: Component<HistoryPanelProps> = (props) => (
+  <Show when={props.state}>
+    {(state) => (
+      <Show keyed when={state().element}>
+        {(_element) => (
+          <HistoryPanelBody
+            state={state}
+            position={() => props.position}
+            onDismiss={props.onDismiss}
+            onStep={props.onStep}
+            onSubmit={props.onSubmit}
+          />
+        )}
+      </Show>
+    )}
+  </Show>
+);
+
+interface HistoryPanelBodyProps {
+  state: Accessor<HistoryPanelState>;
+  position: () => DropdownAnchor | null;
+  onDismiss: () => void;
+  onStep: (direction: 1 | -1) => void;
+  onSubmit: () => void;
+}
+
+const HistoryPanelBody: Component<HistoryPanelBodyProps> = (props) => {
+  let containerRef: HTMLDivElement | undefined;
+  const dropdown = createAnchoredDropdown(() => containerRef, props.position);
+
+  const tagDisplay = createMemo(() =>
+    getTagDisplay({
+      tagName: props.state().tagName,
+      componentName: props.state().componentName,
+    }),
+  );
+
+  const moments = createMemo(() => props.state().moments);
+  const hasMoments = createMemo(() => moments().length > 0);
+  const currentMoment = createMemo<HistoryMoment | null>(() => {
+    const list = moments();
+    if (list.length === 0) return null;
+    return list[props.state().cursor] ?? null;
+  });
+  const canStepBack = createMemo(() => props.state().cursor > 0);
+  const canStepForward = createMemo(() => props.state().cursor < moments().length - 1);
+
+  onMount(() => {
+    dropdown.measure();
+
+    const unregisterDismiss = registerOverlayDismiss({
+      isOpen: () => true,
+      onDismiss: props.onDismiss,
+      shouldIgnoreRightClick: true,
+    });
+
+    const handleWindowKeyDown = (event: KeyboardEvent) => {
+      if (isEventFromOverlay(event, "data-react-grab-input")) return;
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        props.onStep(-1);
+        return;
+      }
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        props.onStep(1);
+        return;
+      }
+      if (event.key === "Enter") {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        props.onSubmit();
+      }
+    };
+    window.addEventListener("keydown", handleWindowKeyDown, { capture: true });
+
+    onCleanup(() => {
+      unregisterDismiss();
+      window.removeEventListener("keydown", handleWindowKeyDown, { capture: true });
+      dropdown.clearAnimationHandles();
+    });
+  });
+
+  return (
+    <Show when={dropdown.shouldMount()}>
+      <div
+        ref={containerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Component render history"
+        data-react-grab-ignore-events
+        data-react-grab-history-panel
+        class={cn(
+          "fixed font-sans text-[13px] antialiased [filter:var(--rg-drop-shadow)] select-none",
+          dropdown.isAnimatedIn()
+            ? "transition-[opacity,transform] duration-220 ease-spring"
+            : "transition-[opacity,transform] duration-120 ease-drawer",
+        )}
+        style={{
+          top: `${dropdown.displayPosition().top}px`,
+          left: `${dropdown.displayPosition().left}px`,
+          "z-index": `${Z_INDEX_OVERLAY}`,
+          "pointer-events": dropdown.isAnimatedIn() ? "auto" : "none",
+          "transform-origin": DROPDOWN_EDGE_TRANSFORM_ORIGIN[dropdown.lastAnchorEdge()],
+          opacity: dropdown.isAnimatedIn() ? "1" : "0",
+          transform: dropdown.isAnimatedIn() ? "scale(1)" : "scale(0.92)",
+        }}
+        onPointerDown={suppressMenuEvent}
+        onMouseDown={suppressMenuEvent}
+        onClick={suppressMenuEvent}
+        onContextMenu={suppressMenuEvent}
+      >
+        <Surface
+          class="flex flex-col justify-center items-start overflow-hidden w-fit h-fit"
+          style={{
+            "min-width": `${HISTORY_PANEL_MIN_WIDTH_PX}px`,
+            "max-width": `${HISTORY_PANEL_MAX_WIDTH_PX}px`,
+          }}
+        >
+          <div class="contain-layout shrink-0 flex items-center gap-1 pt-1.5 pb-1 h-fit px-2 w-full self-stretch justify-between">
+            <TagBadge
+              tagName={tagDisplay().tagName}
+              componentName={tagDisplay().componentName}
+              isClickable={false}
+              onClick={() => {}}
+              shrink
+            />
+            <Show when={hasMoments()}>
+              <EditPanelCopyButton onCopy={props.onSubmit} />
+            </Show>
+          </div>
+
+          <Show
+            when={currentMoment()}
+            fallback={
+              <div class="flex items-center justify-center w-full px-3 py-2 [border-top-width:0.5px] border-t-solid border-t-[var(--rg-border-subtle)]">
+                <span class="text-[var(--rg-text-secondary)] text-[12px] leading-4">
+                  No renders recorded yet
+                </span>
+              </div>
+            }
+          >
+            {(moment) => (
+              <>
+                <div class="contain-layout shrink-0 flex flex-col items-start gap-0.5 px-2 py-1.5 w-full self-stretch [border-top-width:0.5px] border-t-solid border-t-[var(--rg-border-subtle)]">
+                  <Show
+                    when={moment().changes.length > 0}
+                    fallback={
+                      <span class="text-[var(--rg-text-secondary)] text-[12px] leading-4">
+                        Re-rendered (no tracked prop or state change)
+                      </span>
+                    }
+                  >
+                    <For each={moment().changes}>
+                      {(change) => (
+                        <div class="flex items-center gap-1.5 w-full min-w-0 tabular-nums">
+                          <span class="text-[var(--rg-text-secondary)] text-[11px] leading-4 shrink-0">
+                            {change.label}
+                          </span>
+                          <span class="text-[var(--rg-text-primary)] text-[12px] leading-4 truncate">
+                            {change.prev}
+                          </span>
+                          <span class="text-[var(--rg-text-secondary)] text-[11px] leading-4 shrink-0">
+                            →
+                          </span>
+                          <span class="text-[var(--rg-text-primary)] text-[12px] leading-4 truncate">
+                            {change.next}
+                          </span>
+                        </div>
+                      )}
+                    </For>
+                  </Show>
+                </div>
+
+                <div class="contain-layout shrink-0 flex items-center justify-between gap-2 px-2 py-1.5 w-full self-stretch [border-top-width:0.5px] border-t-solid border-t-[var(--rg-border-subtle)]">
+                  <div
+                    class="opacity-100 transition-opacity"
+                    style={{ opacity: canStepBack() ? "1" : "0.3" }}
+                  >
+                    <StepArrow
+                      direction="left"
+                      active={false}
+                      onPointerDown={() => props.onStep(-1)}
+                    />
+                  </div>
+                  <span class="text-[var(--rg-text-secondary)] text-[11px] leading-4 tabular-nums">
+                    {props.state().cursor + 1} / {moments().length}
+                    <span class="mx-1">·</span>
+                    {formatRelativeTime(moment().timestamp)}
+                  </span>
+                  <div
+                    class="opacity-100 transition-opacity"
+                    style={{ opacity: canStepForward() ? "1" : "0.3" }}
+                  >
+                    <StepArrow
+                      direction="right"
+                      active={false}
+                      onPointerDown={() => props.onStep(1)}
+                    />
+                  </div>
+                </div>
+              </>
+            )}
+          </Show>
+        </Surface>
+      </div>
+    </Show>
+  );
+};

--- a/packages/react-grab/src/components/renderer.tsx
+++ b/packages/react-grab/src/components/renderer.tsx
@@ -14,6 +14,7 @@ import { SelectionLabel } from "./selection-label/index.js";
 import { Toolbar } from "./toolbar/index.js";
 import { ContextMenu } from "./context-menu.js";
 import { EditPanel } from "./edit-panel/index.js";
+import { HistoryPanel } from "./history-panel/index.js";
 import { ToolbarMenu } from "./toolbar/toolbar-menu.js";
 
 export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
@@ -180,6 +181,13 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
         onSubmit={props.onEditPanelSubmit ?? (() => {})}
         onPendingEditsChange={props.onEditPanelPendingEditsChange}
         onInteractingChange={props.onEditPanelInteractingChange}
+      />
+      <HistoryPanel
+        state={props.historyPanelState ?? null}
+        position={props.historyPanelPosition ?? null}
+        onDismiss={props.onHistoryPanelDismiss ?? (() => {})}
+        onStep={props.onHistoryPanelStep ?? (() => {})}
+        onSubmit={props.onHistoryPanelSubmit ?? (() => {})}
       />
     </>
   );

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -158,6 +158,20 @@ export const TOOLBAR_DEFAULT_POSITION_RATIO = 0.5;
 export const DEFAULT_ACTION_ID = "copy";
 export const COMMENT_ACTION_ID = "comment";
 export const EDIT_ACTION_ID = "edit";
+export const HISTORY_ACTION_ID = "history";
+
+// Render-history recorder bounds. The recorder observes every React commit, so
+// the per-commit work and retained memory must both stay capped to avoid
+// leaking or degrading a busy app over time.
+export const HISTORY_MAX_ENTRIES = 300;
+export const HISTORY_MAX_FIBERS_PER_ENTRY = 40;
+export const HISTORY_MAX_CHANGES_PER_FIBER = 8;
+export const HISTORY_MAX_VALUE_LENGTH = 80;
+// Upper bound on moments shown for one component in the time-travel panel.
+export const HISTORY_MAX_MOMENTS = 100;
+
+export const HISTORY_PANEL_MIN_WIDTH_PX = 220;
+export const HISTORY_PANEL_MAX_WIDTH_PX = 340;
 
 export const TOOLTIP_DELAY_MS = 400;
 export const TOOLTIP_GRACE_PERIOD_MS = 800;

--- a/packages/react-grab/src/core/history-mode.ts
+++ b/packages/react-grab/src/core/history-mode.ts
@@ -1,0 +1,221 @@
+import { createSignal, type Accessor } from "solid-js";
+import {
+  getFiberFromHostInstance,
+  getFiberId,
+  isCompositeFiber,
+  traverseFiber,
+  type Fiber,
+} from "bippy";
+import { HISTORY_MAX_MOMENTS } from "../constants.js";
+import type { HistoryMoment, HistoryPanelState, Position } from "../types.js";
+import { clampToRange } from "../utils/clamp-to-range.js";
+import { formatHistoryPrompt } from "../utils/format-history-prompt.js";
+import { getTagName } from "../utils/get-tag-name.js";
+import { getNearestComponentName, resolveSource } from "./context.js";
+import { getRenderHistoryEntries } from "./render-history.js";
+
+export interface HistoryModeOverrides {
+  filePath?: string;
+  lineNumber?: number;
+  componentName?: string;
+  tagName?: string;
+}
+
+interface HistoryModeDependencies {
+  store: {
+    selectionFilePath: string | null;
+    selectionLineNumber: number | null;
+    wasActivatedByToggle: boolean;
+  };
+  actions: {
+    setPointer: (position: Position) => void;
+    setFrozenElement: (element: Element) => void;
+    freeze: () => void;
+    unfreeze: () => void;
+  };
+  isActivated: Accessor<boolean>;
+  activateRenderer: () => void;
+  deactivateRenderer: () => void;
+  performCopyWithLabel: (options: {
+    element: Element;
+    cursorX: number;
+    extraPrompt?: string;
+    shouldDeactivateAfter: boolean;
+  }) => void;
+  onOpen?: () => void;
+  onClose?: () => void;
+}
+
+export interface HistoryModeController {
+  state: Accessor<HistoryPanelState | null>;
+  trigger: (element: Element, position: Position, overrides?: HistoryModeOverrides) => boolean;
+  step: (direction: 1 | -1) => void;
+  dismiss: () => void;
+  closePreservingRenderer: () => void;
+  reset: () => void;
+  submit: () => void;
+  isOpen: Accessor<boolean>;
+}
+
+const findComponentFiber = (element: Element): Fiber | null => {
+  const hostFiber = getFiberFromHostInstance(element);
+  if (!hostFiber) return null;
+  if (isCompositeFiber(hostFiber)) return hostFiber;
+  return traverseFiber(hostFiber, (fiber) => isCompositeFiber(fiber), true);
+};
+
+const collectMoments = (targetFiberId: number, targetDisplayName: string): HistoryMoment[] => {
+  const byId: HistoryMoment[] = [];
+  const byName: HistoryMoment[] = [];
+  for (const entry of getRenderHistoryEntries()) {
+    const matchedById = entry.fibers.find((fiber) => fiber.fiberId === targetFiberId);
+    if (matchedById) {
+      byId.push({ id: entry.id, timestamp: entry.timestamp, changes: matchedById.changes });
+      continue;
+    }
+    const matchedByName = entry.fibers.find((fiber) => fiber.displayName === targetDisplayName);
+    if (matchedByName) {
+      byName.push({ id: entry.id, timestamp: entry.timestamp, changes: matchedByName.changes });
+    }
+  }
+  // Fiber identity is the precise signal; the display-name pass only fills in
+  // when a remount changed the id, so it's a fallback rather than a merge.
+  const moments = byId.length > 0 ? byId : byName;
+  if (moments.length > HISTORY_MAX_MOMENTS) {
+    return moments.slice(moments.length - HISTORY_MAX_MOMENTS);
+  }
+  return moments;
+};
+
+export const createHistoryModeController = (
+  dependencies: HistoryModeDependencies,
+): HistoryModeController => {
+  const [state, setState] = createSignal<HistoryPanelState | null>(null);
+
+  const clearAll = () => {
+    const wasOpen = state() !== null;
+    setState(null);
+    if (wasOpen) dependencies.onClose?.();
+  };
+
+  const resolveComponentNameIntoState = (element: Element) => {
+    void getNearestComponentName(element).then((nearestComponentName) => {
+      if (!nearestComponentName) return;
+      setState((current) => {
+        if (!current || current.element !== element || current.componentName) return current;
+        return { ...current, componentName: nearestComponentName };
+      });
+    });
+  };
+
+  const resolveSourceIntoState = (element: Element) => {
+    void resolveSource(element)
+      .then((source) => {
+        if (!source) return;
+        setState((current) => {
+          if (!current || current.element !== element || current.filePath) return current;
+          return {
+            ...current,
+            filePath: source.filePath,
+            lineNumber: source.lineNumber ?? undefined,
+          };
+        });
+      })
+      .catch(() => undefined);
+  };
+
+  const trigger = (
+    element: Element,
+    position: Position,
+    overrides: HistoryModeOverrides = {},
+  ): boolean => {
+    if (state() !== null) return false;
+    const componentFiber = findComponentFiber(element);
+    if (!componentFiber) return false;
+
+    const targetFiberId = getFiberId(componentFiber);
+    const componentName = overrides.componentName;
+    const moments = collectMoments(targetFiberId, componentName ?? "");
+
+    setState({
+      element,
+      position,
+      componentName,
+      tagName: overrides.tagName ?? getTagName(element),
+      filePath: overrides.filePath ?? dependencies.store.selectionFilePath ?? undefined,
+      lineNumber: overrides.lineNumber ?? dependencies.store.selectionLineNumber ?? undefined,
+      moments,
+      cursor: Math.max(0, moments.length - 1),
+    });
+
+    if (!componentName) resolveComponentNameIntoState(element);
+    if (!overrides.filePath && dependencies.store.selectionFilePath === null) {
+      resolveSourceIntoState(element);
+    }
+
+    if (!dependencies.isActivated()) {
+      dependencies.activateRenderer();
+    }
+    dependencies.actions.setPointer(position);
+    dependencies.actions.setFrozenElement(element);
+    dependencies.actions.freeze();
+    dependencies.onOpen?.();
+    return true;
+  };
+
+  const step = (direction: 1 | -1) => {
+    setState((current) => {
+      if (!current || current.moments.length === 0) return current;
+      const nextCursor = clampToRange(current.cursor + direction, 0, current.moments.length - 1);
+      if (nextCursor === current.cursor) return current;
+      return { ...current, cursor: nextCursor };
+    });
+  };
+
+  const dismiss = () => {
+    if (state() === null) return;
+    clearAll();
+    if (dependencies.store.wasActivatedByToggle) {
+      dependencies.deactivateRenderer();
+    } else {
+      dependencies.actions.unfreeze();
+    }
+  };
+
+  const closePreservingRenderer = () => {
+    if (state() === null) return;
+    clearAll();
+    dependencies.actions.unfreeze();
+  };
+
+  const submit = () => {
+    const currentState = state();
+    if (!currentState) return;
+    const moment = currentState.moments[currentState.cursor];
+    const element = currentState.element;
+    const cursorX = currentState.position.x;
+    const componentName = currentState.componentName ?? currentState.tagName ?? "Component";
+    const prompt = moment ? formatHistoryPrompt(componentName, moment) : undefined;
+    clearAll();
+    if (!dependencies.store.wasActivatedByToggle) {
+      dependencies.actions.unfreeze();
+    }
+    dependencies.performCopyWithLabel({
+      element,
+      cursorX,
+      extraPrompt: prompt,
+      shouldDeactivateAfter: dependencies.store.wasActivatedByToggle,
+    });
+  };
+
+  return {
+    state,
+    trigger,
+    step,
+    dismiss,
+    closePreservingRenderer,
+    reset: clearAll,
+    submit,
+    isOpen: () => state() !== null,
+  };
+};

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -81,6 +81,7 @@ import {
   DEFAULT_ACTION_ID,
   COMMENT_ACTION_ID,
   EDIT_ACTION_ID,
+  HISTORY_ACTION_ID,
   REACT_GRAB_ATTRIBUTE_NAME,
 } from "../constants.js";
 import { getBoundsCenter } from "../utils/get-bounds-center.js";
@@ -112,6 +113,7 @@ import type {
   ElementLabelVariant,
 } from "../types.js";
 import { createEditModeController, type EditModeOverrides } from "./edit-mode.js";
+import { createHistoryModeController } from "./history-mode.js";
 import { createPluginRegistry } from "./plugin-registry.js";
 import { createLabelController } from "./label-controller.js";
 import { createArrowNavigator } from "./arrow-navigation.js";
@@ -126,6 +128,7 @@ import { loadToolbarState, saveToolbarState } from "../components/toolbar/state.
 import { copyPlugin } from "./plugins/copy.js";
 import { commentPlugin } from "./plugins/comment.js";
 import { editPlugin } from "./plugins/edit.js";
+import { historyPlugin } from "./plugins/history.js";
 import { openPlugin } from "./plugins/open.js";
 import {
   freezeAnimations,
@@ -146,7 +149,7 @@ import { getNearestEdge } from "../utils/get-nearest-edge.js";
 import { findShortcutAction } from "../utils/action-shortcuts.js";
 import { createKeyboardSelectionController } from "./keyboard-selection.js";
 
-const builtInPlugins = [copyPlugin, editPlugin, commentPlugin, openPlugin];
+const builtInPlugins = [copyPlugin, editPlugin, historyPlugin, commentPlugin, openPlugin];
 
 interface CopyWithLabelOptions {
   element: Element;
@@ -305,6 +308,9 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     const [isToolbarSelectHovered, setIsToolbarSelectHovered] = createSignal(false);
     const [toolbarMenuPosition, setToolbarMenuPosition] = createSignal<DropdownAnchor | null>(null);
     const [editPanelPosition, setEditPanelPosition] = createSignal<DropdownAnchor | null>(null);
+    const [historyPanelPosition, setHistoryPanelPosition] = createSignal<DropdownAnchor | null>(
+      null,
+    );
     // Forward-ref wrappers because activateRenderer / deactivateRenderer /
     // performCopyWithLabel are declared later in this scope. The wrappers
     // are captured by the controller; the underlying lookups happen at
@@ -329,8 +335,30 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       },
     });
 
+    const historyMode = createHistoryModeController({
+      store,
+      actions,
+      isActivated,
+      activateRenderer: () => activateRenderer(),
+      deactivateRenderer: () => deactivateRenderer(),
+      performCopyWithLabel: (options) => performCopyWithLabel(options),
+      onOpen: () => {
+        dismissToolbarMenu();
+        stopHistoryPanelTracking?.();
+        stopHistoryPanelTracking = trackDropdownPosition(
+          computeHistoryPanelAnchor,
+          setHistoryPanelPosition,
+        );
+      },
+      onClose: () => {
+        stopHistoryPanelTracking?.();
+        stopHistoryPanelTracking = null;
+        setHistoryPanelPosition(null);
+      },
+    });
+
     const isModalPopoverOpen = createMemo(
-      () => store.contextMenuPosition !== null || editMode.isOpen(),
+      () => store.contextMenuPosition !== null || editMode.isOpen() || historyMode.isOpen(),
     );
     const isAnyPopoverOpen = createMemo(
       () => isModalPopoverOpen() || toolbarMenuPosition() !== null,
@@ -338,6 +366,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     let toolbarElement: HTMLDivElement | undefined;
     let stopToolbarMenuTracking: (() => void) | null = null;
     let stopEditPanelTracking: (() => void) | null = null;
+    let stopHistoryPanelTracking: (() => void) | null = null;
     let didSwitchEditTargetOnPointerDown = false;
 
     let shiftSelectionLabelAnchorRatioByElement = new WeakMap<Element, number>();
@@ -518,6 +547,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     );
     const toolbarActiveActionId = createMemo(() => {
       if (editMode.isOpen()) return EDIT_ACTION_ID;
+      if (historyMode.isOpen()) return HISTORY_ACTION_ID;
       if (isCommentMode()) return COMMENT_ACTION_ID;
       if (isPendingContextMenuSelect()) return pendingToolbarActionId();
       if (isActivated()) return DEFAULT_ACTION_ID;
@@ -1373,6 +1403,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       stopSpaceDragRepositioning();
       actions.deactivate();
       editMode.resetWithDiscard();
+      historyMode.reset();
       dismissToolbarMenu();
       stopShiftMultiSelecting();
       clearArrowNavigation();
@@ -1491,6 +1522,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       overrides: EditModeOverrides = {},
     ): boolean => editMode.trigger(element, position, overrides);
 
+    const openHistoryMode = (
+      element: Element,
+      position: Position,
+      overrides: EditModeOverrides = {},
+    ): boolean => historyMode.trigger(element, position, overrides);
+
     const tryHandleEditModeElementSwitch = (clientX: number, clientY: number): boolean => {
       if (!editMode.isOpen() || store.contextMenuPosition !== null) return false;
       const element = getElementsAtPoint(clientX, clientY).find(isValidGrabbableElement);
@@ -1533,6 +1570,15 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
       if (actionId === EDIT_ACTION_ID) {
         const didOpen = openEditMode(element, position, currentSelectionEditOverrides(element));
+        if (!didOpen) return true;
+        actions.clearInputText();
+        actions.exitPromptMode();
+        clearPendingToolbarSelection();
+        return true;
+      }
+
+      if (actionId === HISTORY_ACTION_ID) {
+        const didOpen = openHistoryMode(element, position, currentSelectionEditOverrides(element));
         if (!didOpen) return true;
         actions.clearInputText();
         actions.exitPromptMode();
@@ -1603,6 +1649,11 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
       if (actionId === EDIT_ACTION_ID) {
         openEditMode(element, position, currentSelectionEditOverrides(element));
+        return;
+      }
+
+      if (actionId === HISTORY_ACTION_ID) {
+        openHistoryMode(element, position, currentSelectionEditOverrides(element));
         return;
       }
 
@@ -2316,6 +2367,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       if (isCopying()) return false;
       if (store.contextMenuPosition !== null) return false;
       if (editMode.isOpen()) return false;
+      if (historyMode.isOpen()) return false;
 
       const isShiftF10 = event.key === "F10" && event.shiftKey;
       const isContextMenuKey = event.key === "ContextMenu";
@@ -2447,7 +2499,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       const targetElement = target instanceof HTMLElement ? target : null;
       return Boolean(
         targetElement?.closest("[data-react-grab-discard-copy]") ||
-          targetElement?.closest("[data-react-grab-discard-yes]"),
+        targetElement?.closest("[data-react-grab-discard-yes]"),
       );
     };
 
@@ -2806,6 +2858,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       (event: MouseEvent) => {
         if (!isRendererActive() || isCopying() || isPromptMode()) return;
         if (editMode.isOpen()) return;
+        if (historyMode.isOpen()) return;
         if (keyboardSelection.isPendingDismiss()) {
           event.preventDefault();
           event.stopPropagation();
@@ -3068,6 +3121,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       stopToolbarMenuTracking = null;
       stopEditPanelTracking?.();
       stopEditPanelTracking = null;
+      stopHistoryPanelTracking?.();
+      stopHistoryPanelTracking = null;
       grabbedBoxTimeouts.forEach((timeoutId) => window.clearTimeout(timeoutId));
       grabbedBoxTimeouts.clear();
       labelController.cancelAllFades();
@@ -3445,6 +3500,19 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         hideContextMenuAction();
       };
 
+      const enterHistoryModeAction = () => {
+        const didOpen = openHistoryMode(element, position, {
+          filePath,
+          lineNumber,
+          componentName,
+          tagName,
+        });
+        if (didOpen) {
+          clearPendingToolbarSelection();
+        }
+        hideContextMenuAction();
+      };
+
       const context: ContextMenuActionContext = {
         element,
         elements,
@@ -3454,6 +3522,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         tagName,
         enterPromptMode: customEnterPromptMode ?? defaultEnterPromptMode,
         enterEditMode: enterEditModeAction,
+        enterHistoryMode: enterHistoryModeAction,
         copy: copyAction,
         hooks: {
           transformHtmlContent: pluginRegistry.hooks.transformHtmlContent,
@@ -3547,6 +3616,18 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       };
     };
 
+    const computeHistoryPanelAnchor = (): DropdownAnchor | null => {
+      const toolbarAnchor = computeDropdownAnchor();
+      if (toolbarAnchor) return toolbarAnchor;
+      const state = historyMode.state();
+      if (!state) return null;
+      return {
+        x: state.position.x,
+        y: state.position.y,
+        edge: "bottom",
+      };
+    };
+
     // Keep sibling dropdown tracking independent; sharing one RAF id breaks anchoring.
     const trackDropdownPosition = (
       getAnchor: () => DropdownAnchor | null,
@@ -3577,6 +3658,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       actions.hideContextMenu();
       dismissToolbarMenu();
       editMode.dismiss();
+      historyMode.dismiss();
     };
 
     const handleToggleToolbarMenu = () => {
@@ -3585,6 +3667,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       } else {
         actions.hideContextMenu();
         if (editMode.isOpen()) editMode.closePreservingRenderer();
+        if (historyMode.isOpen()) historyMode.closePreservingRenderer();
         stopToolbarMenuTracking?.();
         stopToolbarMenuTracking = trackDropdownPosition(
           computeDropdownAnchor,
@@ -3619,6 +3702,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       setTimeout(() => {
         dismissToolbarMenu();
         if (editMode.isOpen()) editMode.closePreservingRenderer();
+        if (historyMode.isOpen()) historyMode.closePreservingRenderer();
         if (!isActivated()) {
           actions.setWasActivatedByToggle(true);
           activateRenderer();
@@ -3754,6 +3838,11 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
                 onEditPanelSubmit={editMode.submit}
                 onEditPanelPendingEditsChange={editMode.setPendingEdits}
                 onEditPanelInteractingChange={editMode.setInteracting}
+                historyPanelState={historyMode.state()}
+                historyPanelPosition={historyPanelPosition()}
+                onHistoryPanelDismiss={historyMode.dismiss}
+                onHistoryPanelStep={historyMode.step}
+                onHistoryPanelSubmit={historyMode.submit}
               />
             );
           }, rendererRoot);
@@ -3836,6 +3925,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         stopToolbarMenuTracking = null;
         stopEditPanelTracking?.();
         stopEditPanelTracking = null;
+        stopHistoryPanelTracking?.();
+        stopHistoryPanelTracking = null;
         toolbarStateChangeCallbacks.clear();
         dispose();
       },

--- a/packages/react-grab/src/core/plugins/history.ts
+++ b/packages/react-grab/src/core/plugins/history.ts
@@ -1,0 +1,26 @@
+import type { Plugin } from "../../types.js";
+import { startRenderHistory, stopRenderHistory } from "../render-history.js";
+
+export const historyPlugin: Plugin = {
+  name: "history",
+  setup: () => {
+    startRenderHistory();
+    return {
+      actions: [
+        {
+          id: "history",
+          label: "History",
+          shortcut: "H",
+          shortcutModifier: false,
+          showInToolbarMenu: true,
+          onAction: (context) => {
+            context.enterHistoryMode?.();
+          },
+        },
+      ],
+      cleanup: () => {
+        stopRenderHistory();
+      },
+    };
+  },
+};

--- a/packages/react-grab/src/core/render-history.ts
+++ b/packages/react-grab/src/core/render-history.ts
@@ -32,6 +32,23 @@ let isRecording = false;
 // so the handler stays a single monomorphic function (no per-commit closure).
 let pendingFibers: HistoryFiberChange[] = [];
 
+// Records a change only when the two renders format differently. Objects and
+// arrays get a new identity on nearly every render (inline literals), so an
+// identity-only diff whose readable value is unchanged is pure noise and is
+// dropped rather than shown as a confusing "X → X" row.
+const pushChange = (
+  changes: HistoryChange[],
+  kind: HistoryChange["kind"],
+  label: string,
+  prevValue: unknown,
+  nextValue: unknown,
+): void => {
+  const prev = formatHistoryValue(prevValue);
+  const next = formatHistoryValue(nextValue);
+  if (prev === next) return;
+  changes.push({ kind, label, prev, next });
+};
+
 const captureFiberChanges = (fiber: Fiber): HistoryChange[] => {
   const changes: HistoryChange[] = [];
 
@@ -39,12 +56,7 @@ const captureFiberChanges = (fiber: Fiber): HistoryChange[] => {
     if (changes.length >= HISTORY_MAX_CHANGES_PER_FIBER) return true;
     if (propName === "children") return;
     if (Object.is(nextValue, prevValue)) return;
-    changes.push({
-      kind: "props",
-      label: propName,
-      prev: formatHistoryValue(prevValue),
-      next: formatHistoryValue(nextValue),
-    });
+    pushChange(changes, "props", propName, prevValue, nextValue);
   });
 
   // Only useState/useReducer hooks carry an update `queue`; useMemo/useRef/
@@ -58,12 +70,13 @@ const captureFiberChanges = (fiber: Fiber): HistoryChange[] => {
     stateIndex += 1;
     if (!prevNode) return;
     if (Object.is(nextNode.memoizedState, prevNode.memoizedState)) return;
-    changes.push({
-      kind: "state",
-      label: `state ${currentStateIndex}`,
-      prev: formatHistoryValue(prevNode.memoizedState),
-      next: formatHistoryValue(nextNode.memoizedState),
-    });
+    pushChange(
+      changes,
+      "state",
+      `state ${currentStateIndex}`,
+      prevNode.memoizedState,
+      nextNode.memoizedState,
+    );
   });
 
   return changes;

--- a/packages/react-grab/src/core/render-history.ts
+++ b/packages/react-grab/src/core/render-history.ts
@@ -1,0 +1,120 @@
+// Continuously records what changed on every React commit so the time-travel
+// panel can replay a component's recent history. This piggybacks on bippy's
+// commit instrumentation (the same devtools hook react-grab already relies on
+// for source resolution and freezing) and keeps a bounded ring buffer so a
+// long-lived, busy app never grows this unbounded.
+import {
+  getDisplayName,
+  getFiberId,
+  instrument,
+  isCompositeFiber,
+  traverseProps,
+  traverseRenderedFibers,
+  traverseState,
+  type Fiber,
+  type FiberRoot,
+} from "bippy";
+import {
+  HISTORY_MAX_CHANGES_PER_FIBER,
+  HISTORY_MAX_ENTRIES,
+  HISTORY_MAX_FIBERS_PER_ENTRY,
+} from "../constants.js";
+import type { HistoryChange, HistoryEntry, HistoryFiberChange } from "../types.js";
+import { formatHistoryValue } from "../utils/format-history-value.js";
+import { logRecoverableError } from "../utils/log-recoverable-error.js";
+
+const entries: HistoryEntry[] = [];
+let nextEntryId = 1;
+let isInstrumented = false;
+let isRecording = false;
+
+// Mutated per-commit by the stable onRender handler below. Kept at module scope
+// so the handler stays a single monomorphic function (no per-commit closure).
+let pendingFibers: HistoryFiberChange[] = [];
+
+const captureFiberChanges = (fiber: Fiber): HistoryChange[] => {
+  const changes: HistoryChange[] = [];
+
+  traverseProps(fiber, (propName, nextValue, prevValue) => {
+    if (changes.length >= HISTORY_MAX_CHANGES_PER_FIBER) return true;
+    if (propName === "children") return;
+    if (Object.is(nextValue, prevValue)) return;
+    changes.push({
+      kind: "props",
+      label: propName,
+      prev: formatHistoryValue(prevValue),
+      next: formatHistoryValue(nextValue),
+    });
+  });
+
+  // Only useState/useReducer hooks carry an update `queue`; useMemo/useRef/
+  // useEffect nodes don't. Filtering on it isolates real state transitions from
+  // the effect/memo churn that changes identity on every render.
+  let stateIndex = 0;
+  traverseState(fiber, (nextNode, prevNode) => {
+    if (changes.length >= HISTORY_MAX_CHANGES_PER_FIBER) return true;
+    if (!nextNode || nextNode.queue == null) return;
+    const currentStateIndex = stateIndex;
+    stateIndex += 1;
+    if (!prevNode) return;
+    if (Object.is(nextNode.memoizedState, prevNode.memoizedState)) return;
+    changes.push({
+      kind: "state",
+      label: `state ${currentStateIndex}`,
+      prev: formatHistoryValue(prevNode.memoizedState),
+      next: formatHistoryValue(nextNode.memoizedState),
+    });
+  });
+
+  return changes;
+};
+
+const onRender = (fiber: Fiber, phase: string): void => {
+  if (phase !== "update") return;
+  if (pendingFibers.length >= HISTORY_MAX_FIBERS_PER_ENTRY) return;
+  if (!isCompositeFiber(fiber)) return;
+  const changes = captureFiberChanges(fiber);
+  if (changes.length === 0) return;
+  pendingFibers.push({
+    fiberId: getFiberId(fiber),
+    displayName: getDisplayName(fiber.type) ?? "Unknown",
+    changes,
+  });
+};
+
+const onCommitFiberRoot = (_rendererID: number, root: FiberRoot): void => {
+  if (!isRecording) return;
+  pendingFibers = [];
+  try {
+    traverseRenderedFibers(root, onRender);
+  } catch (error) {
+    logRecoverableError("render-history traversal failed", error);
+    return;
+  }
+  if (pendingFibers.length === 0) return;
+  entries.push({ id: nextEntryId++, timestamp: Date.now(), fibers: pendingFibers });
+  if (entries.length > HISTORY_MAX_ENTRIES) {
+    entries.splice(0, entries.length - HISTORY_MAX_ENTRIES);
+  }
+};
+
+export const startRenderHistory = (): void => {
+  isRecording = true;
+  if (isInstrumented) return;
+  isInstrumented = true;
+  try {
+    instrument({ name: "react-grab-history", onCommitFiberRoot });
+  } catch (error) {
+    logRecoverableError("render-history instrumentation failed", error);
+  }
+};
+
+export const stopRenderHistory = (): void => {
+  isRecording = false;
+};
+
+export const getRenderHistoryEntries = (): readonly HistoryEntry[] => entries;
+
+export const clearRenderHistory = (): void => {
+  entries.length = 0;
+};

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -158,6 +158,50 @@ export interface ActionContext {
 export interface ContextMenuActionContext extends ActionContext {
   copy?: () => void;
   enterEditMode?: () => void;
+  enterHistoryMode?: () => void;
+}
+
+export type HistoryChangeKind = "props" | "state" | "context";
+
+export interface HistoryChange {
+  kind: HistoryChangeKind;
+  label: string;
+  prev: string;
+  next: string;
+}
+
+export interface HistoryFiberChange {
+  fiberId: number;
+  displayName: string;
+  changes: HistoryChange[];
+}
+
+// One React commit that mutated at least one composite fiber. Ordered oldest
+// to newest by the recorder.
+export interface HistoryEntry {
+  id: number;
+  timestamp: number;
+  fibers: HistoryFiberChange[];
+}
+
+// A single point on one component's timeline, projected from a HistoryEntry
+// down to just the changes for the component being inspected.
+export interface HistoryMoment {
+  id: number;
+  timestamp: number;
+  changes: HistoryChange[];
+}
+
+export interface HistoryPanelState {
+  element: Element;
+  position: Position;
+  componentName?: string;
+  tagName?: string;
+  filePath?: string;
+  lineNumber?: number;
+  moments: HistoryMoment[];
+  // Index into `moments`; starts on the most recent moment.
+  cursor: number;
 }
 
 interface EditablePropertyBase {
@@ -546,6 +590,11 @@ export interface ReactGrabRendererProps {
   onEditPanelSubmit?: (pendingEdits: PendingEdits) => void;
   onEditPanelPendingEditsChange?: (pendingEdits: PendingEdits) => void;
   onEditPanelInteractingChange?: (interacting: boolean) => void;
+  historyPanelState?: HistoryPanelState | null;
+  historyPanelPosition?: DropdownAnchor | null;
+  onHistoryPanelDismiss?: () => void;
+  onHistoryPanelStep?: (direction: 1 | -1) => void;
+  onHistoryPanelSubmit?: () => void;
 }
 
 export interface GrabbedBox {

--- a/packages/react-grab/src/utils/format-history-prompt.ts
+++ b/packages/react-grab/src/utils/format-history-prompt.ts
@@ -1,0 +1,14 @@
+import type { HistoryMoment } from "../types.js";
+import { formatRelativeTime } from "./format-relative-time.js";
+
+// Describes a single point on a component's render timeline as an agent-ready
+// note, e.g. "Counter re-rendered 12s ago — state 0: 4 → 5".
+export const formatHistoryPrompt = (componentName: string, moment: HistoryMoment): string => {
+  const changeLines = moment.changes.map(
+    (change) => `  - ${change.label}: ${change.prev} → ${change.next}`,
+  );
+  return [
+    `${componentName} re-rendered ${formatRelativeTime(moment.timestamp)}:`,
+    ...changeLines,
+  ].join("\n");
+};

--- a/packages/react-grab/src/utils/format-history-value.ts
+++ b/packages/react-grab/src/utils/format-history-value.ts
@@ -1,40 +1,63 @@
 import { HISTORY_MAX_VALUE_LENGTH } from "../constants.js";
 
+const HISTORY_MAX_OBJECT_KEYS = 4;
+const HISTORY_MAX_ARRAY_ITEMS = 4;
+
 const truncate = (text: string): string =>
   text.length > HISTORY_MAX_VALUE_LENGTH ? `${text.slice(0, HISTORY_MAX_VALUE_LENGTH - 1)}…` : text;
 
+// Depth-0 label for a nested value: primitives are shown literally, everything
+// composite collapses to its type so nesting can't blow up the string.
+const formatScalar = (value: unknown): string => {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  const valueType = typeof value;
+  if (valueType === "string") return JSON.stringify(value);
+  if (valueType === "number" || valueType === "boolean" || valueType === "bigint") {
+    return String(value);
+  }
+  if (valueType === "function") {
+    const name = (value as { name?: string }).name;
+    return name ? `ƒ ${name}` : "ƒ";
+  }
+  if (valueType === "symbol") return String(value);
+  if (Array.isArray(value)) return `Array(${value.length})`;
+  if (value instanceof Element) return `<${value.tagName.toLowerCase()}>`;
+  const constructorName = (value as { constructor?: { name?: string } }).constructor?.name;
+  return constructorName && constructorName !== "Object" ? constructorName : "{…}";
+};
+
 // Turns an arbitrary fiber prop/state value into a short, human-readable label
-// for the time-travel panel. Never throws: any getter or circular structure
-// falls back to its type so recording a commit can't crash the host app.
+// for the time-travel panel. Objects and arrays get one level of shallow
+// expansion so two renders can actually be told apart (e.g. `{opacity: 0}` vs
+// `{opacity: 1}`) instead of collapsing to an identical opaque shape. Never
+// throws: any getter or circular structure falls back to its type so recording
+// a commit can't crash the host app.
 export const formatHistoryValue = (value: unknown): string => {
   try {
-    if (value === null) return "null";
-    if (value === undefined) return "undefined";
-
-    const valueType = typeof value;
-    if (valueType === "string") return truncate(JSON.stringify(value));
-    if (valueType === "number" || valueType === "boolean" || valueType === "bigint") {
-      return truncate(String(value));
+    if (value === null || value === undefined || typeof value !== "object") {
+      return truncate(formatScalar(value));
     }
-    if (valueType === "function") {
-      const name = (value as { name?: string }).name;
-      return name ? `ƒ ${name}` : "ƒ";
-    }
-    if (valueType === "symbol") return truncate(String(value));
 
-    if (Array.isArray(value)) return truncate(`Array(${value.length})`);
+    if (value instanceof Element) return truncate(`<${value.tagName.toLowerCase()}>`);
 
-    if (value instanceof Element) {
-      return truncate(`<${value.tagName.toLowerCase()}>`);
+    if (Array.isArray(value)) {
+      if (value.length === 0) return "[]";
+      if (value.length > HISTORY_MAX_ARRAY_ITEMS) return `Array(${value.length})`;
+      return truncate(`[${value.map((item) => formatScalar(item)).join(", ")}]`);
     }
 
     const constructorName = (value as { constructor?: { name?: string } }).constructor?.name;
-    if (constructorName && constructorName !== "Object") {
-      return truncate(constructorName);
-    }
+    if (constructorName && constructorName !== "Object") return truncate(constructorName);
 
-    const keys = Object.keys(value as object);
-    return truncate(`{${keys.slice(0, 4).join(", ")}${keys.length > 4 ? ", …" : ""}}`);
+    const keys = Object.keys(value);
+    if (keys.length === 0) return "{}";
+    const shownKeys = keys.slice(0, HISTORY_MAX_OBJECT_KEYS);
+    const entries = shownKeys.map(
+      (key) => `${key}: ${formatScalar((value as Record<string, unknown>)[key])}`,
+    );
+    if (keys.length > HISTORY_MAX_OBJECT_KEYS) entries.push("…");
+    return truncate(`{ ${entries.join(", ")} }`);
   } catch {
     return "(unserializable)";
   }

--- a/packages/react-grab/src/utils/format-history-value.ts
+++ b/packages/react-grab/src/utils/format-history-value.ts
@@ -1,0 +1,41 @@
+import { HISTORY_MAX_VALUE_LENGTH } from "../constants.js";
+
+const truncate = (text: string): string =>
+  text.length > HISTORY_MAX_VALUE_LENGTH ? `${text.slice(0, HISTORY_MAX_VALUE_LENGTH - 1)}…` : text;
+
+// Turns an arbitrary fiber prop/state value into a short, human-readable label
+// for the time-travel panel. Never throws: any getter or circular structure
+// falls back to its type so recording a commit can't crash the host app.
+export const formatHistoryValue = (value: unknown): string => {
+  try {
+    if (value === null) return "null";
+    if (value === undefined) return "undefined";
+
+    const valueType = typeof value;
+    if (valueType === "string") return truncate(JSON.stringify(value));
+    if (valueType === "number" || valueType === "boolean" || valueType === "bigint") {
+      return truncate(String(value));
+    }
+    if (valueType === "function") {
+      const name = (value as { name?: string }).name;
+      return name ? `ƒ ${name}` : "ƒ";
+    }
+    if (valueType === "symbol") return truncate(String(value));
+
+    if (Array.isArray(value)) return truncate(`Array(${value.length})`);
+
+    if (value instanceof Element) {
+      return truncate(`<${value.tagName.toLowerCase()}>`);
+    }
+
+    const constructorName = (value as { constructor?: { name?: string } }).constructor?.name;
+    if (constructorName && constructorName !== "Object") {
+      return truncate(constructorName);
+    }
+
+    const keys = Object.keys(value as object);
+    return truncate(`{${keys.slice(0, 4).join(", ")}${keys.length > 4 ? ", …" : ""}}`);
+  } catch {
+    return "(unserializable)";
+  }
+};

--- a/packages/react-grab/src/utils/format-relative-time.ts
+++ b/packages/react-grab/src/utils/format-relative-time.ts
@@ -1,0 +1,10 @@
+// Compact "time ago" label for the render-history timeline (e.g. "12s ago").
+export const formatRelativeTime = (timestamp: number): string => {
+  const secondsAgo = Math.max(0, Math.round((Date.now() - timestamp) / 1000));
+  if (secondsAgo < 1) return "just now";
+  if (secondsAgo < 60) return `${secondsAgo}s ago`;
+  const minutesAgo = Math.round(secondsAgo / 60);
+  if (minutesAgo < 60) return `${minutesAgo}m ago`;
+  const hoursAgo = Math.round(minutesAgo / 60);
+  return `${hoursAgo}h ago`;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a **time-travel history** feature to react-grab: track the history of exactly what React did, and scrub back and forward through it — a compact "mini screen" like the compact edit panel, but its ←/→ walk a component's whole render history instead of stepping a style value.

## How it works

- **`core/render-history.ts`** — a bounded, always-on recorder built on bippy's commit instrumentation (`instrument({ onCommitFiberRoot })` + `traverseRenderedFibers`). On every commit it captures, per updated composite fiber, the changed props and `useState`/`useReducer` state as `prev → next` pairs. Only `useState`/`useReducer` hooks (the ones carrying an update `queue`) are recorded, which cleanly excludes effect/memo/ref churn. Everything is capped (entries, fibers-per-entry, changes-per-fiber, value length) and wrapped in try/catch so it can't grow unbounded or crash the host app.
- **`core/history-mode.ts`** — a controller mirroring `edit-mode.ts`. Given a selected element it resolves the nearest composite fiber, projects the global timeline down to that component's moments (matched by stable fiber id, with a display-name fallback), freezes the page, and manages the scrub cursor. Enter/Copy hands the current moment to a coding agent via the existing copy pipeline.
- **`components/history-panel/`** — the mini-screen UI, reusing `Surface`, `TagBadge`, `StepArrow`, `createAnchoredDropdown`, and `registerOverlayDismiss`. Shows the current change(s), a `n / total · time-ago` position, and left/right arrows. ←/→ step, Enter copies, Esc dismisses.
- **`core/plugins/history.ts`** — registers the recorder and a **History** action (`H` shortcut, shown in the toolbar overflow menu and right-click menu), consistent with the existing copy/style/comment/open plugins.
- Wired into `core/index.tsx` and `renderer.tsx` alongside edit mode (activeActionId, action dispatch, popover dismissal, anchor tracking, teardown).

The History action lives in the toolbar overflow menu / context menu / `H` shortcut (not as a 4th main toolbar button), so existing toolbar behavior is unchanged.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm format` clean
- `pnpm test:unit` — 58 passed
- New `e2e/history-panel.spec.ts` — records commits, opens the panel, scrubs with ←/→, dismisses with Esc
- Re-ran `toolbar-actions` + `keyboard-navigation` e2e (45 passed) to confirm no regression in the edit/toolbar/keyboard flows

## Note

Recording is always-on once react-grab initializes (that's what makes "history of exactly what happened" available the moment you inspect a component). The per-commit work is kept minimal and bounded; it piggybacks on the devtools hook react-grab already installs.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-015add35-2379-4b23-85ea-6f70f39790d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-015add35-2379-4b23-85ea-6f70f39790d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a time-travel render history to `react-grab` that records prop and `useState`/`useReducer` changes on every React commit and lets you scrub a component’s timeline. Diff output is now readable and skips identity-only churn, and the recorder loads `beforeInteractive` so commits are captured from app start.

- **New Features**
  - Always-on recorder via `bippy` devtools hook with bounded storage (ring buffer and caps).
  - History action in menus and `H` shortcut; compact panel shows changes and n/total · time-ago; ←/→ to scrub, Enter to copy, Esc to dismiss.
  - History mode freezes the page during scrubbing and projects the global timeline to the selected component; integrated alongside edit mode.

- **Bug Fixes**
  - Render-history diffs use readable labels and drop no-op/identity-only changes.
  - Load script with Next.js `next/script` `beforeInteractive` to install the `bippy` hook before React initializes.

<sup>Written for commit afaccf6e64acc7343a6f5d6b3a0dfb4102ff31c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

