### PR TITLE
Fix immediate theme updates

### DIFF
--- a/packages/react-grab/e2e/app-theme-detection.spec.ts
+++ b/packages/react-grab/e2e/app-theme-detection.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type ReactGrabPageObject } from "./fixtures.js";
+import { ATTRIBUTE_NAME } from "./constants.js";
 
 // react-grab paints its overlay in the *inverse* of the detected app theme so it
 // stays legible. The host therefore carries `data-rg-theme="dark"` on a light app
@@ -34,24 +35,6 @@ const resolveOverlayThemeForBackground = async (
 
   return waitForOverlayTheme(reactGrab, expectedTheme);
 };
-
-const getOverlayThemeObservedDuringBodyStyleMutation = async (
-  reactGrab: ReactGrabPageObject,
-  backgroundColor: string,
-): Promise<string | null> =>
-  reactGrab.page.evaluate(
-    (color) =>
-      new Promise<string | null>((resolve) => {
-        const host = document.querySelector("[data-react-grab]");
-        const observer = new MutationObserver(() => {
-          observer.disconnect();
-          resolve(host?.getAttribute("data-rg-theme") ?? null);
-        });
-        observer.observe(document.body, { attributes: true, attributeFilter: ["style"] });
-        document.body.style.backgroundColor = color;
-      }),
-    backgroundColor,
-  );
 
 test.describe("App Theme Detection", () => {
   // Regression: modern browsers serialize computed colors authored with oklch()
@@ -98,9 +81,21 @@ test.describe("App Theme Detection", () => {
       OVERLAY_THEME_ON_LIGHT_APP,
     );
 
-    const overlayTheme = await getOverlayThemeObservedDuringBodyStyleMutation(
-      reactGrab,
-      "rgb(17, 17, 17)",
+    const overlayTheme = await reactGrab.page.evaluate(
+      ({ attributeName, backgroundColor }) =>
+        new Promise<string | null>((resolve) => {
+          const host = document.querySelector(`[${attributeName}]`);
+          const observer = new MutationObserver(() => {
+            observer.disconnect();
+            resolve(host?.getAttribute("data-rg-theme") ?? null);
+          });
+          observer.observe(document.body, { attributes: true, attributeFilter: ["style"] });
+          document.body.style.backgroundColor = backgroundColor;
+        }),
+      {
+        attributeName: ATTRIBUTE_NAME,
+        backgroundColor: "rgb(17, 17, 17)",
+      },
     );
 
     expect(overlayTheme).toBe(OVERLAY_THEME_ON_DARK_APP);

--- a/packages/react-grab/e2e/app-theme-detection.spec.ts
+++ b/packages/react-grab/e2e/app-theme-detection.spec.ts
@@ -35,6 +35,24 @@ const resolveOverlayThemeForBackground = async (
   return waitForOverlayTheme(reactGrab, expectedTheme);
 };
 
+const getOverlayThemeObservedDuringBodyStyleMutation = async (
+  reactGrab: ReactGrabPageObject,
+  backgroundColor: string,
+): Promise<string | null> =>
+  reactGrab.page.evaluate(
+    (color) =>
+      new Promise<string | null>((resolve) => {
+        const host = document.querySelector("[data-react-grab]");
+        const observer = new MutationObserver(() => {
+          observer.disconnect();
+          resolve(host?.getAttribute("data-rg-theme") ?? null);
+        });
+        observer.observe(document.body, { attributes: true, attributeFilter: ["style"] });
+        document.body.style.backgroundColor = color;
+      }),
+    backgroundColor,
+  );
+
 test.describe("App Theme Detection", () => {
   // Regression: modern browsers serialize computed colors authored with oklch()
   // in their own color space, so the previous rgb()-only parser failed to read
@@ -63,6 +81,26 @@ test.describe("App Theme Detection", () => {
       reactGrab,
       "oklch(0.145 0 0)",
       OVERLAY_THEME_ON_DARK_APP,
+    );
+
+    expect(overlayTheme).toBe(OVERLAY_THEME_ON_DARK_APP);
+  });
+
+  test("updates before the next frame when a body background mutation changes the theme", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.page.emulateMedia({ colorScheme: "light" });
+    await reactGrab.page.evaluate(() => {
+      document.documentElement.classList.remove("dark", "light");
+      document.body.style.backgroundColor = "rgb(255, 255, 255)";
+    });
+    expect(await waitForOverlayTheme(reactGrab, OVERLAY_THEME_ON_LIGHT_APP)).toBe(
+      OVERLAY_THEME_ON_LIGHT_APP,
+    );
+
+    const overlayTheme = await getOverlayThemeObservedDuringBodyStyleMutation(
+      reactGrab,
+      "rgb(17, 17, 17)",
     );
 
     expect(overlayTheme).toBe(OVERLAY_THEME_ON_DARK_APP);

--- a/packages/react-grab/e2e/app-theme-detection.spec.ts
+++ b/packages/react-grab/e2e/app-theme-detection.spec.ts
@@ -101,6 +101,42 @@ test.describe("App Theme Detection", () => {
     expect(overlayTheme).toBe(OVERLAY_THEME_ON_DARK_APP);
   });
 
+  test("updates before the next frame when a CSS variable background changes the theme", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.page.emulateMedia({ colorScheme: "light" });
+    await reactGrab.page.evaluate(() => {
+      document.documentElement.classList.remove("dark", "light");
+      document.documentElement.style.setProperty("--background", "rgb(255, 255, 255)");
+      document.body.style.backgroundColor = "var(--background)";
+    });
+    expect(await waitForOverlayTheme(reactGrab, OVERLAY_THEME_ON_LIGHT_APP)).toBe(
+      OVERLAY_THEME_ON_LIGHT_APP,
+    );
+
+    const overlayTheme = await reactGrab.page.evaluate(
+      ({ attributeName, backgroundColor }) =>
+        new Promise<string | null>((resolve) => {
+          const host = document.querySelector(`[${attributeName}]`);
+          const observer = new MutationObserver(() => {
+            observer.disconnect();
+            resolve(host?.getAttribute("data-rg-theme") ?? null);
+          });
+          observer.observe(document.documentElement, {
+            attributes: true,
+            attributeFilter: ["style"],
+          });
+          document.documentElement.style.setProperty("--background", backgroundColor);
+        }),
+      {
+        attributeName: ATTRIBUTE_NAME,
+        backgroundColor: "rgb(17, 17, 17)",
+      },
+    );
+
+    expect(overlayTheme).toBe(OVERLAY_THEME_ON_DARK_APP);
+  });
+
   // `color-scheme: light dark` advertises support for both schemes; the active
   // one follows the OS preference, not the token order. Previously the first
   // token ("light") was always returned, mis-detecting dark-OS visitors.

--- a/packages/react-grab/src/utils/detect-app-theme.ts
+++ b/packages/react-grab/src/utils/detect-app-theme.ts
@@ -14,6 +14,11 @@ interface ThemeWatcherResult {
   cleanup: () => void;
 }
 
+interface ThemeInputsFingerprint {
+  immediate: string;
+  full: string;
+}
+
 const THEME_ATTRIBUTES = [
   "data-theme",
   "data-mode",
@@ -172,25 +177,38 @@ const detectTheme = (): AppTheme => {
 
 const invertTheme = (theme: AppTheme): AppTheme => (theme === "dark" ? "light" : "dark");
 
-// Attribute-level snapshot of everything the mutation-driven re-detection can
-// react to. Reading it never forces style recalc, unlike detectTheme whose
-// getComputedStyle calls do — which made every unrelated body style write
-// (e.g. our own user-select/touch-action toggles) trigger a forced recalc per
-// frame. If this fingerprint is unchanged, the mutation cannot have changed
-// the detected theme, so detectTheme is skipped.
-const getThemeInputsFingerprint = (): string => {
-  const fingerprintParts: string[] = [];
+// Attribute-level snapshot of direct theme signals. Reading it never forces
+// style recalc, unlike detectTheme whose getComputedStyle calls do — which made
+// every unrelated body style write (e.g. our own user-select/touch-action
+// toggles) trigger a forced recalc per frame.
+const getImmediateThemeInputsFingerprint = (): string => {
+  const immediateFingerprintParts: string[] = [];
   for (const element of [document.documentElement, document.body]) {
     if (!element) continue;
-    fingerprintParts.push(element.className);
+    immediateFingerprintParts.push(element.className);
     for (const attributeName of THEME_ATTRIBUTES) {
-      fingerprintParts.push(element.getAttribute(attributeName) ?? "");
+      immediateFingerprintParts.push(element.getAttribute(attributeName) ?? "");
     }
     for (const { attribute } of PRESENCE_ATTRIBUTES) {
-      fingerprintParts.push(element.hasAttribute(attribute) ? "1" : "");
+      immediateFingerprintParts.push(element.hasAttribute(attribute) ? "1" : "");
     }
     const inlineStyle = element.style;
-    fingerprintParts.push(inlineStyle.colorScheme, inlineStyle.backgroundColor, inlineStyle.color);
+    immediateFingerprintParts.push(
+      inlineStyle.colorScheme,
+      inlineStyle.backgroundColor,
+      inlineStyle.color,
+    );
+  }
+  return immediateFingerprintParts.join("|");
+};
+
+const getThemeInputsFingerprint = (
+  immediate = getImmediateThemeInputsFingerprint(),
+): ThemeInputsFingerprint => {
+  const customPropertyFingerprintParts: string[] = [];
+  for (const element of [document.documentElement, document.body]) {
+    if (!element) continue;
+    const inlineStyle = element.style;
     // Inline custom properties (e.g. `--background`) can drive the computed
     // background/color through `var()` references in stylesheets, so they are
     // part of the theme inputs even though the direct color properties are not
@@ -198,11 +216,17 @@ const getThemeInputsFingerprint = (): string => {
     for (let propertyIndex = 0; propertyIndex < inlineStyle.length; propertyIndex++) {
       const propertyName = inlineStyle[propertyIndex];
       if (propertyName.startsWith("--")) {
-        fingerprintParts.push(`${propertyName}:${inlineStyle.getPropertyValue(propertyName)}`);
+        customPropertyFingerprintParts.push(
+          `${propertyName}:${inlineStyle.getPropertyValue(propertyName)}`,
+        );
       }
     }
   }
-  return fingerprintParts.join("|");
+  const customProperties = customPropertyFingerprintParts.join("|");
+  return {
+    immediate,
+    full: customProperties ? `${immediate}|${customProperties}` : immediate,
+  };
 };
 
 const OBSERVED_ATTRIBUTES: string[] = [
@@ -221,11 +245,11 @@ export const watchAppTheme = (
   onChange?: (reactGrabTheme: AppTheme) => void,
 ): ThemeWatcherResult => {
   let lastAppliedTheme: AppTheme | null = null;
-  let lastInputsFingerprint: string | null = null;
+  let lastInputsFingerprint: ThemeInputsFingerprint | null = null;
   let pendingFrame: number | null = null;
 
-  const applyTheme = (inputsFingerprint = getThemeInputsFingerprint()): AppTheme => {
-    if (inputsFingerprint === lastInputsFingerprint && lastAppliedTheme !== null) {
+  const applyThemeForFingerprint = (inputsFingerprint: ThemeInputsFingerprint): AppTheme => {
+    if (inputsFingerprint.full === lastInputsFingerprint?.full && lastAppliedTheme !== null) {
       // Even when re-detection is skipped, flush pending style with one
       // targeted read. Skipping every read here lets invalidations from the
       // freeze path's universal-selector rule churn accumulate until
@@ -248,6 +272,8 @@ export const watchAppTheme = (
     return reactGrabTheme;
   };
 
+  const applyCurrentTheme = (): AppTheme => applyThemeForFingerprint(getThemeInputsFingerprint());
+
   const cancelScheduledApplyTheme = (): void => {
     if (pendingFrame === null) return;
     nativeCancelAnimationFrame(pendingFrame);
@@ -258,20 +284,20 @@ export const watchAppTheme = (
     if (pendingFrame !== null) return;
     pendingFrame = nativeRequestAnimationFrame(() => {
       pendingFrame = null;
-      applyTheme();
+      applyCurrentTheme();
     });
   };
 
-  const initialTheme = applyTheme();
+  const initialTheme = applyCurrentTheme();
 
   const handleThemeInputMutation = (): void => {
-    const inputsFingerprint = getThemeInputsFingerprint();
-    if (inputsFingerprint === lastInputsFingerprint) {
+    const immediateFingerprint = getImmediateThemeInputsFingerprint();
+    if (immediateFingerprint === lastInputsFingerprint?.immediate) {
       scheduleApplyTheme();
       return;
     }
     cancelScheduledApplyTheme();
-    applyTheme(inputsFingerprint);
+    applyThemeForFingerprint(getThemeInputsFingerprint(immediateFingerprint));
   };
 
   const observer = new MutationObserver(handleThemeInputMutation);
@@ -285,9 +311,9 @@ export const watchAppTheme = (
     // Body may not exist yet during early script execution; observe it once
     // it appears and re-evaluate (the initial background may differ from
     // the fallback used above).
-    bodyObserver = new MutationObserver(() => {
+    bodyObserver = new MutationObserver((_mutationRecords, bodyAvailabilityObserver) => {
       if (!document.body) return;
-      bodyObserver!.disconnect();
+      bodyAvailabilityObserver.disconnect();
       bodyObserver = null;
       observer.observe(document.body, OBSERVER_OPTIONS);
       handleThemeInputMutation();

--- a/packages/react-grab/src/utils/detect-app-theme.ts
+++ b/packages/react-grab/src/utils/detect-app-theme.ts
@@ -224,8 +224,7 @@ export const watchAppTheme = (
   let lastInputsFingerprint: string | null = null;
   let pendingFrame: number | null = null;
 
-  const applyTheme = (): AppTheme => {
-    const inputsFingerprint = getThemeInputsFingerprint();
+  const applyTheme = (inputsFingerprint = getThemeInputsFingerprint()): AppTheme => {
     if (inputsFingerprint === lastInputsFingerprint && lastAppliedTheme !== null) {
       // Even when re-detection is skipped, flush pending style with one
       // targeted read. Skipping every read here lets invalidations from the
@@ -249,6 +248,12 @@ export const watchAppTheme = (
     return reactGrabTheme;
   };
 
+  const cancelScheduledApplyTheme = (): void => {
+    if (pendingFrame === null) return;
+    nativeCancelAnimationFrame(pendingFrame);
+    pendingFrame = null;
+  };
+
   const scheduleApplyTheme = () => {
     if (pendingFrame !== null) return;
     pendingFrame = nativeRequestAnimationFrame(() => {
@@ -259,7 +264,17 @@ export const watchAppTheme = (
 
   const initialTheme = applyTheme();
 
-  const observer = new MutationObserver(scheduleApplyTheme);
+  const handleThemeInputMutation = (): void => {
+    const inputsFingerprint = getThemeInputsFingerprint();
+    if (inputsFingerprint === lastInputsFingerprint) {
+      scheduleApplyTheme();
+      return;
+    }
+    cancelScheduledApplyTheme();
+    applyTheme(inputsFingerprint);
+  };
+
+  const observer = new MutationObserver(handleThemeInputMutation);
   observer.observe(document.documentElement, OBSERVER_OPTIONS);
 
   let bodyObserver: MutationObserver | null = null;
@@ -275,7 +290,7 @@ export const watchAppTheme = (
       bodyObserver!.disconnect();
       bodyObserver = null;
       observer.observe(document.body, OBSERVER_OPTIONS);
-      applyTheme();
+      handleThemeInputMutation();
     });
     bodyObserver.observe(document.documentElement, { childList: true });
   }
@@ -296,9 +311,7 @@ export const watchAppTheme = (
       bodyObserver?.disconnect();
       observer.disconnect();
       mediaQuery.removeEventListener("change", handleMediaChange);
-      if (pendingFrame !== null) {
-        nativeCancelAnimationFrame(pendingFrame);
-      }
+      cancelScheduledApplyTheme();
     },
   };
 };

--- a/packages/react-grab/src/utils/detect-app-theme.ts
+++ b/packages/react-grab/src/utils/detect-app-theme.ts
@@ -14,11 +14,6 @@ interface ThemeWatcherResult {
   cleanup: () => void;
 }
 
-interface ThemeInputsFingerprint {
-  immediate: string;
-  full: string;
-}
-
 const THEME_ATTRIBUTES = [
   "data-theme",
   "data-mode",
@@ -177,38 +172,25 @@ const detectTheme = (): AppTheme => {
 
 const invertTheme = (theme: AppTheme): AppTheme => (theme === "dark" ? "light" : "dark");
 
-// Attribute-level snapshot of direct theme signals. Reading it never forces
-// style recalc, unlike detectTheme whose getComputedStyle calls do — which made
-// every unrelated body style write (e.g. our own user-select/touch-action
-// toggles) trigger a forced recalc per frame.
-const getImmediateThemeInputsFingerprint = (): string => {
-  const immediateFingerprintParts: string[] = [];
+// Attribute-level snapshot of everything the mutation-driven re-detection can
+// react to. Reading it never forces style recalc, unlike detectTheme whose
+// getComputedStyle calls do — which made every unrelated body style write
+// (e.g. our own user-select/touch-action toggles) trigger a forced recalc per
+// frame. If this fingerprint is unchanged, the mutation cannot have changed
+// the detected theme, so detectTheme is skipped.
+const getThemeInputsFingerprint = (): string => {
+  const fingerprintParts: string[] = [];
   for (const element of [document.documentElement, document.body]) {
     if (!element) continue;
-    immediateFingerprintParts.push(element.className);
+    fingerprintParts.push(element.className);
     for (const attributeName of THEME_ATTRIBUTES) {
-      immediateFingerprintParts.push(element.getAttribute(attributeName) ?? "");
+      fingerprintParts.push(element.getAttribute(attributeName) ?? "");
     }
     for (const { attribute } of PRESENCE_ATTRIBUTES) {
-      immediateFingerprintParts.push(element.hasAttribute(attribute) ? "1" : "");
+      fingerprintParts.push(element.hasAttribute(attribute) ? "1" : "");
     }
     const inlineStyle = element.style;
-    immediateFingerprintParts.push(
-      inlineStyle.colorScheme,
-      inlineStyle.backgroundColor,
-      inlineStyle.color,
-    );
-  }
-  return immediateFingerprintParts.join("|");
-};
-
-const getThemeInputsFingerprint = (
-  immediate = getImmediateThemeInputsFingerprint(),
-): ThemeInputsFingerprint => {
-  const customPropertyFingerprintParts: string[] = [];
-  for (const element of [document.documentElement, document.body]) {
-    if (!element) continue;
-    const inlineStyle = element.style;
+    fingerprintParts.push(inlineStyle.colorScheme, inlineStyle.backgroundColor, inlineStyle.color);
     // Inline custom properties (e.g. `--background`) can drive the computed
     // background/color through `var()` references in stylesheets, so they are
     // part of the theme inputs even though the direct color properties are not
@@ -216,17 +198,11 @@ const getThemeInputsFingerprint = (
     for (let propertyIndex = 0; propertyIndex < inlineStyle.length; propertyIndex++) {
       const propertyName = inlineStyle[propertyIndex];
       if (propertyName.startsWith("--")) {
-        customPropertyFingerprintParts.push(
-          `${propertyName}:${inlineStyle.getPropertyValue(propertyName)}`,
-        );
+        fingerprintParts.push(`${propertyName}:${inlineStyle.getPropertyValue(propertyName)}`);
       }
     }
   }
-  const customProperties = customPropertyFingerprintParts.join("|");
-  return {
-    immediate,
-    full: customProperties ? `${immediate}|${customProperties}` : immediate,
-  };
+  return fingerprintParts.join("|");
 };
 
 const OBSERVED_ATTRIBUTES: string[] = [
@@ -245,11 +221,11 @@ export const watchAppTheme = (
   onChange?: (reactGrabTheme: AppTheme) => void,
 ): ThemeWatcherResult => {
   let lastAppliedTheme: AppTheme | null = null;
-  let lastInputsFingerprint: ThemeInputsFingerprint | null = null;
+  let lastInputsFingerprint: string | null = null;
   let pendingFrame: number | null = null;
 
-  const applyThemeForFingerprint = (inputsFingerprint: ThemeInputsFingerprint): AppTheme => {
-    if (inputsFingerprint.full === lastInputsFingerprint?.full && lastAppliedTheme !== null) {
+  const applyThemeForFingerprint = (inputsFingerprint: string): AppTheme => {
+    if (inputsFingerprint === lastInputsFingerprint && lastAppliedTheme !== null) {
       // Even when re-detection is skipped, flush pending style with one
       // targeted read. Skipping every read here lets invalidations from the
       // freeze path's universal-selector rule churn accumulate until
@@ -291,13 +267,13 @@ export const watchAppTheme = (
   const initialTheme = applyCurrentTheme();
 
   const handleThemeInputMutation = (): void => {
-    const immediateFingerprint = getImmediateThemeInputsFingerprint();
-    if (immediateFingerprint === lastInputsFingerprint?.immediate) {
+    const inputsFingerprint = getThemeInputsFingerprint();
+    if (inputsFingerprint === lastInputsFingerprint) {
       scheduleApplyTheme();
       return;
     }
     cancelScheduledApplyTheme();
-    applyThemeForFingerprint(getThemeInputsFingerprint(immediateFingerprint));
+    applyThemeForFingerprint(inputsFingerprint);
   };
 
   const observer = new MutationObserver(handleThemeInputMutation);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Updates app theme detection synchronously for root/body theme-input mutations so the overlay does not flash the stale inverse theme before the next animation frame.
- Covers both direct background mutations and CSS-variable-only theme switches that drive computed backgrounds through `var()`.
- Adds e2e regressions that read `data-rg-theme` during mutation delivery after dark body background and CSS-variable background changes.

### Testing
- `nr build`
- `pnpm --filter react-grab exec playwright test e2e/app-theme-detection.spec.ts --project=chromium --reporter=list`
- `pnpm typecheck`
- GitHub CI is green on the latest pushed commit, including lint, typecheck, build, unit, CLI, e2e shards, perf, Bugbot, Vercel Agent Review, and Cubic.

### Review
- Ran `/simplify` with code-quality, performance, and reuse reviewers plus a thermo-nuclear code-quality audit.
- Addressed Cubic's CSS-variable-only theme mutation comment with a production fix and focused regression.

### Notes
- `pnpm lint` and `pnpm format` currently fail locally before checking/formatting code because Vite Plus cannot load `/workspace/vite.config.ts` with `ERR_UNKNOWN_FILE_EXTENSION`; the tool reports the local Node `v22.14.0` is below the required Node range for TypeScript config loading. GitHub CI lint passes on the PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7528ac92-61c1-4e42-9720-664b6070dbcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7528ac92-61c1-4e42-9720-664b6070dbcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overlay theme flicker by updating the detected app theme immediately on root, body, and CSS variable mutations; otherwise defers to the next frame. Simplifies mutation handling and adds e2e coverage for instant updates.

- **Bug Fixes**
  - Apply synchronously when the immediate fingerprint changes (including CSS variable writes); compute the full fingerprint only when needed.
  - Cancel any pending `requestAnimationFrame`; use a single mutation handler and observe body once it appears.
  - Add Playwright e2e asserting correct `data-rg-theme` at the moment of body and CSS variable background mutations.

<sup>Written for commit a562ad965f953ed361d0b925a13c5f7a7e326575. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

