### PR TITLE
fix(react-grab): correct overlay rendering and keyboard behavior

### DIFF
--- a/packages/react-grab/e2e/copy-failure.spec.ts
+++ b/packages/react-grab/e2e/copy-failure.spec.ts
@@ -46,6 +46,22 @@ const clickErrorButton = async (
   );
 };
 
+const focusErrorButton = async (
+  reactGrab: { page: import("@playwright/test").Page },
+  buttonAttribute: string,
+): Promise<void> => {
+  await reactGrab.page.evaluate(
+    ({ attrName, target }) => {
+      const host = document.querySelector(`[${attrName}]`);
+      const root = host?.shadowRoot?.querySelector(`[${attrName}]`);
+      const button = root?.querySelector<HTMLButtonElement>(`[${target}]`);
+      if (!button) throw new Error(`Error button [${target}] not found`);
+      button.focus();
+    },
+    { attrName: ATTRIBUTE_NAME, target: buttonAttribute },
+  );
+};
+
 const isErrorViewGone = (reactGrab: { page: import("@playwright/test").Page }) =>
   reactGrab.page.evaluate((attrName) => {
     const host = document.querySelector(`[${attrName}]`);
@@ -167,5 +183,19 @@ test.describe("Copy failure feedback", () => {
     await expect.poll(() => isErrorViewGone(reactGrab), { timeout: 5000 }).toBe(true);
     const instances = await reactGrab.getLabelInstancesInfo();
     expect(instances.some((instance) => instance.status === "error")).toBe(false);
+  });
+
+  test("Enter on the focused Ok button acknowledges instead of retrying", async ({ reactGrab }) => {
+    await forceCopyResult(reactGrab, false);
+
+    await reactGrab.activate();
+    await reactGrab.hoverUntilSelected("li");
+    await reactGrab.clickElement("li");
+    await readErrorView(reactGrab);
+    await focusErrorButton(reactGrab, "data-react-grab-error-ok");
+
+    await reactGrab.page.keyboard.press("Enter");
+
+    await expect.poll(() => isErrorViewGone(reactGrab), { timeout: 5000 }).toBe(true);
   });
 });

