### PR TITLE
Add animated selection session bar

### DIFF
--- a/packages/react-grab/e2e/selection-session-bar.spec.ts
+++ b/packages/react-grab/e2e/selection-session-bar.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from "./fixtures.js";
+import { ATTRIBUTE_NAME } from "./constants.js";
+import type { Page } from "@playwright/test";
+
+interface SelectionSessionBarState {
+  isVisible: boolean;
+  multiSelectEnabled: boolean;
+  selectedText: string | null;
+  copyDisabled: boolean | null;
+}
+
+const getSelectionSessionBarState = async (page: Page): Promise<SelectionSessionBarState> => {
+  return page.evaluate((attributeName: string) => {
+    const host = document.querySelector(`[${attributeName}]`);
+    const root = host?.shadowRoot?.querySelector(`[${attributeName}]`);
+    const bar = root?.querySelector<HTMLElement>("[data-react-grab-selection-session-bar]");
+    const multiSelectButton = bar?.querySelector(
+      "[data-react-grab-selection-session-enable-multi-select]",
+    );
+    const selectedText = bar?.querySelector<HTMLElement>(".tabular-nums")?.textContent ?? null;
+    const copyButton = bar?.querySelector<HTMLButtonElement>(
+      "[data-react-grab-selection-session-copy]",
+    );
+
+    return {
+      isVisible: Boolean(bar),
+      multiSelectEnabled: !multiSelectButton,
+      selectedText,
+      copyDisabled: copyButton?.disabled ?? null,
+    };
+  }, ATTRIBUTE_NAME);
+};
+
+test.describe("Selection session bar", () => {
+  test("should opt into persistent multi-select and copy the accumulated selection", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.activate();
+
+    await expect
+      .poll(() => getSelectionSessionBarState(reactGrab.page))
+      .toMatchObject({
+        isVisible: true,
+        multiSelectEnabled: false,
+      });
+    await reactGrab.page.evaluate((attributeName) => {
+      const host = document.querySelector(`[${attributeName}]`);
+      const root = host?.shadowRoot?.querySelector(`[${attributeName}]`);
+      root
+        ?.querySelector<HTMLButtonElement>(
+          "[data-react-grab-selection-session-enable-multi-select]",
+        )
+        ?.click();
+    }, ATTRIBUTE_NAME);
+
+    const todoItems = reactGrab.page.locator("[data-testid='todo-list'] li");
+    await todoItems.nth(0).click({ force: true });
+    await todoItems.nth(1).click({ force: true });
+
+    await expect
+      .poll(() => getSelectionSessionBarState(reactGrab.page))
+      .toMatchObject({
+        isVisible: true,
+        multiSelectEnabled: true,
+        selectedText: "2 selected",
+        copyDisabled: false,
+      });
+
+    await reactGrab.page.evaluate((attributeName) => {
+      const host = document.querySelector(`[${attributeName}]`);
+      const root = host?.shadowRoot?.querySelector(`[${attributeName}]`);
+      root?.querySelector<HTMLButtonElement>("[data-react-grab-selection-session-copy]")?.click();
+    }, ATTRIBUTE_NAME);
+
+    await expect.poll(() => reactGrab.getClipboardContent()).toContain("TodoItem");
+  });
+});

--- a/packages/react-grab/src/components/renderer.tsx
+++ b/packages/react-grab/src/components/renderer.tsx
@@ -11,6 +11,7 @@ import { ContextMenu } from "./context-menu.js";
 import { EditPanel } from "./edit-panel/index.js";
 import { ToolbarMenu } from "./toolbar/toolbar-menu.js";
 import { HierarchyMenu } from "./toolbar/hierarchy-menu.js";
