### PR TITLE
fix(react-grab): harden runtime lifecycle and actions

### DIFF
--- a/packages/react-grab/e2e/context-menu.spec.ts
+++ b/packages/react-grab/e2e/context-menu.spec.ts
@@ -642,6 +642,44 @@ test.describe("Context Menu", () => {
       expect(isDisabled).toBe(true);
     });
 
+    test("disabled action should not run through its keyboard shortcut", async ({ reactGrab }) => {
+      await reactGrab.page.evaluate(() => {
+        const api = (
+          window as {
+            __REACT_GRAB__?: {
+              unregisterPlugin: (name: string) => void;
+              registerPlugin: (plugin: Record<string, unknown>) => void;
+            };
+          }
+        ).__REACT_GRAB__;
+
+        api?.unregisterPlugin("disabled-shortcut-action");
+        api?.registerPlugin({
+          name: "disabled-shortcut-action",
+          actions: [
+            {
+              id: "disabled-shortcut-action",
+              label: "Disabled Shortcut Action",
+              enabled: false,
+              shortcut: "K",
+              onAction: () => {
+                (window as { __disabledShortcutCalled?: boolean }).__disabledShortcutCalled = true;
+              },
+            },
+          ],
+        });
+      });
+
+      await reactGrab.activate();
+      await reactGrab.hoverUntilSelected("li:first-child");
+      await reactGrab.pressModifierKeyCombo("k");
+
+      const actionCalled = await reactGrab.page.evaluate(
+        () => (window as { __disabledShortcutCalled?: boolean }).__disabledShortcutCalled ?? false,
+      );
+      expect(actionCalled).toBe(false);
+    });
+
     test("action enabled function should receive context", async ({ reactGrab }) => {
       await reactGrab.page.evaluate(() => {
         const api = (

--- a/packages/react-grab/e2e/copy-feedback.spec.ts
+++ b/packages/react-grab/e2e/copy-feedback.spec.ts
@@ -295,6 +295,27 @@ test.describe("Copy Feedback Behavior", () => {
   });
 
   test.describe("Immediate Grabbing Feedback", () => {
+    test("deactivation clears feedback waiting for component metadata", async ({ reactGrab }) => {
+      await reactGrab.page.evaluate(() => {
+        window.fetch = () => new Promise<Response>(() => {});
+      });
+
+      await reactGrab.activate();
+      await reactGrab.hoverUntilSelected("li:first-child");
+      await reactGrab.clickElement("li:first-child");
+
+      await expect
+        .poll(async () => {
+          const instances = await reactGrab.getLabelInstancesInfo();
+          return instances.some((instance) => instance.status === "copying");
+        })
+        .toBe(true);
+
+      await reactGrab.deactivate();
+
+      await expect.poll(() => reactGrab.getLabelInstancesInfo()).toEqual([]);
+    });
+
     test("should enter copying state immediately on click", async ({ reactGrab }) => {
       await reactGrab.activate();
       await reactGrab.hoverUntilSelected("li:first-child");

--- a/packages/react-grab/src/components/context-menu.tsx
+++ b/packages/react-grab/src/components/context-menu.tsx
@@ -34,6 +34,7 @@ import { suppressMenuEvent } from "../utils/suppress-menu-event.js";
 import { registerOverlayDismiss } from "../utils/register-overlay-dismiss.js";
 import { ignoreRealInput } from "../utils/runtime-mode.js";
 import { findShortcutAction } from "../utils/action-shortcuts.js";
+import { executeContextMenuAction } from "../utils/execute-context-menu-action.js";
 
 interface ContextMenuProps {
   position: Position | null;
@@ -158,7 +159,7 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
       label: action.label,
       action: () => {
         if (context) {
-          action.onAction(context);
+          executeContextMenuAction(action, context);
         }
       },
       enabled: resolveActionEnabled(action, context),
@@ -245,7 +246,7 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
         if (!resolveActionEnabled(action, context)) return;
         event.preventDefault();
         event.stopPropagation();
-        action.onAction(context);
+        executeContextMenuAction(action, context);
         props.onHide();
       };
 
@@ -324,7 +325,9 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
                 event.stopPropagation();
                 if (props.hasFilePath && props.actionContext) {
                   const openAction = props.actions?.find((action) => action.id === "open");
-                  openAction?.onAction(props.actionContext);
+                  if (openAction) {
+                    executeContextMenuAction(openAction, props.actionContext);
+                  }
                 }
               }}
               shrink

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -153,6 +153,7 @@ import { logRecoverableError } from "../utils/log-recoverable-error.js";
 import { getNearestEdge } from "../utils/get-nearest-edge.js";
 import { findShortcutAction } from "../utils/action-shortcuts.js";
 import { createKeyboardSelectionController } from "./keyboard-selection.js";
+import { executeContextMenuAction } from "../utils/execute-context-menu-action.js";
 
 const builtInPlugins = [copyPlugin, editPlugin, commentPlugin, openPlugin];
 
@@ -189,6 +190,7 @@ interface LabeledCopyOptions {
   primaryElement: Element;
   targetElements: Element[];
   labelInstanceIds: string[];
+  operationGeneration: number;
   extraPrompt?: string;
   shouldDeactivateAfter?: boolean;
   onComplete?: () => void;
@@ -247,6 +249,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
   return createRoot((dispose) => {
     let disposed = false;
+    let copyOperationGeneration = 0;
+    const pendingLabeledCopyInstanceIds = new Set<string>();
     let disposeRenderer: (() => void) | undefined;
 
     const pluginRegistry = createPluginRegistry(settableOptions);
@@ -303,9 +307,22 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       );
     });
 
+    const originalHostBodyStyles = new Map<"userSelect" | "touchAction", string>();
+
     const setHostBodyStyle = (property: "userSelect" | "touchAction", value: string) => {
       if (IS_DEMO) return;
+      if (!originalHostBodyStyles.has(property)) {
+        originalHostBodyStyles.set(property, document.body.style[property]);
+      }
       document.body.style[property] = value;
+    };
+
+    const restoreHostBodyStyle = (property: "userSelect" | "touchAction") => {
+      if (IS_DEMO) return;
+      const originalValue = originalHostBodyStyles.get(property);
+      if (originalValue === undefined) return;
+      document.body.style[property] = originalValue;
+      originalHostBodyStyles.delete(property);
     };
 
     createEffect(
@@ -317,7 +334,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           setHostBodyStyle("touchAction", "none");
         } else if (!activated && previousActivated) {
           unfreezeGlobalInteractions();
-          setHostBodyStyle("touchAction", "");
+          restoreHostBodyStyle("touchAction");
         }
       }),
     );
@@ -670,8 +687,25 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     const labelController = createLabelController(
       actions,
       () => store.labelInstances,
-      () => retryCopyByInstanceId.clear(),
+      () => {
+        retryCopyByInstanceId.clear();
+        pendingLabeledCopyInstanceIds.clear();
+      },
     );
+
+    const invalidatePendingLabeledCopies = () => {
+      copyOperationGeneration += 1;
+      for (const labelInstanceId of pendingLabeledCopyInstanceIds) {
+        labelController.dismissInstance(labelInstanceId);
+      }
+      pendingLabeledCopyInstanceIds.clear();
+    };
+
+    const finishPendingLabeledCopy = (labelInstanceIds: readonly string[]) => {
+      for (const labelInstanceId of labelInstanceIds) {
+        pendingLabeledCopyInstanceIds.delete(labelInstanceId);
+      }
+    };
 
     const attemptClipboardAndLabel = async (
       clipboardOperation: () => Promise<boolean>,
@@ -730,6 +764,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       }
 
       const didSucceed = await attemptClipboardAndLabel(clipboardOperation, labelInstanceIds);
+      if (labelInstanceIds) finishPendingLabeledCopy(labelInstanceIds);
 
       if (labelInstanceIds) {
         registerCopyRetry(
@@ -841,8 +876,13 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
 
     const runLabeledCopy = (copy: LabeledCopyOptions) => {
+      for (const labelInstanceId of copy.labelInstanceIds) {
+        pendingLabeledCopyInstanceIds.add(labelInstanceId);
+      }
+
       void getNearestComponentName(copy.primaryElement)
         .then(async (componentName) => {
+          if (disposed || copy.operationGeneration !== copyOperationGeneration) return;
           await executeCopyOperation(
             () =>
               copyElementsToClipboard(
@@ -856,6 +896,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           copy.onComplete?.();
         })
         .catch((error) => {
+          if (disposed || copy.operationGeneration !== copyOperationGeneration) return;
+          finishPendingLabeledCopy(copy.labelInstanceIds);
           logRecoverableError("Copy operation failed", error);
           const normalizedMessage = normalizeErrorMessage(error, "Action failed");
           for (const labelInstanceId of copy.labelInstanceIds) {
@@ -884,7 +926,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
               actions.unfreeze();
             }
           }
-        });
+        })
+        .finally(() => finishPendingLabeledCopy(copy.labelInstanceIds));
     };
 
     const performCopyWithLabel = (options: CopyWithLabelOptions) => {
@@ -920,6 +963,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
       const tagName = getTagName(element);
       clearCopyFeedbackCooldown();
+      invalidatePendingLabeledCopies();
       actions.startCopy();
 
       const labelInstanceId = tagName
@@ -934,6 +978,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         primaryElement: element,
         targetElements: allTargetElements,
         labelInstanceIds: labelInstanceId ? [labelInstanceId] : [],
+        operationGeneration: copyOperationGeneration,
         extraPrompt,
         shouldDeactivateAfter,
         onComplete,
@@ -955,6 +1000,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       const primaryElement = elements[0];
 
       clearCopyFeedbackCooldown();
+      invalidatePendingLabeledCopies();
       actions.startCopy();
 
       const labelInstanceIds = labelController.createPerElementInstances(labelEntries, "copying");
@@ -963,6 +1009,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         primaryElement,
         targetElements: elements,
         labelInstanceIds,
+        operationGeneration: copyOperationGeneration,
         shouldDeactivateAfter,
         onComplete,
       });
@@ -1569,6 +1616,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
 
     const deactivateRenderer = () => {
+      invalidatePendingLabeledCopies();
       const wasDragging = isDragging();
       const previousFocused = store.previouslyFocusedElement;
       stopSpaceDragRepositioning();
@@ -1581,7 +1629,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       setIsPendingContextMenuSelect(false);
       setPendingToolbarActionId(null);
       if (wasDragging) {
-        setHostBodyStyle("userSelect", "");
+        restoreHostBodyStyle("userSelect");
         releaseDragPreview();
       }
       if (keydownSpamTimerId) window.clearTimeout(keydownSpamTimerId);
@@ -1739,7 +1787,10 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       actions.clearInputText();
       actions.exitPromptMode();
       clearPendingToolbarSelection();
-      action.onAction(buildImmediateActionContext(element, position));
+      const context = buildImmediateActionContext(element, position);
+      if (!executeContextMenuAction(action, context)) {
+        openContextMenu(element, position);
+      }
       return true;
     };
 
@@ -1811,7 +1862,10 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         return;
       }
 
-      action.onAction(buildImmediateActionContext(element, position));
+      const context = buildImmediateActionContext(element, position);
+      if (!executeContextMenuAction(action, context)) {
+        openContextMenu(element, position);
+      }
     };
 
     const handleComment = () => {
@@ -2205,7 +2259,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       releaseDragPreview();
       actions.cancelDrag();
       autoScroller.stop();
-      setHostBodyStyle("userSelect", "");
+      restoreHostBodyStyle("userSelect");
       // Detection pauses during active drags, so restore the hover target for
       // the element under the cursor without waiting for the next pointermove.
       redetectElementUnderPointer();
@@ -2236,7 +2290,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       }
       stopSpaceDragRepositioning();
       autoScroller.stop();
-      setHostBodyStyle("userSelect", "");
+      restoreHostBodyStyle("userSelect");
 
       if (dragSelectionRect) {
         handleDragSelection(dragSelectionRect, hasModifierKeyHeld, isShiftHeld);
@@ -2466,7 +2520,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       }
 
       const position = { x: pointer().x, y: pointer().y };
-      action.onAction(buildImmediateActionContext(element, position));
+      const context = buildImmediateActionContext(element, position);
+      if (!executeContextMenuAction(action, context)) return false;
 
       event.preventDefault();
       event.stopImmediatePropagation();
@@ -2994,7 +3049,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       ignoreRealInput((event: PointerEvent) => {
         if (event.button !== 0) return;
         if (!event.isPrimary) return;
-        if (isEventFromOverlay(event, "data-react-grab-ignore-events")) return;
+        if (!isDragging() && isEventFromOverlay(event, "data-react-grab-ignore-events")) return;
         if (isModalPopoverOpen()) return;
         const isActive = isRendererActive() || isSelectionInteractionLocked() || isDragging();
         const hasModifierKeyHeld = event.metaKey || event.ctrlKey;
@@ -3065,6 +3120,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         if (!event.isPrimary) return;
         cancelActiveDrag();
       }),
+      { capture: true },
     );
 
     eventListenerManager.addWindowListener(
@@ -3298,9 +3354,11 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       grabbedBoxTimeouts.forEach((timeoutId) => window.clearTimeout(timeoutId));
       grabbedBoxTimeouts.clear();
       labelController.cancelAllFades();
+      retryCopyByInstanceId.clear();
       autoScroller.stop();
-      setHostBodyStyle("userSelect", "");
-      setHostBodyStyle("touchAction", "");
+      unfreezeGlobalInteractions();
+      restoreHostBodyStyle("userSelect");
+      restoreHostBodyStyle("touchAction");
       setCursorOverride(null);
       keyboardClaimer.restore();
       setScopeContainer(null);
@@ -4084,11 +4142,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         forceDeactivateAll();
         dismissAllPopups();
         actions.clearGrabbedBoxes();
-        actions.clearLabelInstances();
+        labelController.clearAll();
         actions.setSelectionSource(null, null);
       },
       dispose: () => {
         disposed = true;
+        invalidatePendingLabeledCopies();
         hasInited = false;
         disposeRenderer?.();
         stopToolbarMenuTracking?.();

--- a/packages/react-grab/src/core/plugin-registry.ts
+++ b/packages/react-grab/src/core/plugin-registry.ts
@@ -1,3 +1,4 @@
+import { getOwner, onCleanup } from "solid-js";
 import { createStore } from "solid-js/store";
 import type {
   Position,
@@ -21,6 +22,7 @@ import type {
 } from "../types.js";
 import { DEFAULT_THEME, deepMergeTheme } from "./theme.js";
 import { DEFAULT_KEY_HOLD_DURATION_MS, DEFAULT_MAX_CONTEXT_LINES } from "../constants.js";
+import { logRecoverableError } from "../utils/log-recoverable-error.js";
 
 interface RegisteredPlugin {
   plugin: Plugin;
@@ -58,6 +60,7 @@ type HookName = keyof PluginHooks;
 const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
   const plugins = new Map<string, RegisteredPlugin>();
   const directOptionOverrides: Partial<OptionsState> = {};
+  let isDisposed = false;
 
   const [store, setStore] = createStore<PluginStoreState>({
     theme: DEFAULT_THEME,
@@ -112,6 +115,7 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
   ];
 
   const setOptions = (optionUpdates: SettableOptions) => {
+    if (isDisposed) return;
     for (const optionKey of SETTABLE_OPTION_KEYS) {
       if (optionUpdates[optionKey] !== undefined) {
         setOption(optionKey, optionUpdates[optionKey]!);
@@ -120,6 +124,7 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
   };
 
   const register = (plugin: Plugin, api: ReactGrabAPI) => {
+    if (isDisposed) return;
     if (plugins.has(plugin.name)) {
       unregister(plugin.name);
     }
@@ -149,14 +154,37 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
   };
 
   const unregister = (name: string) => {
+    if (isDisposed) return;
     const registered = plugins.get(name);
     if (!registered) return;
 
-    if (registered.config.cleanup) {
-      registered.config.cleanup();
+    plugins.delete(name);
+    try {
+      registered.config.cleanup?.();
+    } catch (error) {
+      logRecoverableError(`Plugin cleanup failed for "${name}"`, error);
+    }
+    recomputeStore();
+  };
+
+  const dispose = () => {
+    if (isDisposed) return;
+    isDisposed = true;
+
+    const registeredPlugins = Array.from(plugins.values());
+    plugins.clear();
+    for (const optionKey of SETTABLE_OPTION_KEYS) {
+      delete directOptionOverrides[optionKey];
     }
 
-    plugins.delete(name);
+    for (const { plugin, config } of registeredPlugins) {
+      try {
+        config.cleanup?.();
+      } catch (error) {
+        logRecoverableError(`Plugin cleanup failed for "${plugin.name}"`, error);
+      }
+    }
+
     recomputeStore();
   };
 
@@ -168,12 +196,19 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     hookName: K,
     ...args: Parameters<NonNullable<PluginHooks[K]>>
   ): void => {
-    for (const { config } of plugins.values()) {
+    for (const { plugin, config } of plugins.values()) {
       const hook = config.hooks?.[hookName] as
         | ((...hookArgs: Parameters<NonNullable<PluginHooks[K]>>) => void)
         | undefined;
       if (hook) {
-        hook(...args);
+        try {
+          hook(...args);
+        } catch (error) {
+          logRecoverableError(
+            `Plugin hook "${String(hookName)}" failed for "${plugin.name}"`,
+            error,
+          );
+        }
       }
     }
   };
@@ -183,14 +218,21 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     ...args: Parameters<NonNullable<PluginHooks[K]>>
   ): boolean => {
     let handled = false;
-    for (const { config } of plugins.values()) {
+    for (const { plugin, config } of plugins.values()) {
       const hook = config.hooks?.[hookName] as
         | ((...hookArgs: Parameters<NonNullable<PluginHooks[K]>>) => boolean | void)
         | undefined;
       if (hook) {
-        const result = hook(...args);
-        if (result === true) {
-          handled = true;
+        try {
+          const result = hook(...args);
+          if (result === true) {
+            handled = true;
+          }
+        } catch (error) {
+          logRecoverableError(
+            `Plugin hook "${String(hookName)}" failed for "${plugin.name}"`,
+            error,
+          );
         }
       }
     }
@@ -255,19 +297,37 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
       element: Element,
     ): { wasIntercepted: boolean; pendingResult?: Promise<boolean> } => {
       let wasIntercepted = false;
-      let pendingResult: Promise<boolean> | undefined;
-      for (const { config } of plugins.values()) {
+      const pendingResults: Promise<boolean>[] = [];
+      for (const { plugin, config } of plugins.values()) {
         const hook = config.hooks?.onElementSelect;
         if (hook) {
-          const result = hook(element);
-          if (result === true) {
+          try {
+            const result = hook(element);
+            if (result === true) {
+              wasIntercepted = true;
+            } else if (result instanceof Promise) {
+              wasIntercepted = true;
+              pendingResults.push(
+                result.catch((error) => {
+                  logRecoverableError(
+                    `Plugin hook "onElementSelect" failed for "${plugin.name}"`,
+                    error,
+                  );
+                  return false;
+                }),
+              );
+            }
+          } catch (error) {
             wasIntercepted = true;
-          } else if (result instanceof Promise) {
-            wasIntercepted = true;
-            pendingResult = result;
+            logRecoverableError(`Plugin hook "onElementSelect" failed for "${plugin.name}"`, error);
+            pendingResults.push(Promise.resolve(false));
           }
         }
       }
+      const pendingResult =
+        pendingResults.length > 0
+          ? Promise.all(pendingResults).then((results) => results.every(Boolean))
+          : undefined;
       return { wasIntercepted, pendingResult };
     },
     onDragStart: (startX: number, startY: number) => callHook("onDragStart", startX, startY),
@@ -308,11 +368,16 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
       callHookReduceSync("transformOpenFileUrl", url, filePath, lineNumber),
   };
 
+  if (getOwner()) {
+    onCleanup(dispose);
+  }
+
   return {
     register,
     unregister,
     getPluginNames,
     setOptions,
+    dispose,
     store,
     hooks,
   };

--- a/packages/react-grab/src/utils/execute-context-menu-action.ts
+++ b/packages/react-grab/src/utils/execute-context-menu-action.ts
@@ -1,0 +1,28 @@
+import type { ContextMenuAction, ContextMenuActionContext } from "../types.js";
+import { logRecoverableError } from "./log-recoverable-error.js";
+import { resolveActionEnabled } from "./resolve-action-enabled.js";
+
+export const executeContextMenuAction = (
+  action: ContextMenuAction,
+  context: ContextMenuActionContext,
+): boolean => {
+  try {
+    if (!resolveActionEnabled(action, context)) return false;
+  } catch (error) {
+    logRecoverableError(`Action "${action.id}" enabled check failed`, error);
+    return false;
+  }
+
+  try {
+    const pendingAction = action.onAction(context);
+    if (pendingAction) {
+      void pendingAction.catch((error: unknown) => {
+        logRecoverableError(`Action "${action.id}" failed`, error);
+      });
+    }
+  } catch (error) {
+    logRecoverableError(`Action "${action.id}" failed`, error);
+  }
+
+  return true;
+};

--- a/packages/react-grab/tests/execute-context-menu-action.test.ts
+++ b/packages/react-grab/tests/execute-context-menu-action.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import type { ContextMenuActionContext } from "../src/types.js";
+import { executeContextMenuAction } from "../src/utils/execute-context-menu-action.js";
+
+const createContext = (): ContextMenuActionContext => ({
+  element: Object.create(null),
+  elements: [],
+  hooks: {
+    transformHtmlContent: async (html) => html,
+    onOpenFile: () => false,
+    transformOpenFileUrl: (url) => url,
+  },
+  performWithFeedback: async () => {},
+  hideContextMenu: () => {},
+  cleanup: () => {},
+});
+
+describe("executeContextMenuAction", () => {
+  it("contains enabled predicate failures and skips the action", () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const onAction = vi.fn();
+
+    const didExecute = executeContextMenuAction(
+      {
+        id: "throwing-enabled",
+        label: "Throwing Enabled",
+        enabled: () => {
+          throw new Error("enabled failed");
+        },
+        onAction,
+      },
+      createContext(),
+    );
+
+    expect(didExecute).toBe(false);
+    expect(onAction).not.toHaveBeenCalled();
+    expect(warning).toHaveBeenCalledOnce();
+    warning.mockRestore();
+  });
+});

--- a/packages/react-grab/tests/plugin-registry.test.ts
+++ b/packages/react-grab/tests/plugin-registry.test.ts
@@ -1,0 +1,135 @@
+import { createRoot } from "solid-js";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { createNoopApi } from "../src/core/noop-api.js";
+import { createPluginRegistry } from "../src/core/plugin-registry.js";
+
+const createElement = (): Element => Object.create(null);
+
+describe("createPluginRegistry", () => {
+  it("aggregates every asynchronous element selection result", async () => {
+    const registry = createPluginRegistry();
+    const firstHook = vi.fn(() => Promise.resolve(true));
+    const secondHook = vi.fn(() => Promise.resolve(false));
+
+    registry.register({ name: "first", hooks: { onElementSelect: firstHook } }, createNoopApi());
+    registry.register({ name: "second", hooks: { onElementSelect: secondHook } }, createNoopApi());
+
+    const result = registry.hooks.onElementSelect(createElement());
+
+    expect(result.wasIntercepted).toBe(true);
+    expect(await result.pendingResult).toBe(false);
+    expect(firstHook).toHaveBeenCalledOnce();
+    expect(secondHook).toHaveBeenCalledOnce();
+  });
+
+  it("turns rejected and thrown element selection hooks into failed results", async () => {
+    const registry = createPluginRegistry();
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    registry.register(
+      {
+        name: "rejecting",
+        hooks: { onElementSelect: () => Promise.reject(new Error("rejected")) },
+      },
+      createNoopApi(),
+    );
+    registry.register(
+      {
+        name: "throwing",
+        hooks: {
+          onElementSelect: () => {
+            throw new Error("thrown");
+          },
+        },
+      },
+      createNoopApi(),
+    );
+
+    const result = registry.hooks.onElementSelect(createElement());
+
+    expect(result.wasIntercepted).toBe(true);
+    expect(await result.pendingResult).toBe(false);
+    expect(warning).toHaveBeenCalledTimes(2);
+    warning.mockRestore();
+  });
+
+  it("removes a plugin even when its cleanup throws", () => {
+    const registry = createPluginRegistry();
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    registry.register(
+      {
+        name: "failing-cleanup",
+        actions: [{ id: "removed", label: "Removed", onAction: () => {} }],
+        setup: () => ({
+          cleanup: () => {
+            throw new Error("cleanup failed");
+          },
+        }),
+      },
+      createNoopApi(),
+    );
+
+    registry.unregister("failing-cleanup");
+
+    expect(registry.getPluginNames()).toEqual([]);
+    expect(registry.store.actions).toEqual([]);
+    expect(warning).toHaveBeenCalledOnce();
+    warning.mockRestore();
+  });
+
+  it("cleans every plugin when its Solid owner is disposed", () => {
+    const firstCleanup = vi.fn(() => {
+      throw new Error("cleanup failed");
+    });
+    const secondCleanup = vi.fn();
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const ownedRegistry = createRoot((disposeOwner) => {
+      const registry = createPluginRegistry();
+      registry.register(
+        { name: "first", setup: () => ({ cleanup: firstCleanup }) },
+        createNoopApi(),
+      );
+      registry.register(
+        { name: "second", setup: () => ({ cleanup: secondCleanup }) },
+        createNoopApi(),
+      );
+      return { registry, disposeOwner };
+    });
+
+    ownedRegistry.disposeOwner();
+
+    expect(firstCleanup).toHaveBeenCalledOnce();
+    expect(secondCleanup).toHaveBeenCalledOnce();
+    expect(ownedRegistry.registry.getPluginNames()).toEqual([]);
+    ownedRegistry.registry.register({ name: "late" }, createNoopApi());
+    expect(ownedRegistry.registry.getPluginNames()).toEqual([]);
+    expect(warning).toHaveBeenCalledOnce();
+    warning.mockRestore();
+  });
+
+  it("isolates notification hook failures between plugins", () => {
+    const registry = createPluginRegistry();
+    const laterHook = vi.fn();
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    registry.register(
+      {
+        name: "throwing",
+        hooks: {
+          onActivate: () => {
+            throw new Error("hook failed");
+          },
+        },
+      },
+      createNoopApi(),
+    );
+    registry.register({ name: "later", hooks: { onActivate: laterHook } }, createNoopApi());
+
+    registry.hooks.onActivate();
+
+    expect(laterHook).toHaveBeenCalledOnce();
+    expect(warning).toHaveBeenCalledOnce();
+    warning.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- isolate plugin setup, hook, cleanup, and async selection failures
- dispose plugin registries with their Solid owner and invalidate stale copy work
- clear pending copy feedback immediately on deactivation, including stalled async preparation
- enforce action enabled checks across menu and shortcut paths while containing predicate and action errors
- restore host page interaction styles during deactivation and disposal

## Validation

- `nr build`
- `nr test:unit` in `packages/react-grab` (100 tests)
- focused Vite Plus development E2E for disabled action shortcuts and pending-copy deactivation
- `nr lint`
- `nr typecheck`
- `nr format:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core activation, copy lifecycle, plugin hooks, and global pointer/body-style behavior; failures are mostly contained via logging, but regressions could affect grab UX or third-party plugins.
> 
> **Overview**
> Hardens **react-grab** runtime so plugin failures, stale async work, and action edge cases do not leave the overlay or host page in a bad state.
> 
> **Plugin registry** now wraps hook/cleanup calls in try/catch with recoverable logging, aggregates **all** async `onElementSelect` promises (success only if every hook succeeds), removes plugins before cleanup so a throwing cleanup cannot block unregister, exposes **`dispose`** tied to the Solid owner via `onCleanup`, and ignores register/unregister/setOptions after disposal.
> 
> **Copy / label feedback** tracks pending labeled copies with a generation counter: new copies, deactivation, and dispose **invalidate** in-flight metadata fetches and dismiss stuck “copying” labels; disposal and reset route label clearing through the label controller and restore host `userSelect` / `touchAction` from saved originals instead of blanking styles.
> 
> **Actions** go through shared **`executeContextMenuAction`**, which enforces `enabled`, contains predicate/action errors, and surfaces async rejections; toolbar, shortcut, and menu paths use it so disabled shortcuts do not fire and failed runs can fall back to opening the context menu where appropriate.
> 
> **Pointer handling** allows overlay-ignored `pointerup` during active drags; **`pointercancel`** uses capture. E2E covers disabled shortcut actions and clearing copy feedback when deactivating during a stalled fetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f294581d38c22fb66d1aa57abb1ca2dadc6ad45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->