--- a/packages/react-grab/e2e/copy-failure.spec.ts
+++ b/packages/react-grab/e2e/copy-failure.spec.ts
@@ -193,6 +193,7 @@ test.describe("Copy failure feedback", () => {
     await reactGrab.clickElement("li");
     await readErrorView(reactGrab);
     await focusErrorButton(reactGrab, "data-react-grab-error-ok");
+    await expect.poll(() => isErrorViewGone(reactGrab)).toBe(false);
 
     await reactGrab.page.keyboard.press("Enter");
 

--- a/packages/react-grab/e2e/keyboard-navigation.spec.ts
+++ b/packages/react-grab/e2e/keyboard-navigation.spec.ts
@@ -393,6 +393,22 @@ test.describe("Keyboard Navigation", () => {
     expect(await reactGrab.getClipboardContent()).toBe("");
   });
 
+  test("Enter on the focused More options button opens the completed-item menu", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.activate();
+    await reactGrab.hoverUntilSelected("[data-testid='todo-list'] li:first-child");
+    await reactGrab.clickElement("[data-testid='todo-list'] li:first-child");
+    await expect.poll(() => reactGrab.getLabelStatusText(), { timeout: 2000 }).toBe("Copied");
+
+    const moreOptionsButton = reactGrab.page.locator("[data-react-grab-more-options]");
+    await expect(moreOptionsButton).toHaveAccessibleName("More options");
+    await moreOptionsButton.focus();
+    await reactGrab.page.keyboard.press("Enter");
+
+    await expect.poll(() => reactGrab.isContextMenuVisible()).toBe(true);
+  });
+
   test("arrow keys continue navigation while the discard-selection prompt is open", async ({
     reactGrab,
   }) => {

--- a/packages/react-grab/e2e/shift-multi-select.spec.ts
+++ b/packages/react-grab/e2e/shift-multi-select.spec.ts
@@ -203,6 +203,52 @@ test.describe("Shift Multi-Select", () => {
     await reactGrab.page.keyboard.up("Shift");
   });
 
+  test("should preserve frozen label instances across viewport updates", async ({ reactGrab }) => {
+    await reactGrab.activate();
+
+    const firstItem = reactGrab.page.locator("[data-testid='todo-list'] li").first();
+    const secondItem = reactGrab.page.locator("[data-testid='todo-list'] li").nth(1);
+    const firstBox = await firstItem.boundingBox();
+    const secondBox = await secondItem.boundingBox();
+    if (!firstBox || !secondBox) throw new Error("Could not get bounding boxes");
+
+    await reactGrab.page.keyboard.up("Shift");
+    await reactGrab.page.keyboard.down("Shift");
+    await reactGrab.page.mouse.click(
+      firstBox.x + firstBox.width / 2,
+      firstBox.y + firstBox.height / 2,
+    );
+    await reactGrab.page.mouse.click(
+      secondBox.x + secondBox.width / 2,
+      secondBox.y + secondBox.height / 2,
+    );
+    await expect
+      .poll(async () =>
+        reactGrab.page.evaluate(() => {
+          const host = document.querySelector("[data-react-grab]");
+          return (
+            host?.shadowRoot?.querySelectorAll("[data-react-grab-selection-label]").length ?? 0
+          );
+        }),
+      )
+      .toBe(SHIFT_LABEL_ANCHORED_COUNT);
+
+    const didPreserveLabelInstance = await reactGrab.page.evaluate(async () => {
+      const host = document.querySelector("[data-react-grab]");
+      const initialLabel = host?.shadowRoot?.querySelector("[data-react-grab-selection-label]");
+      if (!initialLabel) throw new Error("Could not find frozen label");
+
+      window.dispatchEvent(new Event("scroll"));
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+      const currentLabel = host?.shadowRoot?.querySelector("[data-react-grab-selection-label]");
+      return currentLabel === initialLabel;
+    });
+
+    expect(didPreserveLabelInstance).toBe(true);
+    await reactGrab.page.keyboard.up("Shift");
+  });
+
   test("should keep every shift-selected label anchored to its click position", async ({
     reactGrab,
   }) => {

--- a/packages/react-grab/src/components/overlay-canvas.tsx
+++ b/packages/react-grab/src/components/overlay-canvas.tsx
@@ -81,6 +81,7 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
   let canvasHeight = 0;
   let devicePixelRatio = 1;
   let animationFrameId: number | null = null;
+  let fadeWakeTimeoutId: number | null = null;
   let previousFrameTimestamp: number | null = null;
 
   const layers: Record<LayerName, OffscreenLayer> = {
@@ -369,6 +370,7 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
     );
 
     let shouldContinueAnimating = false;
+    let nextFadeDelayMs: number | null = null;
 
     if (dragAnimation?.isInitialized) {
       if (interpolateBounds(dragAnimation, dragLerpForFrame)) {
@@ -410,7 +412,7 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
         animation.fadeStartTimestamp = null;
       }
 
-      if (animation.createdAt) {
+      if (animation.createdAt !== undefined) {
         const elapsed = currentTimestamp - animation.createdAt;
         const fadeOutDeadline = FEEDBACK_DURATION_MS + FADE_DURATION_MS;
 
@@ -423,6 +425,10 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
           const easeOut = 1 - (1 - fadeProgress) * (1 - fadeProgress);
           animation.opacity = 1 - easeOut;
           shouldContinueAnimating = true;
+        } else {
+          const fadeDelayMs = FEEDBACK_DURATION_MS - elapsed;
+          nextFadeDelayMs =
+            nextFadeDelayMs === null ? fadeDelayMs : Math.min(nextFadeDelayMs, fadeDelayMs);
         }
 
         return true;
@@ -442,10 +448,23 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
     } else {
       animationFrameId = null;
       previousFrameTimestamp = null;
+      if (nextFadeDelayMs !== null) {
+        fadeWakeTimeoutId = window.setTimeout(
+          () => {
+            fadeWakeTimeoutId = null;
+            scheduleAnimationFrame();
+          },
+          Math.max(0, nextFadeDelayMs),
+        );
+      }
     }
   };
 
   const scheduleAnimationFrame = () => {
+    if (fadeWakeTimeoutId !== null) {
+      window.clearTimeout(fadeWakeTimeoutId);
+      fadeWakeTimeoutId = null;
+    }
     if (animationFrameId !== null) return;
     animationFrameId = nativeRequestAnimationFrame(runAnimationFrame);
   };
@@ -640,6 +659,9 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
       }
       if (animationFrameId !== null) {
         nativeCancelAnimationFrame(animationFrameId);
+      }
+      if (fadeWakeTimeoutId !== null) {
+        window.clearTimeout(fadeWakeTimeoutId);
       }
     });
   });