+import { SelectionSessionBar } from "./selection-session-bar.js";
 
 export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
   return (
@@ -26,6 +27,15 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
         labelInstances={props.labelInstances}
       />
       <FrozenGlow visible={props.isFrozen ?? false} />
+      <SelectionSessionBar
+        visible={props.selectionSessionVisible ?? false}
+        selectedCount={props.selectionSessionSelectedCount ?? 0}
+        multiSelectEnabled={props.selectionSessionMultiSelectEnabled ?? false}
+        onCancel={props.onSelectionSessionCancel}
+        onEnableMultiSelect={props.onSelectionSessionEnableMultiSelect}
+        onClear={props.onSelectionSessionClear}
+        onCopy={props.onSelectionSessionCopy}
+      />
       <Show when={props.selectionLabelVisible && (props.frozenLabelEntries?.length ?? 0) > 0}>
         <Index each={props.frozenLabelEntries ?? []}>
           {(entry, entryIndex) => (

--- a/packages/react-grab/src/components/selection-session-bar.tsx
+++ b/packages/react-grab/src/components/selection-session-bar.tsx
@@ -1,0 +1,150 @@
+import { createEffect, createSignal, on, onCleanup, onMount, Show, type Component } from "solid-js";
+import {
+  SELECTION_SESSION_BAR_ACCENT_COLOR,
+  SELECTION_SESSION_BAR_BACKGROUND_COLOR,
+  SELECTION_SESSION_BAR_HEIGHT_PX,
+  SELECTION_SESSION_ANIMATION_DURATION_MS,
+  SELECTION_SESSION_ANIMATION_EASING,
+  Z_INDEX_OVERLAY,
+} from "../constants.js";
+import { nativeCancelAnimationFrame, nativeRequestAnimationFrame } from "../utils/native-raf.js";
+
+interface SelectionSessionBarProps {
+  visible: boolean;
+  selectedCount: number;
+  multiSelectEnabled: boolean;
+  onCancel?: () => void;
+  onEnableMultiSelect?: () => void;
+  onClear?: () => void;
+  onCopy?: () => void;
+}
+
+export const SelectionSessionBar: Component<SelectionSessionBarProps> = (props) => {
+  const hostname = window.location.hostname || "this page";
+  const [shouldRender, setShouldRender] = createSignal(props.visible);
+  const [isAnimatedIn, setIsAnimatedIn] = createSignal(false);
+  let enterAnimationFrameId: number | null = null;
+  let exitAnimationTimerId: number | null = null;
+
+  onMount(() => {
+    if (props.visible) {
+      enterAnimationFrameId = nativeRequestAnimationFrame(() => setIsAnimatedIn(true));
+    }
+  });
+
+  createEffect(
+    on(
+      () => props.visible,
+      (visible) => {
+        if (enterAnimationFrameId !== null) {
+          nativeCancelAnimationFrame(enterAnimationFrameId);
+          enterAnimationFrameId = null;
+        }
+        if (exitAnimationTimerId !== null) {
+          window.clearTimeout(exitAnimationTimerId);
+          exitAnimationTimerId = null;
+        }
+
+        if (visible) {
+          setShouldRender(true);
+          enterAnimationFrameId = nativeRequestAnimationFrame(() => {
+            enterAnimationFrameId = null;
+            setIsAnimatedIn(true);
+          });
+          return;
+        }
+
+        setIsAnimatedIn(false);
+        exitAnimationTimerId = window.setTimeout(() => {
+          exitAnimationTimerId = null;
+          setShouldRender(false);
+        }, SELECTION_SESSION_ANIMATION_DURATION_MS);
+      },
+      { defer: true },
+    ),
+  );
+
+  onCleanup(() => {
+    if (enterAnimationFrameId !== null) nativeCancelAnimationFrame(enterAnimationFrameId);
+    if (exitAnimationTimerId !== null) window.clearTimeout(exitAnimationTimerId);
+  });
+
+  return (
+    <Show when={shouldRender()}>
+      <div
+        data-react-grab-selection-session-bar
+        class="fixed inset-x-0 top-0 px-2.5 flex items-center text-white font-sans antialiased [font-synthesis:none] [box-shadow:0_1px_0_rgba(255,255,255,0.08),0_2px_10px_rgba(0,0,0,0.16)] pointer-events-none will-change-[transform,opacity]"
+        style={{
+          height: `${SELECTION_SESSION_BAR_HEIGHT_PX}px`,
+          background: SELECTION_SESSION_BAR_BACKGROUND_COLOR,
+          opacity: isAnimatedIn() ? 1 : 0,
+          transform: isAnimatedIn() ? "translateY(0)" : "translateY(-100%)",
+          transition: `transform ${SELECTION_SESSION_ANIMATION_DURATION_MS}ms ${SELECTION_SESSION_ANIMATION_EASING}, opacity ${SELECTION_SESSION_ANIMATION_DURATION_MS}ms ease-out`,
+          "z-index": Z_INDEX_OVERLAY,
+        }}
+      >
+        <div class="flex items-center">
+          <button
+            data-react-grab-ignore-events
+            data-react-grab-selection-session-cancel
+            aria-label="Cancel selection"
+            type="button"
+            class="size-7 flex items-center justify-center rounded-md text-[21px] leading-none font-light text-white/65 hover:text-white hover:bg-white/8 pointer-events-auto cursor-pointer interactive-scale"
+            onClick={() => props.onCancel?.()}
+          >
+            ×
+          </button>
+        </div>
+
+        <div class="absolute left-1/2 -translate-x-1/2 flex items-center gap-1.5 text-[13px] font-medium whitespace-nowrap">
+          <span class="text-white/95">Selecting</span>
+          <span class="text-white/35">·</span>
+          <span class="text-white/65 max-sm:hidden">{hostname}</span>
+          <Show when={props.multiSelectEnabled}>
+            <span class="text-white/35">·</span>
+            <span class="text-white/85 tabular-nums">{props.selectedCount} selected</span>
+          </Show>
+        </div>
+
+        <div class="ml-auto flex items-center gap-1.5">
+          <Show
+            when={props.multiSelectEnabled}
+            fallback={
+              <button
+                data-react-grab-ignore-events
+                data-react-grab-selection-session-enable-multi-select
+                type="button"
+                class="h-7 px-2.5 rounded-md text-[12px] font-medium text-white/75 bg-white/8 hover:text-white hover:bg-white/12 pointer-events-auto cursor-pointer interactive-scale"
+                onClick={() => props.onEnableMultiSelect?.()}
+              >
+                Multiple
+              </button>
+            }
+          >
+            <button
+              data-react-grab-ignore-events
+              data-react-grab-selection-session-clear
+              type="button"
+              disabled={props.selectedCount === 0}
+              class="h-7 px-2.5 rounded-md text-[12px] font-medium text-white/65 hover:text-white hover:bg-white/8 disabled:opacity-35 disabled:cursor-default pointer-events-auto cursor-pointer interactive-scale"
+              onClick={() => props.onClear?.()}
+            >
+              Clear
+            </button>
+            <button
+              data-react-grab-ignore-events
+              data-react-grab-selection-session-copy
+              type="button"
+              disabled={props.selectedCount === 0}
+              class="h-7 min-w-14 px-2.5 rounded-md text-[12px] font-semibold text-white disabled:opacity-40 disabled:cursor-default pointer-events-auto cursor-pointer interactive-scale"
+              style={{ background: SELECTION_SESSION_BAR_ACCENT_COLOR }}
+              onClick={() => props.onCopy?.()}
+            >
+              Copy{props.selectedCount > 0 ? ` ${props.selectedCount}` : ""}
+            </button>
+          </Show>
+        </div>
+      </div>
+    </Show>
+  );
+};

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -99,6 +99,11 @@ export const OVERLAY_BORDER_COLOR_DEFAULT = overlayColor(0.5);
 export const OVERLAY_FILL_COLOR_DEFAULT = overlayColor(0.08);
 export const FROZEN_GLOW_COLOR = overlayColor(0.15);
 export const FROZEN_GLOW_EDGE_PX = 50;
+export const SELECTION_SESSION_BAR_HEIGHT_PX = 42;
+export const SELECTION_SESSION_BAR_BACKGROUND_COLOR = "#162f47";
+export const SELECTION_SESSION_BAR_ACCENT_COLOR = "#0485ff";
+export const SELECTION_SESSION_ANIMATION_DURATION_MS = 180;
+export const SELECTION_SESSION_ANIMATION_EASING = "cubic-bezier(0.16, 1, 0.3, 1)";
 
 export const ARROW_HEIGHT_PX = 8;
 export const ARROW_MIN_SIZE_PX = 4;

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -530,6 +530,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
     let previousSpaceDragPointerPage: Position | null = null;
     const [isShiftMultiSelecting, setIsShiftMultiSelecting] = createSignal(false);
+    const [isPersistentMultiSelecting, setIsPersistentMultiSelecting] = createSignal(false);
+    const isMultiSelecting = () => isShiftMultiSelecting() || isPersistentMultiSelecting();
     let lastWindowFocusTimestamp = 0;
     let isCopyFeedbackCooldownActive = false;
     let copyFeedbackCooldownTimerId: number | null = null;
@@ -993,7 +995,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     // multi-select, copying, an open popover, or a pending mouse-handoff).
     const hierarchySourceElement = createMemo(() => {
       if (!isActivated()) return null;
-      if (isPromptMode() || isShiftMultiSelecting() || isCopying()) return null;
+      if (isPromptMode() || isMultiSelecting() || isCopying()) return null;
       if (isAnyPopoverOpen()) return null;
       if (keyboardSelection.isPendingDismiss()) return null;
       // Without Shift the tree only follows an active keyboard-navigation
@@ -1134,7 +1136,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     });
 
     const pendingShiftSelectionElement = createMemo((): Element | null => {
-      if (!isShiftMultiSelecting()) return null;
+      if (!isMultiSelecting()) return null;
       if (store.pendingCommentMode || isPendingContextMenuSelect()) return null;
 
       const element = store.detectedElement;
@@ -1330,7 +1332,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     });
 
     const shiftSelectionLabelMouseX = createMemo((): number | undefined => {
-      if (!isShiftMultiSelecting()) return undefined;
+      if (!isMultiSelecting()) return undefined;
       if (store.frozenElements.length !== 1) return undefined;
       void viewportVersion();
 
@@ -1576,6 +1578,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       editMode.resetWithDiscard();
       dismissToolbarMenu();
       stopShiftMultiSelecting();
+      setIsPersistentMultiSelecting(false);
       clearKeyboardNavigation();
       keyboardSelection.clear();
       setIsPendingContextMenuSelect(false);
@@ -1831,8 +1834,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
     const handlePointerMove = (clientX: number, clientY: number, isShiftHeld: boolean) => {
       const shouldTrackPendingShiftSelection =
-        isShiftHeld &&
-        isShiftMultiSelecting() &&
+        (isShiftHeld || isPersistentMultiSelecting()) &&
+        isMultiSelecting() &&
         !isDragging() &&
         !store.pendingCommentMode &&
         !isPendingContextMenuSelect();
@@ -1913,12 +1916,15 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     const handlePointerDown = (clientX: number, clientY: number, isShiftHeld: boolean) => {
       if (!isRendererActive() || isSelectionInteractionLocked()) return false;
 
-      if (!isShiftHeld && isShiftMultiSelecting()) {
+      if (!isShiftHeld && isShiftMultiSelecting() && !isPersistentMultiSelecting()) {
         stopShiftMultiSelecting();
       }
 
       const shouldPreserveKeyboardSelection = keyboardSelection.selectedElement() !== null;
-      actions.startDrag({ x: clientX, y: clientY }, isShiftHeld || shouldPreserveKeyboardSelection);
+      actions.startDrag(
+        { x: clientX, y: clientY },
+        isShiftHeld || isPersistentMultiSelecting() || shouldPreserveKeyboardSelection,
+      );
       actions.setPointer({ x: clientX, y: clientY });
       setHostBodyStyle("userSelect", "none");
 
@@ -2014,6 +2020,17 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       });
     };
 
+    const clearPersistentMultiSelection = () => {
+      stopShiftMultiSelecting();
+      actions.unfreeze();
+      clearKeyboardNavigation();
+    };
+
+    const copyPersistentMultiSelection = () => {
+      if (store.frozenElements.length === 0) return;
+      commitShiftMultiSelection();
+    };
+
     const handleDragSelection = (
       dragSelectionRect: ReturnType<typeof calculateDragRectangle>,
       hasModifierKeyHeld: boolean,
@@ -2028,7 +2045,9 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       if (selectedElements.length === 0) return;
 
       const isShiftAccumulating =
-        isShiftHeld && !store.pendingCommentMode && !isPendingContextMenuSelect();
+        (isShiftHeld || isPersistentMultiSelecting()) &&
+        !store.pendingCommentMode &&
+        !isPendingContextMenuSelect();
 
       // In the shift-accumulating branch we must freeze on the COMBINED set
       // (prior accumulated + newly dragged), because freezeAllAnimations
@@ -2128,7 +2147,11 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       // with the eventual commitShiftMultiSelection on Shift release. So
       // we always return when Shift is held: toggle when an element is
       // under the pointer, no-op when it isn't.
-      if (isShiftHeld && !store.pendingCommentMode && !isPendingContextMenuSelect()) {
+      if (
+        (isShiftHeld || isPersistentMultiSelecting()) &&
+        !store.pendingCommentMode &&
+        !isPendingContextMenuSelect()
+      ) {
         const elementAtPointer = liveElementAtPointer();
         if (elementAtPointer !== null) {
           toggleShiftMultiSelection(elementAtPointer, { x: clientX, y: clientY });
@@ -2351,7 +2374,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     ): boolean => {
       if (!isActivated()) return false;
       if (isPromptMode()) return false;
-      if (isShiftMultiSelecting()) return false;
+      if (isMultiSelecting()) return false;
       if (keyboardSelection.isPendingDismiss() && !options.allowPendingKeyboardSelection)
         return false;
       const navigationKey = resolveNavigationKey(event);
@@ -2769,7 +2792,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           event.stopPropagation();
         }
 
-        if (event.key === "Shift" && isShiftMultiSelecting()) {
+        if (event.key === "Shift" && isShiftMultiSelecting() && !isPersistentMultiSelecting()) {
           // If shift is released mid-drag, abort the in-progress drag
           // before committing. Without this, performCopyWithLabel ->
           // startCopy moves state out of "active+dragging", which makes
@@ -2907,7 +2930,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           !isPromptMode() &&
           isFrozenPhase() &&
           !event.shiftKey &&
-          !isShiftMultiSelecting()
+          !isMultiSelecting()
         ) {
           if (keyboardSelection.consumeMouseHandoff()) {
             showKeyboardSelectionDismissPrompt();
@@ -3083,7 +3106,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           event.preventDefault();
           event.stopImmediatePropagation();
 
-          if (store.wasActivatedByToggle && !isPromptMode() && !event.shiftKey) {
+          if (
+            store.wasActivatedByToggle &&
+            !isPersistentMultiSelecting() &&
+            !isPromptMode() &&
+            !event.shiftKey
+          ) {
             if (!isHoldingKeys()) {
               deactivateRenderer();
             } else {
@@ -3953,6 +3981,17 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
                 }
                 toolbarVisible={pluginRegistry.store.theme.toolbar.enabled}
                 isActive={isActivated()}
+                selectionSessionVisible={
+                  isActivated() &&
+                  !isPromptMode() &&
+                  (toolbarActiveActionId() ?? DEFAULT_ACTION_ID) === DEFAULT_ACTION_ID
+                }
+                selectionSessionSelectedCount={store.frozenElements.length}
+                selectionSessionMultiSelectEnabled={isPersistentMultiSelecting()}
+                onSelectionSessionCancel={deactivateRenderer}
+                onSelectionSessionEnableMultiSelect={() => setIsPersistentMultiSelecting(true)}
+                onSelectionSessionClear={clearPersistentMultiSelection}
+                onSelectionSessionCopy={copyPersistentMultiSelection}
                 onToggleActive={handleToggleActive}
                 onActivateAction={handleActivateAction}
                 activeActionId={toolbarActiveActionId()}

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -565,6 +565,13 @@ export interface ReactGrabRendererProps {
   discardPrompt?: SelectionDiscardPrompt;
   toolbarVisible?: boolean;
   isActive?: boolean;
+  selectionSessionVisible?: boolean;
+  selectionSessionSelectedCount?: number;
+  selectionSessionMultiSelectEnabled?: boolean;
+  onSelectionSessionCancel?: () => void;
+  onSelectionSessionEnableMultiSelect?: () => void;
+  onSelectionSessionClear?: () => void;
+  onSelectionSessionCopy?: () => void;
   onToggleActive?: () => void;
   onActivateAction?: (actionId: string) => void;
   activeActionId?: string | null;

--- a/packages/react-grab/src/utils/overlay-color.ts
+++ b/packages/react-grab/src/utils/overlay-color.ts
@@ -3,8 +3,8 @@ import { supportsDisplayP3 } from "./supports-display-p3.js";
 // On wide-gamut displays (MacBook Pro, recent iPhones) we use Display P3 for
 // more vibrant overlay highlights, falling back to sRGB rgba() elsewhere.
 const isWideGamut = supportsDisplayP3();
-const SRGB_COMPONENTS = "210, 57, 192";
-const P3_COMPONENTS = "0.84 0.19 0.78";
+const SRGB_COMPONENTS = "4, 133, 255";
+const P3_COMPONENTS = "0.22836 0.51355 0.96734";
 
 export const overlayColor = (alpha: number): string =>
   isWideGamut


### PR DESCRIPTION
## Summary
- update the React Grab selection highlight to #0485FF
- add a compact animated selection session bar
- support opt-in persistent multi-select with clear and copy actions
- add focused end-to-end coverage for the multi-select flow

## Validation
- build
- typecheck
- lint
- formatting
- 60 unit tests
- focused Playwright selection-session test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a compact, animated selection session bar for managing selections, including opt‑in persistent multi‑select with Clear and Copy actions. Also updates the selection highlight color to #0485FF.

- **New Features**
  - Session bar shows when the tool is active (default mode), with smooth enter/exit animation.
  - Enable persistent multi‑select via “Multiple”; selections accumulate without holding Shift and display a running count.
  - “Clear” removes the accumulated selection; “Copy” copies it when non‑empty.
  - Integrated into renderer and core selection logic; covered by a focused Playwright test for the multi‑select copy flow.

<sup>Written for commit 51f2b61f02ccc83a8436438dfcd400d6bf6e1e4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

