### PR TITLE
Fix component display name resolution

### DIFF
--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -31,7 +31,6 @@ const isSourceComponentName = (name: string): boolean => {
   if (name.length <= 1) return false;
   if (isInternalComponentName(name)) return false;
   if (name[0] !== name[0].toUpperCase()) return false;
-  if (name.endsWith("Provider") || name.endsWith("Context")) return false;
   return true;
 };
 

--- a/packages/react-grab/src/utils/is-useful-component-name.ts
+++ b/packages/react-grab/src/utils/is-useful-component-name.ts
@@ -59,6 +59,8 @@ const NEXT_INTERNAL_COMPONENT_NAMES = new Set([
   "html",
 ]);
 
+const PLACEHOLDER_COMPONENT_NAMES = new Set(["<anonymous>", "<unknown>", "Anonymous", "Unknown"]);
+
 const REACT_INTERNAL_COMPONENT_NAMES = new Set([
   "Suspense",
   "Fragment",
@@ -67,12 +69,22 @@ const REACT_INTERNAL_COMPONENT_NAMES = new Set([
   "SuspenseList",
 ]);
 
-const LIBRARY_INTERNAL_COMPONENT_NAMES = new Set(["MotionDOMComponent"]);
+const LIBRARY_INTERNAL_COMPONENT_NAMES = new Set(["MotionDOMComponent", "Slot", "SlotClone"]);
+const LIBRARY_INTERNAL_COMPONENT_SUFFIXES = [
+  ".Slot",
+  ".SlotClone",
+  ".Slottable",
+  "ProviderProvider",
+];
 
 export const isInternalComponentName = (name: string): boolean => {
+  if (PLACEHOLDER_COMPONENT_NAMES.has(name)) return true;
   if (NEXT_INTERNAL_COMPONENT_NAMES.has(name)) return true;
   if (REACT_INTERNAL_COMPONENT_NAMES.has(name)) return true;
   if (LIBRARY_INTERNAL_COMPONENT_NAMES.has(name)) return true;
+  for (const suffix of LIBRARY_INTERNAL_COMPONENT_SUFFIXES) {
+    if (name.endsWith(suffix)) return true;
+  }
   for (const prefix of NON_COMPONENT_PREFIXES) {
     if (name.startsWith(prefix)) return true;
   }
@@ -82,6 +94,5 @@ export const isInternalComponentName = (name: string): boolean => {
 export const isUsefulComponentName = (name: string): boolean => {
   if (!name) return false;
   if (isInternalComponentName(name)) return false;
-  if (name === "SlotClone" || name === "Slot") return false;
   return true;
 };

--- a/packages/react-grab/src/utils/is-useful-component-name.ts
+++ b/packages/react-grab/src/utils/is-useful-component-name.ts
@@ -71,6 +71,9 @@ const REACT_INTERNAL_COMPONENT_NAMES = new Set([
 
 const LIBRARY_INTERNAL_COMPONENT_NAMES = new Set(["MotionDOMComponent", "Slot", "SlotClone"]);
 const LIBRARY_INTERNAL_COMPONENT_SUFFIXES = [
+  ".Consumer",
+  ".Context",
+  ".Provider",
   ".Slot",
   ".SlotClone",
   ".Slottable",

--- a/packages/react-grab/tests/context.test.ts
+++ b/packages/react-grab/tests/context.test.ts
@@ -81,6 +81,7 @@ describe("selectResolvedSource", () => {
     const internalFrames: StackFrame[] = [
       { fileName: "/src/app/slot.tsx", functionName: "SlotClone" },
       { fileName: "/src/app/anonymous.tsx", functionName: "Anonymous" },
+      { fileName: "/src/app/theme-context.tsx", functionName: "ThemeContext.Provider" },
       appFrame,
     ];
 

--- a/packages/react-grab/tests/context.test.ts
+++ b/packages/react-grab/tests/context.test.ts
@@ -76,6 +76,41 @@ describe("selectResolvedSource", () => {
       componentName: "Widget",
     });
   });
+
+  it("skips placeholder and slot-wrapper frame names", () => {
+    const internalFrames: StackFrame[] = [
+      { fileName: "/src/app/slot.tsx", functionName: "SlotClone" },
+      { fileName: "/src/app/anonymous.tsx", functionName: "Anonymous" },
+      appFrame,
+    ];
+
+    expect(selectResolvedSource(null, internalFrames)).toMatchObject({
+      filePath: "/src/app/widget.tsx",
+      componentName: "Widget",
+    });
+  });
+
+  it("keeps authored provider and context frame names", () => {
+    expect(
+      selectResolvedSource(null, [
+        { fileName: "/src/app/auth-provider.tsx", functionName: "AuthProvider" },
+        appFrame,
+      ]),
+    ).toMatchObject({
+      filePath: "/src/app/auth-provider.tsx",
+      componentName: "AuthProvider",
+    });
+
+    expect(
+      selectResolvedSource(null, [
+        { fileName: "/src/app/cart-context.tsx", functionName: "CartContext" },
+        appFrame,
+      ]),
+    ).toMatchObject({
+      filePath: "/src/app/cart-context.tsx",
+      componentName: "CartContext",
+    });
+  });
 });
 
 describe("formatStackContext", () => {

--- a/packages/react-grab/tests/is-useful-component-name.test.ts
+++ b/packages/react-grab/tests/is-useful-component-name.test.ts
@@ -13,6 +13,13 @@ describe("isUsefulComponentName", () => {
     expect(isUsefulComponentName("TooltipProviderProvider")).toBe(false);
   });
 
+  it.each(["ThemeContext.Consumer", "Theme.Context", "ThemeContext.Provider"])(
+    "filters the React context wrapper %s",
+    (componentName) => {
+      expect(isUsefulComponentName(componentName)).toBe(false);
+    },
+  );
+
   it.each([
     "Slot",
     "SlotClone",

--- a/packages/react-grab/tests/is-useful-component-name.test.ts
+++ b/packages/react-grab/tests/is-useful-component-name.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vite-plus/test";
+import { isUsefulComponentName } from "../src/utils/is-useful-component-name.js";
+
+describe("isUsefulComponentName", () => {
+  it.each(["<anonymous>", "Anonymous", "<unknown>", "Unknown"])(
+    "filters the placeholder component name %s",
+    (componentName) => {
+      expect(isUsefulComponentName(componentName)).toBe(false);
+    },
+  );
+
+  it("filters generated context providers with a duplicated Provider suffix", () => {
+    expect(isUsefulComponentName("TooltipProviderProvider")).toBe(false);
+  });
+
+  it.each([
+    "Slot",
+    "SlotClone",
+    "CollectionSlot.Slot",
+    "CollectionSlot.SlotClone",
+    "TooltipContent.Slottable",
+  ])("filters the slot wrapper %s", (componentName) => {
+    expect(isUsefulComponentName(componentName)).toBe(false);
+  });
+
+  it.each(["TooltipProvider", "SlotMachine", "AnonymousForm"])(
+    "keeps the authored component name %s",
+    (componentName) => {
+      expect(isUsefulComponentName(componentName)).toBe(true);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- filter placeholder names and generated duplicate provider wrappers
- filter owner-prefixed Radix slot internals consistently across fiber and stack resolution
- preserve authored Provider and Context component names in source stacks
- add regression coverage for each resolution case

## Verification

- nr build
- nr test (883 passed; 3 unrelated tests passed on retry and were reported flaky)
- nr lint
- nr typecheck
- nr format

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only display/stack resolution logic with expanded unit tests; no auth, data, or runtime behavior changes for end users.
> 
> **Overview**
> Improves **which stack frame names count as real components** when resolving source locations and trace context, so grabs skip noise and still surface authored app components.
> 
> **Internal name filtering** is centralized in `isInternalComponentName`: placeholder labels (`<anonymous>`, `Anonymous`, etc.), Radix/slot wrappers (`Slot`, `SlotClone`, `*.Provider`, `ProviderProvider`, etc.), and similar generated frames are treated as internal. Duplicated `Slot`/`SlotClone` checks were removed from `isUsefulComponentName` in favor of that list.
> 
> **Authored `*Provider` / `*Context` names** are no longer dropped by a blanket suffix rule in `isSourceComponentName`; only names classified as internal are excluded, so stacks can prefer frames like `AuthProvider` or `CartContext` instead of always skipping them.
> 
> Regression tests cover `selectResolvedSource`, placeholder/slot skipping, and preserved provider/context names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a58b3a5ac7dbd9e75591b194d6ffa89b537fd5b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes component display name resolution by filtering placeholder, React context wrapper, and slot-wrapper internals while keeping authored Provider/Context names. This improves source stack selection and avoids noisy frames.

- **Bug Fixes**
  - Filter internals: placeholders (`<anonymous>`, `<unknown>`, `Anonymous`, `Unknown`), React context wrappers (`.Provider`, `.Context`, `.Consumer` like `ThemeContext.Provider`), Radix slot wrappers (`Slot`, `SlotClone`, `.Slot`, `.SlotClone`, `.Slottable`), and duplicated `ProviderProvider`.
  - Preserve authored `*Provider` and `*Context` names in source stacks.
  - Added regression tests for all cases.

<sup>Written for commit a58b3a5ac7dbd9e75591b194d6ffa89b537fd5b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