--- a/packages/react-grab/src/components/renderer.tsx
+++ b/packages/react-grab/src/components/renderer.tsx
@@ -28,16 +28,20 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
       <FrozenGlow visible={props.isFrozen ?? false} />
       <Show when={props.selectionLabelVisible && (props.frozenLabelEntries?.length ?? 0) > 0}>
         <For each={props.frozenLabelEntries ?? []}>
-          {(entry, entryIndex) => (
-            <SelectionLabel
-              tagName={entry.tagName}
-              componentName={entry.componentName}
-              selectionBounds={entry.bounds}
-              mouseX={entry.mouseX}
-              visible={true}
-              shouldToggleExpandOnClick={entryIndex() === 0}
-              onToggleExpand={entryIndex() === 0 ? props.onToggleExpand : undefined}
-            />
+          {(entryAccessor, entryIndex) => (
+            <Show when={entryAccessor.read()}>
+              {(entry) => (
+                <SelectionLabel
+                  tagName={entry().tagName}
+                  componentName={entry().componentName}
+                  selectionBounds={entry().bounds}
+                  mouseX={entry().mouseX}
+                  visible={true}
+                  shouldToggleExpandOnClick={entryIndex() === 0}
+                  onToggleExpand={entryIndex() === 0 ? props.onToggleExpand : undefined}
+                />
+              )}
+            </Show>
           )}
         </For>
       </Show>

--- a/packages/react-grab/src/components/renderer.tsx
+++ b/packages/react-grab/src/components/renderer.tsx
@@ -1,4 +1,4 @@
-import { Index, Show, type Component } from "solid-js";
+import { For, Show, type Component } from "solid-js";
 import type { ReactGrabRendererProps } from "../types.js";
 import { DEFAULT_ACTION_ID } from "../constants.js";
 import { requestOpenFile } from "../utils/open-file.js";
@@ -27,19 +27,19 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
       />
       <FrozenGlow visible={props.isFrozen ?? false} />
       <Show when={props.selectionLabelVisible && (props.frozenLabelEntries?.length ?? 0) > 0}>
-        <Index each={props.frozenLabelEntries ?? []}>
+        <For each={props.frozenLabelEntries ?? []}>
           {(entry, entryIndex) => (
             <SelectionLabel
-              tagName={entry().tagName}
-              componentName={entry().componentName}
-              selectionBounds={entry().bounds}
-              mouseX={entry().mouseX}
+              tagName={entry.tagName}
+              componentName={entry.componentName}
+              selectionBounds={entry.bounds}
+              mouseX={entry.mouseX}
               visible={true}
-              shouldToggleExpandOnClick={entryIndex === 0}
-              onToggleExpand={entryIndex === 0 ? props.onToggleExpand : undefined}
+              shouldToggleExpandOnClick={entryIndex() === 0}
+              onToggleExpand={entryIndex() === 0 ? props.onToggleExpand : undefined}
             />
           )}
-        </Index>
+        </For>
       </Show>
       <Show when={props.selectionLabelVisible && props.pendingShiftPreviewEntry}>
         {(pendingEntry) => (
@@ -84,38 +84,37 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
           isContextMenuOpen={props.contextMenuPosition !== null}
         />
       </Show>
-      <Index each={props.labelInstances ?? []}>
+      <For each={props.labelInstances ?? []}>
         {(instance) => (
           <SelectionLabel
-            tagName={instance().tagName}
-            componentName={instance().componentName}
-            elementsCount={instance().elementsCount}
-            selectionBounds={instance().bounds}
-            mouseX={instance().mouseX}
+            tagName={instance.tagName}
+            componentName={instance.componentName}
+            elementsCount={instance.elementsCount}
+            selectionBounds={instance.bounds}
+            mouseX={instance.mouseX}
             visible={true}
-            status={instance().status}
-            statusText={instance().statusText}
-            isPromptMode={instance().isPromptMode}
-            inputValue={instance().inputValue}
-            error={instance().errorMessage}
-            hideArrow={instance().hideArrow}
+            status={instance.status}
+            statusText={instance.statusText}
+            isPromptMode={instance.isPromptMode}
+            inputValue={instance.inputValue}
+            error={instance.errorMessage}
+            hideArrow={instance.hideArrow}
             onShowContextMenu={(() => {
-              const currentInstance = instance();
               const hasCompletedStatus =
-                currentInstance.status === "copied" || currentInstance.status === "fading";
-              if (!hasCompletedStatus || !isElementConnected(currentInstance.element)) {
+                instance.status === "copied" || instance.status === "fading";
+              if (!hasCompletedStatus || !isElementConnected(instance.element)) {
                 return undefined;
               }
-              return () => props.onShowContextMenuInstance?.(currentInstance.id);
+              return () => props.onShowContextMenuInstance?.(instance.id);
             })()}
-            onRetry={() => props.onRetryInstance?.(instance().id)}
-            onAcknowledgeError={() => props.onAcknowledgeErrorInstance?.(instance().id)}
+            onRetry={() => props.onRetryInstance?.(instance.id)}
+            onAcknowledgeError={() => props.onAcknowledgeErrorInstance?.(instance.id)}
             onHoverChange={(isHovered) =>
-              props.onLabelInstanceHoverChange?.(instance().id, isHovered)
+              props.onLabelInstanceHoverChange?.(instance.id, isHovered)
             }
           />
         )}
-      </Index>
+      </For>
       <Show when={props.toolbarVisible !== false}>
         <Toolbar
           isActive={props.isActive}

--- a/packages/react-grab/src/components/selection-label/completion-view.tsx
+++ b/packages/react-grab/src/components/selection-label/completion-view.tsx
@@ -2,6 +2,7 @@ import { createSignal, onCleanup, Show, type Component } from "solid-js";
 import type { CompletionViewProps } from "../../types.js";
 import { FEEDBACK_DURATION_MS, FADE_DURATION_MS } from "../../constants.js";
 import { createConfirmationKeyboard } from "../../utils/create-confirmation-keyboard.js";
+import { isEventFromOverlay } from "../../utils/is-event-from-overlay.js";
 import { IconReturn } from "../icons/icon-return.jsx";
 import { IconEllipsis } from "../icons/icon-ellipsis.jsx";
 import { cn } from "../../utils/cn.js";
@@ -16,8 +17,10 @@ interface MoreOptionsButtonProps {
 const MoreOptionsButton: Component<MoreOptionsButtonProps> = (props) => {
   return (
     <button
+      type="button"
       data-react-grab-ignore-events
       data-react-grab-more-options
+      aria-label="More options"
       class={cn(
         buttonVariants({ variant: "ghost" }),
         "group size-4 text-[var(--rg-text-secondary)] hover:text-[var(--rg-text-primary)]",
@@ -33,7 +36,11 @@ const MoreOptionsButton: Component<MoreOptionsButtonProps> = (props) => {
         props.onClick();
       }}
     >
-      <IconEllipsis size={14} class="opacity-50 group-hover:opacity-100 transition-opacity" />
+      <IconEllipsis
+        size={14}
+        aria-hidden="true"
+        class="opacity-50 group-hover:opacity-100 transition-opacity"
+      />
     </button>
   );
 };
@@ -67,6 +74,7 @@ export const CompletionView: Component<CompletionViewProps> = (props) => {
 
   const { claimFocus } = createConfirmationKeyboard({
     onEnter: (event) => {
+      if (isEventFromOverlay(event, "data-react-grab-more-options")) return;
       event.preventDefault();
       event.stopPropagation();
       handleAccept();

--- a/packages/react-grab/src/components/selection-label/error-view.tsx
+++ b/packages/react-grab/src/components/selection-label/error-view.tsx
@@ -1,6 +1,7 @@
 import { Show, type Component } from "solid-js";
 import type { ErrorViewProps } from "../../types.js";
 import { createConfirmationKeyboard } from "../../utils/create-confirmation-keyboard.js";
+import { isEventFromOverlay } from "../../utils/is-event-from-overlay.js";
 import { IconRetry } from "../icons/icon-retry.jsx";
 import { Button } from "../ui/button.js";
 import { BottomSection } from "./bottom-section.js";
@@ -8,6 +9,7 @@ import { BottomSection } from "./bottom-section.js";
 export const ErrorView: Component<ErrorViewProps> = (props) => {
   const { claimFocus } = createConfirmationKeyboard({
     onEnter: (event) => {
+      if (isEventFromOverlay(event, "data-react-grab-error-ok")) return;
       event.preventDefault();
       event.stopPropagation();
       props.onRetry?.();

--- a/packages/react-grab/src/components/slot.tsx
+++ b/packages/react-grab/src/components/slot.tsx
@@ -60,7 +60,7 @@ const DigitColumn: Component<DigitColumnProps> = (props) => {
         }
         setExitingDigit({ digit: previousDigit, direction: props.direction });
         if (exitTimerId !== null) clearTimeout(exitTimerId);
-        exitTimerId = setTimeout(() => setExitingDigit(null), SLOT_TRANSITION_MS);
+        exitTimerId = setTimeout(() => setExitingDigit(null), props.delayMs + SLOT_TRANSITION_MS);
       },
       { defer: true },
     ),

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -116,6 +116,7 @@ import type {
   HierarchyState,
   HierarchyEntry,
   FrozenLabelEntry,
+  FrozenLabelEntryAccessor,
   PerformWithFeedbackOptions,
   SettableOptions,
   SourceInfo,
@@ -1274,26 +1275,27 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       (element) => {
         const tagName = getTagName(element) || "element";
         const componentName = getComponentDisplayName(element) ?? undefined;
-        return createMemo<FrozenLabelEntry | null>(() => {
-          void viewportVersion();
-          if (!isElementConnected(element)) return null;
-          const bounds = createElementBounds(element);
-          const anchorRatio = shiftSelectionLabelAnchorRatioByElement.get(element);
-          const mouseX =
-            anchorRatio === undefined ? undefined : bounds.x + bounds.width * anchorRatio;
-          return { tagName, componentName, bounds, mouseX };
-        });
+        return {
+          read: createMemo<FrozenLabelEntry | null>(() => {
+            void viewportVersion();
+            if (!isElementConnected(element)) return null;
+            const bounds = createElementBounds(element);
+            const anchorRatio = shiftSelectionLabelAnchorRatioByElement.get(element);
+            const mouseX =
+              anchorRatio === undefined ? undefined : bounds.x + bounds.width * anchorRatio;
+            return { tagName, componentName, bounds, mouseX };
+          }),
+        };
       },
     );
 
-    const frozenLabelEntries = createMemo((): FrozenLabelEntry[] => {
+    const frozenLabelEntries = createMemo((): FrozenLabelEntryAccessor[] => {
       if (isPromptMode() || store.frozenElements.length < 2) return [];
-      const entries: FrozenLabelEntry[] = [];
-      for (const readEntry of frozenLabelEntryAccessors()) {
-        const entry = readEntry();
-        if (entry !== null) entries.push(entry);
+      const entryAccessors: FrozenLabelEntryAccessor[] = [];
+      for (const entryAccessor of frozenLabelEntryAccessors()) {
+        if (entryAccessor.read() !== null) entryAccessors.push(entryAccessor);
       }
-      return entries;
+      return entryAccessors;
     });
 
     const pendingShiftPreviewEntry = createMemo((): FrozenLabelEntry | null => {

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -525,13 +525,17 @@ export interface FrozenLabelEntry {
   mouseX?: number;
 }
 
+export interface FrozenLabelEntryAccessor {
+  read: () => FrozenLabelEntry | null;
+}
+
 export interface ReactGrabRendererProps {
   selectionVisible?: boolean;
   selectionBounds?: OverlayBounds;
   selectionBoundsMultiple?: OverlayBounds[];
   selectionShouldSnap?: boolean;
   selectionElementsCount?: number;
-  frozenLabelEntries?: FrozenLabelEntry[];
+  frozenLabelEntries?: FrozenLabelEntryAccessor[];
   pendingShiftPreviewEntry?: FrozenLabelEntry;
   selectionFilePath?: string;
   selectionLineNumber?: number;


### PR DESCRIPTION
## Summary

- preserve Solid component identity for object-backed label collections
- let canvas animation frames sleep until feedback fade work resumes
- keep delayed slot exits alive for their full transition
- route Enter correctly to focused error and completion controls across Shadow DOM
- add accessible semantics to the completed-item options button

## Validation

- `nr build`
- package unit suite (94 tests)
- Vite Plus development E2E: copy failure, keyboard navigation, and visual feedback (63 tests)
- `nr lint`
- `nr typecheck`
- `nr format:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to overlay UI, Solid rendering, and keyboard routing in the dev overlay; no auth, persistence, or host-app API surface changes.
> 
> **Overview**
> Fixes **overlay** behavior and **keyboard** handling in `react-grab` so multi-select labels stay stable and Enter does what the focused control implies.
> 
> **Rendering & performance:** The overlay canvas can **stop `requestAnimationFrame`** during the post-copy feedback hold and **wake with a timeout** right before fade-out, instead of spinning frames idle. Grabbed-box fade logic treats `createdAt` as optional and schedules the next wake from the minimum remaining delay.
> 
> **Solid list identity:** Frozen shift-select labels and completed **label instances** move from `Index` to **`For`**, with frozen entries exposed as **`FrozenLabelEntryAccessor`** (`read()` memos) so viewport/scroll updates refresh bounds without remounting DOM nodes (covered by a new shift-multi-select E2E).
> 
> **Keyboard & a11y:** Global confirmation **Enter** handlers in error and completion views **bail out** when the event targets the focused **Ok** or **More options** buttons (`isEventFromOverlay`), so Enter acknowledges/opens the menu instead of retrying or “Keep”. The more-options control gets **`type="button"`**, **`aria-label="More options"`**, and hidden icon semantics.
> 
> **Animation:** Slot digit exit cleanup waits **`delayMs + SLOT_TRANSITION_MS`** so staggered exits aren’t clipped early.
> 
> New E2E cases cover Enter on Ok (acknowledge) and More options (context menu).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36548d99fc0c8ee1935d9f6ed51307a987e63d13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overlay rendering and keyboard interactions in `react-grab` for smoother visuals and predictable Enter key behavior. Improves label stability across viewport updates, reduces unnecessary canvas work, and adds accessible controls.

- **Bug Fixes**
  - Overlay: pause animation frames until fade begins, wake via timeout, and clear timers on cleanup for efficient rendering.
  - Labels: switch `frozenLabelEntries` to accessor objects (`FrozenLabelEntryAccessor`) and use Solid `For` with null filtering to preserve component identity across viewport updates; also use `For` for `labelInstances` to prevent flicker. Adds E2E verifying frozen labels persist through scroll.
  - Animations: keep delayed slot exits visible for the full transition (`delayMs + SLOT_TRANSITION_MS`) to avoid clipping.
  - Keyboard/a11y: route Enter correctly across Shadow DOM (Error “Ok” acknowledges, not retry; “More options” opens menu); add `aria-label`, `type="button"`, and hidden icon; new E2E tests for these cases.

<sup>Written for commit 36548d99fc0c8ee1935d9f6ed51307a987e63d13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

