### PR TITLE
fix + cleanup: address thermo review findings from the past 20 days

### DIFF
--- a/packages/react-grab/docs/architecture.md
+++ b/packages/react-grab/docs/architecture.md
@@ -95,7 +95,7 @@ On unfreeze, animations are `finish()`ed rather than resumed. This is deliberate
 
 The module [utils/freeze-pseudo-states.ts](../src/utils/freeze-pseudo-states.ts) handles CSS pseudo-classes like `:hover` and `:focus`. When the user activates grab mode and hovers over an element, that element may have styles that only apply in the `:hover` state (e.g. a button changing color). As soon as the pointer moves to the react-grab overlay, the browser removes the `:hover` state from the original element and the visual appearance changes.
 
-To prevent this, `freezePseudoStates` captures the current computed styles that are associated with the `:hover` and `:focus` pseudo-classes and applies them as inline styles on the element. This way, even after the pointer moves away, the element continues to look exactly as it did when the user first pointed at it. On unfreeze, the injected inline styles are removed.
+To prevent this, `collectPseudoStates`/`applyPseudoStates` (batched behind `freezeGlobalInteractions` in [utils/freeze-global-interactions.ts](../src/utils/freeze-global-interactions.ts)) capture the current computed styles that are associated with the `:hover` and `:focus` pseudo-classes and apply them as inline styles on the element. This way, even after the pointer moves away, the element continues to look exactly as it did when the user first pointed at it. On unfreeze, the injected inline styles are removed.
 
 ## Notes about the overlay
 

