### PR TITLE
fix(react-grab): animate toolbar collapse border-radius from a finite value

### DIFF
--- a/packages/react-grab/src/components/toolbar/toolbar-content.tsx
+++ b/packages/react-grab/src/components/toolbar/toolbar-content.tsx
@@ -98,7 +98,12 @@ export const ToolbarContent: Component<ToolbarContentProps> = (props) => {
     <div
       data-react-grab-toolbar-panel
       class={cn(
-        "flex items-center justify-center rounded-full antialiased relative overflow-visible [font-synthesis:none]",
+        // rounded-full is calc(infinity * 1px); transitioning border-radius
+        // from that clamped huge value to the collapsed 10px/0 stays pill-
+        // shaped for the whole duration and snaps on the last frame. 13px is
+        // half the expanded 26px thickness, so it renders identically to
+        // rounded-full but interpolates visibly in sync with the collapse.
+        "flex items-center justify-center rounded-[13px] antialiased relative overflow-visible [font-synthesis:none]",
         outerTransitionClass(),
         isVertical() && "flex-col",
         "bg-[var(--rg-panel-bg)] [box-shadow:var(--rg-shadow)]",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When hiding (collapsing) the toolbar, the pill's bottom corners stayed fully round for the whole 140ms collapse and then snapped flat at the last frame, so the shape looked wrong for a beat before the border radius "resolved."

The panel used Tailwind's `rounded-full`, which is `calc(infinity * 1px)` — Chromium clamps it to ~3.35e7px. The collapse transition therefore interpolated `border-radius` from ~33 million px down to `10px`/`0`, and an interpolation starting that high stays visually pill-shaped for nearly the entire duration:

| time | before (computed radius) | after (computed radius) |
|------|--------------------------|-------------------------|
| 0ms | 3.36e7px | 13px |
| ~30ms | 2.23e7px | 10.7px / 3.2px |
| ~60ms | 3.54e6px | 10.2px / 0.7px |
| ~100ms | 8.39e5px | 10.03px / 0.14px |
| end | 10px / 0px | 10px / 0px |

## Fix

Swap `rounded-full` for `rounded-[13px]` on the toolbar panel. 13px is half the expanded 26px thickness, so the expanded pill renders pixel-identically, but the radius now interpolates in sync with the width/height collapse instead of snapping at the end.

## Verification

- Measured computed `border-radius` at intervals during collapse before/after the change (table above) against the live e2e Vite app.
- Confirmed the expanded toolbar renders identically (13px on a 26px-tall pill is fully clamped):

[Expanded toolbar with finite radius](https://cursor.com/agents/bc-c94b5698-1738-4ecf-a788-0d648cdaf37a/artifacts?path=%2Ftmp%2Fframe-000ms.png)

- `pnpm test` (749 passed), `pnpm lint`, `pnpm typecheck`, `pnpm format` all clean.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c94b5698-1738-4ecf-a788-0d648cdaf37a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c94b5698-1738-4ecf-a788-0d648cdaf37a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Smooths the toolbar collapse animation in `react-grab` by animating border-radius from a finite value so corners don’t snap at the end. The expanded look is unchanged.

- **Bug Fixes**
  - Replaced `rounded-full` with `rounded-[13px]` on the toolbar panel (13px = half of 26px height) to allow a smooth border-radius interpolation during collapse.

<sup>Written for commit bc96856f1630c8de9af7a93868886ca4cbb11a48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

