### PR TITLE
fix(react-grab): make interaction freezes exception safe

### DIFF
--- a/packages/react-grab/e2e/freeze-pseudo-states.spec.ts
+++ b/packages/react-grab/e2e/freeze-pseudo-states.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "./fixtures.js";
+
+test("preserves unrelated inline style writes made while frozen", async ({ reactGrab }) => {
+  const targetElement = reactGrab.page.locator("li").first();
+  await targetElement.evaluate((element) => {
+    element.style.setProperty("background-color", "rgb(1, 2, 3)", "important");
+  });
+  await targetElement.hover();
+  await reactGrab.activate();
+
+  await targetElement.evaluate((element) => {
+    element.style.setProperty("background-color", "rgb(4, 5, 6)");
+    element.style.setProperty("--page-owned-state", "updated");
+    element.style.setProperty("margin-top", "7px");
+  });
+  await reactGrab.deactivate();
+
+  await expect
+    .poll(() =>
+      targetElement.evaluate((element) => ({
+        backgroundColor: element.style.getPropertyValue("background-color"),
+        backgroundColorPriority: element.style.getPropertyPriority("background-color"),
+        pageOwnedState: element.style.getPropertyValue("--page-owned-state"),
+        marginTop: element.style.getPropertyValue("margin-top"),
+      })),
+    )
+    .toEqual({
+      backgroundColor: "rgb(1, 2, 3)",
+      backgroundColorPriority: "important",
+      pageOwnedState: "updated",
+      marginTop: "7px",
+    });
+});

--- a/packages/react-grab/src/components/toolbar/index.tsx
+++ b/packages/react-grab/src/components/toolbar/index.tsx
@@ -196,8 +196,7 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
       () => [props.isActive, props.isContextMenuOpen] as const,
       ([isActive, isContextMenuOpen]) => {
         if (!isActive && !isContextMenuOpen && unfreezeUpdatesCallback) {
-          unfreezeUpdatesCallback();
-          unfreezeUpdatesCallback = null;
+          releaseInteractionFreeze();
         }
       },
     ),

--- a/packages/react-grab/src/primitives.ts
+++ b/packages/react-grab/src/primitives.ts
@@ -95,9 +95,11 @@ export { copyContent } from "./utils/copy-content.js";
 export const getElementsAtPosition = (clientX: number, clientY: number): Element[] => {
   if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) return [];
   suspendPointerEventsFreeze();
-  const elements = document.elementsFromPoint(clientX, clientY);
-  resumePointerEventsFreeze();
-  return Array.from(elements);
+  try {
+    return Array.from(document.elementsFromPoint(clientX, clientY));
+  } finally {
+    resumePointerEventsFreeze();
+  }
 };
 
 const freezeCleanupFns = new Set<() => void>();