--- a/packages/react-grab/e2e/perf-bench.spec.ts
+++ b/packages/react-grab/e2e/perf-bench.spec.ts
@@ -258,7 +258,7 @@ test.describe("@perf benchmarks", () => {
       hoverTargets.push({ x: box.x + box.width / 2, y: box.y + box.height / 2 });
     }
     if (hoverTargets.length === 0) {
-      test.skip(true, "no animated targets in e2e-app");
+      test.skip(true, "no animated targets in e2e-app-vite");
       return;
     }
 

--- a/packages/react-grab/scripts/deopt-trace.mjs
+++ b/packages/react-grab/scripts/deopt-trace.mjs
@@ -51,7 +51,7 @@ const waitForServer = async (url, timeoutMs) => {
 };
 
 const startDevServer = () => {
-  log(`starting e2e-app dev server (pnpm --filter ${E2E_APP_FILTER} dev) ...`);
+  log(`starting e2e-app-vite dev server (pnpm --filter ${E2E_APP_FILTER} dev) ...`);
   const child = spawn("pnpm", ["--filter", E2E_APP_FILTER, "dev"], {
     cwd: REPO_ROOT,
     stdio: ["ignore", "pipe", "pipe"],
@@ -421,7 +421,7 @@ const runScenarios = async (page) => {
 // synthetic per-cell loops above never touch (context menu, keyboard nav, copy
 // flow, modals, drag through real listeners, etc.).
 const runFullAppScenarios = async (page) => {
-  log("navigating to full e2e-app");
+  log("navigating to full e2e-app-vite");
   await page.goto(E2E_APP_URL, { waitUntil: "domcontentloaded" });
   await page.waitForFunction(() => Boolean(window.__REACT_GRAB__), null, { timeout: 10_000 });
   await page.waitForSelector("[data-testid='todo-list']", { timeout: 10_000 });

--- a/packages/react-grab/src/components/context-menu.tsx
+++ b/packages/react-grab/src/components/context-menu.tsx
@@ -256,11 +256,9 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
       if (event.key === "Enter") {
         const activeItem = menuStore.getActiveItem();
         if (activeItem) {
-          if (activeItem.isEnabled()) {
-            event.preventDefault();
-            event.stopPropagation();
-            activeItem.onSelect();
-          }
+          event.preventDefault();
+          event.stopPropagation();
+          if (activeItem.isEnabled()) activeItem.onSelect();
           return;
         }
       }

--- a/packages/react-grab/src/components/edit-panel/active-property-control.tsx
+++ b/packages/react-grab/src/components/edit-panel/active-property-control.tsx
@@ -13,7 +13,7 @@ interface ActivePropertyControlProps {
   onEditComplete: () => void;
   onInvalidCommit: () => void;
   onInteract: () => void;
-  onColorPickerRegister?: (trigger: (() => void) | null, owner?: () => void) => void;
+  onColorPickerRegister?: (trigger: () => void) => () => void;
   showLabel: boolean;
   tailwindLabel?: string | null;
   emphasized?: boolean;

--- a/packages/react-grab/src/components/edit-panel/color-picker.tsx
+++ b/packages/react-grab/src/components/edit-panel/color-picker.tsx
@@ -16,7 +16,7 @@ interface ColorPickerProps {
   onCommit: (value: string, source: "keyboard" | "pointer") => void;
   onEditComplete?: () => void;
   onInvalidCommit?: () => void;
-  onRegisterTrigger?: (trigger: (() => void) | null, owner?: () => void) => void;
+  onRegisterTrigger?: (trigger: () => void) => () => void;
   onInteract?: () => void;
   emphasized?: boolean;
 }
@@ -41,8 +41,8 @@ export const ColorPicker: Component<ColorPickerProps> = (props) => {
 
   onMount(() => {
     const openPicker = () => nativePickerRef?.click();
-    props.onRegisterTrigger?.(openPicker);
-    onCleanup(() => props.onRegisterTrigger?.(null, openPicker));
+    const unregisterTrigger = props.onRegisterTrigger?.(openPicker);
+    onCleanup(() => unregisterTrigger?.());
   });
 
   const commitHex = () => {

--- a/packages/react-grab/src/components/edit-panel/index.tsx
+++ b/packages/react-grab/src/components/edit-panel/index.tsx
@@ -40,6 +40,7 @@ import { isEventFromOverlay } from "../../utils/is-event-from-overlay.js";
 import { registerOverlayDismiss } from "../../utils/register-overlay-dismiss.js";
 import { suppressMenuEvent } from "../../utils/suppress-menu-event.js";
 import { TagBadge } from "../selection-label/tag-badge.js";
+import { Button } from "../ui/button.js";
 import { Surface } from "../ui/surface.js";
 import { ActivePropertyControl } from "./active-property-control.js";
 import { HIDDEN_FOCUS_PRESERVING_STYLE } from "./constants.js";
@@ -88,6 +89,14 @@ interface EditPanelBodyProps {
   onSubmit: (pendingEdits: PendingEdits) => void;
   onPendingEditsChange?: (pendingEdits: PendingEdits) => void;
   onInteractingChange?: (interacting: boolean) => void;
+}
+
+interface CommitOptions {
+  flashDirection?: 1 | -1;
+  shouldFocus?: boolean;
+  shouldCompact?: boolean;
+  isFromKeyRepeat?: boolean;
+  source?: "keyboard" | "pointer";
 }
 
 const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
@@ -241,14 +250,6 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
     setInlineNumericSearchQuery(null);
     setIsCompact(false);
   };
-
-  interface CommitOptions {
-    flashDirection?: 1 | -1;
-    shouldFocus?: boolean;
-    shouldCompact?: boolean;
-    isFromKeyRepeat?: boolean;
-    source?: "keyboard" | "pointer";
-  }
 
   const commit = (
     property: EditableProperty,
@@ -407,21 +408,13 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
   };
 
   let colorPickerTriggers: Array<() => void> = [];
-  const registerColorPickerTrigger = (trigger: (() => void) | null, owner?: () => void) => {
-    if (trigger === null) {
-      if (owner === undefined) {
-        colorPickerTriggers = [];
-        return;
-      }
-      colorPickerTriggers = colorPickerTriggers.filter(
-        (registeredTrigger) => registeredTrigger !== owner,
-      );
-      return;
-    }
-    colorPickerTriggers = colorPickerTriggers.filter(
-      (registeredTrigger) => registeredTrigger !== trigger,
-    );
+  const registerColorPickerTrigger = (trigger: () => void) => {
     colorPickerTriggers.push(trigger);
+    return () => {
+      colorPickerTriggers = colorPickerTriggers.filter(
+        (registeredTrigger) => registeredTrigger !== trigger,
+      );
+    };
   };
 
   const getCurrentColorPickerTrigger = () => {
@@ -634,11 +627,9 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
                 Discard edits?
               </span>
               <div class="flex items-center gap-[5px]">
-                <button
+                <Button
                   data-react-grab-ignore-events
                   data-react-grab-discard-button="cancel"
-                  type="button"
-                  class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[var(--rg-surface-hover)] [border-width:0.5px] border-solid border-[var(--rg-border-button)] cursor-pointer transition-all hover:bg-[var(--rg-surface-active)] press-scale h-[17px]"
                   onClick={(event) => {
                     event.preventDefault();
                     event.stopPropagation();
@@ -648,12 +639,11 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
                   <span class="text-[var(--rg-text-primary)] text-[13px] leading-3.5 font-sans font-medium">
                     No
                   </span>
-                </button>
-                <button
+                </Button>
+                <Button
+                  variant="destructive"
                   data-react-grab-ignore-events
                   data-react-grab-discard-button="confirm"
-                  type="button"
-                  class="contain-layout shrink-0 flex items-center justify-center px-[3px] py-px rounded-sm bg-[var(--rg-error-bg)] cursor-pointer transition-all hover:bg-[var(--rg-error-bg-hover)] press-scale h-[17px]"
                   onClick={(event) => {
                     event.preventDefault();
                     event.stopPropagation();
@@ -663,7 +653,7 @@ const EditPanelBody: Component<EditPanelBodyProps> = (props) => {
                   <span class="text-[var(--rg-error-text)] text-[13px] leading-3.5 font-sans font-medium">
                     Yes
                   </span>
-                </button>
+                </Button>
               </div>
             </div>
           </Show>

--- a/packages/react-grab/src/components/edit-panel/property-list.tsx
+++ b/packages/react-grab/src/components/edit-panel/property-list.tsx
@@ -22,7 +22,7 @@ interface PropertyListProps {
   onSelect: (index: number) => void;
   onStep: (direction: 1 | -1) => void;
   onCommit: (value: number | string, source: "keyboard" | "pointer") => void;
-  onColorPickerRegister: (trigger: (() => void) | null, owner?: () => void) => void;
+  onColorPickerRegister: (trigger: () => void) => () => void;
   onEditComplete: () => void;
   onInvalidCommit: () => void;
   onInteract: () => void;

--- a/packages/react-grab/src/components/menu/menu-item.tsx
+++ b/packages/react-grab/src/components/menu/menu-item.tsx
@@ -19,17 +19,19 @@ interface MenuItemProps {
 export const MenuItem: Component<MenuItemProps> = (props) => {
   const store = useMenuStore();
   const domId = store.createItemId();
+  // The store identity is fixed for the lifetime of the row. Solid props are
+  // live getters, so capture `value` once and use the same identity for
+  // registration, hover/active checks, and cleanup — otherwise a reactive
+  // `value` change would desync them.
+  const registeredValue = props.value;
   const role = (): "menuitem" | "menuitemradio" => props.role ?? "menuitem";
   const isEnabled = (): boolean => !props.disabled;
-  const isActive = (): boolean => store.activeValue() === props.value;
+  const isActive = (): boolean => store.activeValue() === registeredValue;
 
   let buttonElement: HTMLButtonElement | undefined;
 
   onMount(() => {
     if (!buttonElement) return;
-    // Solid props are live getters; without this capture the onCleanup below
-    // could unregister a different value than was registered.
-    const registeredValue = props.value;
     store.registerItem({
       value: registeredValue,
       domId,
@@ -45,7 +47,7 @@ export const MenuItem: Component<MenuItemProps> = (props) => {
       ref={buttonElement}
       id={domId}
       data-react-grab-ignore-events
-      data-react-grab-menu-item={props.dataId ?? props.value}
+      data-react-grab-menu-item={props.dataId ?? registeredValue}
       type="button"
       role={role()}
       aria-checked={role() === "menuitemradio" ? Boolean(props.checked) : undefined}
@@ -58,7 +60,7 @@ export const MenuItem: Component<MenuItemProps> = (props) => {
       )}
       onPointerDown={(event) => event.stopPropagation()}
       onPointerEnter={() => {
-        if (isEnabled() && store.canActivateOnHover()) store.setActiveItem(props.value);
+        if (isEnabled() && store.canActivateOnHover()) store.setActiveItem(registeredValue);
       }}
       onPointerLeave={() => {
         if (store.clearActiveOnPointerLeave) store.setActiveItem(null);

--- a/packages/react-grab/src/components/menu/menu-item.tsx
+++ b/packages/react-grab/src/components/menu/menu-item.tsx
@@ -27,8 +27,8 @@ export const MenuItem: Component<MenuItemProps> = (props) => {
 
   onMount(() => {
     if (!buttonElement) return;
-    // Registration is not reactive, so capture `value` once and unregister the
-    // same identity even if props.value were to change on a live row.
+    // Solid props are live getters; without this capture the onCleanup below
+    // could unregister a different value than was registered.
     const registeredValue = props.value;
     store.registerItem({
       value: registeredValue,

--- a/packages/react-grab/src/components/menu/menu-item.tsx
+++ b/packages/react-grab/src/components/menu/menu-item.tsx
@@ -27,14 +27,17 @@ export const MenuItem: Component<MenuItemProps> = (props) => {
 
   onMount(() => {
     if (!buttonElement) return;
+    // Registration is not reactive, so capture `value` once and unregister the
+    // same identity even if props.value were to change on a live row.
+    const registeredValue = props.value;
     store.registerItem({
-      value: props.value,
+      value: registeredValue,
       domId,
       element: buttonElement,
       isEnabled,
       onSelect: () => props.onSelect?.(),
     });
-    onCleanup(() => store.unregisterItem(props.value));
+    onCleanup(() => store.unregisterItem(registeredValue));
   });
 
   return (

--- a/packages/react-grab/src/components/selection-label/index.tsx
+++ b/packages/react-grab/src/components/selection-label/index.tsx
@@ -532,29 +532,24 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
             </div>
           </Show>
 
-          <Show when={props.discardPrompt}>
-            {(discardPrompt) => {
-              const currentDiscardPrompt = discardPrompt();
-              return (
-                <DiscardPrompt
-                  label={
-                    currentDiscardPrompt.isKeyboardSelection
-                      ? "Discard selection?"
-                      : currentDiscardPrompt.label
+          <Show when={props.discardPrompt} keyed>
+            {(discardPrompt) => (
+              <DiscardPrompt
+                label={
+                  discardPrompt.isKeyboardSelection ? "Discard selection?" : discardPrompt.label
+                }
+                showCancel={!discardPrompt.isKeyboardSelection}
+                cancelOnEscape={discardPrompt.cancelOnEscape}
+                onConfirm={discardPrompt.onConfirm}
+                onCopy={discardPrompt.onCopy}
+                onCancel={() => {
+                  if (!discardPrompt.isKeyboardSelection) {
+                    discardPrompt.onCancel?.();
                   }
-                  showCancel={!currentDiscardPrompt.isKeyboardSelection}
-                  cancelOnEscape={currentDiscardPrompt.cancelOnEscape}
-                  onConfirm={currentDiscardPrompt.onConfirm}
-                  onCopy={currentDiscardPrompt.onCopy}
-                  onCancel={() => {
-                    if (!currentDiscardPrompt.isKeyboardSelection) {
-                      currentDiscardPrompt.onCancel?.();
-                    }
-                    inputRef?.focus({ preventScroll: true });
-                  }}
-                />
-              );
-            }}
+                  inputRef?.focus({ preventScroll: true });
+                }}
+              />
+            )}
           </Show>
 
           <Show when={props.error}>

--- a/packages/react-grab/src/components/toolbar/index.tsx
+++ b/packages/react-grab/src/components/toolbar/index.tsx
@@ -21,8 +21,10 @@ import {
   EDIT_ACTION_ID,
 } from "../../constants.js";
 import { freezeUpdates } from "../../utils/freeze-updates.js";
-import { freezeGlobalAnimations, unfreezeGlobalAnimations } from "../../utils/freeze-animations.js";
-import { freezePseudoStates, unfreezePseudoStates } from "../../utils/freeze-pseudo-states.js";
+import {
+  freezeGlobalInteractions,
+  unfreezeGlobalInteractions,
+} from "../../utils/freeze-global-interactions.js";
 import { ToolbarContent } from "./toolbar-content.js";
 import { getVisualViewport } from "../../utils/get-visual-viewport.js";
 import {
@@ -89,8 +91,7 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
       if (unfreezeUpdatesCallback) {
         unfreezeUpdatesCallback();
         unfreezeUpdatesCallback = null;
-        unfreezeGlobalAnimations();
-        unfreezePseudoStates();
+        unfreezeGlobalInteractions();
       }
     },
     onPositionUpdate: (newPosition) => setPosition(newPosition),
@@ -155,8 +156,7 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
       setHoveredActionId(actionId);
       if (options?.shouldFreezeInteractions !== false && !unfreezeUpdatesCallback) {
         unfreezeUpdatesCallback = freezeUpdates();
-        freezeGlobalAnimations();
-        freezePseudoStates(event.clientX, event.clientY);
+        freezeGlobalInteractions(event.clientX, event.clientY);
       }
       options?.onHoverChange?.(true);
     },
@@ -169,8 +169,7 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
       ) {
         unfreezeUpdatesCallback?.();
         unfreezeUpdatesCallback = null;
-        unfreezeGlobalAnimations();
-        unfreezePseudoStates();
+        unfreezeGlobalInteractions();
       }
       options?.onHoverChange?.(false);
     },
@@ -564,7 +563,11 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
     clearTimeout(resizeTimeout);
     clearTimeout(collapseAnimationTimeout);
 
-    unfreezeUpdatesCallback?.();
+    if (unfreezeUpdatesCallback) {
+      unfreezeUpdatesCallback();
+      unfreezeUpdatesCallback = null;
+      unfreezeGlobalInteractions();
+    }
   });
 
   const currentPosition = () => {

--- a/packages/react-grab/src/components/toolbar/index.tsx
+++ b/packages/react-grab/src/components/toolbar/index.tsx
@@ -83,7 +83,9 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
   const releaseInteractionFreeze = () => {
     unfreezeUpdatesCallback?.();
     unfreezeUpdatesCallback = null;
-    unfreezeGlobalInteractions();
+    // While grab mode is active, core owns the global freeze and releases it
+    // on deactivation; only release it when this hover latch is the sole owner.
+    if (!props.isActive) unfreezeGlobalInteractions();
   };
 
   const drag = createToolbarDrag({
@@ -564,15 +566,7 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
     clearTimeout(resizeTimeout);
     clearTimeout(collapseAnimationTimeout);
 
-    if (!unfreezeUpdatesCallback) return;
-    // While grab mode is active, core owns the global freeze and releases it on
-    // deactivation; only release it here when this hover latch is the sole owner.
-    if (props.isActive) {
-      unfreezeUpdatesCallback();
-      unfreezeUpdatesCallback = null;
-      return;
-    }
-    releaseInteractionFreeze();
+    if (unfreezeUpdatesCallback) releaseInteractionFreeze();
   });
 
   const currentPosition = () => {

--- a/packages/react-grab/src/components/toolbar/index.tsx
+++ b/packages/react-grab/src/components/toolbar/index.tsx
@@ -79,6 +79,13 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
   const [isToolbarHovered, setIsToolbarHovered] = createSignal(false);
   const [selectIconRotationDeg, setSelectIconRotationDeg] = createSignal(0);
   const [hoveredActionId, setHoveredActionId] = createSignal<string | null>(null);
+
+  const releaseInteractionFreeze = () => {
+    unfreezeUpdatesCallback?.();
+    unfreezeUpdatesCallback = null;
+    unfreezeGlobalInteractions();
+  };
+
   const drag = createToolbarDrag({
     getContainerRef: () => containerRef,
     isCollapsed,
@@ -88,11 +95,7 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
       // clear the hover here or the tooltip flashes at the snapped position
       // once isDragging/isSnapping settle.
       setHoveredActionId(null);
-      if (unfreezeUpdatesCallback) {
-        unfreezeUpdatesCallback();
-        unfreezeUpdatesCallback = null;
-        unfreezeGlobalInteractions();
-      }
+      if (unfreezeUpdatesCallback) releaseInteractionFreeze();
     },
     onPositionUpdate: (newPosition) => setPosition(newPosition),
     onSnapEdgeChange: (edge, ratio) => {
@@ -167,9 +170,7 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
         !props.isActive &&
         !props.isContextMenuOpen
       ) {
-        unfreezeUpdatesCallback?.();
-        unfreezeUpdatesCallback = null;
-        unfreezeGlobalInteractions();
+        releaseInteractionFreeze();
       }
       options?.onHoverChange?.(false);
     },
@@ -563,11 +564,15 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
     clearTimeout(resizeTimeout);
     clearTimeout(collapseAnimationTimeout);
 
-    if (unfreezeUpdatesCallback) {
+    if (!unfreezeUpdatesCallback) return;
+    // While grab mode is active, core owns the global freeze and releases it on
+    // deactivation; only release it here when this hover latch is the sole owner.
+    if (props.isActive) {
       unfreezeUpdatesCallback();
       unfreezeUpdatesCallback = null;
-      unfreezeGlobalInteractions();
+      return;
     }
+    releaseInteractionFreeze();
   });
 
   const currentPosition = () => {

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -56,6 +56,14 @@ export const SOURCE_FETCH_TIMEOUT_MS = 8000;
 // dozens of elements in a row. Without the cap each hovered element starts its
 // own fetch at once, and react-grab becomes part of the saturation it is
 // waiting on.
+//
+// This is deliberately NOT the `keepalive` request limit. `keepalive` (the
+// modern navigator.sendBeacon) keeps a request alive across a page navigation,
+// but the Fetch spec caps its body at 64 KB and allows only ~15 inflight
+// keepalive requests for the whole page; source bundles are larger than 64 KB
+// and a grab never navigates away, so keepalive does not apply here. The limit
+// we work around is the ordinary per-origin connection pool, which constrains
+// every fetch whether or not it sets keepalive.
 export const MAX_CONCURRENT_SOURCE_FETCHES = 3;
 export const MIN_HOLD_FOR_ACTIVATION_AFTER_COPY_MS = 200;
 export const FINDER_TIMEOUT_MS = 200;
@@ -159,6 +167,8 @@ export const FROZEN_ELEMENT_ATTRIBUTE = "data-react-grab-frozen";
 // threshold only guards pathological animation-heavy pages.
 export const WAAPI_GLOBAL_FREEZE_MAX_ANIMATIONS = 200;
 
+// Theme-detection thresholds (see detect-app-theme.ts). A background below
+// this relative luminance reads as a dark theme.
 export const LUMINANCE_DARK_THRESHOLD = 0.18;
 // Text this light sits well above any light theme's (dark) body text, so it only
 // appears when the app paints onto a dark surface - revealing a dark theme.

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -40,6 +40,23 @@ export const SYMBOLICATION_TIMEOUT_MS = 5000;
 // un-cancelable bundle fetch is stuck behind a saturated connection pool, and
 // exists to free the queue slot rather than to bound normal latency.
 export const SOURCE_FETCH_TIMEOUT_MS = 8000;
+// Cap on react-grab's own concurrent source-resolution fetches.
+//
+// Resolving a grabbed element's source location fetches its JS bundle and source
+// map (through bippy) and, on Next.js, POSTs to the dev symbolication endpoint.
+// In development these run over HTTP/1.1, where Chrome keeps at most ~6 open
+// connections per origin. A real app's data fetches routinely hold all 6 (a
+// dashboard waiting on several slow API calls), so a react-grab fetch waits in
+// the browser's connection queue behind them. That wait is what surfaces as the
+// "Grabbing…" state never resolving.
+//
+// We cannot speed up the app's requests, so we avoid adding to the pressure
+// instead: capping our own in-flight fetches below the pool size leaves
+// connections for the page and bounds the fan-out when a drag-select hovers
+// dozens of elements in a row. Without the cap each hovered element starts its
+// own fetch at once, and react-grab becomes part of the saturation it is
+// waiting on.
+export const MAX_CONCURRENT_SOURCE_FETCHES = 3;
 export const MIN_HOLD_FOR_ACTIVATION_AFTER_COPY_MS = 200;
 export const FINDER_TIMEOUT_MS = 200;
 export const MAX_SELECTOR_COMBINATIONS = 10_000;
@@ -133,6 +150,22 @@ export const ARROW_KEYS = new Set(["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRi
 export { REACT_GRAB_ATTRIBUTE_NAME } from "./utils/react-grab-attribute-name.js";
 
 export const FROZEN_ELEMENT_ATTRIBUTE = "data-react-grab-frozen";
+
+// Pausing animations individually via WAAPI avoids the full-document style
+// recalc that a universal `*` selector forces — profiled at ~62ms on a real
+// (CSS-heavy) app even with a single animation on the page. But each WAAPI
+// pause/finish has a per-animation cost, so above this many running animations
+// one batched `*`-selector recalc wins. Real apps sit far below this; the
+// threshold only guards pathological animation-heavy pages.
+export const WAAPI_GLOBAL_FREEZE_MAX_ANIMATIONS = 200;
+
+export const LUMINANCE_DARK_THRESHOLD = 0.18;
+// Text this light sits well above any light theme's (dark) body text, so it only
+// appears when the app paints onto a dark surface - revealing a dark theme.
+export const LIGHT_TEXT_LUMINANCE_THRESHOLD = 0.6;
+// Faint text composites toward the backdrop, making its own color an unreliable
+// theme signal, so the foreground heuristic ignores anything more translucent.
+export const OPAQUE_TEXT_MIN_ALPHA = 0.5;
 
 export const USER_IGNORE_ATTRIBUTE = "data-react-grab-ignore";
 

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -127,18 +127,11 @@ import { copyPlugin } from "./plugins/copy.js";
 import { commentPlugin } from "./plugins/comment.js";
 import { editPlugin } from "./plugins/edit.js";
 import { openPlugin } from "./plugins/open.js";
+import { freezeAnimations, freezeAllAnimations } from "../utils/freeze-animations.js";
 import {
-  freezeAnimations,
-  freezeAllAnimations,
-  collectGlobalAnimationsToFreeze,
-  applyGlobalAnimationFreeze,
-  unfreezeGlobalAnimations,
-} from "../utils/freeze-animations.js";
-import {
-  collectPseudoStates,
-  applyPseudoStates,
-  unfreezePseudoStates,
-} from "../utils/freeze-pseudo-states.js";
+  freezeGlobalInteractions,
+  unfreezeGlobalInteractions,
+} from "../utils/freeze-global-interactions.js";
 import { freezeUpdates } from "../utils/freeze-updates.js";
 import { generateId } from "../utils/generate-id.js";
 import { logRecoverableError } from "../utils/log-recoverable-error.js";
@@ -276,18 +269,10 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     createEffect(
       on(isActivated, (activated, previousActivated) => {
         if (activated && !previousActivated) {
-          // Batch all layout reads before any DOM writes. The pseudo-state
-          // snapshot (getComputedStyle/elementFromPoint) and getAnimations()
-          // each force a style/layout flush; doing both reads first, then both
-          // writes, collapses two full-document recalcs into one.
-          const pseudoSnapshot = collectPseudoStates(pointer().x, pointer().y);
-          const animationsToFreeze = collectGlobalAnimationsToFreeze();
-          applyPseudoStates(pseudoSnapshot);
-          applyGlobalAnimationFreeze(animationsToFreeze);
+          freezeGlobalInteractions(pointer().x, pointer().y);
           document.body.style.touchAction = "none";
         } else if (!activated && previousActivated) {
-          unfreezePseudoStates();
-          unfreezeGlobalAnimations();
+          unfreezeGlobalInteractions();
           document.body.style.touchAction = "";
         }
       }),
@@ -2447,7 +2432,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       const targetElement = target instanceof HTMLElement ? target : null;
       return Boolean(
         targetElement?.closest("[data-react-grab-discard-copy]") ||
-          targetElement?.closest("[data-react-grab-discard-yes]"),
+        targetElement?.closest("[data-react-grab-discard-yes]"),
       );
     };
 

--- a/packages/react-grab/src/core/keyboard-selection.ts
+++ b/packages/react-grab/src/core/keyboard-selection.ts
@@ -1,4 +1,5 @@
 import { createSignal, type Accessor } from "solid-js";
+import { createPointerMovePromptHandoff } from "../utils/create-pointer-move-prompt-handoff.js";
 import { isElementConnected } from "../utils/is-element-connected.js";
 
 interface KeyboardSelectionController {
@@ -14,14 +15,14 @@ interface KeyboardSelectionController {
 export const createKeyboardSelectionController = (): KeyboardSelectionController => {
   const [isPendingDismiss, setIsPendingDismiss] = createSignal(false);
   let selectedElement: Element | null = null;
-  let isMouseHandoffArmed = false;
+  const mouseHandoff = createPointerMovePromptHandoff();
 
   const connectedSelection = (): Element | null =>
     isElementConnected(selectedElement) ? selectedElement : null;
 
   const clear = () => {
     selectedElement = null;
-    isMouseHandoffArmed = false;
+    mouseHandoff.clear();
     setIsPendingDismiss(false);
   };
 
@@ -38,14 +39,11 @@ export const createKeyboardSelectionController = (): KeyboardSelectionController
     select: (element, options) => {
       selectedElement = element;
       setIsPendingDismiss(false);
-      isMouseHandoffArmed = Boolean(options?.shouldPromptBeforeMouseHandoff);
+      if (options?.shouldPromptBeforeMouseHandoff) mouseHandoff.arm();
+      else mouseHandoff.clear();
     },
     clear,
-    consumeMouseHandoff: () => {
-      if (!isMouseHandoffArmed) return false;
-      isMouseHandoffArmed = false;
-      return connectedSelection() !== null;
-    },
+    consumeMouseHandoff: () => mouseHandoff.consume() && connectedSelection() !== null,
     showDismissPrompt: () => {
       if (!connectedSelection()) {
         clear();

--- a/packages/react-grab/src/core/next-server-frames.ts
+++ b/packages/react-grab/src/core/next-server-frames.ts
@@ -23,23 +23,38 @@ const devirtualizeServerUrl = (url: string): string => {
   return url;
 };
 
-interface NextJsOriginalFrame {
-  file: string | null;
+interface UsableOriginalFrame {
+  file: string;
   line1: number | null;
   column1: number | null;
-  ignored: boolean;
 }
 
-interface NextJsFrameResult {
-  status: string;
-  value?: { originalStackFrame: NextJsOriginalFrame | null };
-}
-
-const isNextJsFrameResult = (candidate: unknown): candidate is NextJsFrameResult =>
-  typeof candidate === "object" &&
-  candidate !== null &&
-  "status" in candidate &&
-  typeof candidate.status === "string";
+// Validates one entry of the dev server's PromiseSettledResult[] response down
+// to exactly the fields the frame rewrite consumes; anything malformed (or
+// rejected/ignored) degrades to the unsymbolicated frame.
+const extractUsableOriginalFrame = (result: unknown): UsableOriginalFrame | null => {
+  if (typeof result !== "object" || result === null) return null;
+  if (!("status" in result) || result.status !== "fulfilled") return null;
+  if (!("value" in result) || typeof result.value !== "object" || result.value === null)
+    return null;
+  if (!("originalStackFrame" in result.value)) return null;
+  const originalFrame = result.value.originalStackFrame;
+  if (typeof originalFrame !== "object" || originalFrame === null) return null;
+  if (!("file" in originalFrame) || typeof originalFrame.file !== "string" || !originalFrame.file)
+    return null;
+  if ("ignored" in originalFrame && Boolean(originalFrame.ignored)) return null;
+  return {
+    file: originalFrame.file,
+    line1:
+      "line1" in originalFrame && typeof originalFrame.line1 === "number"
+        ? originalFrame.line1
+        : null,
+    column1:
+      "column1" in originalFrame && typeof originalFrame.column1 === "number"
+        ? originalFrame.column1
+        : null,
+  };
+};
 
 interface NextJsRequestFrame {
   file: string;
@@ -113,19 +128,15 @@ export const symbolicateServerFrames = async (
     const symbolicatedFrames = [...frames];
 
     for (let resultIndex = 0; resultIndex < serverFrameIndices.length; resultIndex++) {
-      const symbolicationResult: unknown = symbolicationResults[resultIndex];
-      if (!isNextJsFrameResult(symbolicationResult)) continue;
-      if (symbolicationResult.status !== "fulfilled") continue;
-
-      const originalStackFrame = symbolicationResult.value?.originalStackFrame;
-      if (!originalStackFrame?.file || originalStackFrame.ignored) continue;
+      const originalFrame = extractUsableOriginalFrame(symbolicationResults[resultIndex]);
+      if (!originalFrame) continue;
 
       const originalFrameIndex = serverFrameIndices[resultIndex];
       symbolicatedFrames[originalFrameIndex] = {
         ...frames[originalFrameIndex],
-        fileName: originalStackFrame.file,
-        lineNumber: originalStackFrame.line1 ?? undefined,
-        columnNumber: originalStackFrame.column1 ?? undefined,
+        fileName: originalFrame.file,
+        lineNumber: originalFrame.line1 ?? undefined,
+        columnNumber: originalFrame.column1 ?? undefined,
         isSymbolicated: true,
       };
     }

--- a/packages/react-grab/src/core/next-server-frames.ts
+++ b/packages/react-grab/src/core/next-server-frames.ts
@@ -35,6 +35,12 @@ interface NextJsFrameResult {
   value?: { originalStackFrame: NextJsOriginalFrame | null };
 }
 
+const isNextJsFrameResult = (candidate: unknown): candidate is NextJsFrameResult =>
+  typeof candidate === "object" &&
+  candidate !== null &&
+  "status" in candidate &&
+  typeof candidate.status === "string";
+
 interface NextJsRequestFrame {
   file: string;
   methodName: string;
@@ -102,12 +108,14 @@ export const symbolicateServerFrames = async (
 
     if (!response.ok) return frames;
 
-    const symbolicationResults = (await response.json()) as NextJsFrameResult[];
+    const symbolicationResults: unknown = await response.json();
+    if (!Array.isArray(symbolicationResults)) return frames;
     const symbolicatedFrames = [...frames];
 
     for (let resultIndex = 0; resultIndex < serverFrameIndices.length; resultIndex++) {
-      const symbolicationResult = symbolicationResults[resultIndex];
-      if (symbolicationResult?.status !== "fulfilled") continue;
+      const symbolicationResult: unknown = symbolicationResults[resultIndex];
+      if (!isNextJsFrameResult(symbolicationResult)) continue;
+      if (symbolicationResult.status !== "fulfilled") continue;
 
       const originalStackFrame = symbolicationResult.value?.originalStackFrame;
       if (!originalStackFrame?.file || originalStackFrame.ignored) continue;

--- a/packages/react-grab/src/primitives.ts
+++ b/packages/react-grab/src/primitives.ts
@@ -1,9 +1,8 @@
+import { freezeAnimations } from "./utils/freeze-animations.js";
 import {
-  freezeAnimations,
-  freezeGlobalAnimations,
-  unfreezeGlobalAnimations,
-} from "./utils/freeze-animations.js";
-import { freezePseudoStates, unfreezePseudoStates } from "./utils/freeze-pseudo-states.js";
+  freezeGlobalInteractions,
+  unfreezeGlobalInteractions,
+} from "./utils/freeze-global-interactions.js";
 import { freezeUpdates } from "./utils/freeze-updates.js";
 import {
   suspendPointerEventsFreeze,
@@ -115,8 +114,7 @@ export const freeze = (elements?: Element[]): void => {
   _isFreezeActive = true;
   freezeCleanupFns.add(freezeUpdates());
   freezeCleanupFns.add(freezeAnimations(elements ?? [document.body]));
-  freezeGlobalAnimations();
-  freezePseudoStates();
+  freezeGlobalInteractions();
 };
 
 /**
@@ -135,8 +133,7 @@ export const unfreeze = (): void => {
   }
   freezeCleanupFns.clear();
   freezeAnimations([]);
-  unfreezeGlobalAnimations();
-  unfreezePseudoStates();
+  unfreezeGlobalInteractions();
 };
 
 /**

--- a/packages/react-grab/src/primitives.ts
+++ b/packages/react-grab/src/primitives.ts
@@ -113,8 +113,11 @@ let _isFreezeActive = false;
 export const freeze = (elements?: Element[]): void => {
   _isFreezeActive = true;
   freezeCleanupFns.add(freezeUpdates());
-  freezeCleanupFns.add(freezeAnimations(elements ?? [document.body]));
+  // Batched layout reads must run before freezeAnimations injects its
+  // stylesheet and sets frozen attributes, or those writes force a second
+  // full-document style recalc under the reads.
   freezeGlobalInteractions();
+  freezeCleanupFns.add(freezeAnimations(elements ?? [document.body]));
 };
 
 /**

--- a/packages/react-grab/src/utils/collect-design-tokens.ts
+++ b/packages/react-grab/src/utils/collect-design-tokens.ts
@@ -149,11 +149,11 @@ const nextValueOnGrid = (current: number, direction: 1 | -1, unitPx: number): nu
 let cachedNames: { styleSheetCount: number; names: Set<string> } | null = null;
 
 const collectCustomPropertyNames = (): Set<string> => {
-  const styleSheetCount = document.styleSheets.length;
+  const styleSheetCount = document.styleSheets.length + document.adoptedStyleSheets.length;
   if (cachedNames && cachedNames.styleSheetCount === styleSheetCount) return cachedNames.names;
 
   const customPropertyNames = new Set<string>();
-  for (const styleSheet of Array.from(document.styleSheets)) {
+  for (const styleSheet of [...Array.from(document.styleSheets), ...document.adoptedStyleSheets]) {
     let rules: CSSRuleList;
     try {
       // Cross-origin stylesheets throw on `.cssRules` access.

--- a/packages/react-grab/src/utils/collect-design-tokens.ts
+++ b/packages/react-grab/src/utils/collect-design-tokens.ts
@@ -142,18 +142,32 @@ const nextValueOnGrid = (current: number, direction: 1 | -1, unitPx: number): nu
 };
 
 // The custom-property *names* are document-global and unchanged across element
-// switches, so the (O(rules)) stylesheet walk is memoized. Keying on the sheet
-// count invalidates it when stylesheets are added/removed (HMR, dynamic styles)
-// — token name sets effectively never change without that. Values still resolve
-// per element since custom properties cascade/scope.
-let cachedNames: { styleSheetCount: number; names: Set<string> } | null = null;
+// switches, so the (O(rules)) stylesheet walk is memoized. Keying on the two
+// sheet counts (separately, so a swap between the lists cannot alias) invalidates
+// it when stylesheets are added/removed (HMR, dynamic styles) — token name sets
+// effectively never change without that. Values still resolve per element since
+// custom properties cascade/scope.
+let cachedNames: {
+  documentSheetCount: number;
+  adoptedSheetCount: number;
+  names: Set<string>;
+} | null = null;
 
 const collectCustomPropertyNames = (): Set<string> => {
-  const styleSheetCount = document.styleSheets.length + document.adoptedStyleSheets.length;
-  if (cachedNames && cachedNames.styleSheetCount === styleSheetCount) return cachedNames.names;
+  // Missing on older Safari/Firefox.
+  const adoptedStyleSheets = document.adoptedStyleSheets ?? [];
+  const documentSheetCount = document.styleSheets.length;
+  const adoptedSheetCount = adoptedStyleSheets.length;
+  if (
+    cachedNames &&
+    cachedNames.documentSheetCount === documentSheetCount &&
+    cachedNames.adoptedSheetCount === adoptedSheetCount
+  ) {
+    return cachedNames.names;
+  }
 
   const customPropertyNames = new Set<string>();
-  for (const styleSheet of [...Array.from(document.styleSheets), ...document.adoptedStyleSheets]) {
+  for (const styleSheet of [...Array.from(document.styleSheets), ...adoptedStyleSheets]) {
     let rules: CSSRuleList;
     try {
       // Cross-origin stylesheets throw on `.cssRules` access.
@@ -163,7 +177,7 @@ const collectCustomPropertyNames = (): Set<string> => {
     }
     collectNamesFromRules(rules, customPropertyNames);
   }
-  cachedNames = { styleSheetCount, names: customPropertyNames };
+  cachedNames = { documentSheetCount, adoptedSheetCount, names: customPropertyNames };
   return customPropertyNames;
 };
 

--- a/packages/react-grab/src/utils/collect-design-tokens.ts
+++ b/packages/react-grab/src/utils/collect-design-tokens.ts
@@ -142,32 +142,39 @@ const nextValueOnGrid = (current: number, direction: 1 | -1, unitPx: number): nu
 };
 
 // The custom-property *names* are document-global and unchanged across element
-// switches, so the (O(rules)) stylesheet walk is memoized. Keying on the two
-// sheet counts (separately, so a swap between the lists cannot alias) invalidates
-// it when stylesheets are added/removed (HMR, dynamic styles) — token name sets
+// switches, so the (O(rules)) stylesheet walk is memoized. Keying on the
+// document sheet count plus the adopted sheet identities invalidates it when
+// stylesheets are added/removed/swapped (HMR, dynamic styles) — token name sets
 // effectively never change without that. Values still resolve per element since
 // custom properties cascade/scope.
 let cachedNames: {
   documentSheetCount: number;
-  adoptedSheetCount: number;
+  adoptedSheets: readonly CSSStyleSheet[];
   names: Set<string>;
 } | null = null;
 
+const areSheetsSame = (
+  previousSheets: readonly CSSStyleSheet[],
+  currentSheets: readonly CSSStyleSheet[],
+): boolean =>
+  previousSheets.length === currentSheets.length &&
+  previousSheets.every((sheet, sheetIndex) => sheet === currentSheets[sheetIndex]);
+
 const collectCustomPropertyNames = (): Set<string> => {
-  // Missing on older Safari/Firefox.
-  const adoptedStyleSheets = document.adoptedStyleSheets ?? [];
+  // `document.adoptedStyleSheets` is missing on older Safari/Firefox, and is a
+  // live array — snapshot it so the cached copy can't be mutated in place.
+  const adoptedSheets = Array.from(document.adoptedStyleSheets ?? []);
   const documentSheetCount = document.styleSheets.length;
-  const adoptedSheetCount = adoptedStyleSheets.length;
   if (
     cachedNames &&
     cachedNames.documentSheetCount === documentSheetCount &&
-    cachedNames.adoptedSheetCount === adoptedSheetCount
+    areSheetsSame(cachedNames.adoptedSheets, adoptedSheets)
   ) {
     return cachedNames.names;
   }
 
   const customPropertyNames = new Set<string>();
-  for (const styleSheet of [...Array.from(document.styleSheets), ...adoptedStyleSheets]) {
+  for (const styleSheet of [...document.styleSheets, ...adoptedSheets]) {
     let rules: CSSRuleList;
     try {
       // Cross-origin stylesheets throw on `.cssRules` access.
@@ -177,7 +184,7 @@ const collectCustomPropertyNames = (): Set<string> => {
     }
     collectNamesFromRules(rules, customPropertyNames);
   }
-  cachedNames = { documentSheetCount, adoptedSheetCount, names: customPropertyNames };
+  cachedNames = { documentSheetCount, adoptedSheets, names: customPropertyNames };
   return customPropertyNames;
 };
 

--- a/packages/react-grab/src/utils/detect-app-theme.ts
+++ b/packages/react-grab/src/utils/detect-app-theme.ts
@@ -1,3 +1,8 @@
+import {
+  LIGHT_TEXT_LUMINANCE_THRESHOLD,
+  LUMINANCE_DARK_THRESHOLD,
+  OPAQUE_TEXT_MIN_ALPHA,
+} from "../constants.js";
 import { nativeCancelAnimationFrame, nativeRequestAnimationFrame } from "./native-raf.js";
 import { parseAnyColor } from "./parse-any-color.js";
 import { parseHexChannels } from "./parse-color.js";
@@ -24,14 +29,6 @@ const PRESENCE_ATTRIBUTES: readonly { attribute: string; theme: AppTheme }[] = [
   { attribute: "data-dark", theme: "dark" },
   { attribute: "data-light", theme: "light" },
 ];
-
-const LUMINANCE_DARK_THRESHOLD = 0.18;
-// Text this light sits well above any light theme's (dark) body text, so it only
-// appears when the app paints onto a dark surface - revealing a dark theme.
-const LIGHT_TEXT_LUMINANCE_THRESHOLD = 0.6;
-// Faint text composites toward the backdrop, making its own color an unreliable
-// theme signal, so the foreground heuristic ignores anything more translucent.
-const OPAQUE_TEXT_MIN_ALPHA = 0.5;
 
 const getRelativeLuminance = (red: number, green: number, blue: number): number => {
   const [linearRed, linearGreen, linearBlue] = [red, green, blue].map((channel) => {

--- a/packages/react-grab/src/utils/freeze-animations.ts
+++ b/packages/react-grab/src/utils/freeze-animations.ts
@@ -1,4 +1,4 @@
-import { FROZEN_ELEMENT_ATTRIBUTE } from "../constants.js";
+import { FROZEN_ELEMENT_ATTRIBUTE, WAAPI_GLOBAL_FREEZE_MAX_ANIMATIONS } from "../constants.js";
 import { createStyleElement } from "./create-style-element.js";
 import { freezeGsap, unfreezeGsap } from "./freeze-gsap.js";
 
@@ -18,14 +18,6 @@ const GLOBAL_FREEZE_STYLES = `
 `;
 
 const SVG_ROOT_SELECTOR = "svg";
-
-// Pausing animations individually via WAAPI avoids the full-document style
-// recalc that a universal `*` selector forces — profiled at ~62ms on a real
-// (CSS-heavy) app even with a single animation on the page. But each WAAPI
-// pause/finish has a per-animation cost, so above this many running animations
-// one batched `*`-selector recalc wins. Real apps sit far below this; the
-// threshold only guards pathological animation-heavy pages.
-const WAAPI_GLOBAL_FREEZE_MAX_ANIMATIONS = 200;
 
 let styleElement: HTMLStyleElement | null = null;
 let frozenElements: Element[] = [];
@@ -198,7 +190,7 @@ export const collectGlobalAnimationsToFreeze = (): Animation[] => {
   if (globalAnimationStyleElement) return [];
   const runningAnimations: Animation[] = [];
   for (const animation of document.getAnimations()) {
-    if (isShadowAnimation(animation)) continue; // leave react-grab's own UI running
+    if (isShadowAnimation(animation)) continue;
     if (animation.playState === "running") runningAnimations.push(animation);
   }
   return runningAnimations;
@@ -232,11 +224,6 @@ export const applyGlobalAnimationFreeze = (runningAnimations: Animation[]): void
   );
   pauseSvgAnimations(globalFrozenSvgElements);
   freezeGsap();
-};
-
-export const freezeGlobalAnimations = (): void => {
-  if (globalAnimationStyleElement) return;
-  applyGlobalAnimationFreeze(collectGlobalAnimationsToFreeze());
 };
 
 export const unfreezeGlobalAnimations = (): void => {

--- a/packages/react-grab/src/utils/freeze-global-interactions.ts
+++ b/packages/react-grab/src/utils/freeze-global-interactions.ts
@@ -1,0 +1,26 @@
+import {
+  applyGlobalAnimationFreeze,
+  collectGlobalAnimationsToFreeze,
+  unfreezeGlobalAnimations,
+} from "./freeze-animations.js";
+import {
+  applyPseudoStates,
+  collectPseudoStates,
+  unfreezePseudoStates,
+} from "./freeze-pseudo-states.js";
+
+// Batches every layout read (elementFromPoint, getComputedStyle,
+// document.getAnimations) ahead of every freeze write. Interleaving them makes
+// the injected freeze styles invalidate the tree between reads, forcing a
+// second full-document recalc (profiled at ~59ms on a large app).
+export const freezeGlobalInteractions = (cursorX?: number, cursorY?: number): void => {
+  const pseudoSnapshot = collectPseudoStates(cursorX, cursorY);
+  const animationsToFreeze = collectGlobalAnimationsToFreeze();
+  applyPseudoStates(pseudoSnapshot);
+  applyGlobalAnimationFreeze(animationsToFreeze);
+};
+
+export const unfreezeGlobalInteractions = (): void => {
+  unfreezePseudoStates();
+  unfreezeGlobalAnimations();
+};

--- a/packages/react-grab/src/utils/freeze-pseudo-states.ts
+++ b/packages/react-grab/src/utils/freeze-pseudo-states.ts
@@ -218,10 +218,6 @@ export const applyPseudoStates = (snapshot: PseudoFreezeSnapshot | null): void =
   installPointerEventsFreeze();
 };
 
-export const freezePseudoStates = (cursorX?: number, cursorY?: number): void => {
-  applyPseudoStates(collectPseudoStates(cursorX, cursorY));
-};
-
 export const unfreezePseudoStates = (): void => {
   clearElementPositionCache();
 

--- a/packages/react-grab/src/utils/source-fetch-queue.ts
+++ b/packages/react-grab/src/utils/source-fetch-queue.ts
@@ -1,30 +1,4 @@
-import { SOURCE_FETCH_TIMEOUT_MS } from "../constants.js";
-
-// Cap on react-grab's own concurrent source-resolution fetches.
-//
-// Resolving a grabbed element's source location fetches its JS bundle and source
-// map (through bippy) and, on Next.js, POSTs to the dev symbolication endpoint.
-// In development these run over HTTP/1.1, where Chrome keeps at most ~6 open
-// connections per origin. A real app's data fetches routinely hold all 6 (a
-// dashboard waiting on several slow API calls), so a react-grab fetch waits in
-// the browser's connection queue behind them. That wait is what surfaces as the
-// "Grabbing…" state never resolving.
-//
-// We cannot speed up the app's requests, so we avoid adding to the pressure
-// instead: capping our own in-flight fetches below the pool size leaves
-// connections for the page and bounds the fan-out when a drag-select hovers
-// dozens of elements in a row. Without the cap each hovered element starts its
-// own fetch at once, and react-grab becomes part of the saturation it is
-// waiting on.
-//
-// This is deliberately NOT the `keepalive` request limit. `keepalive` (the
-// modern navigator.sendBeacon) keeps a request alive across a page navigation,
-// but the Fetch spec caps its body at 64 KB and allows only ~15 inflight
-// keepalive requests for the whole page; source bundles are larger than 64 KB
-// and a grab never navigates away, so keepalive does not apply here. The limit
-// we work around is the ordinary per-origin connection pool, which constrains
-// every fetch whether or not it sets keepalive.
-const MAX_CONCURRENT_SOURCE_FETCHES = 3;
+import { MAX_CONCURRENT_SOURCE_FETCHES, SOURCE_FETCH_TIMEOUT_MS } from "../constants.js";
 
 let activeFetchCount = 0;
 const waitingForSlot: Array<() => void> = [];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

A deep two-pass review (bug audit + code-quality audit against AGENTS.md) of everything shipped in the last 20 days (`de4ec5c8...e56fcc1b`, 24 commits) surfaced a handful of real issues and rule violations. This PR fixes all of them. A second thermo pass was then run on this PR itself, and cubic's review findings were addressed as well (see the per-commit sections below).

## Bug fixes

- **`collect-design-tokens`**: the custom-property name walk only looked at `document.styleSheets`, so apps shipping theme variables through `document.adoptedStyleSheets` (constructible stylesheets — Lit, CSS-in-JS "speedy" mode) got zero tokens and the design-token feature silently did nothing. Adopted sheets are now included in both the walk and the cache key.
- **`context-menu`**: Enter on a *disabled* highlighted row now calls `preventDefault`/`stopPropagation` before returning, matching the comment's stated intent — previously the keydown could fall through to the host page in toggle-activated sessions.
- **`menu-item`**: registration captures `props.value` once, so `onCleanup` unregisters the same identity that was registered (previously a latent leak if `value` changed on a live row).
- **`selection-label`**: the discard prompt `<Show>` is now `keyed`, so a direct truthy-to-truthy transition between the keyboard-selection and prompt-mode variants re-renders the correct label/buttons instead of freezing the first variant.
- **`toolbar`**: unmounting while a hover-freeze was active leaked the global animation/pseudo-state freeze; cleanup now releases it.

## Performance

- **Freeze read/write batching applied everywhere**: the profiled collect-then-apply split (reads before writes, avoiding a ~59ms double full-document recalc) was only used in `core/index.tsx`; the toolbar hover path and `primitives.ts` still called the interleaving wrappers. There is now a single canonical `freezeGlobalInteractions`/`unfreezeGlobalInteractions` helper in `utils/freeze-global-interactions.ts`, all three call sites use it, and the naive wrappers are deleted so future callers can't grab the wrong API.

## Cleanup against AGENTS.md

- Magic numbers moved to `constants.ts` (with their why-comments): `WAAPI_GLOBAL_FREEZE_MAX_ANIMATIONS`, `MAX_CONCURRENT_SOURCE_FETCHES`, and the theme luminance/alpha thresholds.
- Edit-panel discard prompt now uses the `ui/Button` `chip`/`destructive` variants instead of byte-for-byte duplicated class strings (e2e `data-react-grab-discard-button` attributes preserved).
- `CommitOptions` interface hoisted from inside the component body to module scope.
- Color-picker trigger registry simplified from null-argument dispatch (with a dead clear-all branch) to register-returns-unregister.
- `keyboard-selection` reuses the `create-pointer-move-prompt-handoff` latch instead of hand-rolling the same semantics.
- `next-server-frames` shape-guards the symbolication response instead of a bare `as` cast.
- Stale `e2e-app` strings updated after the `e2e-app-vite` rename; one restating comment trimmed; architecture doc updated for the freeze API change.

## Second-pass review fixes (commit 2)

A thermo review of this PR's own diff found and fixed:

- **`collect-design-tokens`**: `document.adoptedStyleSheets` is now guarded (`?? []`) for older Safari/Firefox, and the name cache keys on both sheet counts separately so a document-sheet/adopted-sheet swap in one tick can't alias to a stale cache.
- **`toolbar`**: the three copy-pasted freeze-release sites collapsed into one `releaseInteractionFreeze` helper, and the unmount cleanup now leaves the global freeze to core while grab mode is active (so a runtime toolbar-disable can't defrost an active session) while still releasing the React-updates freeze.
- **`primitives.freeze()`**: the batched reads now run before `freezeAnimations`' stylesheet/attribute writes, honoring the helper's read-before-write contract at the last remaining call site.
- **`constants.ts`**: restored the "deliberately NOT the keepalive limit" rationale paragraph that the move had dropped; added missing context for `LUMINANCE_DARK_THRESHOLD`.

## Cubic review fixes (commit 3)

- **`toolbar`**: the `isActive` ownership guard moved into `releaseInteractionFreeze` itself, so the drag-start and mouse-leave paths also leave the global freeze to core during an active grab session.
- **`collect-design-tokens`**: the token-name cache now keys on the adopted sheet identities (snapshotted), so a same-length sheet swap invalidates it; dropped a redundant `Array.from`.
- **`next-server-frames`**: the response guard validates the full nested shape down to exactly the fields the frame rewrite consumes (`extractUsableOriginalFrame`).
- **`menu-item`**: hover/active checks and the data attribute use the same captured value as the store registration, so a reactive `value` change cannot desync a live row.

## Not addressed (flagged for follow-up)

- `core/index.tsx` is ~3.9k lines (4x the 1k rule); continuing the controller-extraction pattern (`edit-mode.ts`, `keyboard-selection.ts`) is a much larger refactor than this pass.
- The two discard-prompt implementations still use two different data-attribute schemes; unifying them would churn e2e selectors and is left for a dedicated change.

## Testing

Each commit verified independently:

- `pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm format` — all clean
- `pnpm --filter react-grab test:unit` — 58 passed
- `pnpm test` (full Playwright e2e + CLI vitest) — 749 e2e passed, 230 CLI tests passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5405f23-0e32-4ebf-a54a-3b0496eac841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5405f23-0e32-4ebf-a54a-3b0496eac841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes recent regressions and unifies how we freeze interactions to speed up activation and avoid leaks. Apps using constructible stylesheets now get tokens, Enter never falls through from highlighted menu items, prompts re-render, and toolbar hover freezes clean up safely.

- **Bug Fixes**
  - `collect-design-tokens`: include `document.adoptedStyleSheets`, guard older browsers, and key the cache on document sheet count plus adopted sheet identities (snapshot).
  - `context-menu`: always prevent Enter on a highlighted item; call onSelect only if it’s enabled.
  - `menu-item`: capture `value` at mount and use it for unregister, hover/active checks, and the data attribute to avoid desync on reactive changes.
  - `selection-label`: keyed discard prompt so variant switches re-render correctly.
  - `toolbar`: release hover/global freeze via a helper; keep the global freeze owned by core during an active grab across drag-start, mouse-leave, and unmount.

- **Refactors**
  - New `freezeGlobalInteractions` batches reads before writes; used in core activation, toolbar hover, and primitives; removed older wrappers.
  - Moved `WAAPI_GLOBAL_FREEZE_MAX_ANIMATIONS`, `MAX_CONCURRENT_SOURCE_FETCHES`, and theme thresholds to `constants.ts` with added rationale.
  - Simplified color picker trigger API (register returns unregister) and switched discard prompt to `ui/Button` variants.
  - Keyboard selection reuses the pointer-move handoff; Next.js frame symbolication now validates the nested response shape it consumes.
  - Updated e2e references to `e2e-app-vite`; architecture doc reflects the freeze API.

<sup>Written for commit 39f25fbfb20b8c58762b2547fb35a428b65fe0fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