--- a/packages/react-grab/src/utils/freeze-animations.ts
+++ b/packages/react-grab/src/utils/freeze-animations.ts
@@ -139,7 +139,7 @@ export const freezeAllAnimations = (elements: Element[]): void => {
   unfreezeAllAnimations();
   lastInputElements = [...elements];
   ensureStylesInjected();
-  frozenElements = elements;
+  frozenElements = [...elements];
   frozenSvgElements = collectFrozenSvgElements(frozenElements);
   pauseSvgAnimations(frozenSvgElements);
 

--- a/packages/react-grab/src/utils/freeze-pseudo-states.ts
+++ b/packages/react-grab/src/utils/freeze-pseudo-states.ts
@@ -60,11 +60,16 @@ const FOCUS_STYLE_PROPERTIES = [
 interface FrozenPseudoState {
   element: HTMLElement;
   frozenPropertyValues: Map<string, string>;
-  originalStyles: string;
+  originalPropertyValues: Map<string, InlineStyleProperty>;
 }
 
-const frozenHoverElements = new Map<HTMLElement, string>();
-const frozenFocusElements = new Map<HTMLElement, string>();
+interface InlineStyleProperty {
+  value: string;
+  priority: string;
+}
+
+const frozenHoverElements = new Map<HTMLElement, Map<string, InlineStyleProperty>>();
+const frozenFocusElements = new Map<HTMLElement, Map<string, InlineStyleProperty>>();
 
 const stopEvent = (event: Event): void => {
   event.stopImmediatePropagation();
@@ -78,21 +83,26 @@ const preventFocusChange = (event: Event): void => {
 const freezeElement = (
   element: HTMLElement,
   properties: readonly string[],
-  alreadyFrozen?: Map<HTMLElement, string>,
+  alreadyFrozen?: ReadonlyMap<HTMLElement, unknown>,
 ): FrozenPseudoState | null => {
   if (alreadyFrozen?.has(element)) return null;
 
   const computed = getComputedStyle(element);
   const frozenPropertyValues = new Map<string, string>();
+  const originalPropertyValues = new Map<string, InlineStyleProperty>();
 
-  for (const prop of properties) {
-    const computedValue = computed.getPropertyValue(prop);
+  for (const property of properties) {
+    const computedValue = computed.getPropertyValue(property);
     if (computedValue) {
-      frozenPropertyValues.set(prop, computedValue);
+      frozenPropertyValues.set(property, computedValue);
+      originalPropertyValues.set(property, {
+        value: element.style.getPropertyValue(property),
+        priority: element.style.getPropertyPriority(property),
+      });
     }
   }
 
-  return { element, frozenPropertyValues, originalStyles: element.style.cssText };
+  return { element, frozenPropertyValues, originalPropertyValues };
 };
 
 const collectHoveredElements = (cursorX: number, cursorY: number): HTMLElement[] => {
@@ -122,19 +132,27 @@ const collectFocusedElements = (): HTMLElement[] => {
 
 const applyFrozenStates = (
   states: FrozenPseudoState[],
-  storageMap: Map<HTMLElement, string>,
+  storageMap: Map<HTMLElement, Map<string, InlineStyleProperty>>,
 ): void => {
-  for (const { element, frozenPropertyValues, originalStyles } of states) {
-    storageMap.set(element, originalStyles);
+  for (const { element, frozenPropertyValues, originalPropertyValues } of states) {
+    storageMap.set(element, originalPropertyValues);
     for (const [property, value] of frozenPropertyValues) {
       element.style.setProperty(property, value, "important");
     }
   }
 };
 
-const restoreFrozenStates = (storageMap: Map<HTMLElement, string>): void => {
-  for (const [element, originalStyles] of storageMap) {
-    element.style.cssText = originalStyles;
+const restoreFrozenStates = (
+  storageMap: Map<HTMLElement, Map<string, InlineStyleProperty>>,
+): void => {
+  for (const [element, originalPropertyValues] of storageMap) {
+    for (const [property, originalProperty] of originalPropertyValues) {
+      if (originalProperty.value) {
+        element.style.setProperty(property, originalProperty.value, originalProperty.priority);
+      } else {
+        element.style.removeProperty(property);
+      }
+    }
   }
   storageMap.clear();
 };

--- a/packages/react-grab/src/utils/freeze-pseudo-states.ts
+++ b/packages/react-grab/src/utils/freeze-pseudo-states.ts
@@ -59,12 +59,12 @@ const FOCUS_STYLE_PROPERTIES = [
 
 interface FrozenPseudoState {
   element: HTMLElement;
-  frozenStyles: string;
-  originalPropertyValues: Map<string, string>;
+  frozenPropertyValues: Map<string, string>;
+  originalStyles: string;
 }
 
-const frozenHoverElements = new Map<HTMLElement, Map<string, string>>();
-const frozenFocusElements = new Map<HTMLElement, Map<string, string>>();
+const frozenHoverElements = new Map<HTMLElement, string>();
+const frozenFocusElements = new Map<HTMLElement, string>();
 
 const stopEvent = (event: Event): void => {
   event.stopImmediatePropagation();
@@ -75,39 +75,24 @@ const preventFocusChange = (event: Event): void => {
   event.stopImmediatePropagation();
 };
 
-const collectOriginalPropertyValues = (
-  element: HTMLElement,
-  properties: readonly string[],
-): Map<string, string> => {
-  const originalPropertyValues = new Map<string, string>();
-  for (const prop of properties) {
-    const inlineValue = element.style.getPropertyValue(prop);
-    if (inlineValue) {
-      originalPropertyValues.set(prop, inlineValue);
-    }
-  }
-  return originalPropertyValues;
-};
-
 const freezeElement = (
   element: HTMLElement,
   properties: readonly string[],
-  alreadyFrozen?: Map<HTMLElement, Map<string, string>>,
+  alreadyFrozen?: Map<HTMLElement, string>,
 ): FrozenPseudoState | null => {
   if (alreadyFrozen?.has(element)) return null;
 
   const computed = getComputedStyle(element);
-  let frozenStyles = element.style.cssText;
-  const originalPropertyValues = collectOriginalPropertyValues(element, properties);
+  const frozenPropertyValues = new Map<string, string>();
 
   for (const prop of properties) {
     const computedValue = computed.getPropertyValue(prop);
     if (computedValue) {
-      frozenStyles += `${prop}: ${computedValue} !important; `;
+      frozenPropertyValues.set(prop, computedValue);
     }
   }
 
-  return { element, frozenStyles, originalPropertyValues };
+  return { element, frozenPropertyValues, originalStyles: element.style.cssText };
 };
 
 const collectHoveredElements = (cursorX: number, cursorY: number): HTMLElement[] => {
@@ -137,27 +122,19 @@ const collectFocusedElements = (): HTMLElement[] => {
 
 const applyFrozenStates = (
   states: FrozenPseudoState[],
-  storageMap: Map<HTMLElement, Map<string, string>>,
+  storageMap: Map<HTMLElement, string>,
 ): void => {
-  for (const { element, frozenStyles, originalPropertyValues } of states) {
-    storageMap.set(element, originalPropertyValues);
-    element.style.cssText = frozenStyles;
+  for (const { element, frozenPropertyValues, originalStyles } of states) {
+    storageMap.set(element, originalStyles);
+    for (const [property, value] of frozenPropertyValues) {
+      element.style.setProperty(property, value, "important");
+    }
   }
 };
 
-const restoreFrozenStates = (
-  storageMap: Map<HTMLElement, Map<string, string>>,
-  styleProperties: readonly string[],
-): void => {
-  for (const [element, originalPropertyValues] of storageMap) {
-    for (const prop of styleProperties) {
-      const originalValue = originalPropertyValues.get(prop);
-      if (originalValue) {
-        element.style.setProperty(prop, originalValue);
-      } else {
-        element.style.removeProperty(prop);
-      }
-    }
+const restoreFrozenStates = (storageMap: Map<HTMLElement, string>): void => {
+  for (const [element, originalStyles] of storageMap) {
+    element.style.cssText = originalStyles;
   }
   storageMap.clear();
 };
@@ -236,8 +213,8 @@ export const unfreezePseudoStates = (): void => {
     document.removeEventListener(eventType, preventFocusChange, true);
   }
 
-  restoreFrozenStates(frozenHoverElements, HOVER_STYLE_PROPERTIES);
-  restoreFrozenStates(frozenFocusElements, FOCUS_STYLE_PROPERTIES);
+  restoreFrozenStates(frozenHoverElements);
+  restoreFrozenStates(frozenFocusElements);
 
   uninstallPointerEventsFreeze();
 };

--- a/packages/react-grab/src/utils/freeze-updates.ts
+++ b/packages/react-grab/src/utils/freeze-updates.ts
@@ -89,6 +89,7 @@ const pausedQueueStates = new WeakMap<HookQueue, PausedQueueState>();
 const pausedContextStates = new WeakMap<ContextDependency, PausedContextState>();
 const renderersWithPatchedDispatcher = new WeakSet<ReactRenderer>();
 const typedFiberRoots = _fiberRoots as Set<FiberRootLike>;
+const pausedFiberRoots = new Set<FiberRootLike>();
 
 const getFiberRoot = (fiber: Fiber): FiberRootLike | null => {
   let current: Fiber | null = fiber;
@@ -557,16 +558,15 @@ const clearPendingUpdates = (): void => {
 };
 
 const resumeUpdates = (): void => {
-  let fiberRootsToResume = new Set<FiberRootLike>();
+  const fiberRootsToResume = new Set(pausedFiberRoots);
   try {
-    fiberRootsToResume = collectFiberRoots();
+    for (const fiberRoot of collectFiberRoots()) {
+      fiberRootsToResume.add(fiberRoot);
+    }
   } catch (error) {
     logRecoverableError("Collecting fiber roots failed during unfreeze", error);
   }
 
-  const storeCallbacksToInvoke = Array.from(pendingStoreCallbacks);
-  const transitionCallbacksToInvoke = pendingTransitionCallbacks.slice();
-  const stateUpdatesToInvoke = pendingStateUpdates.slice();
   isUpdatesPaused = false;
 
   try {
@@ -578,11 +578,15 @@ const resumeUpdates = (): void => {
       }
     }
 
+    const storeCallbacksToInvoke = Array.from(pendingStoreCallbacks);
+    const transitionCallbacksToInvoke = pendingTransitionCallbacks.slice();
+    const stateUpdatesToInvoke = pendingStateUpdates.slice();
     invokeCallbacks(storeCallbacksToInvoke);
     invokeCallbacks(transitionCallbacksToInvoke);
     invokeCallbacks(stateUpdatesToInvoke);
     scheduleReactUpdate(fiberRootsToResume);
   } finally {
+    pausedFiberRoots.clear();
     clearPendingUpdates();
   }
 };
@@ -599,6 +603,7 @@ export const freezeUpdates = (): (() => void) => {
 
       const fiberRoots = collectFiberRoots();
       for (const fiberRoot of fiberRoots) {
+        pausedFiberRoots.add(fiberRoot);
         traverseFibersAndPause(fiberRoot.current);
       }
     } catch (error) {

--- a/packages/react-grab/src/utils/freeze-updates.ts
+++ b/packages/react-grab/src/utils/freeze-updates.ts
@@ -567,27 +567,27 @@ const resumeUpdates = (): void => {
     logRecoverableError("Collecting fiber roots failed during unfreeze", error);
   }
 
+  pausedFiberRoots.clear();
   isUpdatesPaused = false;
 
-  try {
-    for (const fiberRoot of fiberRootsToResume) {
-      try {
-        traverseFibersAndResume(fiberRoot.current);
-      } catch (error) {
-        logRecoverableError("Resuming a fiber root failed during unfreeze", error);
-      }
+  for (const fiberRoot of fiberRootsToResume) {
+    try {
+      traverseFibersAndResume(fiberRoot.current);
+    } catch (error) {
+      logRecoverableError("Resuming a fiber root failed during unfreeze", error);
     }
+  }
 
-    const storeCallbacksToInvoke = Array.from(pendingStoreCallbacks);
-    const transitionCallbacksToInvoke = pendingTransitionCallbacks.slice();
-    const stateUpdatesToInvoke = pendingStateUpdates.slice();
-    invokeCallbacks(storeCallbacksToInvoke);
-    invokeCallbacks(transitionCallbacksToInvoke);
-    invokeCallbacks(stateUpdatesToInvoke);
+  const storeCallbacksToInvoke = Array.from(pendingStoreCallbacks);
+  const transitionCallbacksToInvoke = pendingTransitionCallbacks.slice();
+  const stateUpdatesToInvoke = pendingStateUpdates.slice();
+  clearPendingUpdates();
+
+  invokeCallbacks(storeCallbacksToInvoke);
+  invokeCallbacks(transitionCallbacksToInvoke);
+  invokeCallbacks(stateUpdatesToInvoke);
+  if (!isUpdatesPaused) {
     scheduleReactUpdate(fiberRootsToResume);
-  } finally {
-    pausedFiberRoots.clear();
-    clearPendingUpdates();
   }
 };
 

--- a/packages/react-grab/src/utils/freeze-updates.ts
+++ b/packages/react-grab/src/utils/freeze-updates.ts
@@ -59,6 +59,7 @@ interface PausedContextState {
 }
 
 let isUpdatesPaused = false;
+let freezeOwnerCount = 0;
 
 const getOrCache = <K extends object, V>(cache: WeakMap<K, V>, key: K, create: () => V): V => {
   const cached = cache.get(key);
@@ -549,43 +550,71 @@ const initializeFreezeSupport = (): void => {
   }
 };
 
+const clearPendingUpdates = (): void => {
+  pendingStoreCallbacks.clear();
+  pendingTransitionCallbacks.length = 0;
+  pendingStateUpdates.length = 0;
+};
+
+const resumeUpdates = (): void => {
+  let fiberRootsToResume = new Set<FiberRootLike>();
+  try {
+    fiberRootsToResume = collectFiberRoots();
+  } catch (error) {
+    logRecoverableError("Collecting fiber roots failed during unfreeze", error);
+  }
+
+  const storeCallbacksToInvoke = Array.from(pendingStoreCallbacks);
+  const transitionCallbacksToInvoke = pendingTransitionCallbacks.slice();
+  const stateUpdatesToInvoke = pendingStateUpdates.slice();
+  isUpdatesPaused = false;
+
+  try {
+    for (const fiberRoot of fiberRootsToResume) {
+      try {
+        traverseFibersAndResume(fiberRoot.current);
+      } catch (error) {
+        logRecoverableError("Resuming a fiber root failed during unfreeze", error);
+      }
+    }
+
+    invokeCallbacks(storeCallbacksToInvoke);
+    invokeCallbacks(transitionCallbacksToInvoke);
+    invokeCallbacks(stateUpdatesToInvoke);
+    scheduleReactUpdate(fiberRootsToResume);
+  } finally {
+    clearPendingUpdates();
+  }
+};
+
 export const freezeUpdates = (): (() => void) => {
   // Demo mode is display-only and must never pause the host app's React renders,
   // even via the toolbar's own (ungated) freeze path.
   if (IS_DEMO) return () => {};
-  if (isUpdatesPaused) return () => {};
 
-  initializeFreezeSupport();
-  isUpdatesPaused = true;
+  if (freezeOwnerCount === 0) {
+    try {
+      initializeFreezeSupport();
+      isUpdatesPaused = true;
 
-  const fiberRoots = collectFiberRoots();
-  for (const fiberRoot of fiberRoots) {
-    traverseFibersAndPause(fiberRoot.current);
+      const fiberRoots = collectFiberRoots();
+      for (const fiberRoot of fiberRoots) {
+        traverseFibersAndPause(fiberRoot.current);
+      }
+    } catch (error) {
+      logRecoverableError("Pausing React updates failed", error);
+      if (isUpdatesPaused) resumeUpdates();
+      return () => {};
+    }
   }
 
+  freezeOwnerCount += 1;
+  let didReleaseFreeze = false;
+
   return () => {
-    if (!isUpdatesPaused) return;
-
-    try {
-      const fiberRootsToResume = collectFiberRoots();
-      for (const fiberRoot of fiberRootsToResume) {
-        traverseFibersAndResume(fiberRoot.current);
-      }
-
-      const storeCallbacksToInvoke = Array.from(pendingStoreCallbacks);
-      const transitionCallbacksToInvoke = pendingTransitionCallbacks.slice();
-      const stateUpdatesToInvoke = pendingStateUpdates.slice();
-
-      isUpdatesPaused = false;
-
-      invokeCallbacks(storeCallbacksToInvoke);
-      invokeCallbacks(transitionCallbacksToInvoke);
-      invokeCallbacks(stateUpdatesToInvoke);
-      scheduleReactUpdate(fiberRootsToResume);
-    } finally {
-      pendingStoreCallbacks.clear();
-      pendingTransitionCallbacks.length = 0;
-      pendingStateUpdates.length = 0;
-    }
+    if (didReleaseFreeze) return;
+    didReleaseFreeze = true;
+    freezeOwnerCount -= 1;
+    if (freezeOwnerCount === 0) resumeUpdates();
   };
 };

--- a/packages/react-grab/src/utils/get-element-at-position.ts
+++ b/packages/react-grab/src/utils/get-element-at-position.ts
@@ -17,6 +17,7 @@ interface PositionCache {
 interface IFrameHoverCache {
   element: HTMLIFrameElement;
   rect: DOMRect;
+  timestamp: number;
 }
 
 let cache: PositionCache | null = null;
@@ -56,10 +57,13 @@ export const getElementsAtPoint = (clientX: number, clientY: number): Element[] 
   if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) return [];
   cancelScheduledResume();
   suspendPointerEventsFreeze();
-  const elements = document.elementsFromPoint(clientX, clientY);
-  scheduleResume();
-  if (!getScopeContainer()) return elements;
-  return elements.filter(isWithinScope);
+  try {
+    const elements = document.elementsFromPoint(clientX, clientY);
+    if (!getScopeContainer()) return elements;
+    return elements.filter(isWithinScope);
+  } finally {
+    scheduleResume();
+  }
 };
 
 export const getElementAtPosition = (clientX: number, clientY: number): Element | null => {
@@ -72,8 +76,18 @@ export const getElementAtPosition = (clientX: number, clientY: number): Element 
   // pending resume timer re-enable `html { pointer-events: none }`, which stops
   // the browser from dispatching pointer events into the iframe's document -
   // the source of lag on srcdoc iframes running their own React/JIT pipelines.
-  if (hoveredIframe && isPointInsideRect(clientX, clientY, hoveredIframe.rect)) {
-    return hoveredIframe.element;
+  if (hoveredIframe) {
+    const cachedIframe = hoveredIframe.element;
+    const isIframeCacheFresh = now - hoveredIframe.timestamp < ELEMENT_POSITION_THROTTLE_MS;
+    if (
+      cachedIframe.isConnected &&
+      isIframeCacheFresh &&
+      isPointInsideRect(clientX, clientY, hoveredIframe.rect)
+    ) {
+      return cachedIframe;
+    }
+    hoveredIframe = null;
+    if (cache?.element === cachedIframe) cache = null;
   }
 
   if (cache) {
@@ -99,38 +113,39 @@ export const getElementAtPosition = (clientX: number, clientY: number): Element 
   //     dropdowns/tooltips during the hit-test toggle
   cancelScheduledResume();
   suspendPointerEventsFreeze();
+  try {
+    let result: Element | null = null;
 
-  let result: Element | null = null;
-
-  // elementFromPoint returns the topmost element, but if it's not grabbable
-  // (e.g. a transparent overlay) or out of scope (e.g. an external element
-  // overlapping the scoped container) we fall back to elementsFromPoint, which
-  // returns the full z-ordered stack, and take the first grabbable in-scope one.
-  const topElement = document.elementFromPoint(clientX, clientY);
-  if (topElement && isValidGrabbableElement(topElement) && isWithinScope(topElement)) {
-    result = topElement;
-  } else {
-    const elementsAtPoint = document.elementsFromPoint(clientX, clientY);
-    for (const candidateElement of elementsAtPoint) {
-      if (
-        candidateElement !== topElement &&
-        isValidGrabbableElement(candidateElement) &&
-        isWithinScope(candidateElement)
-      ) {
-        result = candidateElement;
-        break;
+    // elementFromPoint returns the topmost element, but if it's not grabbable
+    // (e.g. a transparent overlay) or out of scope (e.g. an external element
+    // overlapping the scoped container) we fall back to elementsFromPoint, which
+    // returns the full z-ordered stack, and take the first grabbable in-scope one.
+    const topElement = document.elementFromPoint(clientX, clientY);
+    if (topElement && isValidGrabbableElement(topElement) && isWithinScope(topElement)) {
+      result = topElement;
+    } else {
+      const elementsAtPoint = document.elementsFromPoint(clientX, clientY);
+      for (const candidateElement of elementsAtPoint) {
+        if (
+          candidateElement !== topElement &&
+          isValidGrabbableElement(candidateElement) &&
+          isWithinScope(candidateElement)
+        ) {
+          result = candidateElement;
+          break;
+        }
       }
     }
+
+    hoveredIframe =
+      result instanceof HTMLIFrameElement
+        ? { element: result, rect: result.getBoundingClientRect(), timestamp: now }
+        : null;
+    cache = { clientX, clientY, element: result, timestamp: now };
+    return result;
+  } finally {
+    scheduleResume();
   }
-
-  scheduleResume();
-
-  hoveredIframe =
-    result instanceof HTMLIFrameElement
-      ? { element: result, rect: result.getBoundingClientRect() }
-      : null;
-  cache = { clientX, clientY, element: result, timestamp: now };
-  return result;
 };
 
 export const clearElementPositionCache = (): void => {


### PR DESCRIPTION
## Summary

- make nested React-update freezes reference counted and idempotent
- guarantee pointer-event restoration when hit testing throws
- preserve and restore exact inline pseudo-state styles
- prevent mutable animation inputs and stale iframe hit-test caches
- release the complete toolbar interaction freeze on dismissal

## Validation

- `nr build`
- package unit suite (94 tests)
- Vite Plus development E2E: freeze updates, freeze animations, and API methods (59 tests)
- `nr lint`
- `nr typecheck`
- `nr format:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch React-internals patching, global pointer-events toggling, and inline style restoration during grab mode—high impact on host page behavior if regressions slip through, but scoped to dev tooling with added E2E coverage.
> 
> **Overview**
> Hardens **react-grab** interaction freezes so nested owners, hit-testing errors, and pseudo-state snapshots do not leave the page stuck or clobber host styles.
> 
> **React update freezes** are now reference-counted with idempotent release callbacks; paused fiber roots are tracked and buffered work replays only after the last owner releases. Pause failures roll back via `resumeUpdates`, and unfreeze paths wrap fiber traversal in try/catch.
> 
> **Pointer-events / hit testing** uses `try/finally` in `getElementsAtPosition`, `getElementsAtPoint`, and `getElementAtPosition` so the pointer-events freeze always resumes even when `elementFromPoint` throws. Iframe hover cache entries get timestamps, `isConnected` checks, and invalidation when stale.
> 
> **Pseudo-state freezing** stops replacing `element.style.cssText` and instead snapshots each pinned property’s inline value and priority, applies computed values with `!important` per property, and restores only those keys on unfreeze—so unrelated inline writes during grab mode are preserved (covered by a new E2E spec).
> 
> **Toolbar dismissal** routes through `releaseInteractionFreeze()` so React pause and global interactions release together when grab/context menu closes. Animation freeze clones element arrays to avoid mutating caller input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65506889f820d82599c01f1a452769458ed9a5ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make interaction freezes in `react-grab` exception-safe and ref-counted, isolating reentrant sessions so React updates and pointer events always restore correctly. Hardens pseudo-state freezing and iframe hit tests to avoid stale or lost state.

- **Bug Fixes**
  - React update freezes are ref-counted, idempotent, and reentrant-safe; paused roots are tracked and buffered work replays only after the final release.
  - Always resume pointer events with try/finally in hit-testing and `getElementsAtPosition`.
  - Pseudo-state freezes snapshot per-property inline values (with priority), apply `!important`, and restore them so unrelated inline writes made while frozen are preserved.
  - Clone animation element lists to avoid mutating inputs.
  - Iframe hover cache adds timestamps, TTL checks, and `isConnected` validation; stale or disconnected entries are cleared.
  - Dismissing the toolbar calls `releaseInteractionFreeze()` to fully release the global freeze.

<sup>Written for commit 65506889f820d82599c01f1a452769458ed9a5ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

