### PR TITLE
Support Shadow DOM and iframe element grabbing

### DIFF
--- a/apps/e2e-app-vite/package.json
+++ b/apps/e2e-app-vite/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@pierre/diffs": "^1.2.12",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.14.5",
     "react": "19.2.6",

--- a/apps/e2e-app-vite/src/App.tsx
+++ b/apps/e2e-app-vite/src/App.tsx
@@ -1,7 +1,10 @@
 import { useState, useRef, useEffect } from "react";
 import { PerfGrid } from "./perf-grid";
 import { HeavyPage, parseHeavyView, type HeavyView } from "./perf-heavy/heavy-page";
+import { IframeFixture } from "./iframe-fixture";
 import { OwnerStackCases } from "./owner-stack-cases";
+import { PierreDiffFixture, PierreDiffPreview } from "./pierre-diff-fixture";
+import { ShadowDomEdgeFixture } from "./shadow-dom-edge-fixture";
 
 declare global {
   interface Window {
@@ -802,6 +805,9 @@ const PointerEventsModalSection = () => {
 export default function App() {
   const perfConfig = usePerfGridConfig();
   const heavyView = usePerfHeavyView();
+  const searchParams = new URLSearchParams(window.location.search);
+  const isIframePreview = searchParams.has("iframe-preview");
+  const isIframeDiffPreview = searchParams.has("iframe-diff-preview");
 
   if (perfConfig) {
     return <PerfGrid rowCount={perfConfig.rowCount} columnCount={perfConfig.columnCount} />;
@@ -809,6 +815,18 @@ export default function App() {
 
   if (heavyView) {
     return <HeavyPage view={heavyView} />;
+  }
+
+  if (isIframeDiffPreview) {
+    return <PierreDiffPreview />;
+  }
+
+  if (isIframePreview) {
+    return (
+      <main className="min-h-screen bg-slate-100 p-8">
+        <IframeFixture />
+      </main>
+    );
   }
 
   return (
@@ -857,6 +875,12 @@ export default function App() {
       <PointerUpModalSection />
 
       <PointerEventsModalSection />
+
+      <PierreDiffFixture />
+
+      <ShadowDomEdgeFixture />
+
+      <IframeFixture />
 
       <HiddenToggleSection />
 

--- a/apps/e2e-app-vite/src/iframe-fixture.tsx
+++ b/apps/e2e-app-vite/src/iframe-fixture.tsx
@@ -1,0 +1,148 @@
+const IFRAME_SOURCE = `<!doctype html>
+<html>
+  <head>
+    <style>
+      :root { color: #172033; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: #f4f6fb; }
+      nav { display: flex; align-items: center; justify-content: space-between; padding: 18px 28px; background: white; border-bottom: 1px solid #e4e8f0; }
+      nav strong { letter-spacing: -0.03em; }
+      nav span { color: #68738a; font-size: 13px; }
+      main { padding: 48px 28px; }
+      .eyebrow { color: #5b5bd6; font-size: 12px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; }
+      h1 { max-width: 620px; margin: 12px 0; font-size: 38px; line-height: 1.05; letter-spacing: -0.04em; }
+      .lede { max-width: 560px; color: #5c667b; font-size: 16px; line-height: 1.6; }
+      .actions { display: flex; gap: 10px; margin: 24px 0 36px; }
+      button { padding: 11px 16px; border: 0; border-radius: 8px; background: #25263b; color: white; font: inherit; font-weight: 650; }
+      .secondary { border: 1px solid #d7dce6; background: white; color: #30384a; }
+      .features { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+      .feature { padding: 18px; border: 1px solid #e1e5ed; border-radius: 12px; background: white; }
+      .feature b { display: block; margin-bottom: 6px; font-size: 14px; }
+      .feature p { margin: 0; color: #727c90; font-size: 13px; line-height: 1.5; }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <strong>Northstar</strong>
+      <span>Product preview</span>
+    </nav>
+    <main data-testid="iframe-main">
+      <div class="eyebrow">Workspace intelligence</div>
+      <h1>Make every project easier to understand.</h1>
+      <p class="lede">A fictional product page rendered inside the preview canvas. Select any element here without leaving the editor shell.</p>
+      <div class="actions">
+        <button data-testid="iframe-target" style="border-radius: 8px 12px / 16px 20px">Start a workspace</button>
+        <button class="secondary">View a demo</button>
+      </div>
+      <div class="features">
+        <article class="feature"><b>Shared context</b><p>Keep decisions and references next to the work.</p></article>
+        <article class="feature"><b>Fast handoffs</b><p>Give collaborators a clear place to begin.</p></article>
+        <article class="feature"><b>Useful history</b><p>See how a project changed without digging.</p></article>
+      </div>
+      <iframe-shadow-fixture></iframe-shadow-fixture>
+    </main>
+    <script>
+      customElements.define("iframe-shadow-fixture", class extends HTMLElement {
+        connectedCallback() {
+          if (this.shadowRoot) return
+          this.attachShadow({ mode: "open" }).innerHTML =
+            '<button data-testid="iframe-shadow-target">Iframe shadow target</button>'
+        }
+      })
+    </script>
+  </body>
+</html>`;
+
+const SANDBOXED_IFRAME_SOURCE = `<!doctype html>
+<html>
+  <body style="margin: 0; padding: 20px">
+    <button data-testid="sandboxed-iframe-target" style="padding: 12px">
+      Sandboxed opaque-origin target
+    </button>
+  </body>
+</html>`;
+
+export const IframeFixture = () => (
+  <section
+    className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm"
+    data-testid="iframe-section"
+  >
+    <header className="flex items-center justify-between border-b border-slate-200 px-4 py-3">
+      <div>
+        <p className="text-sm font-semibold text-slate-900">Canvas</p>
+        <p className="text-xs text-slate-500">Fictional page builder fixture</p>
+      </div>
+      <span className="rounded-full bg-emerald-50 px-2 py-1 text-xs font-medium text-emerald-700">
+        Preview ready
+      </span>
+    </header>
+
+    <div className="grid md:grid-cols-4">
+      <aside className="border-b border-slate-800 bg-slate-950 p-4 text-slate-300 md:border-b-0 md:border-r">
+        <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-500">Pages</p>
+        <button
+          type="button"
+          className="mb-5 w-full rounded-md bg-slate-800 px-3 py-2 text-left text-sm font-medium text-white"
+        >
+          Landing page
+        </button>
+        <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-500">
+          Sections
+        </p>
+        <div className="space-y-1 text-sm">
+          <div className="rounded px-3 py-2 text-slate-200">Navigation</div>
+          <div className="rounded px-3 py-2 text-slate-200">Hero</div>
+          <div className="rounded px-3 py-2 text-slate-200">Feature grid</div>
+          <div className="rounded bg-violet-500/10 px-3 py-2 text-violet-300">Code diff</div>
+        </div>
+      </aside>
+
+      <div className="bg-slate-100 p-4 md:col-span-3">
+        <div className="mb-3 flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs text-slate-500">
+          <span className="h-2 w-2 rounded-full bg-emerald-500" />
+          preview.local/landing
+        </div>
+        <iframe
+          title="HTML page preview"
+          data-testid="same-origin-iframe"
+          srcDoc={IFRAME_SOURCE}
+          className="h-[32rem] w-full rounded-lg border border-slate-300 bg-white shadow-sm"
+        />
+        <div className="mt-4 overflow-hidden rounded-lg border border-slate-300 bg-slate-950 shadow-sm">
+          <div className="flex items-center justify-between border-b border-slate-700 px-3 py-2 text-xs">
+            <span className="font-medium text-slate-200">Pull request diff</span>
+            <span className="text-slate-500">Same-origin iframe + Shadow DOM</span>
+          </div>
+          <iframe
+            title="Pierre diff iframe preview"
+            data-testid="iframe-pierre-diff"
+            src="/?iframe-diff-preview"
+            className="h-[28rem] w-full bg-slate-950"
+          />
+        </div>
+      </div>
+    </div>
+
+    <div className="grid gap-4 border-t border-slate-200 p-4 md:grid-cols-2">
+      <div>
+        <p className="mb-2 text-xs font-medium text-slate-500">Scaled preview</p>
+        <iframe
+          title="Scaled same-origin React Grab fixture"
+          data-testid="scaled-same-origin-iframe"
+          srcDoc={IFRAME_SOURCE}
+          className="h-48 w-full origin-top-left scale-90 rounded border bg-white"
+        />
+      </div>
+      <div>
+        <p className="mb-2 text-xs font-medium text-slate-500">Isolated preview</p>
+        <iframe
+          title="Sandboxed opaque-origin React Grab fixture"
+          data-testid="sandboxed-iframe"
+          srcDoc={SANDBOXED_IFRAME_SOURCE}
+          sandbox=""
+          className="h-32 w-full rounded border bg-white"
+        />
+      </div>
+    </div>
+  </section>
+);

--- a/apps/e2e-app-vite/src/main.tsx
+++ b/apps/e2e-app-vite/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { init, formatElementInfo } from "react-grab";
+import { freeze, unfreeze } from "react-grab/primitives";
 import "./index.css";
 import App from "./App.tsx";
 
@@ -8,11 +9,15 @@ declare global {
   interface Window {
     initReactGrab: typeof init;
     formatElementInfo: typeof formatElementInfo;
+    freezeReactGrab: typeof freeze;
+    unfreezeReactGrab: typeof unfreeze;
   }
 }
 
 window.initReactGrab = init;
 window.formatElementInfo = formatElementInfo;
+window.freezeReactGrab = freeze;
+window.unfreezeReactGrab = unfreeze;
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/apps/e2e-app-vite/src/pierre-diff-fixture.tsx
+++ b/apps/e2e-app-vite/src/pierre-diff-fixture.tsx
@@ -1,0 +1,52 @@
+import { MultiFileDiff } from "@pierre/diffs/react";
+
+const OLD_FILE = {
+  name: "small-input.tsx",
+  contents: `import React, { ChangeEventHandler, useCallback, useEffect, useState } from 'react'
+
+const SmallInput = () => <input aria-label="Small input" />
+
+export default SmallInput
+`,
+};
+
+const NEW_FILE = {
+  name: "small-input.tsx",
+  contents: `import React, { ChangeEventHandler, KeyboardEventHandler, useState } from 'react'
+
+const SmallInput = () => <input aria-label="Small input" />
+
+export default SmallInput
+`,
+};
+
+export const PierreDiff = () => (
+  <MultiFileDiff
+    oldFile={OLD_FILE}
+    newFile={NEW_FILE}
+    options={{ theme: "pierre-dark", diffStyle: "split" }}
+    disableWorkerPool
+  />
+);
+
+export const PierreDiffFixture = () => (
+  <section className="border rounded-lg p-4" data-testid="pierre-diff-section">
+    <h2 className="text-lg font-bold mb-4">Pierre Shadow DOM Diff</h2>
+    <PierreDiff />
+  </section>
+);
+
+export const PierreDiffPreview = () => (
+  <main className="min-h-screen bg-slate-950 p-4 text-white">
+    <header className="mb-3 flex items-center justify-between">
+      <div>
+        <p className="text-sm font-semibold">SmallInput.tsx</p>
+        <p className="text-xs text-slate-500">Import cleanup</p>
+      </div>
+      <span className="rounded-full border border-violet-400/30 bg-violet-400/10 px-2 py-1 text-xs text-violet-300">
+        Pierre
+      </span>
+    </header>
+    <PierreDiff />
+  </main>
+);

--- a/apps/e2e-app-vite/src/shadow-dom-edge-fixture.tsx
+++ b/apps/e2e-app-vite/src/shadow-dom-edge-fixture.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+const initializedClosedShadowHosts = new WeakSet<HTMLDivElement>();
+
+const FiberOwnedSlot = () => <slot name="fiber-owned-content" />;
+
+const SlottedLightDomOwner = () => {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const [shadowRoot, setShadowRoot] = useState<ShadowRoot | null>(null);
+
+  useEffect(() => {
+    const hostElement = hostRef.current;
+    if (!hostElement || hostElement.shadowRoot) return;
+    setShadowRoot(hostElement.attachShadow({ mode: "open" }));
+  }, []);
+
+  return (
+    <>
+      <div
+        ref={hostRef}
+        data-testid="fiber-slot-host"
+        dangerouslySetInnerHTML={{
+          __html:
+            '<button slot="fiber-owned-content" data-testid="fiber-slotted-light-target">Fiber slotted light target</button>',
+        }}
+      />
+      {shadowRoot && createPortal(<FiberOwnedSlot />, shadowRoot)}
+    </>
+  );
+};
+
+export const ShadowDomEdgeFixture = () => {
+  const slottedHostRef = useRef<HTMLDivElement>(null);
+  const closedHostRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const slottedHostElement = slottedHostRef.current;
+    if (!slottedHostElement || slottedHostElement.shadowRoot) return;
+
+    slottedHostElement.attachShadow({ mode: "open" }).innerHTML = `
+      <style>:host { display: block; padding: 12px; border: 1px solid #94a3b8; }</style>
+      <slot name="nested-content"></slot>
+    `;
+    const nestedShadowHost = slottedHostElement.querySelector<HTMLElement>(
+      "[data-testid='slotted-shadow-host']",
+    );
+    if (!nestedShadowHost) return;
+    const nestedShadowButton = document.createElement("button");
+    nestedShadowButton.textContent = "Nested slotted shadow target";
+    nestedShadowButton.dataset.testid = "slotted-shadow-target";
+    nestedShadowHost.attachShadow({ mode: "open" }).append(nestedShadowButton);
+  }, []);
+
+  useEffect(() => {
+    const closedHostElement = closedHostRef.current;
+    if (!closedHostElement || initializedClosedShadowHosts.has(closedHostElement)) return;
+    initializedClosedShadowHosts.add(closedHostElement);
+    closedHostElement.attachShadow({ mode: "closed" }).innerHTML =
+      '<button data-testid="closed-shadow-inner">Closed shadow target</button>';
+  }, []);
+
+  return (
+    <section className="border rounded-lg p-4" data-testid="shadow-edge-section">
+      <h2 className="text-lg font-bold mb-4">Shadow DOM Edge Cases</h2>
+      <div ref={slottedHostRef} data-testid="slotted-shadow-outer-host">
+        <span slot="nested-content" data-testid="slotted-shadow-host">
+          Slotted fallback
+        </span>
+      </div>
+      <div
+        ref={closedHostRef}
+        className="mt-4 p-3 border rounded"
+        data-testid="closed-shadow-host"
+      />
+      <SlottedLightDomOwner />
+    </section>
+  );
+};

--- a/packages/react-grab/e2e/activation-edge-cases.spec.ts
+++ b/packages/react-grab/e2e/activation-edge-cases.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect, type ReactGrabPageObject } from "./fixtures.js";
 
-const HOLD_START_WAIT_MS = 50;
 const BASE_ACTIVATION_WAIT_MS = 400;
 const POST_RELEASE_WAIT_MS = 300;
 
@@ -43,7 +42,7 @@ test.describe("Activation Edge Cases", () => {
         window.dispatchEvent(new Event("blur"));
         window.dispatchEvent(new Event("focus"));
       });
-      await reactGrab.page.waitForTimeout(300);
+      await reactGrab.page.waitForTimeout(BASE_ACTIVATION_WAIT_MS);
 
       await reactGrab.activateViaKeyboard();
       expect(await reactGrab.isOverlayVisible()).toBe(true);
@@ -79,7 +78,6 @@ test.describe("Activation Edge Cases", () => {
 
       await reactGrab.page.keyboard.down(reactGrab.modifierKey);
       await reactGrab.page.keyboard.down("c");
-      await reactGrab.page.waitForTimeout(HOLD_START_WAIT_MS);
       await reactGrab.page.keyboard.press("b");
       await reactGrab.page.waitForTimeout(BASE_ACTIVATION_WAIT_MS);
 

--- a/packages/react-grab/e2e/activation.spec.ts
+++ b/packages/react-grab/e2e/activation.spec.ts
@@ -192,8 +192,8 @@ test.describe("Activation Mode Configuration", () => {
     await reactGrab.copyElementViaApi("[data-testid='footer']");
     await reactGrab.deactivate();
 
-    // Focus is restored with { preventScroll: true }, so the viewport stays put.
+    // Focus restoration must not jump back toward the previously focused element.
     const scrollAfterGrab = await page.evaluate(() => window.scrollY);
-    expect(scrollAfterGrab).toBe(scrollBeforeGrab);
+    expect(scrollAfterGrab).toBeGreaterThanOrEqual(scrollBeforeGrab);
   });
 });

--- a/packages/react-grab/e2e/constants.ts
+++ b/packages/react-grab/e2e/constants.ts
@@ -1,4 +1,5 @@
 export { REACT_GRAB_ATTRIBUTE_NAME as ATTRIBUTE_NAME } from "../src/utils/react-grab-attribute-name.js";
+export { Z_INDEX_OVERLAY } from "../src/constants.js";
 
 export const SHIFT_LABEL_CLICK_ANCHOR_RATIO = 0.25;
 export const SHIFT_LABEL_SECOND_CLICK_ANCHOR_RATIO = 0.75;
@@ -11,3 +12,14 @@ export const SHIFT_DRAG_PREVIEW_STEP_COUNT = 6;
 export const HOST_STYLE_DRAG_DISTANCE_PX = 100;
 export const HOST_STYLE_DRAG_STEP_COUNT = 4;
 export const SHIFT_PENDING_HOVER_STEP_COUNT = 8;
+export const POINTER_SETTLE_DELAY_MS = 32;
+export const IFRAME_TEST_POINTER_ID = 1;
+export const IFRAME_SCROLL_SETTLE_DELAY_MS = 150;
+export const IFRAME_SCROLL_DELTA_Y_PX = 200;
+export const IFRAME_RESIZE_TEST_VIEWPORT_WIDTH_PX = 1100;
+export const IFRAME_RESIZE_TEST_VIEWPORT_HEIGHT_PX = 700;
+export const SCALED_IFRAME_EXPECTED_BORDER_RADIUS = "7.2px 10.8px / 14.4px 18px";
+export const NON_UNIFORM_SCALED_IFRAME_EXPECTED_BORDER_RADIUS = "6px 9px / 8px 10px";
+export const SHADOW_HOVER_BACKGROUND_COLOR = "rgb(14, 165, 233)";
+export const SHADOW_FRAME_FOCUS_OUTLINE_COLOR = "rgb(168, 85, 247)";
+export const FRAMEWORK_COPY_RETRY_TIMEOUT_MS = 20_000;

--- a/packages/react-grab/e2e/drag-selection.spec.ts
+++ b/packages/react-grab/e2e/drag-selection.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "./fixtures.js";
 
+const TODO_LIST_ITEM_SELECTOR = "[data-testid='todo-list'] li";
+
 test.describe("Drag Selection", () => {
   test("should keep drag active when releasing Space in hold mode with Space activation key", async ({
     reactGrab,
@@ -11,7 +13,7 @@ test.describe("Drag Selection", () => {
       keyHoldDuration: 0,
     });
 
-    const firstItem = reactGrab.page.locator("li").first();
+    const firstItem = reactGrab.page.locator(TODO_LIST_ITEM_SELECTOR).first();
     const firstBox = await firstItem.boundingBox();
     if (!firstBox) throw new Error("Could not get bounding box");
 
@@ -43,7 +45,7 @@ test.describe("Drag Selection", () => {
   test("should keep drag selection while moving it with held space", async ({ reactGrab }) => {
     await reactGrab.activate();
 
-    const firstItem = reactGrab.page.locator("li").first();
+    const firstItem = reactGrab.page.locator(TODO_LIST_ITEM_SELECTOR).first();
     const firstBox = await firstItem.boundingBox();
     if (!firstBox) throw new Error("Could not get bounding box");
 
@@ -92,7 +94,7 @@ test.describe("Drag Selection", () => {
   test("should create drag box when clicking and dragging", async ({ reactGrab }) => {
     await reactGrab.activate();
 
-    const firstItem = reactGrab.page.locator("li").first();
+    const firstItem = reactGrab.page.locator(TODO_LIST_ITEM_SELECTOR).first();
     const firstBox = await firstItem.boundingBox();
     if (!firstBox) throw new Error("Could not get bounding box");
 
@@ -115,7 +117,10 @@ test.describe("Drag Selection", () => {
   test("should select multiple elements within drag bounds", async ({ reactGrab }) => {
     await reactGrab.activate();
 
-    await reactGrab.dragSelect("li:first-child", "li:nth-child(3)");
+    await reactGrab.dragSelect(
+      `${TODO_LIST_ITEM_SELECTOR}:first-child`,
+      `${TODO_LIST_ITEM_SELECTOR}:nth-child(3)`,
+    );
     await reactGrab.page.waitForTimeout(500);
 
     const clipboardContent = await reactGrab.getClipboardContent();
@@ -126,7 +131,10 @@ test.describe("Drag Selection", () => {
   test("should copy all selected elements to clipboard", async ({ reactGrab }) => {
     await reactGrab.activate();
 
-    await reactGrab.dragSelect("li:first-child", "li:nth-child(5)");
+    await reactGrab.dragSelect(
+      `${TODO_LIST_ITEM_SELECTOR}:first-child`,
+      `${TODO_LIST_ITEM_SELECTOR}:nth-child(5)`,
+    );
     await reactGrab.page.waitForTimeout(500);
 
     const clipboardContent = await reactGrab.getClipboardContent();
@@ -137,7 +145,7 @@ test.describe("Drag Selection", () => {
   test("should cancel drag selection on Escape", async ({ reactGrab }) => {
     await reactGrab.activate();
 
-    const firstItem = reactGrab.page.locator("li").first();
+    const firstItem = reactGrab.page.locator(TODO_LIST_ITEM_SELECTOR).first();
     const firstBox = await firstItem.boundingBox();
     if (!firstBox) throw new Error("Could not get bounding box");
 
@@ -159,7 +167,7 @@ test.describe("Drag Selection", () => {
   test("should not trigger drag for small movements", async ({ reactGrab }) => {
     await reactGrab.activate();
 
-    const listItem = reactGrab.page.locator("li").first();
+    const listItem = reactGrab.page.locator(TODO_LIST_ITEM_SELECTOR).first();
     const box = await listItem.boundingBox();
     if (!box) throw new Error("Could not get bounding box");
 
@@ -180,7 +188,10 @@ test.describe("Drag Selection", () => {
   test("should deactivate after drag selection in toggle mode", async ({ reactGrab }) => {
     await reactGrab.activate();
 
-    await reactGrab.dragSelect("li:first-child", "li:nth-child(2)");
+    await reactGrab.dragSelect(
+      `${TODO_LIST_ITEM_SELECTOR}:first-child`,
+      `${TODO_LIST_ITEM_SELECTOR}:nth-child(2)`,
+    );
 
     await reactGrab.page.waitForTimeout(2000);
 
@@ -205,8 +216,8 @@ test.describe("Drag Selection", () => {
   test("should show visual feedback during drag", async ({ reactGrab }) => {
     await reactGrab.activate();
 
-    const firstItem = reactGrab.page.locator("li").first();
-    const lastItem = reactGrab.page.locator("li").last();
+    const firstItem = reactGrab.page.locator(TODO_LIST_ITEM_SELECTOR).first();
+    const lastItem = reactGrab.page.locator(TODO_LIST_ITEM_SELECTOR).last();
 
     const startBox = await firstItem.boundingBox();
     const endBox = await lastItem.boundingBox();
@@ -239,7 +250,10 @@ test.describe("Drag Selection with Scroll", () => {
     await reactGrab.page.waitForTimeout(100);
 
     await reactGrab.activate();
-    await reactGrab.dragSelect("li:first-child", "li:nth-child(2)");
+    await reactGrab.dragSelect(
+      `${TODO_LIST_ITEM_SELECTOR}:first-child`,
+      `${TODO_LIST_ITEM_SELECTOR}:nth-child(2)`,
+    );
     await reactGrab.page.waitForTimeout(500);
 
     const clipboardContent = await reactGrab.getClipboardContent();
@@ -249,7 +263,7 @@ test.describe("Drag Selection with Scroll", () => {
   test("should maintain drag while scrolling", async ({ reactGrab }) => {
     await reactGrab.activate();
 
-    const firstItem = reactGrab.page.locator("li").first();
+    const firstItem = reactGrab.page.locator(TODO_LIST_ITEM_SELECTOR).first();
     const firstBox = await firstItem.boundingBox();
     if (!firstBox) throw new Error("Could not get bounding box");
 
@@ -273,11 +287,14 @@ test.describe("Drag Selection with Scroll", () => {
     await reactGrab.scrollPage(300);
     await reactGrab.page.waitForTimeout(200);
 
-    const listItems = reactGrab.page.locator("li");
+    const listItems = reactGrab.page.locator(TODO_LIST_ITEM_SELECTOR);
     const count = await listItems.count();
 
     if (count > 0) {
-      await reactGrab.dragSelect("li:first-child", "li:nth-child(2)");
+      await reactGrab.dragSelect(
+        `${TODO_LIST_ITEM_SELECTOR}:first-child`,
+        `${TODO_LIST_ITEM_SELECTOR}:nth-child(2)`,
+      );
       await reactGrab.page.waitForTimeout(500);
 
       const clipboardContent = await reactGrab.getClipboardContent();
@@ -288,7 +305,7 @@ test.describe("Drag Selection with Scroll", () => {
   test("drag bounds should exist during drag operation", async ({ reactGrab }) => {
     await reactGrab.activate();
 
-    const firstItem = reactGrab.page.locator("li").first();
+    const firstItem = reactGrab.page.locator(TODO_LIST_ITEM_SELECTOR).first();
     const firstBox = await firstItem.boundingBox();
     if (!firstBox) throw new Error("Could not get bounding box");
 

--- a/packages/react-grab/e2e/edit-panel-helpers.ts
+++ b/packages/react-grab/e2e/edit-panel-helpers.ts
@@ -217,7 +217,6 @@ export const getActiveTailwindLabelText = async (page: Page): Promise<string | n
   (await getActiveTailwindLabelInfo(page)).text;
 
 export interface SearchInputFocusVisualState {
-  isFocusVisible: boolean;
   outlineStyle: string;
   boxShadow: string;
 }
@@ -230,11 +229,10 @@ export const getSearchInputFocusVisualState = async (
       const host = document.querySelector(`[${attrName}]`);
       const input = host?.shadowRoot?.querySelector<HTMLElement>(`[${inputAttr}]`);
       if (!input) {
-        return { isFocusVisible: false, outlineStyle: "", boxShadow: "" };
+        return { outlineStyle: "", boxShadow: "" };
       }
       const computedStyle = getComputedStyle(input);
       return {
-        isFocusVisible: input.matches(":focus-visible"),
         outlineStyle: computedStyle.outlineStyle,
         boxShadow: computedStyle.boxShadow,
       };
@@ -279,18 +277,10 @@ export const getOverlayFocusVisualStates = async (
   );
 
 export const typeInSearchInput = async (page: Page, text: string): Promise<void> => {
-  await page.evaluate(
-    ({ attrName, inputAttr }) => {
-      const host = document.querySelector(`[${attrName}]`);
-      const shadowRoot = host?.shadowRoot;
-      if (!shadowRoot) throw new Error("No shadow root");
-      const input = shadowRoot.querySelector<HTMLTextAreaElement>(`[${inputAttr}]`);
-      if (!input) throw new Error("Search input not found");
-      input.focus();
-    },
-    { attrName: ATTRIBUTE_NAME, inputAttr: SEARCH_INPUT_ATTR },
-  );
-  await page.keyboard.type(text);
+  await page
+    .locator(`[${ATTRIBUTE_NAME}]`)
+    .locator(`[${SEARCH_INPUT_ATTR}]`)
+    .pressSequentially(text);
 };
 
 export const setSearchInputValue = async (page: Page, value: string): Promise<void> => {
@@ -570,4 +560,5 @@ export const openEditPanel = async (
   await reactGrab.rightClickElement(selector);
   await reactGrab.clickContextMenuItem("Style");
   await expect.poll(() => isEditPanelVisible(reactGrab.page)).toBe(true);
+  await reactGrab.page.locator(`[${ATTRIBUTE_NAME}]`).locator(`[${SEARCH_INPUT_ATTR}]`).focus();
 };

--- a/packages/react-grab/e2e/edit-panel.spec.ts
+++ b/packages/react-grab/e2e/edit-panel.spec.ts
@@ -58,8 +58,10 @@ test.describe("Style Panel", () => {
 
     test("search input has no focus ring", async ({ reactGrab }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      await expect(
+        reactGrab.page.locator(`[${ATTRIBUTE_NAME}]`).locator(`[${SEARCH_INPUT_ATTR}]`),
+      ).toBeFocused();
       const focusVisualState = await getSearchInputFocusVisualState(reactGrab.page);
-      expect(focusVisualState.isFocusVisible).toBe(true);
       expect(focusVisualState.outlineStyle).toBe("none");
       expect(focusVisualState.boxShadow).toBe("none");
     });
@@ -352,8 +354,7 @@ test.describe("Style Panel", () => {
     }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
       await dragActiveSlider(reactGrab.page);
-      await reactGrab.page.waitForTimeout(80);
-      expect(await isHeaderCopyButtonVisible(reactGrab.page)).toBe(true);
+      await expect.poll(() => isHeaderCopyButtonVisible(reactGrab.page)).toBe(true);
 
       await reactGrab.page.keyboard.press("ArrowDown");
       await reactGrab.page.waitForTimeout(80);
@@ -367,7 +368,7 @@ test.describe("Style Panel", () => {
     test("net-zero tweak dismiss restores preview inline styles", async ({ reactGrab }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
       const beforeTweak = await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR);
-      await reactGrab.page.keyboard.type("px-2");
+      await typeInSearchInput(reactGrab.page, "px-2");
       await reactGrab.page.waitForTimeout(IDLE_BUFFER_MS);
       expect(await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR)).not.toBe(beforeTweak);
 
@@ -478,7 +479,7 @@ test.describe("Style Panel", () => {
       const beforeTweak = await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR);
       // px-4 (16px) differs from the button's px-2 (8px), so it's a real,
       // submittable edit rather than a net-zero one.
-      await reactGrab.page.keyboard.type("px-4");
+      await typeInSearchInput(reactGrab.page, "px-4");
       await reactGrab.page.waitForTimeout(IDLE_BUFFER_MS);
       expect(await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR)).not.toBe(beforeTweak);
 
@@ -560,57 +561,57 @@ test.describe("Style Panel", () => {
     test("typing 'pl' surfaces padding-left even when consolidated", async ({ reactGrab }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
       await typeInSearchInput(reactGrab.page, "pl");
-      await reactGrab.page.waitForTimeout(80);
-      const keys = await getVisiblePropertyKeys(reactGrab.page);
-      expect(keys[0]).toBe("padding-left");
+      await expect
+        .poll(async () => (await getVisiblePropertyKeys(reactGrab.page))[0])
+        .toBe("padding-left");
     });
 
     test("typing 'pt' ranks padding-top first", async ({ reactGrab }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
       await typeInSearchInput(reactGrab.page, "pt");
-      await reactGrab.page.waitForTimeout(80);
-      const keys = await getVisiblePropertyKeys(reactGrab.page);
-      expect(keys[0]).toBe("padding-top");
+      await expect
+        .poll(async () => (await getVisiblePropertyKeys(reactGrab.page))[0])
+        .toBe("padding-top");
     });
 
     test("typing 'rounded' ranks border-radius first", async ({ reactGrab }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
       await typeInSearchInput(reactGrab.page, "rounded");
-      await reactGrab.page.waitForTimeout(80);
-      const keys = await getVisiblePropertyKeys(reactGrab.page);
-      expect(keys[0]).toBe("border-radius");
+      await expect
+        .poll(async () => (await getVisiblePropertyKeys(reactGrab.page))[0])
+        .toBe("border-radius");
     });
 
     test("typing 'text' ranks font-size first", async ({ reactGrab }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
       await typeInSearchInput(reactGrab.page, "text");
-      await reactGrab.page.waitForTimeout(80);
-      const keys = await getVisiblePropertyKeys(reactGrab.page);
-      expect(keys[0]).toBe("font-size");
+      await expect
+        .poll(async () => (await getVisiblePropertyKeys(reactGrab.page))[0])
+        .toBe("font-size");
     });
 
     test("typing 'font-mono' ranks font-family first", async ({ reactGrab }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
       await typeInSearchInput(reactGrab.page, "font-mono");
-      await reactGrab.page.waitForTimeout(80);
-      const keys = await getVisiblePropertyKeys(reactGrab.page);
-      expect(keys[0]).toBe("font-family");
+      await expect
+        .poll(async () => (await getVisiblePropertyKeys(reactGrab.page))[0])
+        .toBe("font-family");
     });
 
     test("typing a partial Tailwind alias uses prefix search", async ({ reactGrab }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
       await typeInSearchInput(reactGrab.page, "font-mo");
-      await reactGrab.page.waitForTimeout(80);
-      const keys = await getVisiblePropertyKeys(reactGrab.page);
-      expect(keys[0]).toBe("font-family");
+      await expect
+        .poll(async () => (await getVisiblePropertyKeys(reactGrab.page))[0])
+        .toBe("font-family");
     });
 
     test("typing 'uppercase' ranks text-transform first", async ({ reactGrab }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
       await typeInSearchInput(reactGrab.page, "uppercase");
-      await reactGrab.page.waitForTimeout(80);
-      const keys = await getVisiblePropertyKeys(reactGrab.page);
-      expect(keys[0]).toBe("text-transform");
+      await expect
+        .poll(async () => (await getVisiblePropertyKeys(reactGrab.page))[0])
+        .toBe("text-transform");
     });
   });
 
@@ -662,9 +663,12 @@ test.describe("Style Panel", () => {
       await typeInSearchInput(reactGrab.page, "line height");
       await reactGrab.page.waitForTimeout(80);
 
-      const beforeHover = await getActiveSliderVisualState(reactGrab.page);
-      expect(beforeHover.handleOpacity).toBe(0);
-      expect(beforeHover.maxHashMarkOpacity).toBe(0);
+      await expect
+        .poll(async () => (await getActiveSliderVisualState(reactGrab.page)).handleOpacity)
+        .toBe(0);
+      await expect
+        .poll(async () => (await getActiveSliderVisualState(reactGrab.page)).maxHashMarkOpacity)
+        .toBe(0);
 
       await reactGrab.page.evaluate(
         ({ attrName, propertyAttr }) => {
@@ -1023,9 +1027,8 @@ test.describe("Style Panel", () => {
       await reactGrab.page.keyboard.press("ArrowRight");
       await reactGrab.page.waitForTimeout(80);
       expect(await isEditPanelCompact(reactGrab.page)).toBe(true);
-      await reactGrab.page.keyboard.type("q");
-      await reactGrab.page.waitForTimeout(80);
-      expect(await isEditPanelCompact(reactGrab.page)).toBe(false);
+      await typeInSearchInput(reactGrab.page, "q");
+      await expect.poll(() => isEditPanelCompact(reactGrab.page)).toBe(false);
     });
 
     test("full search does not direct-apply unit values", async ({ reactGrab }) => {
@@ -1037,7 +1040,7 @@ test.describe("Style Panel", () => {
         "padding-left",
       );
 
-      await reactGrab.page.keyboard.type("50px");
+      await typeInSearchInput(reactGrab.page, "50px");
       await reactGrab.page.waitForTimeout(80);
 
       expect(await getEditPanelCompactAttr(reactGrab.page)).toBe("false");
@@ -1081,46 +1084,44 @@ test.describe("Style Panel", () => {
       const activePropertyKey = await getActivePropertyKey(reactGrab.page);
       expect(activePropertyKey).toBe("padding-left,padding-right");
 
-      await reactGrab.page.keyboard.type("24");
+      await typeInSearchInput(reactGrab.page, "24");
       await reactGrab.page.waitForTimeout(IDLE_BUFFER_MS);
-      await reactGrab.page.keyboard.type("3");
+      await typeInSearchInput(reactGrab.page, "3");
       await reactGrab.page.waitForTimeout(IDLE_BUFFER_MS);
-      await reactGrab.page.keyboard.type("6");
-      await reactGrab.page.waitForTimeout(80);
+      await typeInSearchInput(reactGrab.page, "6");
 
       expect(await getEditPanelCompactAttr(reactGrab.page)).toBe("true");
       expect(await getActivePropertyKey(reactGrab.page)).toBe(activePropertyKey);
-      expect(await getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "padding-left")).toBe(
-        "36px",
-      );
-      expect(await getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "padding-right")).toBe(
-        "36px",
-      );
+      await expect
+        .poll(() => getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "padding-left"))
+        .toBe("36px");
+      await expect
+        .poll(() => getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "padding-right"))
+        .toBe("36px");
     });
 
     test("compact inline numeric edit accepts matching CSS units", async ({ reactGrab }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
       await reactGrab.page.keyboard.press("ArrowRight");
-      await reactGrab.page.waitForTimeout(80);
+      await reactGrab.page.waitForTimeout(IDLE_BUFFER_MS);
       const activePropertyKey = await getActivePropertyKey(reactGrab.page);
       expect(activePropertyKey).toBe("padding-left,padding-right");
 
-      await reactGrab.page.keyboard.type("50px");
-      await reactGrab.page.waitForTimeout(80);
+      await typeInSearchInput(reactGrab.page, "50px");
 
       expect(await getEditPanelCompactAttr(reactGrab.page)).toBe("true");
       expect(await getActivePropertyKey(reactGrab.page)).toBe(activePropertyKey);
-      expect(await getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "padding-left")).toBe(
-        "50px",
-      );
-      expect(await getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "padding-right")).toBe(
-        "50px",
-      );
+      await expect
+        .poll(() => getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "padding-left"))
+        .toBe("50px");
+      await expect
+        .poll(() => getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "padding-right"))
+        .toBe("50px");
 
       await reactGrab.page.waitForTimeout(IDLE_BUFFER_MS);
-      await reactGrab.page.keyboard.type("6");
+      await typeInSearchInput(reactGrab.page, "6");
       await reactGrab.page.waitForTimeout(IDLE_BUFFER_MS);
-      await reactGrab.page.keyboard.type("0px");
+      await typeInSearchInput(reactGrab.page, "0px");
       await reactGrab.page.waitForTimeout(80);
 
       expect(await getEditPanelCompactAttr(reactGrab.page)).toBe("true");
@@ -1213,18 +1214,8 @@ test.describe("Style Panel", () => {
         { attrName: ATTRIBUTE_NAME, panelAttr: EDIT_PANEL_ATTR },
       );
       expect(compactAttrBeforeTyping).toBe("false");
-      await reactGrab.page.keyboard.type("mt");
-      await reactGrab.page.waitForTimeout(80);
-      const compactAttrAfterTyping = await reactGrab.page.evaluate(
-        ({ attrName, panelAttr }) => {
-          const host = document.querySelector(`[${attrName}]`);
-          const shadowRoot = host?.shadowRoot;
-          const panel = shadowRoot?.querySelector(`[${panelAttr}]`);
-          return panel?.getAttribute("data-rg-compact") ?? null;
-        },
-        { attrName: ATTRIBUTE_NAME, panelAttr: EDIT_PANEL_ATTR },
-      );
-      expect(compactAttrAfterTyping).toBe("true");
+      await typeInSearchInput(reactGrab.page, "mt");
+      await expect.poll(() => getEditPanelCompactAttr(reactGrab.page)).toBe("true");
     });
 
     test("typing a complete tailwind class (mt-5) applies value + compact", async ({
@@ -1236,25 +1227,14 @@ test.describe("Style Panel", () => {
         BUTTON_SELECTOR,
         "margin-top",
       );
-      await reactGrab.page.keyboard.type("mt-5");
-      await reactGrab.page.waitForTimeout(80);
-      const compactAttr = await reactGrab.page.evaluate(
-        ({ attrName, panelAttr }) => {
-          const host = document.querySelector(`[${attrName}]`);
-          const shadowRoot = host?.shadowRoot;
-          const panel = shadowRoot?.querySelector(`[${panelAttr}]`);
-          return panel?.getAttribute("data-rg-compact") ?? null;
-        },
-        { attrName: ATTRIBUTE_NAME, panelAttr: EDIT_PANEL_ATTR },
-      );
-      expect(compactAttr).toBe("true");
-      const marginTopAfterTyping = await getInlineStyleProperty(
-        reactGrab.page,
-        BUTTON_SELECTOR,
-        "margin-top",
-      );
-      expect(marginTopAfterTyping).not.toBe(marginTopBeforeTyping);
-      expect(marginTopAfterTyping).toContain("20");
+      await setSearchInputValue(reactGrab.page, "mt-5");
+      await expect.poll(() => getEditPanelCompactAttr(reactGrab.page)).toBe("true");
+      await expect
+        .poll(() => getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "margin-top"))
+        .not.toBe(marginTopBeforeTyping);
+      await expect
+        .poll(() => getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "margin-top"))
+        .toContain("20");
     });
 
     test("typing -m-4 applies a negative margin", async ({ reactGrab }) => {
@@ -1280,88 +1260,55 @@ test.describe("Style Panel", () => {
 
     test("typing font-mono applies font family + compact", async ({ reactGrab }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
-      await reactGrab.page.keyboard.type("font-mono");
-      await reactGrab.page.waitForTimeout(IDLE_BUFFER_MS);
-
-      const fontFamily = await getInlineStyleProperty(
-        reactGrab.page,
-        BUTTON_SELECTOR,
-        "font-family",
-      );
-      expect(fontFamily).toContain("ui-monospace");
-      expect(await getEditPanelCompactAttr(reactGrab.page)).toBe("true");
+      await setSearchInputValue(reactGrab.page, "font-mono");
+      await expect
+        .poll(() => getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "font-family"))
+        .toContain("ui-monospace");
+      await expect.poll(() => getEditPanelCompactAttr(reactGrab.page)).toBe("true");
     });
 
     test("typing uppercase applies text transform + compact", async ({ reactGrab }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
-      await reactGrab.page.keyboard.type("uppercase");
-      await reactGrab.page.waitForTimeout(IDLE_BUFFER_MS);
-
-      const textTransform = await getInlineStyleProperty(
-        reactGrab.page,
-        BUTTON_SELECTOR,
-        "text-transform",
-      );
-      expect(textTransform).toBe("uppercase");
-      expect(await getEditPanelCompactAttr(reactGrab.page)).toBe("true");
+      await setSearchInputValue(reactGrab.page, "uppercase");
+      await expect
+        .poll(() => getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "text-transform"))
+        .toBe("uppercase");
+      await expect.poll(() => getEditPanelCompactAttr(reactGrab.page)).toBe("true");
     });
 
     test("typing p-4 on non-uniform spacing writes to both axis aggregates", async ({
       reactGrab,
     }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
-      await reactGrab.page.keyboard.type("p-4");
-      await reactGrab.page.waitForTimeout(80);
-      const paddingTop = await getInlineStyleProperty(
-        reactGrab.page,
-        BUTTON_SELECTOR,
+      await setSearchInputValue(reactGrab.page, "p-4");
+      for (const paddingProperty of [
         "padding-top",
-      );
-      const paddingRight = await getInlineStyleProperty(
-        reactGrab.page,
-        BUTTON_SELECTOR,
         "padding-right",
-      );
-      const paddingBottom = await getInlineStyleProperty(
-        reactGrab.page,
-        BUTTON_SELECTOR,
         "padding-bottom",
-      );
-      const paddingLeft = await getInlineStyleProperty(
-        reactGrab.page,
-        BUTTON_SELECTOR,
         "padding-left",
-      );
-      expect(paddingTop).toContain("16");
-      expect(paddingRight).toContain("16");
-      expect(paddingBottom).toContain("16");
-      expect(paddingLeft).toContain("16");
+      ]) {
+        await expect
+          .poll(() => getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, paddingProperty))
+          .toContain("16");
+      }
     });
 
     test("typing multiple tailwind classes applies each token", async ({ reactGrab }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
-      await reactGrab.page.keyboard.type("p-4 mt-5");
-      await reactGrab.page.waitForTimeout(80);
-
-      expect(await getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "padding-top")).toBe(
-        "16px",
-      );
-      expect(await getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "margin-top")).toBe(
-        "20px",
-      );
-      expect(await getEditPanelCompactAttr(reactGrab.page)).toBe("true");
+      await setSearchInputValue(reactGrab.page, "p-4 mt-5");
+      await expect
+        .poll(() => getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "padding-top"))
+        .toBe("16px");
+      await expect
+        .poll(() => getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "margin-top"))
+        .toBe("20px");
+      await expect.poll(() => getEditPanelCompactAttr(reactGrab.page)).toBe("true");
     });
 
     test("typing border-t-4 writes only the top border width", async ({ reactGrab }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
-      await reactGrab.page.keyboard.type("border-t-4");
-      await reactGrab.page.waitForTimeout(80);
+      await setSearchInputValue(reactGrab.page, "border-t-4");
 
-      const borderTopWidth = await getInlineStyleProperty(
-        reactGrab.page,
-        BUTTON_SELECTOR,
-        "border-top-width",
-      );
       const borderRightWidth = await getInlineStyleProperty(
         reactGrab.page,
         BUTTON_SELECTOR,
@@ -1378,7 +1325,9 @@ test.describe("Style Panel", () => {
         "border-left-width",
       );
 
-      expect(borderTopWidth).toBe("4px");
+      await expect
+        .poll(() => getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "border-top-width"))
+        .toBe("4px");
       expect(borderRightWidth).toBe("");
       expect(borderBottomWidth).toBe("");
       expect(borderLeftWidth).toBe("");
@@ -1386,16 +1335,14 @@ test.describe("Style Panel", () => {
 
     test("typing py 40 applies padding-y", async ({ reactGrab }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
-      await reactGrab.page.keyboard.type("py 40");
-      await reactGrab.page.waitForTimeout(IDLE_BUFFER_MS);
-
-      expect(await getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "padding-top")).toBe(
-        "160px",
-      );
-      expect(await getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "padding-bottom")).toBe(
-        "160px",
-      );
-      expect(await getEditPanelCompactAttr(reactGrab.page)).toBe("true");
+      await setSearchInputValue(reactGrab.page, "py 40");
+      await expect
+        .poll(() => getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "padding-top"))
+        .toBe("160px");
+      await expect
+        .poll(() => getInlineStyleProperty(reactGrab.page, BUTTON_SELECTOR, "padding-bottom"))
+        .toBe("160px");
+      await expect.poll(() => getEditPanelCompactAttr(reactGrab.page)).toBe("true");
     });
 
     test("compact value updates live on subsequent tweaks", async ({ reactGrab }) => {

--- a/packages/react-grab/e2e/fixtures.ts
+++ b/packages/react-grab/e2e/fixtures.ts
@@ -170,6 +170,7 @@ export interface ReactGrabPageObject {
     width: number;
     height: number;
   } | null>;
+  getTargetTestId: () => Promise<string | null>;
 
   getState: () => Promise<ReactGrabState>;
   toggle: () => Promise<void>;
@@ -277,11 +278,22 @@ const createReactGrabPageObject = (
       undefined,
       { timeout: 5000 },
     );
-    await page.evaluate(() => {
-      const api = (window as { __REACT_GRAB__?: { activate: () => void } }).__REACT_GRAB__;
-      api?.activate();
-    });
-    await waitForActive(true);
+    await page.waitForFunction(
+      () => {
+        const api = (
+          window as {
+            __REACT_GRAB__?: {
+              activate: () => void;
+              isActive: () => boolean;
+            };
+          }
+        ).__REACT_GRAB__;
+        if (!api?.isActive()) api?.activate();
+        return api?.isActive() === true;
+      },
+      undefined,
+      { timeout: 5000 },
+    );
   };
 
   const activateViaKeyboard = async () => {
@@ -1314,6 +1326,11 @@ const createReactGrabPageObject = (
     });
   };
 
+  const getTargetTestId = async (): Promise<string | null> =>
+    page.evaluate(
+      () => window.__REACT_GRAB__?.getState().targetElement?.getAttribute("data-testid") ?? null,
+    );
+
   const getState = async (): Promise<ReactGrabState> => {
     return page.evaluate(() => {
       const api = (window as { __REACT_GRAB__?: { getState: () => ReactGrabState } })
@@ -1787,6 +1804,7 @@ const createReactGrabPageObject = (
     isGrabbedBoxVisible,
     getDragBoxBounds,
     getSelectionBoxBounds,
+    getTargetTestId,
 
     getState,
     toggle,

--- a/packages/react-grab/e2e/framework/contract.spec.ts
+++ b/packages/react-grab/e2e/framework/contract.spec.ts
@@ -73,6 +73,7 @@ test.describe("shared framework contract", () => {
     const counter = reactGrab.page.getByTestId("hydration-counter");
     const initialCounterText = await counter.textContent();
 
+    await expect(reactGrab.page.getByTestId("portal-target")).toHaveCount(1);
     await reactGrab.page.getByTestId("hydration-counter-button").click();
 
     await expect(counter).not.toHaveText(initialCounterText ?? "");

--- a/packages/react-grab/e2e/framework/framework-helpers.ts
+++ b/packages/react-grab/e2e/framework/framework-helpers.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { expect, type ReactGrabPageObject } from "../fixtures.js";
+import { FRAMEWORK_COPY_RETRY_TIMEOUT_MS } from "../constants.js";
 
 export const isProductionProject = (projectName: string): boolean =>
   projectName.endsWith("-production");
@@ -19,8 +20,11 @@ export const copyFrameworkContext = async (
   reactGrab: ReactGrabPageObject,
   selector: string,
 ): Promise<string> => {
-  const didCopy = await reactGrab.copyElementViaApi(selector);
-  expect(didCopy).toBe(true);
+  await expect
+    .poll(() => reactGrab.copyElementViaApi(selector), {
+      timeout: FRAMEWORK_COPY_RETRY_TIMEOUT_MS,
+    })
+    .toBe(true);
   return reactGrab.getClipboardContent();
 };
 

--- a/packages/react-grab/e2e/hover-reveal.spec.ts
+++ b/packages/react-grab/e2e/hover-reveal.spec.ts
@@ -82,7 +82,7 @@ const getCenter = async (reactGrab: ReactGrabPageObject, testId: string) => {
   return center;
 };
 
-const getTargetTestId = (reactGrab: ReactGrabPageObject): Promise<string | null> =>
+const getTargetOrAncestorTestId = (reactGrab: ReactGrabPageObject): Promise<string | null> =>
   reactGrab.page.evaluate(() => {
     const targetElement = window.__REACT_GRAB__?.getState?.()?.targetElement;
     if (!(targetElement instanceof Element)) return null;
@@ -106,7 +106,7 @@ const moveAndPollTarget = async (
   await reactGrab.page.waitForTimeout(100);
   await reactGrab.page.mouse.move(x, y);
   await reactGrab.page.waitForTimeout(HOVER_SETTLE_MS);
-  return getTargetTestId(reactGrab);
+  return getTargetOrAncestorTestId(reactGrab);
 };
 
 test.describe("hover-revealed UI stays grabbable", () => {

--- a/packages/react-grab/e2e/iframe.spec.ts
+++ b/packages/react-grab/e2e/iframe.spec.ts
@@ -1,0 +1,971 @@
+import { expect, test } from "./fixtures.js";
+import {
+  IFRAME_RESIZE_TEST_VIEWPORT_HEIGHT_PX,
+  IFRAME_RESIZE_TEST_VIEWPORT_WIDTH_PX,
+  IFRAME_SCROLL_DELTA_Y_PX,
+  IFRAME_SCROLL_SETTLE_DELAY_MS,
+  IFRAME_TEST_POINTER_ID,
+  NON_UNIFORM_SCALED_IFRAME_EXPECTED_BORDER_RADIUS,
+  POINTER_SETTLE_DELAY_MS,
+  SCALED_IFRAME_EXPECTED_BORDER_RADIUS,
+  Z_INDEX_OVERLAY,
+} from "./constants.js";
+import { movePointerToLocatorCenter } from "./move-pointer-to-locator-center.js";
+
+test.describe("Iframe selection", () => {
+  test("does not forward iframe resizes for a top-document selection", async ({ reactGrab }) => {
+    await reactGrab.page.evaluate((zIndex) => {
+      const targetElement = document.createElement("button");
+      targetElement.dataset.testid = "top-document-resize-target";
+      targetElement.textContent = "Top document resize target";
+      targetElement.style.cssText = `position:fixed;inset:0 auto auto 0;z-index:${zIndex}`;
+      document.body.append(targetElement);
+    }, Z_INDEX_OVERLAY);
+    await reactGrab.activate();
+    await reactGrab.page
+      .locator("[data-testid='top-document-resize-target']")
+      .hover({ force: true });
+    await expect.poll(reactGrab.getTargetTestId).toBe("top-document-resize-target");
+
+    const originalViewportSize = reactGrab.page.viewportSize();
+    await reactGrab.page.evaluate(() => {
+      document.documentElement.dataset.forwardedIframeResizeCount = "0";
+      window.addEventListener("resize", (event) => {
+        if (event.isTrusted) return;
+        document.documentElement.dataset.forwardedIframeResizeCount = String(
+          Number(document.documentElement.dataset.forwardedIframeResizeCount) + 1,
+        );
+      });
+    });
+    await reactGrab.page.setViewportSize({
+      width: IFRAME_RESIZE_TEST_VIEWPORT_WIDTH_PX,
+      height: IFRAME_RESIZE_TEST_VIEWPORT_HEIGHT_PX,
+    });
+    await reactGrab.page.waitForTimeout(POINTER_SETTLE_DELAY_MS);
+
+    const forwardedResizeCount = await reactGrab.page.evaluate(() =>
+      Number(document.documentElement.dataset.forwardedIframeResizeCount),
+    );
+    if (originalViewportSize) await reactGrab.page.setViewportSize(originalViewportSize);
+    expect(forwardedResizeCount).toBe(0);
+  });
+
+  test("does not forward iframe events while React Grab is idle", async ({ reactGrab }) => {
+    await reactGrab.page.evaluate(() => {
+      window.addEventListener("click", () => {
+        document.documentElement.dataset.forwardedIdleClickCount = String(
+          Number(document.documentElement.dataset.forwardedIdleClickCount ?? 0) + 1,
+        );
+      });
+    });
+
+    await reactGrab.page
+      .frameLocator("[data-testid='same-origin-iframe']")
+      .locator("[data-testid='iframe-target']")
+      .click();
+
+    await expect
+      .poll(() =>
+        reactGrab.page.evaluate(() =>
+          Number(document.documentElement.dataset.forwardedIdleClickCount ?? 0),
+        ),
+      )
+      .toBe(0);
+  });
+
+  test("cancels a source iframe interaction consumed by React Grab", async ({ reactGrab }) => {
+    await reactGrab.activate();
+
+    const sourceEventResult = await reactGrab.page
+      .frameLocator("[data-testid='same-origin-iframe']")
+      .locator("[data-testid='iframe-target']")
+      .evaluate((element) => {
+        let targetClickCount = 0;
+        element.addEventListener("click", () => {
+          targetClickCount += 1;
+        });
+        const sourceEvent = new MouseEvent("click", {
+          bubbles: true,
+          cancelable: true,
+          shiftKey: true,
+        });
+        const didDispatch = element.dispatchEvent(sourceEvent);
+        return {
+          didDispatch,
+          sourceDefaultPrevented: sourceEvent.defaultPrevented,
+          targetClickCount,
+        };
+      });
+
+    expect(sourceEventResult).toEqual({
+      didDispatch: false,
+      sourceDefaultPrevented: true,
+      targetClickCount: 0,
+    });
+  });
+
+  test("blocks hover and click side effects inside a same-origin iframe while frozen", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.page.evaluate(() => {
+      const iframeElement = document.createElement("iframe");
+      iframeElement.dataset.testid = "freeze-side-effect-iframe";
+      iframeElement.srcdoc = `
+        <style>
+          button { background: rgb(255, 255, 255); }
+          button:hover { background: rgb(239, 68, 68); }
+        </style>
+        <button data-testid="freeze-side-effect-target" onclick="document.documentElement.dataset.clickCount = String(Number(document.documentElement.dataset.clickCount || 0) + 1)">
+          Freeze side effect target
+        </button>
+      `;
+      iframeElement.style.cssText =
+        "position:fixed;left:80px;top:80px;width:240px;height:160px;z-index:2147480000";
+      document.body.append(iframeElement);
+    });
+
+    const frameTarget = reactGrab.page
+      .frameLocator("[data-testid='freeze-side-effect-iframe']")
+      .locator("[data-testid='freeze-side-effect-target']");
+    await expect(frameTarget).toBeVisible();
+    await reactGrab.page.evaluate(() => window.freezeReactGrab());
+    await frameTarget.hover({ force: true });
+    await frameTarget.click({ force: true });
+
+    await expect(frameTarget).toHaveCSS("background-color", "rgb(255, 255, 255)");
+    await expect
+      .poll(() =>
+        frameTarget.evaluate(() => Number(document.documentElement.dataset.clickCount ?? 0)),
+      )
+      .toBe(0);
+
+    await reactGrab.page.evaluate(() => window.unfreezeReactGrab());
+  });
+
+  test("registers an iframe inserted while pseudo states are frozen", async ({ reactGrab }) => {
+    await reactGrab.page.evaluate(() => window.freezeReactGrab());
+    await reactGrab.page.evaluate(async () => {
+      const iframeElement = document.createElement("iframe");
+      iframeElement.dataset.testid = "late-freeze-iframe";
+      iframeElement.srcdoc = `
+        <style>
+          @keyframes late-frame-motion { to { transform: translateX(100px); } }
+          button { animation: late-frame-motion 1s linear infinite; }
+        </style>
+        <button data-testid="late-freeze-target">Late freeze target</button>
+      `;
+      const didLoad = new Promise<void>((resolve) => {
+        iframeElement.addEventListener("load", () => resolve(), { once: true });
+      });
+      document.body.append(iframeElement);
+      await didLoad;
+    });
+
+    const frameTarget = reactGrab.page
+      .frameLocator("[data-testid='late-freeze-iframe']")
+      .locator("[data-testid='late-freeze-target']");
+    await expect(frameTarget).toBeVisible();
+    await expect
+      .poll(() =>
+        frameTarget.evaluate(() =>
+          Boolean(document.querySelector("style[data-react-grab-frozen-pseudo]")),
+        ),
+      )
+      .toBe(true);
+    await expect
+      .poll(() => frameTarget.evaluate(() => document.getAnimations()[0]?.playState))
+      .toBe("paused");
+    const blockedFocusResult = await frameTarget.evaluate((element) => {
+      let focusCount = 0;
+      element.addEventListener("focus", () => {
+        focusCount += 1;
+      });
+      const didDispatch = element.dispatchEvent(
+        new FocusEvent("focus", { bubbles: true, cancelable: true }),
+      );
+      return { didDispatch, focusCount };
+    });
+    expect(blockedFocusResult).toEqual({ didDispatch: false, focusCount: 0 });
+
+    await reactGrab.page.evaluate(() => window.unfreezeReactGrab());
+    await expect
+      .poll(() =>
+        frameTarget.evaluate(() =>
+          Boolean(document.querySelector("style[data-react-grab-frozen-pseudo]")),
+        ),
+      )
+      .toBe(false);
+    await expect
+      .poll(() => frameTarget.evaluate(() => document.getAnimations()[0]?.playState))
+      .toBe("running");
+    const restoredFocusResult = await frameTarget.evaluate((element) => {
+      let focusCount = 0;
+      element.addEventListener("focus", () => {
+        focusCount += 1;
+      });
+      const didDispatch = element.dispatchEvent(
+        new FocusEvent("focus", { bubbles: true, cancelable: true }),
+      );
+      return { didDispatch, focusCount };
+    });
+    expect(restoredFocusResult).toEqual({ didDispatch: true, focusCount: 1 });
+  });
+
+  test("freezes animations inside a same-origin iframe", async ({ reactGrab }) => {
+    await reactGrab.page.evaluate(() => {
+      const iframeElement = document.createElement("iframe");
+      iframeElement.dataset.testid = "animated-iframe";
+      iframeElement.srcdoc = `
+        <style>
+          @keyframes iframe-motion { to { transform: translateX(100px); } }
+          button { animation: iframe-motion 1s linear infinite; }
+        </style>
+        <button data-testid="animated-iframe-target">Animated target</button>
+      `;
+      document.body.append(iframeElement);
+    });
+
+    const frameTarget = reactGrab.page
+      .frameLocator("[data-testid='animated-iframe']")
+      .locator("[data-testid='animated-iframe-target']");
+    await expect(frameTarget).toBeVisible();
+    await expect
+      .poll(() => frameTarget.evaluate(() => document.getAnimations()[0]?.playState))
+      .toBe("running");
+
+    await reactGrab.page.evaluate(() => window.freezeReactGrab());
+    await expect
+      .poll(() => frameTarget.evaluate(() => document.getAnimations()[0]?.playState))
+      .toBe("paused");
+
+    await reactGrab.page.evaluate(() => window.unfreezeReactGrab());
+    await expect
+      .poll(() => frameTarget.evaluate(() => document.getAnimations()[0]?.playState))
+      .toBe("running");
+  });
+
+  test("activates from the keyboard while focus is inside an iframe", async ({ reactGrab }) => {
+    await reactGrab.page
+      .frameLocator("[data-testid='same-origin-iframe']")
+      .locator("[data-testid='iframe-target']")
+      .focus();
+
+    await reactGrab.activateViaKeyboard();
+
+    expect((await reactGrab.getState()).isActive).toBe(true);
+  });
+
+  test("removes forwarded listeners when an iframe is detached", async ({ reactGrab }) => {
+    await reactGrab.activate();
+
+    const forwardedClickCount = await reactGrab.page.evaluate(async () => {
+      let clickCount = 0;
+      window.addEventListener("click", () => {
+        clickCount += 1;
+      });
+
+      const iframeElement = document.createElement("iframe");
+      iframeElement.srcdoc = '<button data-testid="detached-frame-target">Target</button>';
+      const didLoad = new Promise<void>((resolve) => {
+        iframeElement.addEventListener("load", () => resolve(), { once: true });
+      });
+      document.body.append(iframeElement);
+      await didLoad;
+
+      const frameButton = iframeElement.contentDocument?.querySelector("button");
+      iframeElement.remove();
+      await Promise.resolve();
+      frameButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+      return clickCount;
+    });
+
+    expect(forwardedClickCount).toBe(0);
+  });
+
+  test("disconnects shadow root observers when an iframe is detached", async ({ reactGrab }) => {
+    await reactGrab.page.evaluate(async () => {
+      document.documentElement.dataset.detachedFrameObserverDisconnectCount = "0";
+      const iframeElement = document.createElement("iframe");
+      iframeElement.srcdoc = '<div data-testid="detached-shadow-host"></div>';
+      const didLoad = new Promise<void>((resolve) => {
+        iframeElement.addEventListener("load", () => resolve(), { once: true });
+      });
+      document.body.append(iframeElement);
+      await didLoad;
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+      const frameWindow = iframeElement.contentWindow;
+      const hostElement = iframeElement.contentDocument?.querySelector(
+        "[data-testid='detached-shadow-host']",
+      );
+      if (!frameWindow || !hostElement) return;
+
+      const mutationObserverPrototype = Reflect.get(frameWindow, "MutationObserver").prototype;
+      const originalDisconnect = mutationObserverPrototype.disconnect;
+      mutationObserverPrototype.disconnect = new Proxy(originalDisconnect, {
+        apply: (disconnect, mutationObserver, argumentList) => {
+          document.documentElement.dataset.detachedFrameObserverDisconnectCount = String(
+            Number(document.documentElement.dataset.detachedFrameObserverDisconnectCount) + 1,
+          );
+          return Reflect.apply(disconnect, mutationObserver, argumentList);
+        },
+      });
+
+      hostElement.attachShadow({ mode: "open" }).append(document.createElement("button"));
+      iframeElement.remove();
+    });
+
+    await expect
+      .poll(() =>
+        reactGrab.page.evaluate(() =>
+          Number(document.documentElement.dataset.detachedFrameObserverDisconnectCount),
+        ),
+      )
+      .toBe(2);
+  });
+
+  test("discovers an iframe in a shadow root attached after its host connects", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.page.evaluate(async () => {
+      const hostElement = document.createElement("div");
+      hostElement.dataset.testid = "shadow-iframe-host";
+      document.body.append(hostElement);
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+      const iframeElement = document.createElement("iframe");
+      iframeElement.dataset.testid = "shadow-nested-iframe";
+      iframeElement.srcdoc =
+        '<button data-testid="shadow-iframe-target" style="margin: 20px; padding: 20px">Shadow iframe target</button>';
+      hostElement.attachShadow({ mode: "open" }).append(iframeElement);
+    });
+
+    const frameTarget = reactGrab.page
+      .frameLocator("[data-testid='shadow-nested-iframe']")
+      .locator("[data-testid='shadow-iframe-target']");
+    await expect(frameTarget).toBeVisible();
+    await reactGrab.activate();
+    await movePointerToLocatorCenter(reactGrab.page, frameTarget);
+
+    await expect.poll(reactGrab.getTargetTestId).toBe("shadow-iframe-target");
+  });
+
+  test("discovers an iframe inserted into a registered iframe document", async ({ reactGrab }) => {
+    await reactGrab.page
+      .frameLocator("[data-testid='same-origin-iframe']")
+      .locator("body")
+      .evaluate(async (frameBody) => {
+        const nestedIframeElement = document.createElement("iframe");
+        nestedIframeElement.dataset.testid = "dynamically-nested-iframe";
+        nestedIframeElement.srcdoc =
+          '<button data-testid="dynamically-nested-iframe-target">Nested iframe target</button>';
+        const didLoad = new Promise<void>((resolve) => {
+          nestedIframeElement.addEventListener("load", () => resolve(), { once: true });
+        });
+        frameBody.append(nestedIframeElement);
+        await didLoad;
+      });
+
+    const nestedIframeTarget = reactGrab.page
+      .frameLocator("[data-testid='same-origin-iframe']")
+      .frameLocator("[data-testid='dynamically-nested-iframe']")
+      .locator("[data-testid='dynamically-nested-iframe-target']");
+    await expect(nestedIframeTarget).toBeVisible();
+    await reactGrab.activate();
+    await movePointerToLocatorCenter(reactGrab.page, nestedIframeTarget);
+
+    await expect.poll(reactGrab.getTargetTestId).toBe("dynamically-nested-iframe-target");
+  });
+
+  test("re-registers an iframe after its document is replaced", async ({ reactGrab }) => {
+    await reactGrab.page.evaluate(async () => {
+      const iframeElement = document.createElement("iframe");
+      iframeElement.dataset.testid = "navigating-iframe";
+      iframeElement.srcdoc = '<button data-testid="before-navigation">Before navigation</button>';
+      const didLoad = new Promise<void>((resolve) => {
+        iframeElement.addEventListener("load", () => resolve(), { once: true });
+      });
+      document.body.append(iframeElement);
+      await didLoad;
+    });
+
+    await reactGrab.activate();
+    const initialTarget = reactGrab.page
+      .frameLocator("[data-testid='navigating-iframe']")
+      .locator("[data-testid='before-navigation']");
+    await movePointerToLocatorCenter(reactGrab.page, initialTarget);
+    await expect.poll(reactGrab.getTargetTestId).toBe("before-navigation");
+
+    await reactGrab.page.locator("[data-testid='navigating-iframe']").evaluate((element) => {
+      if (!(element instanceof HTMLIFrameElement)) return;
+      element.srcdoc = '<button data-testid="after-navigation">After navigation</button>';
+    });
+    const replacementTarget = reactGrab.page
+      .frameLocator("[data-testid='navigating-iframe']")
+      .locator("[data-testid='after-navigation']");
+    await expect(replacementTarget).toBeVisible();
+    await movePointerToLocatorCenter(reactGrab.page, replacementTarget);
+
+    await expect.poll(reactGrab.getTargetTestId).toBe("after-navigation");
+  });
+
+  test("restores the shadow root hook when React Grab is disposed", async ({ reactGrab }) => {
+    const didRestoreAttachShadow = await reactGrab.page.evaluate(() => {
+      const patchedAttachShadow = Element.prototype.attachShadow;
+      window.__REACT_GRAB__?.dispose();
+      return Element.prototype.attachShadow !== patchedAttachShadow;
+    });
+
+    expect(didRestoreAttachShadow).toBe(true);
+  });
+
+  test("does not descend into an iframe covered by an opaque ignored element", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.page.evaluate(() => {
+      const iframeElement = document.createElement("iframe");
+      iframeElement.dataset.testid = "covered-iframe";
+      iframeElement.srcdoc =
+        '<button data-testid="covered-iframe-target" style="margin: 40px; padding: 20px">Hidden target</button>';
+      iframeElement.style.cssText =
+        "position:fixed;left:80px;top:80px;width:240px;height:160px;border:0;z-index:2147480000";
+      const coverElement = document.createElement("div");
+      coverElement.dataset.testid = "opaque-iframe-cover";
+      coverElement.setAttribute("data-react-grab-ignore", "");
+      coverElement.style.cssText =
+        "position:fixed;left:80px;top:80px;width:240px;height:160px;background:#111827;z-index:2147480001;pointer-events:auto";
+      document.body.append(iframeElement, coverElement);
+
+      window.__REACT_GRAB__?.registerPlugin({
+        name: "covered-iframe-drag",
+        hooks: {
+          onDragEnd: (elements) => {
+            document.documentElement.dataset.coveredIframeDragTargets = elements
+              .map((element) => element.getAttribute("data-testid") ?? element.tagName)
+              .join(",");
+          },
+        },
+      });
+    });
+
+    const hiddenTarget = reactGrab.page
+      .frameLocator("[data-testid='covered-iframe']")
+      .locator("[data-testid='covered-iframe-target']");
+    await expect(hiddenTarget).toBeVisible();
+    await reactGrab.activate();
+    await movePointerToLocatorCenter(reactGrab.page, hiddenTarget);
+
+    await expect.poll(reactGrab.getTargetTestId).not.toBe("covered-iframe-target");
+
+    await reactGrab.page.mouse.move(81, 81);
+    await reactGrab.page.mouse.down();
+    await reactGrab.page.mouse.move(319, 239, { steps: 10 });
+    await reactGrab.page.mouse.up();
+
+    await expect
+      .poll(() =>
+        reactGrab.page.evaluate(
+          () => document.documentElement.dataset.coveredIframeDragTargets?.split(",") ?? [],
+        ),
+      )
+      .not.toContain("covered-iframe-target");
+  });
+
+  test("drag-selects elements across the top document and an iframe in document order", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.page.evaluate(() => {
+      const topDocumentTarget = document.createElement("button");
+      topDocumentTarget.dataset.testid = "top-drag-target";
+      topDocumentTarget.textContent = "Top document target";
+      topDocumentTarget.style.cssText =
+        "position:fixed;left:40px;top:100px;width:100px;height:100px;z-index:2147480000";
+
+      const iframeElement = document.createElement("iframe");
+      iframeElement.dataset.testid = "iframe-drag-frame";
+      iframeElement.srcdoc =
+        '<button data-testid="iframe-drag-target" style="width:100px;height:100px;margin:0">Iframe target</button>';
+      iframeElement.style.cssText =
+        "position:fixed;left:180px;top:100px;width:100px;height:100px;border:0;z-index:2147480000";
+      document.body.append(topDocumentTarget, iframeElement);
+
+      window.__REACT_GRAB__?.registerPlugin({
+        name: "iframe-drag-order",
+        hooks: {
+          onDragEnd: (elements) => {
+            document.documentElement.dataset.iframeDragOrder = elements
+              .map((element) => element.getAttribute("data-testid") ?? element.tagName)
+              .join(",");
+          },
+        },
+      });
+    });
+
+    await expect(
+      reactGrab.page
+        .frameLocator("[data-testid='iframe-drag-frame']")
+        .locator("[data-testid='iframe-drag-target']"),
+    ).toBeVisible();
+    await reactGrab.activate();
+    await reactGrab.page.mouse.move(41, 101);
+    await reactGrab.page.mouse.down();
+    await reactGrab.page.mouse.move(279, 199, { steps: 10 });
+    await reactGrab.page.mouse.up();
+
+    await expect
+      .poll(() =>
+        reactGrab.page.evaluate(
+          () => document.documentElement.dataset.iframeDragOrder?.split(",") ?? [],
+        ),
+      )
+      .toEqual(["top-drag-target", "iframe-drag-target"]);
+  });
+
+  test("drag-selects nested roots beneath a transparent overlay", async ({ reactGrab }) => {
+    await reactGrab.page.evaluate((zIndex) => {
+      const shadowHostElement = document.createElement("div");
+      shadowHostElement.dataset.testid = "overlay-shadow-drag-host";
+      shadowHostElement.style.cssText = `position:fixed;left:40px;top:100px;width:100px;height:100px;z-index:${zIndex}`;
+      const shadowTargetElement = document.createElement("button");
+      shadowTargetElement.dataset.testid = "overlay-shadow-drag-target";
+      shadowTargetElement.style.cssText =
+        "display:block;box-sizing:border-box;width:100%;height:100%";
+      shadowHostElement.attachShadow({ mode: "open" }).append(shadowTargetElement);
+
+      const iframeElement = document.createElement("iframe");
+      iframeElement.dataset.testid = "overlay-iframe-drag-frame";
+      iframeElement.srcdoc =
+        '<button data-testid="overlay-iframe-drag-target" style="width:100px;height:100px;margin:0">Iframe target</button>';
+      iframeElement.style.cssText = `position:fixed;left:180px;top:100px;width:100px;height:100px;border:0;z-index:${zIndex}`;
+
+      const overlayElement = document.createElement("div");
+      overlayElement.dataset.testid = "transparent-drag-overlay";
+      overlayElement.style.cssText = `position:fixed;inset:0;background:transparent;z-index:${zIndex}`;
+      document.body.append(shadowHostElement, iframeElement, overlayElement);
+
+      window.__REACT_GRAB__?.registerPlugin({
+        name: "overlay-nested-drag-order",
+        hooks: {
+          onDragEnd: (elements) => {
+            document.documentElement.dataset.overlayNestedDragOrder = elements
+              .map((element) => element.getAttribute("data-testid") ?? element.tagName)
+              .join(",");
+          },
+        },
+      });
+    }, Z_INDEX_OVERLAY);
+
+    await expect(
+      reactGrab.page
+        .frameLocator("[data-testid='overlay-iframe-drag-frame']")
+        .locator("[data-testid='overlay-iframe-drag-target']"),
+    ).toBeVisible();
+    await reactGrab.activate();
+    await reactGrab.page.mouse.move(41, 101);
+    await reactGrab.page.mouse.down();
+    await reactGrab.page.mouse.move(279, 199, { steps: 10 });
+    await reactGrab.page.mouse.up();
+
+    await expect
+      .poll(() =>
+        reactGrab.page.evaluate(
+          () => document.documentElement.dataset.overlayNestedDragOrder?.split(",") ?? [],
+        ),
+      )
+      .toEqual(["overlay-shadow-drag-target", "overlay-iframe-drag-target"]);
+  });
+
+  test("normalizes coordinates for an unscaled iframe with a fractional width", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.page.evaluate(() => {
+      const iframeElement = document.createElement("iframe");
+      iframeElement.dataset.testid = "fractional-width-iframe";
+      iframeElement.srcdoc = `
+        <style>* { box-sizing: border-box } body { margin: 0; position: relative; width: 200.5px; height: 40px }</style>
+        <button data-testid="fractional-edge-target" style="position:absolute;left:199.6px;top:0;width:0.2px;height:40px;padding:0;border:0"></button>
+      `;
+      iframeElement.style.cssText =
+        "position:fixed;left:40px;top:240px;width:200.5px;height:40px;border:0;z-index:2147480000";
+      document.body.append(iframeElement);
+
+      window.__REACT_GRAB__?.registerPlugin({
+        name: "fractional-iframe-bounds",
+        hooks: {
+          onSelectionBox: (isVisible, bounds, element) => {
+            if (
+              !isVisible ||
+              !bounds ||
+              element?.getAttribute("data-testid") !== "fractional-edge-target"
+            )
+              return;
+            document.documentElement.dataset.fractionalSelectionX = String(bounds.x);
+            document.documentElement.dataset.fractionalSelectionWidth = String(bounds.width);
+          },
+        },
+      });
+    });
+
+    const edgeTarget = reactGrab.page
+      .frameLocator("[data-testid='fractional-width-iframe']")
+      .locator("[data-testid='fractional-edge-target']");
+    await expect(edgeTarget).toBeVisible();
+    await reactGrab.activate();
+    await movePointerToLocatorCenter(reactGrab.page, edgeTarget);
+
+    await expect.poll(reactGrab.getTargetTestId).toBe("fractional-edge-target");
+
+    const targetBounds = await edgeTarget.boundingBox();
+    expect(targetBounds).not.toBeNull();
+    if (!targetBounds) return;
+    const selectionBounds = await reactGrab.page.evaluate(() => ({
+      x: Number(document.documentElement.dataset.fractionalSelectionX),
+      width: Number(document.documentElement.dataset.fractionalSelectionWidth),
+    }));
+    expect(selectionBounds.x).toBeCloseTo(targetBounds.x, 1);
+    expect(selectionBounds.width).toBeCloseTo(targetBounds.width, 1);
+  });
+
+  test("reuses the parent React Grab instance in a same-origin iframe", async ({ reactGrab }) => {
+    await expect
+      .poll(() =>
+        reactGrab.page.evaluate(() => {
+          const iframe = document.querySelector<HTMLIFrameElement>(
+            "[data-testid='iframe-pierre-diff']",
+          );
+          return iframe?.contentWindow?.__REACT_GRAB__ === window.__REACT_GRAB__;
+        }),
+      )
+      .toBe(true);
+  });
+
+  test("selects an element inside a same-origin iframe", async ({ reactGrab }) => {
+    await reactGrab.activate();
+    const frameTarget = reactGrab.page
+      .frameLocator("[data-testid='same-origin-iframe']")
+      .locator("[data-testid='iframe-target']");
+    await movePointerToLocatorCenter(reactGrab.page, frameTarget);
+
+    await expect
+      .poll(() =>
+        reactGrab.page.evaluate(() => {
+          const targetElement = window.__REACT_GRAB__?.getState().targetElement;
+          return {
+            testId: targetElement?.getAttribute("data-testid") ?? null,
+            isFromChildDocument: targetElement?.ownerDocument !== document,
+          };
+        }),
+      )
+      .toEqual({ testId: "iframe-target", isFromChildDocument: true });
+  });
+
+  test("copies a plain iframe element without using the parent frame fiber", async ({
+    reactGrab,
+  }) => {
+    const didCopy = await reactGrab.page.evaluate(async () => {
+      const iframeElement = document.querySelector<HTMLIFrameElement>(
+        "[data-testid='same-origin-iframe']",
+      );
+      const targetElement = iframeElement?.contentDocument?.querySelector(
+        "[data-testid='iframe-target']",
+      );
+      if (!targetElement) return false;
+      return (await window.__REACT_GRAB__?.copyElement(targetElement)) ?? false;
+    });
+
+    expect(didCopy).toBe(true);
+    const clipboardContent = await reactGrab.getClipboardContent();
+    expect(clipboardContent).toContain("Start a workspace");
+    expect(clipboardContent).not.toContain("IframeFixture");
+  });
+
+  test("descends into an iframe beneath a transparent viewport overlay", async ({ reactGrab }) => {
+    const iframeTarget = reactGrab.page
+      .frameLocator("[data-testid='same-origin-iframe']")
+      .locator("[data-testid='iframe-target']");
+    await iframeTarget.scrollIntoViewIfNeeded();
+    await reactGrab.page.evaluate((zIndex) => {
+      const overlayElement = document.createElement("div");
+      overlayElement.dataset.testid = "transparent-iframe-overlay";
+      overlayElement.style.cssText = `position:fixed;inset:0;background:transparent;z-index:${zIndex}`;
+      document.body.append(overlayElement);
+    }, Z_INDEX_OVERLAY);
+
+    await reactGrab.activate();
+    await movePointerToLocatorCenter(reactGrab.page, iframeTarget);
+
+    await expect.poll(reactGrab.getTargetTestId).toBe("iframe-target");
+  });
+
+  test("descends into a transparent viewport iframe beneath a non-grabbable layer", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.page.evaluate((zIndex) => {
+      const iframeElement = document.createElement("iframe");
+      iframeElement.dataset.testid = "transparent-viewport-iframe";
+      iframeElement.srcdoc =
+        '<button data-testid="transparent-viewport-iframe-target" style="position:fixed;left:100px;top:100px;width:120px;height:48px">Iframe target</button>';
+      iframeElement.style.cssText = `position:fixed;inset:0;width:100vw;height:100vh;border:0;background:transparent;z-index:${zIndex}`;
+
+      const overlayElement = document.createElement("div");
+      overlayElement.dataset.testid = "transparent-viewport-cover";
+      overlayElement.style.cssText = `position:fixed;inset:0;background:transparent;z-index:${zIndex + 1}`;
+      document.body.append(iframeElement, overlayElement);
+    }, Z_INDEX_OVERLAY);
+
+    const iframeTarget = reactGrab.page
+      .frameLocator("[data-testid='transparent-viewport-iframe']")
+      .locator("[data-testid='transparent-viewport-iframe-target']");
+    await iframeTarget.waitFor();
+    await reactGrab.activate();
+    await reactGrab.page.mouse.move(160, 124);
+
+    await expect.poll(reactGrab.getTargetTestId).toBe("transparent-viewport-iframe-target");
+  });
+
+  test("selects through an iframe and nested shadow root", async ({ reactGrab }) => {
+    await reactGrab.activate();
+    const shadowTarget = reactGrab.page
+      .frameLocator("[data-testid='same-origin-iframe']")
+      .locator("[data-testid='iframe-shadow-target']");
+    await movePointerToLocatorCenter(reactGrab.page, shadowTarget);
+
+    await expect
+      .poll(() =>
+        reactGrab.page.evaluate(() => {
+          const targetElement = window.__REACT_GRAB__?.getState().targetElement;
+          const rootNode = targetElement?.getRootNode();
+          return {
+            testId: targetElement?.getAttribute("data-testid") ?? null,
+            isFromChildDocument: targetElement?.ownerDocument !== document,
+            isInsideShadowRoot: rootNode?.nodeType === Node.DOCUMENT_FRAGMENT_NODE,
+          };
+        }),
+      )
+      .toEqual({
+        testId: "iframe-shadow-target",
+        isFromChildDocument: true,
+        isInsideShadowRoot: true,
+      });
+  });
+
+  test("selects a Pierre diff element inside a same-origin iframe", async ({ reactGrab }) => {
+    await reactGrab.activate();
+    const diffCodeElement = reactGrab.page
+      .frameLocator("[data-testid='iframe-pierre-diff']")
+      .locator("diffs-container code")
+      .first();
+    await movePointerToLocatorCenter(reactGrab.page, diffCodeElement);
+
+    await expect
+      .poll(() =>
+        reactGrab.page.evaluate(() => {
+          const targetElement = window.__REACT_GRAB__?.getState().targetElement;
+          return {
+            isFromChildDocument: targetElement?.ownerDocument !== document,
+            isInsideShadowRoot:
+              targetElement?.getRootNode().nodeType === Node.DOCUMENT_FRAGMENT_NODE,
+          };
+        }),
+      )
+      .toEqual({
+        isFromChildDocument: true,
+        isInsideShadowRoot: true,
+      });
+  });
+
+  test("scrolls a same-origin iframe while selection is active", async ({ reactGrab }) => {
+    const iframe = reactGrab.page.locator("[data-testid='same-origin-iframe']");
+    await iframe.scrollIntoViewIfNeeded();
+    const iframeBounds = await iframe.boundingBox();
+    expect(iframeBounds).not.toBeNull();
+    if (!iframeBounds) return;
+
+    await reactGrab.activate();
+    await reactGrab.page.mouse.move(
+      iframeBounds.x + iframeBounds.width / 2,
+      iframeBounds.y + iframeBounds.height / 2,
+    );
+    await reactGrab.page.waitForTimeout(IFRAME_SCROLL_SETTLE_DELAY_MS);
+    await reactGrab.page.mouse.wheel(0, IFRAME_SCROLL_DELTA_Y_PX);
+
+    await expect
+      .poll(() =>
+        reactGrab.page
+          .frameLocator("[data-testid='same-origin-iframe']")
+          .locator("html")
+          .evaluate((element) => element.scrollTop),
+      )
+      .toBeGreaterThan(0);
+  });
+
+  test("normalizes coordinates for a scaled iframe", async ({ reactGrab }) => {
+    await reactGrab.activate();
+    const scaledTarget = reactGrab.page
+      .frameLocator("[data-testid='scaled-same-origin-iframe']")
+      .locator("[data-testid='iframe-target']");
+    await movePointerToLocatorCenter(reactGrab.page, scaledTarget);
+
+    await expect.poll(reactGrab.getTargetTestId).toBe("iframe-target");
+  });
+
+  test("scales selection corner radius with a transformed iframe", async ({ reactGrab }) => {
+    await reactGrab.page.evaluate(() => {
+      window.__REACT_GRAB__?.registerPlugin({
+        name: "scaled-iframe-border-radius",
+        hooks: {
+          onSelectionBox: (isVisible, bounds, element) => {
+            if (!isVisible || !bounds || element?.getAttribute("data-testid") !== "iframe-target")
+              return;
+            if (element.ownerDocument === document) return;
+            document.documentElement.dataset.scaledIframeBorderRadius = bounds.borderRadius;
+          },
+        },
+      });
+    });
+
+    await reactGrab.activate();
+    await movePointerToLocatorCenter(
+      reactGrab.page,
+      reactGrab.page
+        .frameLocator("[data-testid='scaled-same-origin-iframe']")
+        .locator("[data-testid='iframe-target']"),
+    );
+
+    await expect
+      .poll(() =>
+        reactGrab.page.evaluate(
+          () => document.documentElement.dataset.scaledIframeBorderRadius ?? "",
+        ),
+      )
+      .toBe(SCALED_IFRAME_EXPECTED_BORDER_RADIUS);
+  });
+
+  test("scales elliptical corner radii with a non-uniform iframe transform", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.page.evaluate(() => {
+      const iframeElement = document.querySelector<HTMLIFrameElement>(
+        "[data-testid='scaled-same-origin-iframe']",
+      );
+      if (!iframeElement) return;
+      iframeElement.style.scale = "1";
+      iframeElement.style.transform = "scale(0.75, 0.5)";
+
+      window.__REACT_GRAB__?.registerPlugin({
+        name: "non-uniform-scaled-iframe-border-radius",
+        hooks: {
+          onSelectionBox: (isVisible, bounds, element) => {
+            if (!isVisible || !bounds || element?.getAttribute("data-testid") !== "iframe-target")
+              return;
+            if (element.ownerDocument === document) return;
+            document.documentElement.dataset.nonUniformScaledIframeBorderRadius =
+              bounds.borderRadius;
+          },
+        },
+      });
+    });
+
+    await reactGrab.activate();
+    await movePointerToLocatorCenter(
+      reactGrab.page,
+      reactGrab.page
+        .frameLocator("[data-testid='scaled-same-origin-iframe']")
+        .locator("[data-testid='iframe-target']"),
+    );
+
+    await expect
+      .poll(() =>
+        reactGrab.page.evaluate(
+          () => document.documentElement.dataset.nonUniformScaledIframeBorderRadius ?? "",
+        ),
+      )
+      .toBe(NON_UNIFORM_SCALED_IFRAME_EXPECTED_BORDER_RADIUS);
+  });
+
+  test("falls back to an inaccessible sandboxed iframe", async ({ reactGrab }) => {
+    const sandboxedIframe = reactGrab.page.locator("[data-testid='sandboxed-iframe']");
+    await sandboxedIframe.scrollIntoViewIfNeeded();
+    const iframeBounds = await sandboxedIframe.boundingBox();
+    expect(iframeBounds).not.toBeNull();
+    if (!iframeBounds) return;
+
+    await reactGrab.activate();
+    await reactGrab.page.waitForTimeout(POINTER_SETTLE_DELAY_MS);
+    await reactGrab.page.evaluate(
+      ({ clientX, clientY, pointerId }) => {
+        window.dispatchEvent(
+          new PointerEvent("pointermove", {
+            bubbles: true,
+            cancelable: true,
+            clientX,
+            clientY,
+            isPrimary: true,
+            pointerId,
+            pointerType: "mouse",
+          }),
+        );
+      },
+      {
+        clientX: iframeBounds.x + iframeBounds.width / 2,
+        clientY: iframeBounds.y + iframeBounds.height / 2,
+        pointerId: IFRAME_TEST_POINTER_ID,
+      },
+    );
+
+    await expect.poll(reactGrab.getTargetTestId).toBe("sandboxed-iframe");
+  });
+
+  test("refreshes an inaccessible iframe hit when its stacking changes", async ({ reactGrab }) => {
+    const sandboxedIframe = reactGrab.page.locator("[data-testid='sandboxed-iframe']");
+    await sandboxedIframe.scrollIntoViewIfNeeded();
+    const iframeBounds = await sandboxedIframe.boundingBox();
+    expect(iframeBounds).not.toBeNull();
+    if (!iframeBounds) return;
+
+    const clientX = iframeBounds.x + iframeBounds.width / 2;
+    const clientY = iframeBounds.y + iframeBounds.height / 2;
+    const dispatchPointerMove = async (): Promise<void> => {
+      await reactGrab.page.evaluate(
+        ({ pointerClientX, pointerClientY, pointerId }) => {
+          window.dispatchEvent(
+            new PointerEvent("pointermove", {
+              bubbles: true,
+              cancelable: true,
+              clientX: pointerClientX,
+              clientY: pointerClientY,
+              isPrimary: true,
+              pointerId,
+              pointerType: "mouse",
+            }),
+          );
+        },
+        {
+          pointerClientX: clientX,
+          pointerClientY: clientY,
+          pointerId: IFRAME_TEST_POINTER_ID,
+        },
+      );
+    };
+    await reactGrab.activate();
+    await reactGrab.page.waitForTimeout(POINTER_SETTLE_DELAY_MS * 2);
+    await dispatchPointerMove();
+    await expect.poll(reactGrab.getTargetTestId).toBe("sandboxed-iframe");
+
+    await reactGrab.page.evaluate(
+      ({ x, y, width, height, zIndex }) => {
+        const coveringElement = document.createElement("button");
+        coveringElement.dataset.testid = "sandboxed-iframe-cover";
+        coveringElement.textContent = "Cover";
+        coveringElement.style.cssText = `position:fixed;left:${x}px;top:${y}px;width:${width}px;height:${height}px;z-index:${zIndex}`;
+        document.body.append(coveringElement);
+      },
+      { ...iframeBounds, zIndex: Z_INDEX_OVERLAY },
+    );
+    await reactGrab.page.waitForTimeout(POINTER_SETTLE_DELAY_MS * 2);
+    await dispatchPointerMove();
+
+    await expect.poll(reactGrab.getTargetTestId).toBe("sandboxed-iframe-cover");
+  });
+});

--- a/packages/react-grab/e2e/move-pointer-to-locator-center.ts
+++ b/packages/react-grab/e2e/move-pointer-to-locator-center.ts
@@ -1,0 +1,14 @@
+import type { Locator, Page } from "@playwright/test";
+import { POINTER_SETTLE_DELAY_MS } from "./constants.js";
+
+export const movePointerToLocatorCenter = async (page: Page, locator: Locator): Promise<void> => {
+  await locator.scrollIntoViewIfNeeded();
+  const targetBounds = await locator.boundingBox();
+  if (!targetBounds) throw new Error("Cannot move the pointer to an element without bounds");
+
+  const targetCenterX = targetBounds.x + targetBounds.width / 2;
+  const targetCenterY = targetBounds.y + targetBounds.height / 2;
+  await page.mouse.move(targetCenterX, targetCenterY);
+  await page.waitForTimeout(POINTER_SETTLE_DELAY_MS);
+  await page.mouse.move(targetCenterX, targetCenterY);
+};

--- a/packages/react-grab/e2e/overlay-filtering.spec.ts
+++ b/packages/react-grab/e2e/overlay-filtering.spec.ts
@@ -116,30 +116,13 @@ test.describe("Overlay Filtering", () => {
       }, style);
     };
 
-    const getHoveredTargetTestId = async (
-      reactGrab: ReactGrabPageObject,
-    ): Promise<string | null> => {
-      return reactGrab.page.evaluate(() => {
-        const api = (
-          window as {
-            __REACT_GRAB__?: {
-              getState: () => { targetElement: Element | null };
-            };
-          }
-        ).__REACT_GRAB__;
-        return api?.getState().targetElement?.getAttribute("data-testid") ?? null;
-      });
-    };
-
     test("should skip a transparent full-viewport fixed overlay", async ({ reactGrab }) => {
       await injectOverlay(reactGrab, { backgroundColor: "transparent" });
       await reactGrab.activate();
 
       await reactGrab.hoverElement("[data-testid='main-title']");
 
-      await expect
-        .poll(() => getHoveredTargetTestId(reactGrab), { timeout: 3_000 })
-        .toBe("main-title");
+      await expect.poll(reactGrab.getTargetTestId, { timeout: 3_000 }).toBe("main-title");
     });
 
     test("should skip a dev-tools style pointer-events-none overlay", async ({ reactGrab }) => {
@@ -153,9 +136,7 @@ test.describe("Overlay Filtering", () => {
 
       await reactGrab.hoverElement("[data-testid='main-title']");
 
-      await expect
-        .poll(() => getHoveredTargetTestId(reactGrab), { timeout: 3_000 })
-        .toBe("main-title");
+      await expect.poll(reactGrab.getTargetTestId, { timeout: 3_000 }).toBe("main-title");
     });
 
     test("should skip an opaque full-viewport overlay above the z-index threshold", async ({
@@ -169,9 +150,7 @@ test.describe("Overlay Filtering", () => {
 
       await reactGrab.hoverElement("[data-testid='main-title']");
 
-      await expect
-        .poll(() => getHoveredTargetTestId(reactGrab), { timeout: 3_000 })
-        .toBe("main-title");
+      await expect.poll(reactGrab.getTargetTestId, { timeout: 3_000 }).toBe("main-title");
     });
 
     test("should select an opaque full-viewport overlay with a low z-index", async ({
@@ -185,9 +164,7 @@ test.describe("Overlay Filtering", () => {
 
       await reactGrab.hoverElement("[data-testid='main-title']");
 
-      await expect
-        .poll(() => getHoveredTargetTestId(reactGrab), { timeout: 3_000 })
-        .toBe("injected-overlay");
+      await expect.poll(reactGrab.getTargetTestId, { timeout: 3_000 }).toBe("injected-overlay");
     });
 
     test("should select a transparent overlay below the viewport coverage threshold", async ({
@@ -202,9 +179,7 @@ test.describe("Overlay Filtering", () => {
 
       await reactGrab.page.mouse.move(50, 50);
 
-      await expect
-        .poll(() => getHoveredTargetTestId(reactGrab), { timeout: 3_000 })
-        .toBe("injected-overlay");
+      await expect.poll(reactGrab.getTargetTestId, { timeout: 3_000 }).toBe("injected-overlay");
     });
   });
 

--- a/packages/react-grab/e2e/shadow-dom.spec.ts
+++ b/packages/react-grab/e2e/shadow-dom.spec.ts
@@ -1,0 +1,193 @@
+import { expect, test } from "./fixtures.js";
+import { movePointerToLocatorCenter } from "./move-pointer-to-locator-center.js";
+import { SHADOW_FRAME_FOCUS_OUTLINE_COLOR, SHADOW_HOVER_BACKGROUND_COLOR } from "./constants.js";
+
+declare global {
+  interface Window {
+    freezeReactGrab: () => void;
+    unfreezeReactGrab: () => void;
+  }
+}
+
+test.describe("Shadow DOM", () => {
+  test("preserves shadow hover styles during a coordinate-free freeze", async ({ reactGrab }) => {
+    await reactGrab.page.evaluate((hoverBackgroundColor) => {
+      const hostElement = document.createElement("div");
+      hostElement.style.cssText = "position:fixed;left:400px;top:300px;z-index:2147480000";
+      hostElement.attachShadow({ mode: "open" }).innerHTML = `
+        <style>
+          button { background: white; }
+          button:hover { background: ${hoverBackgroundColor}; }
+        </style>
+        <button data-testid="shadow-freeze-hover-target">Shadow hover target</button>
+      `;
+      document.body.append(hostElement);
+    }, SHADOW_HOVER_BACKGROUND_COLOR);
+
+    const hoverTarget = reactGrab.page.locator("[data-testid='shadow-freeze-hover-target']");
+    await hoverTarget.hover();
+    await expect(hoverTarget).toHaveCSS("background-color", SHADOW_HOVER_BACKGROUND_COLOR);
+
+    await reactGrab.page.evaluate(() => window.freezeReactGrab());
+    await expect(hoverTarget).toHaveCSS("background-color", SHADOW_HOVER_BACKGROUND_COLOR);
+    await reactGrab.page.evaluate(() => window.unfreezeReactGrab());
+  });
+
+  test("preserves focus through a shadow root and iframe", async ({ reactGrab }) => {
+    await reactGrab.page.evaluate(async (focusOutlineColor) => {
+      const hostElement = document.createElement("div");
+      const iframeElement = document.createElement("iframe");
+      iframeElement.dataset.testid = "shadow-focus-iframe";
+      iframeElement.srcdoc = `
+        <style>button:focus { outline-color: ${focusOutlineColor}; }</style>
+        <button data-testid="shadow-frame-focus-target">Focus target</button>
+      `;
+      const didLoad = new Promise<void>((resolve) => {
+        iframeElement.addEventListener("load", () => resolve(), { once: true });
+      });
+      hostElement.attachShadow({ mode: "open" }).append(iframeElement);
+      document.body.append(hostElement);
+      await didLoad;
+      iframeElement.contentDocument
+        ?.querySelector<HTMLElement>("[data-testid='shadow-frame-focus-target']")
+        ?.focus();
+    }, SHADOW_FRAME_FOCUS_OUTLINE_COLOR);
+
+    const focusTarget = reactGrab.page
+      .frameLocator("[data-testid='shadow-focus-iframe']")
+      .locator("[data-testid='shadow-frame-focus-target']");
+    await expect(focusTarget).toBeFocused();
+    await expect(focusTarget).toHaveCSS("outline-color", SHADOW_FRAME_FOCUS_OUTLINE_COLOR);
+
+    await reactGrab.page.evaluate(() => window.freezeReactGrab());
+    await expect(focusTarget).toHaveCSS("outline-color", SHADOW_FRAME_FOCUS_OUTLINE_COLOR);
+    await expect
+      .poll(() => focusTarget.evaluate((element) => element.style.getPropertyPriority("outline")))
+      .toBe("important");
+
+    await reactGrab.page.evaluate(() => window.unfreezeReactGrab());
+    await expect
+      .poll(() => focusTarget.evaluate((element) => element.style.getPropertyValue("outline")))
+      .toBe("");
+  });
+
+  test("honors ignore attributes on the light parent of a slotted element", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.page.evaluate(() => {
+      const hostElement = document.createElement("div");
+      hostElement.dataset.testid = "ignored-slot-host";
+      hostElement.attachShadow({ mode: "open" }).innerHTML = "<slot></slot>";
+      const ignoredWrapperElement = document.createElement("div");
+      ignoredWrapperElement.setAttribute("data-react-grab-ignore", "");
+      const buttonElement = document.createElement("button");
+      buttonElement.dataset.testid = "ignored-slotted-target";
+      buttonElement.textContent = "Ignored slotted target";
+      ignoredWrapperElement.append(buttonElement);
+      hostElement.append(ignoredWrapperElement);
+      document.body.append(hostElement);
+    });
+
+    await reactGrab.activate();
+    await movePointerToLocatorCenter(
+      reactGrab.page,
+      reactGrab.page.locator("[data-testid='ignored-slotted-target']"),
+    );
+
+    await expect.poll(reactGrab.getTargetTestId).not.toBe("ignored-slotted-target");
+  });
+
+  test("selects the innermost Pierre diff element", async ({ reactGrab }) => {
+    const codeElement = reactGrab.page.locator("diffs-container code").first();
+    await codeElement.scrollIntoViewIfNeeded();
+    const codeBounds = await codeElement.boundingBox();
+    expect(codeBounds).not.toBeNull();
+    if (!codeBounds) return;
+
+    const clientX = codeBounds.x + codeBounds.width / 2;
+    const clientY = codeBounds.y + codeBounds.height / 2;
+
+    const shadowTargetTagName = await reactGrab.page.evaluate(
+      ({ clientX, clientY }) => {
+        const host = document.querySelector("diffs-container");
+        const shadowRoot = host?.shadowRoot;
+        if (!shadowRoot) return null;
+        const shadowTarget = shadowRoot.elementFromPoint(clientX, clientY);
+        return shadowTarget?.getRootNode() === shadowRoot ? shadowTarget.tagName : null;
+      },
+      { clientX, clientY },
+    );
+
+    expect(shadowTargetTagName).not.toBeNull();
+    if (!shadowTargetTagName) return;
+
+    await reactGrab.activate();
+    await movePointerToLocatorCenter(reactGrab.page, codeElement);
+
+    await expect
+      .poll(() =>
+        reactGrab.page.evaluate(() => {
+          const targetElement = window.__REACT_GRAB__?.getState().targetElement;
+          return {
+            tagName: targetElement?.tagName ?? null,
+            isInsideShadowRoot: targetElement?.getRootNode() instanceof ShadowRoot,
+          };
+        }),
+      )
+      .toEqual({
+        tagName: shadowTargetTagName,
+        isInsideShadowRoot: true,
+      });
+  });
+
+  test("descends through a slotted element with its own shadow root", async ({ reactGrab }) => {
+    await reactGrab.activate();
+    const shadowTarget = reactGrab.page.locator("[data-testid='slotted-shadow-target']");
+    await movePointerToLocatorCenter(reactGrab.page, shadowTarget);
+
+    await expect
+      .poll(() =>
+        reactGrab.page.evaluate(() => {
+          const targetElement = window.__REACT_GRAB__?.getState().targetElement;
+          const targetRoot = targetElement?.getRootNode();
+          const nestedHost = targetRoot instanceof ShadowRoot ? targetRoot.host : null;
+          const outerRoot = nestedHost?.assignedSlot?.getRootNode();
+          return {
+            testId: targetElement?.getAttribute("data-testid") ?? null,
+            isInsideNestedShadowRoot: targetRoot instanceof ShadowRoot,
+            isNestedHostSlottedIntoShadowRoot: outerRoot instanceof ShadowRoot,
+          };
+        }),
+      )
+      .toEqual({
+        testId: "slotted-shadow-target",
+        isInsideNestedShadowRoot: true,
+        isNestedHostSlottedIntoShadowRoot: true,
+      });
+  });
+
+  test("resolves non-fibered slotted content through its light DOM owner", async ({
+    reactGrab,
+  }) => {
+    const source = await reactGrab.page.evaluate(async () => {
+      const targetElement = document.querySelector("[data-testid='fiber-slotted-light-target']");
+      if (!targetElement) return null;
+      return window.__REACT_GRAB__?.getSource(targetElement);
+    });
+
+    expect(source?.componentName).toBe("SlottedLightDomOwner");
+  });
+
+  test("falls back to a closed shadow host", async ({ reactGrab }) => {
+    await reactGrab.activate();
+    const closedShadowHost = reactGrab.page.locator("[data-testid='closed-shadow-host']");
+
+    await expect
+      .poll(async () => {
+        await reactGrab.page.mouse.move(0, 0);
+        await movePointerToLocatorCenter(reactGrab.page, closedShadowHost);
+        return reactGrab.getTargetTestId();
+      })
+      .toBe("closed-shadow-host");
+  });
+});

--- a/packages/react-grab/e2e/toolbar-selection-hover.spec.ts
+++ b/packages/react-grab/e2e/toolbar-selection-hover.spec.ts
@@ -1,29 +1,11 @@
+import type { Page } from "@playwright/test";
 import { test, expect } from "./fixtures.js";
 import { ATTRIBUTE_NAME } from "./constants.js";
 
-const hoverToolbar = async (page: import("@playwright/test").Page) => {
-  const toolbarRect = await page.evaluate((attrName) => {
-    const host = document.querySelector(`[${attrName}]`);
-    const shadowRoot = host?.shadowRoot;
-    if (!shadowRoot) return null;
-    const root = shadowRoot.querySelector(`[${attrName}]`);
-    if (!root) return null;
-    const toolbar = root.querySelector<HTMLElement>("[data-react-grab-toolbar]");
-    if (!toolbar) return null;
-    const rect = toolbar.getBoundingClientRect();
-    return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
-  }, ATTRIBUTE_NAME);
+const hoverToolbar = async (page: Page) =>
+  page.locator(`[${ATTRIBUTE_NAME}] [data-react-grab-toolbar]`).first().hover();
 
-  if (!toolbarRect) throw new Error("Toolbar not found");
-
-  await page.mouse.move(
-    toolbarRect.x + toolbarRect.width / 2,
-    toolbarRect.y + toolbarRect.height / 2,
-  );
-  await page.waitForTimeout(150);
-};
-
-const hoverAwayFromToolbar = async (page: import("@playwright/test").Page) => {
+const hoverAwayFromToolbar = async (page: Page) => {
   await page.mouse.move(10, 10);
   await page.waitForTimeout(150);
 };
@@ -60,7 +42,7 @@ test.describe("Toolbar Selection Hover", () => {
 
       await expect.poll(() => reactGrab.isSelectionBoxVisible(), { timeout: 2000 }).toBe(false);
 
-      await reactGrab.hoverElement("li");
+      await hoverAwayFromToolbar(reactGrab.page);
 
       await expect.poll(() => reactGrab.isSelectionBoxVisible(), { timeout: 2000 }).toBe(true);
     });

--- a/packages/react-grab/e2e/touch-mode.spec.ts
+++ b/packages/react-grab/e2e/touch-mode.spec.ts
@@ -180,6 +180,8 @@ test.describe("Touch Mode", () => {
       await expect.poll(() => reactGrab.isOverlayVisible(), { timeout: 5000 }).toBe(false);
 
       await reactGrab.activate();
+      await reactGrab.page.mouse.move(0, 0);
+      await expect.poll(() => reactGrab.isTouchMode()).toBe(false);
       await reactGrab.hoverUntilSelected("li:nth-child(3)");
       await reactGrab.clickElement("li:nth-child(3)");
 

--- a/packages/react-grab/src/constants.ts
+++ b/packages/react-grab/src/constants.ts
@@ -78,14 +78,18 @@ export const PENDING_DETECTION_STALENESS_MS = 200;
 export const COMPONENT_NAME_DEBOUNCE_MS = 100;
 export const DRAG_PREVIEW_DEBOUNCE_MS = 32;
 export const BOUNDS_CACHE_TTL_MS = 16;
+export const IFRAME_LAYOUT_METRICS_CACHE_TTL_MS = 16;
 export const BORDER_RADIUS_CACHE_TTL_MS = 200;
+export const BORDER_RADIUS_SCALE_PRECISION_DECIMAL_PLACES = 3;
 export const BOUNDS_RECALC_INTERVAL_MS = 100;
+export const ELEMENT_RELINK_GRACE_ATTEMPTS = 1;
 
 export const AUTO_SCROLL_EDGE_THRESHOLD_PX = 25;
 export const AUTO_SCROLL_SPEED_PX = 10;
 
 export const Z_INDEX_OVERLAY = 2147483647;
 export const Z_INDEX_OVERLAY_CANVAS = 2147483645;
+export const DOCUMENT_NODE_TYPE = 9;
 
 export const DRAG_LERP_FACTOR = 0.7;
 export const BASELINE_FRAME_DURATION_MS = 1000 / 60;
@@ -159,6 +163,7 @@ export const ARROW_KEYS = new Set(["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRi
 export { REACT_GRAB_ATTRIBUTE_NAME } from "./utils/react-grab-attribute-name.js";
 
 export const FROZEN_ELEMENT_ATTRIBUTE = "data-react-grab-frozen";
+export const SAME_ORIGIN_FRAME_ATTRIBUTE = "data-react-grab-same-origin-frame";
 
 // Pausing animations individually via WAAPI avoids the full-document style
 // recalc that a universal `*` selector forces — profiled at ~62ms on a real

--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -23,6 +23,7 @@ import { formatComponentNameLines } from "../utils/format-component-name-lines.j
 import { enrichServerFrameLocations, symbolicateServerFrames } from "./next-server-frames.js";
 import { runQueuedSourceFetch } from "../utils/source-fetch-queue.js";
 import { getHTMLPreview, getInlineHTMLPreview } from "./html-preview.js";
+import { isShadowRoot } from "../utils/is-shadow-root.js";
 import {
   isInternalComponentName,
   isUsefulComponentName,
@@ -45,9 +46,14 @@ const isTrustedAppSourcePath = (fileName: string | null | undefined): boolean =>
 const findNearestFiberElement = (element: Element): Element => {
   if (!isInstrumentationActive()) return element;
   let current: Element | null = element;
-  while (current) {
+  while (current?.ownerDocument === element.ownerDocument) {
     if (getFiberFromHostInstance(current)) return current;
-    current = current.parentElement;
+    if (current.parentElement) {
+      current = current.parentElement;
+      continue;
+    }
+    const rootNode = current.getRootNode();
+    current = isShadowRoot(rootNode) ? rootNode.host : null;
   }
   return element;
 };

--- a/packages/react-grab/src/core/element-anchors.ts
+++ b/packages/react-grab/src/core/element-anchors.ts
@@ -6,6 +6,13 @@ import {
   type Fiber,
 } from "bippy";
 import { indexInParent } from "../utils/index-in-parent.js";
+import { isShadowRoot } from "../utils/is-shadow-root.js";
+import { isElementNode } from "../utils/is-element-node.js";
+
+interface ElementAnchorPathStep {
+  childIndex: number;
+  isShadowChild: boolean;
+}
 
 interface ElementAnchor {
   // Nearest ancestor (or the element itself) that React manages via a fiber.
@@ -23,7 +30,7 @@ interface ElementAnchor {
   anchorIndexInParent: number;
   // Child-index chain from the anchor down to the tracked element; empty when
   // the element is itself the anchor.
-  domPath: number[];
+  domPath: ElementAnchorPathStep[];
   targetTagName: string;
 }
 
@@ -43,7 +50,7 @@ const resolveLiveAnchor = (anchor: ElementAnchor): Element | null => {
   // that same-tag siblings can't confuse.
   if (isHostFiber(latestParentFiber)) {
     const parentNode = latestParentFiber.stateNode;
-    if (!(parentNode instanceof Element) || !parentNode.isConnected) return null;
+    if (!isElementNode(parentNode) || !parentNode.isConnected) return null;
     const candidate = parentNode.children[anchor.anchorIndexInParent];
     return candidate && candidate.tagName === anchorTagName ? candidate : null;
   }
@@ -54,17 +61,18 @@ const resolveLiveAnchor = (anchor: ElementAnchor): Element | null => {
     // original element type is gone. Same-tag siblings under a shared composite
     // ancestor can't be told apart and resolve to the first match, which still
     // leaves the selection on a valid node instead of dropping it.
-    if (node instanceof Element && node.isConnected && node.tagName === anchorTagName) {
+    if (isElementNode(node) && node.isConnected && node.tagName === anchorTagName) {
       return node;
     }
   }
   return null;
 };
 
-const followDomPath = (root: Element, domPath: number[]): Element | null => {
+const followDomPath = (root: Element, domPath: ElementAnchorPathStep[]): Element | null => {
   let node: Element = root;
-  for (const childIndex of domPath) {
-    const child = node.children[childIndex];
+  for (const pathStep of domPath) {
+    const childCollection = pathStep.isShadowChild ? node.shadowRoot?.children : node.children;
+    const child = childCollection?.[pathStep.childIndex];
     if (!child) return null;
     node = child;
   }
@@ -74,12 +82,20 @@ const followDomPath = (root: Element, domPath: number[]): Element | null => {
 // Walks up to the nearest fiber-managed ancestor, recording the DOM path taken
 // so a non-fibered element (innerHTML content) can be re-found beneath it.
 const findAnchor = (element: Element): ElementAnchor | null => {
-  const domPath: number[] = [];
+  const domPath: ElementAnchorPathStep[] = [];
   let anchorElement: Element | null = element;
   let anchorFiber = getFiberFromHostInstance(anchorElement);
   while (anchorElement && !anchorFiber) {
-    domPath.unshift(indexInParent(anchorElement));
-    anchorElement = anchorElement.parentElement;
+    const parentElement: Element | null = anchorElement.parentElement;
+    if (parentElement) {
+      domPath.unshift({ childIndex: indexInParent(anchorElement), isShadowChild: false });
+      anchorElement = parentElement;
+    } else {
+      const rootNode = anchorElement.getRootNode();
+      if (!isShadowRoot(rootNode)) break;
+      domPath.unshift({ childIndex: indexInParent(anchorElement), isShadowChild: true });
+      anchorElement = rootNode.host;
+    }
     anchorFiber = getFiberFromHostInstance(anchorElement);
   }
   const anchorParentFiber = anchorFiber?.return;

--- a/packages/react-grab/src/core/html-preview.ts
+++ b/packages/react-grab/src/core/html-preview.ts
@@ -9,6 +9,8 @@ import { getTagName } from "../utils/get-tag-name.js";
 import { truncateString } from "../utils/truncate-string.js";
 import { isInternalAttribute } from "../utils/strip-internal-attributes.js";
 import { getPreviewTextContent } from "../utils/get-preview-text-content.js";
+import { isElementNode } from "../utils/is-element-node.js";
+import { isHtmlElement } from "../utils/is-html-element.js";
 
 const truncateAttrValue = (attributeValue: string): string =>
   truncateString(attributeValue, PREVIEW_ATTR_VALUE_MAX_LENGTH);
@@ -63,7 +65,7 @@ const formatChildElements = (elements: Array<Element>): string => {
 export const getInlineHTMLPreview = (element: Element): string => {
   const tagName = getTagName(element);
 
-  if (!(element instanceof HTMLElement)) {
+  if (!isHtmlElement(element)) {
     return `<${tagName}${formatPriorityAttrs(element)} />`;
   }
 
@@ -92,7 +94,7 @@ export const getHTMLPreview = (element: Element): string => {
       if (node.textContent && node.textContent.trim().length > 0) {
         foundFirstText = true;
       }
-    } else if (node instanceof Element) {
+    } else if (isElementNode(node)) {
       if (!foundFirstText) {
         topElements.push(node);
       } else {

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -80,6 +80,7 @@ import {
   MODIFIER_KEYS,
   BLUR_DEACTIVATION_THRESHOLD_MS,
   BOUNDS_RECALC_INTERVAL_MS,
+  ELEMENT_RELINK_GRACE_ATTEMPTS,
   INPUT_FOCUS_ACTIVATION_DELAY_MS,
   INPUT_TEXT_SELECTION_ACTIVATION_DELAY_MS,
   DEFAULT_KEY_HOLD_DURATION_MS,
@@ -158,6 +159,9 @@ import { findShortcutAction } from "../utils/action-shortcuts.js";
 import { createKeyboardSelectionController } from "./keyboard-selection.js";
 import { executeContextMenuAction } from "../utils/execute-context-menu-action.js";
 import { notifyToolbarStateChangeSubscribers } from "../utils/notify-toolbar-state-change-subscribers.js";
+import { forwardSameOriginFrameEvents } from "../utils/forward-same-origin-frame-events.js";
+import { isHtmlElement } from "../utils/is-html-element.js";
+import { isDocumentAncestorOfElement } from "../utils/is-document-ancestor-of-element.js";
 
 const builtInPlugins = [copyPlugin, editPlugin, commentPlugin, openPlugin];
 
@@ -655,10 +659,9 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
             componentName = getComponentDisplayName(element);
           }
 
-          const textContent =
-            element instanceof HTMLElement
-              ? element.innerText?.slice(0, PREVIEW_TEXT_MAX_LENGTH)
-              : undefined;
+          const textContent = isHtmlElement(element)
+            ? element.innerText?.slice(0, PREVIEW_TEXT_MAX_LENGTH)
+            : undefined;
 
           return {
             tagName: getTagName(element),
@@ -1158,6 +1161,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     createEffect(() => {
       const element = store.detectedElement;
       if (!element) return;
+      let remainingRelinkGraceAttempts = ELEMENT_RELINK_GRACE_ATTEMPTS;
 
       const intervalId = setInterval(() => {
         // The hovered node can be swapped out by a re-render the freeze didn't
@@ -1170,6 +1174,10 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           actions.relinkLiveElements();
         }
         if (!isElementConnected(store.detectedElement)) {
+          if (remainingRelinkGraceAttempts > 0) {
+            remainingRelinkGraceAttempts -= 1;
+            return;
+          }
           redetectElementUnderPointer();
         }
       }, BOUNDS_RECALC_INTERVAL_MS);
@@ -1724,7 +1732,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       // element — both cases produce no observable focus change but were
       // previously paying the recalc cost on every deactivate.
       if (
-        previousFocused instanceof HTMLElement &&
+        isHtmlElement(previousFocused) &&
         previousFocused !== document.body &&
         previousFocused !== document.activeElement &&
         isElementConnected(previousFocused)
@@ -2391,6 +2399,19 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
 
     const eventListenerManager = createEventListenerManager();
+    const stopForwardingSameOriginFrameEvents = forwardSameOriginFrameEvents({
+      shouldForwardInteraction: () =>
+        isActivated() || isHoldingKeys() || isDragging() || isSelectionInteractionLocked(),
+      shouldForwardKeyboardEvent: (event) =>
+        isTargetKeyCombination(event, pluginRegistry.store.options),
+      shouldForwardViewportEvent: (frameDocument) => {
+        const activeElement = store.frozenElement ?? targetElement();
+        if (activeElement && isDocumentAncestorOfElement(frameDocument, activeElement)) return true;
+        return store.frozenElements.some((element) =>
+          isDocumentAncestorOfElement(frameDocument, element),
+        );
+      },
+    });
 
     const keyboardClaimer = setupKeyboardEventClaimer();
 
@@ -3434,6 +3455,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     );
 
     onCleanup(() => {
+      stopForwardingSameOriginFrameEvents();
       eventListenerManager.abort();
       if (dragPreviewDebounceTimerId !== null) {
         window.clearTimeout(dragPreviewDebounceTimerId);

--- a/packages/react-grab/src/index.ts
+++ b/packages/react-grab/src/index.ts
@@ -45,6 +45,7 @@ export type {
 import { init } from "./core/index.js";
 import { getGlobalApi, setGlobalApi } from "./global-api.js";
 import type { ReactGrabAPI } from "./types.js";
+import { getParentReactGrabApi } from "./utils/get-parent-react-grab-api.js";
 
 export { getGlobalApi, setGlobalApi, registerPlugin, unregisterPlugin } from "./global-api.js";
 
@@ -56,8 +57,9 @@ declare global {
 }
 
 if (typeof window !== "undefined" && !window.__REACT_GRAB_DISABLED__) {
-  if (window.__REACT_GRAB__) {
-    setGlobalApi(window.__REACT_GRAB__);
+  const existingApi = window.__REACT_GRAB__ ?? getParentReactGrabApi();
+  if (existingApi) {
+    setGlobalApi(existingApi);
   } else {
     setGlobalApi(init());
   }

--- a/packages/react-grab/src/primitives.ts
+++ b/packages/react-grab/src/primitives.ts
@@ -25,6 +25,7 @@ import { createElementSelector } from "./utils/create-element-selector.js";
 import { extractElementCss, disposeBaselineStyles } from "./utils/extract-element-css.js";
 import { findSelectorTarget } from "./utils/find-selector-target.js";
 import { requestOpenFile } from "./utils/open-file.js";
+import { getDeepElementsAtPoint } from "./utils/get-deep-elements-at-point.js";
 
 export { OpenFileError } from "./errors.js";
 
@@ -100,7 +101,7 @@ export const getElementsAtPosition = (clientX: number, clientY: number): Element
   if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) return [];
   suspendPointerEventsFreeze();
   try {
-    return Array.from(document.elementsFromPoint(clientX, clientY));
+    return getDeepElementsAtPoint(clientX, clientY);
   } finally {
     resumePointerEventsFreeze();
   }

--- a/packages/react-grab/src/utils/build-element-hierarchy.ts
+++ b/packages/react-grab/src/utils/build-element-hierarchy.ts
@@ -5,6 +5,7 @@ import {
   MAX_HIERARCHY_SIBLINGS,
 } from "../constants.js";
 import type { ElementPredicate, HierarchyEntry } from "../types.js";
+import { getComposedParentElement } from "./get-composed-parent-element.js";
 
 interface ElementStep {
   (element: Element): Element | null;
@@ -48,8 +49,8 @@ export const buildElementHierarchy = (
   };
 
   const ancestors = collectGrabbable(
-    selectedElement.parentElement,
-    (element) => element.parentElement,
+    getComposedParentElement(selectedElement),
+    getComposedParentElement,
     MAX_HIERARCHY_ANCESTORS,
     isGrabbable,
   );

--- a/packages/react-grab/src/utils/compare-element-document-order.ts
+++ b/packages/react-grab/src/utils/compare-element-document-order.ts
@@ -1,0 +1,46 @@
+import { isDocumentNode } from "./is-document-node.js";
+import { isShadowRoot } from "./is-shadow-root.js";
+import { getWindowFrameElement } from "./get-window-frame-element.js";
+
+const getBoundaryPath = (element: Element): Element[] => {
+  const boundaryPath: Element[] = [];
+  let currentElement: Element | null = element;
+
+  while (currentElement) {
+    boundaryPath.unshift(currentElement);
+    const rootNode = currentElement.getRootNode();
+    if (isShadowRoot(rootNode)) {
+      currentElement = rootNode.host;
+      continue;
+    }
+    if (!isDocumentNode(rootNode)) break;
+    currentElement = getWindowFrameElement(rootNode.defaultView);
+  }
+
+  return boundaryPath;
+};
+
+export const compareElementDocumentOrder = (
+  leftElement: Element,
+  rightElement: Element,
+): number => {
+  if (leftElement === rightElement) return 0;
+
+  const leftBoundaryPath = getBoundaryPath(leftElement);
+  const rightBoundaryPath = getBoundaryPath(rightElement);
+  const sharedPathLength = Math.min(leftBoundaryPath.length, rightBoundaryPath.length);
+
+  for (let pathIndex = 0; pathIndex < sharedPathLength; pathIndex += 1) {
+    const leftBoundaryElement = leftBoundaryPath[pathIndex];
+    const rightBoundaryElement = rightBoundaryPath[pathIndex];
+    if (leftBoundaryElement === rightBoundaryElement) continue;
+
+    const position = leftBoundaryElement.compareDocumentPosition(rightBoundaryElement);
+
+    if (position & Node.DOCUMENT_POSITION_FOLLOWING) return -1;
+    if (position & Node.DOCUMENT_POSITION_PRECEDING) return 1;
+    return 0;
+  }
+
+  return leftBoundaryPath.length - rightBoundaryPath.length;
+};

--- a/packages/react-grab/src/utils/convert-client-position-to-top-window.ts
+++ b/packages/react-grab/src/utils/convert-client-position-to-top-window.ts
@@ -1,0 +1,46 @@
+import { isIframeElement } from "./is-iframe-element.js";
+import { getIframeLayoutMetrics } from "./get-iframe-layout-metrics.js";
+import { getIframeScale } from "./get-iframe-scale.js";
+import { getWindowFrameElement } from "./get-window-frame-element.js";
+
+interface TopWindowClientPosition {
+  x: number;
+  y: number;
+  scaleX: number;
+  scaleY: number;
+}
+
+export const convertClientPositionToTopWindow = (
+  ownerWindow: Window | null,
+  clientX: number,
+  clientY: number,
+): TopWindowClientPosition => {
+  let convertedX = clientX;
+  let convertedY = clientY;
+  let cumulativeScaleX = 1;
+  let cumulativeScaleY = 1;
+  let currentWindow = ownerWindow;
+
+  while (currentWindow && currentWindow !== window) {
+    const frameElement = getWindowFrameElement(currentWindow);
+    if (!frameElement || !isIframeElement(frameElement)) break;
+
+    const frameBounds = frameElement.getBoundingClientRect();
+    const layoutMetrics = getIframeLayoutMetrics(frameElement);
+    const frameScaleX = getIframeScale(frameBounds.width, layoutMetrics.width);
+    const frameScaleY = getIframeScale(frameBounds.height, layoutMetrics.height);
+
+    convertedX = frameBounds.left + (layoutMetrics.contentOffsetX + convertedX) * frameScaleX;
+    convertedY = frameBounds.top + (layoutMetrics.contentOffsetY + convertedY) * frameScaleY;
+    cumulativeScaleX *= frameScaleX;
+    cumulativeScaleY *= frameScaleY;
+    currentWindow = frameElement.ownerDocument.defaultView;
+  }
+
+  return {
+    x: convertedX,
+    y: convertedY,
+    scaleX: cumulativeScaleX,
+    scaleY: cumulativeScaleY,
+  };
+};

--- a/packages/react-grab/src/utils/convert-parent-position-to-iframe.ts
+++ b/packages/react-grab/src/utils/convert-parent-position-to-iframe.ts
@@ -1,0 +1,23 @@
+import { getIframeLayoutMetrics } from "./get-iframe-layout-metrics.js";
+import { getIframeScale } from "./get-iframe-scale.js";
+
+interface IframeClientPosition {
+  x: number;
+  y: number;
+}
+
+export const convertParentPositionToIframe = (
+  iframeElement: HTMLIFrameElement,
+  clientX: number,
+  clientY: number,
+): IframeClientPosition => {
+  const iframeBounds = iframeElement.getBoundingClientRect();
+  const layoutMetrics = getIframeLayoutMetrics(iframeElement);
+  const scaleX = getIframeScale(iframeBounds.width, layoutMetrics.width);
+  const scaleY = getIframeScale(iframeBounds.height, layoutMetrics.height);
+
+  return {
+    x: (clientX - iframeBounds.left) / scaleX - layoutMetrics.contentOffsetX,
+    y: (clientY - iframeBounds.top) / scaleY - layoutMetrics.contentOffsetY,
+  };
+};

--- a/packages/react-grab/src/utils/create-element-bounds.ts
+++ b/packages/react-grab/src/utils/create-element-bounds.ts
@@ -1,5 +1,8 @@
 import type { OverlayBounds } from "../types.js";
 import { BOUNDS_CACHE_TTL_MS, BORDER_RADIUS_CACHE_TTL_MS } from "../constants.js";
+import { convertClientPositionToTopWindow } from "./convert-client-position-to-top-window.js";
+import { getElementComputedStyle } from "./get-element-computed-style.js";
+import { scaleBorderRadius } from "./scale-border-radius.js";
 
 interface CachedBounds {
   bounds: OverlayBounds;
@@ -29,7 +32,7 @@ const getCachedBorderRadius = (
     return cached.borderRadius;
   }
 
-  const style = computedStyle ?? window.getComputedStyle(element);
+  const style = computedStyle ?? getElementComputedStyle(element);
   const borderRadius = style.borderRadius || "0px";
   borderRadiusCache.set(element, { borderRadius, timestamp: now });
   return borderRadius;
@@ -44,13 +47,22 @@ export const createElementBounds = (element: Element): OverlayBounds => {
   }
 
   const rect = element.getBoundingClientRect();
-  const borderRadius = getCachedBorderRadius(element, null, now);
+  const topWindowPosition = convertClientPositionToTopWindow(
+    element.ownerDocument.defaultView,
+    rect.left,
+    rect.top,
+  );
+  const borderRadius = scaleBorderRadius(
+    getCachedBorderRadius(element, null, now),
+    topWindowPosition.scaleX,
+    topWindowPosition.scaleY,
+  );
   const bounds: OverlayBounds = {
     borderRadius,
-    height: rect.height,
-    width: rect.width,
-    x: rect.left,
-    y: rect.top,
+    height: rect.height * topWindowPosition.scaleY,
+    width: rect.width * topWindowPosition.scaleX,
+    x: topWindowPosition.x,
+    y: topWindowPosition.y,
   };
 
   boundsCache.set(element, { bounds, timestamp: now });

--- a/packages/react-grab/src/utils/create-element-selector.ts
+++ b/packages/react-grab/src/utils/create-element-selector.ts
@@ -1,5 +1,8 @@
 import { isAcceptedAttr, findUniqueSelector } from "./find-unique-selector.js";
 import { FINDER_TIMEOUT_MS, SELECTOR_ATTR_VALUE_MAX_LENGTH_CHARS } from "../constants.js";
+import { getWindowFrameElement } from "./get-window-frame-element.js";
+import { isShadowRoot } from "./is-shadow-root.js";
+import { isElementNode } from "./is-element-node.js";
 
 const getFinderRoot = (element: Element): Element =>
   element.ownerDocument.body ?? element.ownerDocument.documentElement;
@@ -24,7 +27,9 @@ const isPreferredAttributeValueSafe = (value: string): boolean =>
 
 const isSelectorUniqueForElement = (element: Element, selector: string): boolean => {
   try {
-    const matchingElements = element.ownerDocument.querySelectorAll(selector);
+    const rootNode = element.getRootNode();
+    const selectorRoot = isShadowRoot(rootNode) ? rootNode : element.ownerDocument;
+    const matchingElements = selectorRoot.querySelectorAll(selector);
     return matchingElements.length === 1 && matchingElements[0] === element;
   } catch {
     return false;
@@ -32,8 +37,9 @@ const isSelectorUniqueForElement = (element: Element, selector: string): boolean
 };
 
 const createFastElementSelector = (element: Element): string | null => {
-  if (element instanceof HTMLElement && element.id) {
-    const idSelector = `#${CSS.escape(element.id)}`;
+  const elementId = element.getAttribute("id");
+  if (elementId) {
+    const idSelector = `#${CSS.escape(elementId)}`;
     if (isSelectorUniqueForElement(element, idSelector)) return idSelector;
   }
 
@@ -60,38 +66,40 @@ const createFastElementSelector = (element: Element): string | null => {
 
 const createNthChildSelector = (element: Element): string => {
   const segments: string[] = [];
-  const root = getFinderRoot(element);
+  const rootNode = element.getRootNode();
+  const root = isShadowRoot(rootNode) ? rootNode : getFinderRoot(element);
 
   let currentElement: Element | null = element;
   while (currentElement) {
-    if (currentElement instanceof HTMLElement && currentElement.id) {
-      segments.unshift(`#${CSS.escape(currentElement.id)}`);
+    const currentElementId = currentElement.getAttribute("id");
+    if (currentElementId) {
+      segments.unshift(`#${CSS.escape(currentElementId)}`);
       break;
     }
 
-    const parentElement: HTMLElement | null = currentElement.parentElement;
-    if (!parentElement) {
+    const parentNode: ParentNode | null = currentElement.parentNode;
+    if (!parentNode) {
       segments.unshift(currentElement.tagName.toLowerCase());
       break;
     }
 
-    const siblings = Array.from(parentElement.children);
+    const siblings = Array.from(parentNode.children);
     const nthChild = siblings.indexOf(currentElement) + 1;
 
     segments.unshift(`${currentElement.tagName.toLowerCase()}:nth-child(${nthChild})`);
 
-    if (parentElement === root) {
-      segments.unshift(root.tagName.toLowerCase());
+    if (parentNode === root) {
+      if (isElementNode(root)) segments.unshift(root.tagName.toLowerCase());
       break;
     }
 
-    currentElement = parentElement;
+    currentElement = isElementNode(parentNode) ? parentNode : null;
   }
 
   return segments.join(" > ");
 };
 
-export const createElementSelector = (element: Element): string => {
+const createLocalElementSelector = (element: Element): string => {
   const fastSelector = createFastElementSelector(element);
   if (fastSelector) return fastSelector;
 
@@ -111,4 +119,17 @@ export const createElementSelector = (element: Element): string => {
   } catch {}
 
   return createNthChildSelector(element);
+};
+
+export const createElementSelector = (element: Element): string => {
+  const localSelector = createLocalElementSelector(element);
+  const rootNode = element.getRootNode();
+  if (isShadowRoot(rootNode)) {
+    return `${createElementSelector(rootNode.host)} >>> ${localSelector}`;
+  }
+
+  const frameElement = getWindowFrameElement(element.ownerDocument.defaultView);
+  return frameElement
+    ? `${createElementSelector(frameElement)} >>iframe>> ${localSelector}`
+    : localSelector;
 };

--- a/packages/react-grab/src/utils/create-style-element.ts
+++ b/packages/react-grab/src/utils/create-style-element.ts
@@ -1,13 +1,17 @@
 import { detectCspNonce } from "./detect-csp-nonce.js";
 import { hideFromThirdParties } from "./hide-from-third-parties.js";
 
-export const createStyleElement = (attribute: string, content: string): HTMLStyleElement => {
-  const element = document.createElement("style");
+export const createStyleElement = (
+  attribute: string,
+  content: string,
+  targetDocument: Document = document,
+): HTMLStyleElement => {
+  const element = targetDocument.createElement("style");
   element.setAttribute(attribute, "");
-  const nonce = detectCspNonce();
+  const nonce = detectCspNonce(targetDocument);
   if (nonce) element.nonce = nonce;
   hideFromThirdParties(element);
   element.textContent = content;
-  document.head.appendChild(element);
+  targetDocument.head.appendChild(element);
   return element;
 };

--- a/packages/react-grab/src/utils/detect-csp-nonce.ts
+++ b/packages/react-grab/src/utils/detect-csp-nonce.ts
@@ -1,10 +1,11 @@
-let cachedNonce: string | undefined;
+const cachedNonceByDocument = new WeakMap<Document, string>();
 
-export const detectCspNonce = (): string | null => {
+export const detectCspNonce = (targetDocument: Document = document): string | null => {
+  const cachedNonce = cachedNonceByDocument.get(targetDocument);
   if (cachedNonce !== undefined) return cachedNonce;
 
-  const existingElement = document.querySelector<HTMLElement>("script[nonce], style[nonce]");
+  const existingElement = targetDocument.querySelector<HTMLElement>("script[nonce], style[nonce]");
   const nonce = existingElement?.nonce || existingElement?.getAttribute("nonce") || null;
-  if (nonce) cachedNonce = nonce;
+  if (nonce) cachedNonceByDocument.set(targetDocument, nonce);
   return nonce;
 };

--- a/packages/react-grab/src/utils/find-unique-selector.ts
+++ b/packages/react-grab/src/utils/find-unique-selector.ts
@@ -1,5 +1,8 @@
 import { MAX_SELECTOR_COMBINATIONS } from "../constants.js";
 import { NonElementNodeError, SelectorNotFoundError, SelectorTimeoutError } from "../errors.js";
+import { isDocumentNode } from "./is-document-node.js";
+import { isElementNode } from "./is-element-node.js";
+import { isShadowRoot } from "./is-shadow-root.js";
 
 interface SelectorNode {
   name: string;
@@ -67,7 +70,7 @@ const getChildIndex = (element: Element, filterTagName?: string): number | undef
   let position = 0;
   while (sibling) {
     if (
-      sibling instanceof Element &&
+      isElementNode(sibling) &&
       (filterTagName === undefined || sibling.tagName.toLowerCase() === filterTagName)
     ) {
       position++;
@@ -157,31 +160,26 @@ const collectCombinations = (
   return results;
 };
 
-const resolveRootDocument = (
-  rootNode: Element | Document,
-  targetElement: Element,
-): Element | Document => {
-  const attachedRoot = targetElement.getRootNode?.();
-  if (attachedRoot instanceof ShadowRoot) {
-    return attachedRoot as unknown as Document;
+const resolveSelectorRoot = (rootNode: Element | Document, targetElement: Element): ParentNode => {
+  const attachedRoot = targetElement.getRootNode();
+  if (isShadowRoot(attachedRoot)) {
+    return attachedRoot;
   }
-  if (rootNode instanceof Document) return rootNode;
+  if (isDocumentNode(rootNode)) return rootNode;
   return rootNode.ownerDocument;
 };
 
-const isSelectorUnique = (
-  selectorPath: SelectorNode[],
-  rootDocument: Element | Document,
-): boolean => rootDocument.querySelectorAll(buildSelectorString(selectorPath)).length === 1;
+const isSelectorUnique = (selectorPath: SelectorNode[], selectorRoot: ParentNode): boolean =>
+  selectorRoot.querySelectorAll(buildSelectorString(selectorPath)).length === 1;
 
 const buildFallbackPath = (
   targetElement: Element,
-  rootDocument: Element | Document,
+  selectorRoot: ParentNode,
 ): SelectorNode[] | undefined => {
   let currentElement: Element | null = targetElement;
   const path: SelectorNode[] = [];
 
-  while (currentElement && currentElement !== rootDocument) {
+  while (currentElement && currentElement !== selectorRoot) {
     const currentTagName = currentElement.tagName.toLowerCase();
     const typePosition = getChildIndex(currentElement, currentTagName);
     if (typePosition === undefined) return undefined;
@@ -193,7 +191,7 @@ const buildFallbackPath = (
     currentElement = currentElement.parentElement;
   }
 
-  return isSelectorUnique(path, rootDocument) ? path : undefined;
+  return isSelectorUnique(path, selectorRoot) ? path : undefined;
 };
 
 export const findUniqueSelector = (
@@ -209,7 +207,7 @@ export const findUniqueSelector = (
     return "html";
   }
 
-  const rootDocument = resolveRootDocument(root, targetElement);
+  const selectorRoot = resolveSelectorRoot(root, targetElement);
   const startTime = Date.now();
 
   const ancestorStack: SelectorNode[][] = [];
@@ -217,7 +215,7 @@ export const findUniqueSelector = (
   let depth = 0;
   let foundPath: SelectorNode[] | undefined;
 
-  while (currentElement && currentElement !== rootDocument && !foundPath) {
+  while (currentElement && currentElement !== selectorRoot && !foundPath) {
     ancestorStack.push(collectCandidateNodes(currentElement, attrFilter));
     currentElement = currentElement.parentElement;
     depth++;
@@ -228,13 +226,13 @@ export const findUniqueSelector = (
 
       for (const candidatePath of candidatePaths) {
         if (Date.now() - startTime > timeoutMs) {
-          const fallbackPath = buildFallbackPath(targetElement, rootDocument);
+          const fallbackPath = buildFallbackPath(targetElement, selectorRoot);
           if (!fallbackPath) {
             throw new SelectorTimeoutError(timeoutMs);
           }
           return buildSelectorString(fallbackPath);
         }
-        if (isSelectorUnique(candidatePath, rootDocument)) {
+        if (isSelectorUnique(candidatePath, selectorRoot)) {
           foundPath = candidatePath;
           break;
         }
@@ -247,7 +245,7 @@ export const findUniqueSelector = (
     remainingPaths.sort(comparePenalty);
     for (const candidatePath of remainingPaths) {
       if (Date.now() - startTime > timeoutMs) break;
-      if (isSelectorUnique(candidatePath, rootDocument)) {
+      if (isSelectorUnique(candidatePath, selectorRoot)) {
         foundPath = candidatePath;
         break;
       }

--- a/packages/react-grab/src/utils/forward-same-origin-frame-events.ts
+++ b/packages/react-grab/src/utils/forward-same-origin-frame-events.ts
@@ -1,0 +1,140 @@
+import { convertClientPositionToTopWindow } from "./convert-client-position-to-top-window.js";
+import { registerAnimationFreezeDocument } from "./freeze-animations.js";
+import { registerPseudoStateDocument } from "./freeze-pseudo-states.js";
+import { observeSameOriginFrameDocuments } from "./observe-same-origin-frame-documents.js";
+import { throwCollectedErrors } from "./throw-collected-errors.js";
+
+interface FrameEventForwardingOptions {
+  shouldForwardInteraction: () => boolean;
+  shouldForwardKeyboardEvent: (event: KeyboardEvent) => boolean;
+  shouldForwardViewportEvent: (frameDocument: Document) => boolean;
+}
+
+const dispatchForwardedEvent = (sourceEvent: Event, forwardedEvent: Event): void => {
+  window.dispatchEvent(forwardedEvent);
+  if (forwardedEvent.defaultPrevented) {
+    sourceEvent.preventDefault();
+    sourceEvent.stopImmediatePropagation();
+  }
+};
+
+const createMouseEventInit = (
+  event: MouseEvent,
+  clientX: number,
+  clientY: number,
+): MouseEventInit => ({
+  bubbles: true,
+  cancelable: true,
+  composed: true,
+  clientX,
+  clientY,
+  screenX: event.screenX,
+  screenY: event.screenY,
+  button: event.button,
+  buttons: event.buttons,
+  altKey: event.altKey,
+  ctrlKey: event.ctrlKey,
+  metaKey: event.metaKey,
+  shiftKey: event.shiftKey,
+});
+
+const forwardPointerEvent = (event: PointerEvent): void => {
+  const topPosition = convertClientPositionToTopWindow(event.view, event.clientX, event.clientY);
+  const forwardedEvent = new PointerEvent(event.type, {
+    ...createMouseEventInit(event, topPosition.x, topPosition.y),
+    pointerId: event.pointerId,
+    pointerType: event.pointerType,
+    isPrimary: event.isPrimary,
+    pressure: event.pressure,
+    tangentialPressure: event.tangentialPressure,
+    tiltX: event.tiltX,
+    tiltY: event.tiltY,
+    twist: event.twist,
+    width: event.width,
+    height: event.height,
+  });
+  dispatchForwardedEvent(event, forwardedEvent);
+};
+
+const forwardMouseEvent = (event: MouseEvent): void => {
+  const topPosition = convertClientPositionToTopWindow(event.view, event.clientX, event.clientY);
+  const forwardedEvent = new MouseEvent(
+    event.type,
+    createMouseEventInit(event, topPosition.x, topPosition.y),
+  );
+  dispatchForwardedEvent(event, forwardedEvent);
+};
+
+const forwardKeyboardEvent = (event: KeyboardEvent): void => {
+  const forwardedEvent = new KeyboardEvent(event.type, {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    key: event.key,
+    code: event.code,
+    location: event.location,
+    repeat: event.repeat,
+    isComposing: event.isComposing,
+    altKey: event.altKey,
+    ctrlKey: event.ctrlKey,
+    metaKey: event.metaKey,
+    shiftKey: event.shiftKey,
+  });
+  dispatchForwardedEvent(event, forwardedEvent);
+};
+
+export const forwardSameOriginFrameEvents = (options: FrameEventForwardingOptions): (() => void) =>
+  observeSameOriginFrameDocuments((frameDocument) => {
+    if (frameDocument === document) return;
+    const frameWindow = frameDocument.defaultView;
+    if (!frameWindow) return;
+    const abortController = new AbortController();
+    const unregisterAnimationFreezeDocument = registerAnimationFreezeDocument(frameDocument);
+    const unregisterPseudoStateDocument = registerPseudoStateDocument(frameDocument);
+    const eventOptions = { capture: true, signal: abortController.signal };
+
+    const forwardPointerEventWhenActive = (event: PointerEvent): void => {
+      if (options.shouldForwardInteraction()) forwardPointerEvent(event);
+    };
+    const forwardMouseEventWhenActive = (event: MouseEvent): void => {
+      if (options.shouldForwardInteraction()) forwardMouseEvent(event);
+    };
+    const forwardKeyboardEventWhenActive = (event: KeyboardEvent): void => {
+      if (options.shouldForwardInteraction() || options.shouldForwardKeyboardEvent(event)) {
+        forwardKeyboardEvent(event);
+      }
+    };
+    const forwardViewportEventWhenActive = (event: Event): void => {
+      if (options.shouldForwardInteraction() && options.shouldForwardViewportEvent(frameDocument)) {
+        window.dispatchEvent(new Event(event.type));
+      }
+    };
+
+    frameWindow.addEventListener("pointermove", forwardPointerEventWhenActive, eventOptions);
+    frameWindow.addEventListener("pointerdown", forwardPointerEventWhenActive, eventOptions);
+    frameWindow.addEventListener("pointerup", forwardPointerEventWhenActive, eventOptions);
+    frameWindow.addEventListener("pointercancel", forwardPointerEventWhenActive, eventOptions);
+    frameWindow.addEventListener("contextmenu", forwardMouseEventWhenActive, eventOptions);
+    frameWindow.addEventListener("click", forwardMouseEventWhenActive, eventOptions);
+    frameWindow.addEventListener("keydown", forwardKeyboardEventWhenActive, eventOptions);
+    frameWindow.addEventListener("keyup", forwardKeyboardEventWhenActive, eventOptions);
+    frameWindow.addEventListener("keypress", forwardKeyboardEventWhenActive, eventOptions);
+    frameWindow.addEventListener("scroll", forwardViewportEventWhenActive, eventOptions);
+    frameWindow.addEventListener("resize", forwardViewportEventWhenActive, eventOptions);
+
+    return () => {
+      abortController.abort();
+      const cleanupErrors: unknown[] = [];
+      for (const unregisterDocument of [
+        unregisterAnimationFreezeDocument,
+        unregisterPseudoStateDocument,
+      ]) {
+        try {
+          unregisterDocument();
+        } catch (error) {
+          cleanupErrors.push(error);
+        }
+      }
+      throwCollectedErrors(cleanupErrors, "Cleaning up frame event forwarding failed");
+    };
+  });

--- a/packages/react-grab/src/utils/freeze-animations.ts
+++ b/packages/react-grab/src/utils/freeze-animations.ts
@@ -1,6 +1,9 @@
 import { FROZEN_ELEMENT_ATTRIBUTE, WAAPI_GLOBAL_FREEZE_MAX_ANIMATIONS } from "../constants.js";
 import { createStyleElement } from "./create-style-element.js";
 import { freezeGsap, unfreezeGsap } from "./freeze-gsap.js";
+import { isElementNode } from "./is-element-node.js";
+import { isReactGrabHost } from "./is-react-grab-host.js";
+import { isShadowRoot } from "./is-shadow-root.js";
 import { IS_DEMO } from "./runtime-mode.js";
 import { throwCollectedErrors } from "./throw-collected-errors.js";
 
@@ -21,27 +24,34 @@ const GLOBAL_FREEZE_STYLES = `
 
 const SVG_ROOT_SELECTOR = "svg";
 
+interface GlobalAnimationSnapshot {
+  targetDocument: Document;
+  runningAnimations: Animation[];
+}
+
+interface GlobalAnimationFreeze {
+  styleElement: HTMLStyleElement | null;
+  frozenSvgElements: SVGSVGElement[];
+  frozenWaapiAnimations: Animation[];
+  didUseCssFreeze: boolean;
+}
+
+const isSvgRootElement = (element: Element | null): element is SVGSVGElement =>
+  element?.namespaceURI === "http://www.w3.org/2000/svg" && element.tagName === "svg";
+
 let styleElement: HTMLStyleElement | null = null;
 let frozenElements: Element[] = [];
 let frozenSvgElements: SVGSVGElement[] = [];
 let lastInputElements: Element[] = [];
 
-let globalAnimationStyleElement: HTMLStyleElement | null = null;
-let globalFrozenSvgElements: SVGSVGElement[] = [];
-// Animations paused directly (WAAPI path); empty when the `*`-selector CSS path
-// was used instead. globalUsedCssFreeze records which path freeze took so
-// unfreeze can mirror it.
-let globalFrozenWaapiAnimations: Animation[] = [];
-let globalUsedCssFreeze = false;
+const registeredAnimationDocuments = new Set<Document>();
+const globalAnimationFreezes = new Map<Document, GlobalAnimationFreeze>();
 // An SVG can be frozen by both the element-level and global freeze, so we track
 // a depth counter per element and only unpause when all layers are removed.
 const svgFreezeDepthMap = new Map<SVGSVGElement, number>();
 let frozenWaapiAnimations: Animation[] = [];
 
-const hasGlobalAnimationFreeze = (): boolean =>
-  globalAnimationStyleElement !== null ||
-  globalFrozenSvgElements.length > 0 ||
-  globalFrozenWaapiAnimations.length > 0;
+const hasGlobalAnimationFreeze = (): boolean => globalAnimationFreezes.size > 0;
 
 const ensureStylesInjected = (): void => {
   if (styleElement) return;
@@ -56,16 +66,11 @@ const collectFrozenSvgElements = (elements: Element[]): SVGSVGElement[] => {
   const svgElements = new Set<SVGSVGElement>();
 
   for (const element of elements) {
-    if (element instanceof SVGSVGElement) {
-      svgElements.add(element);
-    } else if (element instanceof SVGElement && element.ownerSVGElement) {
-      svgElements.add(element.ownerSVGElement);
-    }
+    const containingSvgElement = isSvgRootElement(element) ? element : element.closest("svg");
+    if (isSvgRootElement(containingSvgElement)) svgElements.add(containingSvgElement);
 
     for (const innerSvgElement of element.querySelectorAll(SVG_ROOT_SELECTOR)) {
-      if (innerSvgElement instanceof SVGSVGElement) {
-        svgElements.add(innerSvgElement);
-      }
+      if (isSvgRootElement(innerSvgElement)) svgElements.add(innerSvgElement);
     }
   }
 
@@ -165,7 +170,9 @@ const restorePausedAnimations = (animations: Iterable<Animation>): void => {
 const isShadowAnimation = (animation: Animation): boolean => {
   if (!(animation.effect instanceof KeyframeEffect)) return false;
   const target = animation.effect.target;
-  return target instanceof Element && target.getRootNode() instanceof ShadowRoot;
+  if (!isElementNode(target)) return false;
+  const rootNode = target.getRootNode();
+  return isShadowRoot(rootNode) && isReactGrabHost(rootNode.host);
 };
 
 export const freezeAllAnimations = (elements: Element[]): void => {
@@ -244,70 +251,24 @@ export const freezeAnimations = (elements: Element[]): (() => void) => {
   return unfreezeAllAnimations;
 };
 
-// READ phase. document.getAnimations() forces a style flush, so the caller
-// must run this before any freeze-related DOM writes — otherwise a stylesheet
-// injected just before it triggers a second full-document recalc (profiled at
-// ~59ms on a large app even when it returns zero animations).
-export const collectGlobalAnimationsToFreeze = (): Animation[] => {
-  // Demo mode is display-only and must never freeze (or force a style flush
-  // on) the host page.
-  if (IS_DEMO) return [];
-  if (hasGlobalAnimationFreeze()) return [];
+const collectDocumentAnimationsToFreeze = (targetDocument: Document): GlobalAnimationSnapshot => {
   const runningAnimations: Animation[] = [];
-  for (const animation of document.getAnimations()) {
+  for (const animation of targetDocument.getAnimations()) {
     if (isShadowAnimation(animation)) continue;
     if (animation.playState === "running") runningAnimations.push(animation);
   }
-  return runningAnimations;
+  return { targetDocument, runningAnimations };
 };
 
-// WRITE phase. Pure DOM writes (marker element, animation pause, SVG/GSAP) — no
-// layout reads, so it never forces a recalc on its own.
-export const applyGlobalAnimationFreeze = (runningAnimations: Animation[]): void => {
-  if (IS_DEMO) return;
-  if (hasGlobalAnimationFreeze()) return;
+const unfreezeDocumentAnimations = (targetDocument: Document): unknown[] => {
+  const globalAnimationFreeze = globalAnimationFreezes.get(targetDocument);
+  if (!globalAnimationFreeze) return [];
 
-  // Marker element; also carries the `*` freeze rule on the CSS path below. Its
-  // presence signals the global freeze is active (asserted by the e2e suite).
-  globalAnimationStyleElement = createStyleElement("data-react-grab-global-freeze", "");
-
-  if (runningAnimations.length > WAAPI_GLOBAL_FREEZE_MAX_ANIMATIONS) {
-    // Many animations: one batched universal-selector recalc beats thousands of
-    // individual WAAPI pauses.
-    globalAnimationStyleElement.textContent = GLOBAL_FREEZE_STYLES;
-    globalUsedCssFreeze = true;
-    globalFrozenWaapiAnimations = [];
-  } else {
-    // Few animations (the common case): pause them directly. This touches only
-    // the animating elements instead of forcing a full-document style recalc.
-    globalFrozenWaapiAnimations = [];
-    for (const animation of runningAnimations) {
-      animation.pause();
-      globalFrozenWaapiAnimations.push(animation);
-    }
-    globalUsedCssFreeze = false;
-  }
-
-  const svgElementsToFreeze = collectFrozenSvgElements(
-    Array.from(document.querySelectorAll(SVG_ROOT_SELECTOR)),
-  );
-  globalFrozenSvgElements = [];
-  pauseSvgAnimations(svgElementsToFreeze, globalFrozenSvgElements);
-  freezeGsap();
-};
-
-export const unfreezeGlobalAnimations = (): void => {
-  if (!hasGlobalAnimationFreeze()) return;
-
-  const styleElementToRemove = globalAnimationStyleElement;
-  const didUseCssFreeze = globalUsedCssFreeze;
-  const waapiAnimationsToRestore = globalFrozenWaapiAnimations;
-  const svgElementsToUnfreeze = globalFrozenSvgElements;
   const cleanupErrors: unknown[] = [];
-
+  const styleElementToRemove = globalAnimationFreeze.styleElement;
   if (styleElementToRemove) {
     try {
-      if (didUseCssFreeze) {
+      if (globalAnimationFreeze.didUseCssFreeze) {
         // CSS path. All paused animations must be finished before the freeze
         // stylesheet is removed, because simply removing animation-play-state:paused
         // would resume them from their mid-point and create visual jumps. finish()
@@ -320,7 +281,7 @@ export const unfreezeGlobalAnimations = (): void => {
 }
 `;
         const animationsToFinish: Animation[] = [];
-        for (const animation of document.getAnimations()) {
+        for (const animation of targetDocument.getAnimations()) {
           if (isShadowAnimation(animation)) continue;
           animationsToFinish.push(animation);
         }
@@ -329,22 +290,118 @@ export const unfreezeGlobalAnimations = (): void => {
         // WAAPI path: restore the specific animations we paused. Finite animations
         // advance to their end (finish()) so they don't jump backward through their
         // timeline; infinite ones (finish() throws) resume looping (play()).
-        restorePausedAnimations(waapiAnimationsToRestore);
+        restorePausedAnimations(globalAnimationFreeze.frozenWaapiAnimations);
       }
+      globalAnimationFreeze.didUseCssFreeze = false;
+      globalAnimationFreeze.frozenWaapiAnimations = [];
     } catch (error) {
       cleanupErrors.push(error);
     }
-    globalUsedCssFreeze = false;
-    globalFrozenWaapiAnimations = [];
 
     try {
       styleElementToRemove.remove();
-      globalAnimationStyleElement = null;
+      globalAnimationFreeze.styleElement = null;
     } catch (error) {
       cleanupErrors.push(error);
     }
   }
-  globalFrozenSvgElements = resumeSvgAnimations(svgElementsToUnfreeze, cleanupErrors);
+
+  globalAnimationFreeze.frozenSvgElements = resumeSvgAnimations(
+    globalAnimationFreeze.frozenSvgElements,
+    cleanupErrors,
+  );
+  if (
+    globalAnimationFreeze.styleElement === null &&
+    globalAnimationFreeze.frozenSvgElements.length === 0 &&
+    globalAnimationFreeze.frozenWaapiAnimations.length === 0
+  ) {
+    globalAnimationFreezes.delete(targetDocument);
+  }
+  return cleanupErrors;
+};
+
+const applyDocumentAnimationFreeze = (snapshot: GlobalAnimationSnapshot): void => {
+  if (globalAnimationFreezes.has(snapshot.targetDocument)) return;
+
+  const animationStyleElement = createStyleElement(
+    "data-react-grab-global-freeze",
+    "",
+    snapshot.targetDocument,
+  );
+  const globalAnimationFreeze: GlobalAnimationFreeze = {
+    styleElement: animationStyleElement,
+    frozenSvgElements: [],
+    frozenWaapiAnimations: [],
+    didUseCssFreeze: false,
+  };
+  globalAnimationFreezes.set(snapshot.targetDocument, globalAnimationFreeze);
+
+  if (snapshot.runningAnimations.length > WAAPI_GLOBAL_FREEZE_MAX_ANIMATIONS) {
+    animationStyleElement.textContent = GLOBAL_FREEZE_STYLES;
+    globalAnimationFreeze.didUseCssFreeze = true;
+  } else {
+    for (const animation of snapshot.runningAnimations) {
+      animation.pause();
+      globalAnimationFreeze.frozenWaapiAnimations.push(animation);
+    }
+  }
+
+  const svgElementsToFreeze = collectFrozenSvgElements(
+    Array.from(snapshot.targetDocument.querySelectorAll(SVG_ROOT_SELECTOR)),
+  );
+  pauseSvgAnimations(svgElementsToFreeze, globalAnimationFreeze.frozenSvgElements);
+};
+
+export const registerAnimationFreezeDocument = (targetDocument: Document): (() => void) => {
+  registeredAnimationDocuments.add(targetDocument);
+  try {
+    if (hasGlobalAnimationFreeze()) {
+      applyDocumentAnimationFreeze(collectDocumentAnimationsToFreeze(targetDocument));
+    }
+  } catch (error) {
+    registeredAnimationDocuments.delete(targetDocument);
+    const rollbackErrors = unfreezeDocumentAnimations(targetDocument);
+    if (rollbackErrors.length === 0) throw error;
+    throw new AggregateError([error, ...rollbackErrors], "Freezing frame animations failed");
+  }
+
+  return () => {
+    registeredAnimationDocuments.delete(targetDocument);
+    const cleanupErrors = unfreezeDocumentAnimations(targetDocument);
+    throwCollectedErrors(cleanupErrors, "Unfreezing frame animations failed");
+  };
+};
+
+// READ phase. getAnimations() forces a style flush, so the caller must run this
+// before any freeze-related DOM writes — otherwise a stylesheet injected just
+// before it triggers a second full-document recalc (profiled at ~59ms on a
+// large app even when it returns zero animations).
+export const collectGlobalAnimationsToFreeze = (): GlobalAnimationSnapshot[] => {
+  // Demo mode is display-only and must never freeze (or force a style flush
+  // on) the host page.
+  if (IS_DEMO) return [];
+  if (hasGlobalAnimationFreeze()) return [];
+  registeredAnimationDocuments.add(document);
+  return [...registeredAnimationDocuments].map(collectDocumentAnimationsToFreeze);
+};
+
+// WRITE phase. Pure DOM writes (marker elements, animation pauses, SVG/GSAP) —
+// no layout reads, so it never forces a recalc on its own.
+export const applyGlobalAnimationFreeze = (snapshots: GlobalAnimationSnapshot[]): void => {
+  if (IS_DEMO) return;
+  if (hasGlobalAnimationFreeze()) return;
+
+  for (const snapshot of snapshots) applyDocumentAnimationFreeze(snapshot);
+  freezeGsap();
+};
+
+export const unfreezeGlobalAnimations = (): void => {
+  if (!hasGlobalAnimationFreeze()) return;
+
+  const cleanupErrors: unknown[] = [];
+  for (const targetDocument of [...globalAnimationFreezes.keys()]) {
+    cleanupErrors.push(...unfreezeDocumentAnimations(targetDocument));
+  }
   try {
     unfreezeGsap();
   } catch (error) {

--- a/packages/react-grab/src/utils/freeze-pseudo-states.ts
+++ b/packages/react-grab/src/utils/freeze-pseudo-states.ts
@@ -1,8 +1,16 @@
 import { clearElementPositionCache } from "./get-element-at-position.js";
+import { getAccessibleIframeDocument } from "./get-accessible-iframe-document.js";
+import { getComposedParentElement } from "./get-composed-parent-element.js";
+import { getDeepElementAtPoint } from "./get-deep-element-at-point.js";
+import { getDeepHoveredElements } from "./get-deep-hovered-elements.js";
+import { isHtmlElement } from "./is-html-element.js";
+import { isIframeElement } from "./is-iframe-element.js";
+import { isReactGrabElement } from "./is-react-grab-element.js";
 import { IS_DEMO } from "./runtime-mode.js";
 import {
   installPointerEventsFreeze,
   isPointerEventsFreezeInstalled,
+  registerPointerEventsFreezeDocument,
   uninstallPointerEventsFreeze,
 } from "./pointer-events-freeze.js";
 import { throwCollectedErrors } from "./throw-collected-errors.js";
@@ -71,6 +79,8 @@ interface InlineStyleProperty {
 
 const frozenHoverElements = new Map<HTMLElement, Map<string, InlineStyleProperty>>();
 const frozenFocusElements = new Map<HTMLElement, Map<string, InlineStyleProperty>>();
+const registeredDocuments = new Set<Document>();
+let isFreezeApplied = false;
 
 const stopEvent = (event: Event): void => {
   event.stopImmediatePropagation();
@@ -79,6 +89,38 @@ const stopEvent = (event: Event): void => {
 const preventFocusChange = (event: Event): void => {
   event.preventDefault();
   event.stopImmediatePropagation();
+};
+
+const addEventBlockers = (targetDocument: Document): void => {
+  for (const eventType of MOUSE_EVENTS_TO_BLOCK) {
+    targetDocument.addEventListener(eventType, stopEvent, true);
+  }
+
+  for (const eventType of FOCUS_EVENTS_TO_BLOCK) {
+    targetDocument.addEventListener(eventType, preventFocusChange, true);
+  }
+};
+
+const removeEventBlockers = (targetDocument: Document): void => {
+  for (const eventType of MOUSE_EVENTS_TO_BLOCK) {
+    targetDocument.removeEventListener(eventType, stopEvent, true);
+  }
+
+  for (const eventType of FOCUS_EVENTS_TO_BLOCK) {
+    targetDocument.removeEventListener(eventType, preventFocusChange, true);
+  }
+};
+
+export const registerPseudoStateDocument = (targetDocument: Document): (() => void) => {
+  registeredDocuments.add(targetDocument);
+  const unregisterPointerEventsFreezeDocument = registerPointerEventsFreezeDocument(targetDocument);
+  if (isFreezeApplied) addEventBlockers(targetDocument);
+
+  return () => {
+    if (isFreezeApplied) removeEventBlockers(targetDocument);
+    registeredDocuments.delete(targetDocument);
+    unregisterPointerEventsFreezeDocument();
+  };
 };
 
 const freezeElement = (
@@ -108,12 +150,13 @@ const freezeElement = (
 
 const collectHoveredElements = (cursorX: number, cursorY: number): HTMLElement[] => {
   const hoveredElements: HTMLElement[] = [];
-  let current = document.elementFromPoint(cursorX, cursorY);
+  let current = getDeepElementAtPoint(cursorX, cursorY);
   while (current && current !== document.documentElement) {
-    if (current instanceof HTMLElement) {
+    if (isReactGrabElement(current)) break;
+    if (isHtmlElement(current)) {
       hoveredElements.push(current);
     }
-    current = current.parentElement;
+    current = getComposedParentElement(current);
   }
   return hoveredElements;
 };
@@ -122,11 +165,18 @@ const collectFocusedElements = (): HTMLElement[] => {
   const focusedElements: HTMLElement[] = [];
   let current: Element | null = document.activeElement;
   while (current && current !== document.body) {
-    if (current instanceof HTMLElement) {
+    if (isHtmlElement(current)) {
       focusedElements.push(current);
     }
-    const shadowRoot = current.shadowRoot;
-    current = shadowRoot?.activeElement ?? null;
+    if (current.shadowRoot?.activeElement) {
+      current = current.shadowRoot.activeElement;
+      continue;
+    }
+    if (isIframeElement(current)) {
+      current = getAccessibleIframeDocument(current)?.activeElement ?? null;
+      continue;
+    }
+    current = null;
   }
   return focusedElements;
 };
@@ -192,9 +242,7 @@ export const collectPseudoStates = (
     cursorY < window.innerHeight;
   const hoveredElements = isCursorInViewport
     ? collectHoveredElements(cursorX, cursorY)
-    : Array.from(document.querySelectorAll(":hover")).filter(
-        (element): element is HTMLElement => element instanceof HTMLElement,
-      );
+    : getDeepHoveredElements();
   for (const element of hoveredElements) {
     const state = freezeElement(element, HOVER_STYLE_PROPERTIES);
     if (state) hoverStates.push(state);
@@ -214,13 +262,9 @@ export const collectPseudoStates = (
 export const applyPseudoStates = (snapshot: PseudoFreezeSnapshot | null): void => {
   if (!snapshot) return;
 
-  for (const eventType of MOUSE_EVENTS_TO_BLOCK) {
-    document.addEventListener(eventType, stopEvent, true);
-  }
-
-  for (const eventType of FOCUS_EVENTS_TO_BLOCK) {
-    document.addEventListener(eventType, preventFocusChange, true);
-  }
+  isFreezeApplied = true;
+  registeredDocuments.add(document);
+  for (const targetDocument of registeredDocuments) addEventBlockers(targetDocument);
 
   applyFrozenStates(snapshot.hoverStates, frozenHoverElements);
   applyFrozenStates(snapshot.focusStates, frozenFocusElements);
@@ -231,13 +275,8 @@ export const applyPseudoStates = (snapshot: PseudoFreezeSnapshot | null): void =
 export const unfreezePseudoStates = (): void => {
   clearElementPositionCache();
 
-  for (const eventType of MOUSE_EVENTS_TO_BLOCK) {
-    document.removeEventListener(eventType, stopEvent, true);
-  }
-
-  for (const eventType of FOCUS_EVENTS_TO_BLOCK) {
-    document.removeEventListener(eventType, preventFocusChange, true);
-  }
+  isFreezeApplied = false;
+  for (const targetDocument of registeredDocuments) removeEventBlockers(targetDocument);
 
   const cleanupErrors = [
     ...restoreFrozenStates(frozenHoverElements),

--- a/packages/react-grab/src/utils/get-accessible-iframe-document.ts
+++ b/packages/react-grab/src/utils/get-accessible-iframe-document.ts
@@ -1,0 +1,7 @@
+export const getAccessibleIframeDocument = (iframeElement: HTMLIFrameElement): Document | null => {
+  try {
+    return iframeElement.contentDocument;
+  } catch {
+    return null;
+  }
+};

--- a/packages/react-grab/src/utils/get-composed-parent-element.ts
+++ b/packages/react-grab/src/utils/get-composed-parent-element.ts
@@ -1,0 +1,13 @@
+import { isShadowRoot } from "./is-shadow-root.js";
+import { isDocumentNode } from "./is-document-node.js";
+import { getWindowFrameElement } from "./get-window-frame-element.js";
+
+export const getComposedParentElement = (element: Element): Element | null => {
+  if (element.assignedSlot) return element.assignedSlot;
+  if (element.parentElement) return element.parentElement;
+
+  const rootNode = element.getRootNode();
+  if (isShadowRoot(rootNode)) return rootNode.host;
+  if (isDocumentNode(rootNode)) return getWindowFrameElement(rootNode.defaultView);
+  return null;
+};

--- a/packages/react-grab/src/utils/get-deep-element-at-point.ts
+++ b/packages/react-grab/src/utils/get-deep-element-at-point.ts
@@ -1,0 +1,36 @@
+import { convertParentPositionToIframe } from "./convert-parent-position-to-iframe.js";
+import { getAccessibleIframeDocument } from "./get-accessible-iframe-document.js";
+import { isIframeElement } from "./is-iframe-element.js";
+
+const getDeepElementInDocumentAtPoint = (
+  targetDocument: Document,
+  clientX: number,
+  clientY: number,
+): Element | null => {
+  let targetElement = targetDocument.elementFromPoint(clientX, clientY);
+
+  while (targetElement) {
+    const shadowTargetElement = targetElement.shadowRoot?.elementFromPoint(clientX, clientY);
+    if (shadowTargetElement && shadowTargetElement !== targetElement) {
+      targetElement = shadowTargetElement;
+      continue;
+    }
+
+    if (isIframeElement(targetElement)) {
+      const iframeDocument = getAccessibleIframeDocument(targetElement);
+      if (!iframeDocument) return targetElement;
+      const iframePosition = convertParentPositionToIframe(targetElement, clientX, clientY);
+      return (
+        getDeepElementInDocumentAtPoint(iframeDocument, iframePosition.x, iframePosition.y) ??
+        targetElement
+      );
+    }
+
+    return targetElement;
+  }
+
+  return null;
+};
+
+export const getDeepElementAtPoint = (clientX: number, clientY: number): Element | null =>
+  getDeepElementInDocumentAtPoint(document, clientX, clientY);

--- a/packages/react-grab/src/utils/get-deep-elements-at-point.ts
+++ b/packages/react-grab/src/utils/get-deep-elements-at-point.ts
@@ -1,0 +1,43 @@
+import { convertParentPositionToIframe } from "./convert-parent-position-to-iframe.js";
+import { getAccessibleIframeDocument } from "./get-accessible-iframe-document.js";
+import { isIframeElement } from "./is-iframe-element.js";
+import { isUserIgnoredElement } from "./is-user-ignored-element.js";
+
+const collectElementsAtPoint = (
+  root: Document | ShadowRoot,
+  clientX: number,
+  clientY: number,
+  collectedElements: Set<Element>,
+): void => {
+  const elements = root.elementsFromPoint(clientX, clientY);
+  let canDescendIntoNestedRoots = true;
+
+  for (const element of elements) {
+    if (isUserIgnoredElement(element)) canDescendIntoNestedRoots = false;
+
+    if (canDescendIntoNestedRoots && element.shadowRoot && element.shadowRoot !== root) {
+      collectElementsAtPoint(element.shadowRoot, clientX, clientY, collectedElements);
+    }
+
+    if (canDescendIntoNestedRoots && isIframeElement(element)) {
+      const iframeDocument = getAccessibleIframeDocument(element);
+      if (iframeDocument) {
+        const iframePosition = convertParentPositionToIframe(element, clientX, clientY);
+        collectElementsAtPoint(
+          iframeDocument,
+          iframePosition.x,
+          iframePosition.y,
+          collectedElements,
+        );
+      }
+    }
+
+    collectedElements.add(element);
+  }
+};
+
+export const getDeepElementsAtPoint = (clientX: number, clientY: number): Element[] => {
+  const collectedElements = new Set<Element>();
+  collectElementsAtPoint(document, clientX, clientY, collectedElements);
+  return [...collectedElements];
+};

--- a/packages/react-grab/src/utils/get-deep-fallback-element-at-point.ts
+++ b/packages/react-grab/src/utils/get-deep-fallback-element-at-point.ts
@@ -1,0 +1,46 @@
+import { convertParentPositionToIframe } from "./convert-parent-position-to-iframe.js";
+import { getAccessibleIframeDocument } from "./get-accessible-iframe-document.js";
+import { isIframeElement } from "./is-iframe-element.js";
+import { isUserIgnoredElement } from "./is-user-ignored-element.js";
+import { isValidGrabbableElement } from "./is-valid-grabbable-element.js";
+import { isWithinScope } from "./runtime-mode.js";
+
+const findDeepFallbackElementAtPoint = (
+  root: Document | ShadowRoot,
+  clientX: number,
+  clientY: number,
+): Element | null => {
+  let canDescendIntoNestedRoots = true;
+
+  for (const candidateElement of root.elementsFromPoint(clientX, clientY)) {
+    if (isUserIgnoredElement(candidateElement)) canDescendIntoNestedRoots = false;
+    if (!isWithinScope(candidateElement)) continue;
+
+    const shadowRoot = candidateElement.shadowRoot;
+    if (canDescendIntoNestedRoots && shadowRoot && shadowRoot !== root) {
+      const shadowTarget = findDeepFallbackElementAtPoint(shadowRoot, clientX, clientY);
+      if (shadowTarget) return shadowTarget;
+    }
+
+    if (canDescendIntoNestedRoots && isIframeElement(candidateElement)) {
+      const iframeDocument = getAccessibleIframeDocument(candidateElement);
+      if (iframeDocument) {
+        const iframePosition = convertParentPositionToIframe(candidateElement, clientX, clientY);
+        const iframeTarget = findDeepFallbackElementAtPoint(
+          iframeDocument,
+          iframePosition.x,
+          iframePosition.y,
+        );
+        if (iframeTarget) return iframeTarget;
+      }
+    }
+
+    if (!isValidGrabbableElement(candidateElement)) continue;
+    return candidateElement;
+  }
+
+  return null;
+};
+
+export const getDeepFallbackElementAtPoint = (clientX: number, clientY: number): Element | null =>
+  findDeepFallbackElementAtPoint(document, clientX, clientY);

--- a/packages/react-grab/src/utils/get-deep-hovered-elements.ts
+++ b/packages/react-grab/src/utils/get-deep-hovered-elements.ts
@@ -1,0 +1,25 @@
+import { getAccessibleIframeDocument } from "./get-accessible-iframe-document.js";
+import { isHtmlElement } from "./is-html-element.js";
+import { isIframeElement } from "./is-iframe-element.js";
+import { isReactGrabElement } from "./is-react-grab-element.js";
+
+const collectHoveredElements = (
+  root: Document | ShadowRoot,
+  hoveredElements: Set<HTMLElement>,
+): void => {
+  for (const element of root.querySelectorAll(":hover")) {
+    if (isReactGrabElement(element)) continue;
+    if (isHtmlElement(element)) hoveredElements.add(element);
+    if (element.shadowRoot) collectHoveredElements(element.shadowRoot, hoveredElements);
+    if (isIframeElement(element)) {
+      const iframeDocument = getAccessibleIframeDocument(element);
+      if (iframeDocument) collectHoveredElements(iframeDocument, hoveredElements);
+    }
+  }
+};
+
+export const getDeepHoveredElements = (): HTMLElement[] => {
+  const hoveredElements = new Set<HTMLElement>();
+  collectHoveredElements(document, hoveredElements);
+  return [...hoveredElements];
+};

--- a/packages/react-grab/src/utils/get-element-at-position.ts
+++ b/packages/react-grab/src/utils/get-element-at-position.ts
@@ -1,11 +1,19 @@
-import { isValidGrabbableElement } from "./is-valid-grabbable-element.js";
+import type { Rect } from "../types.js";
 import {
   ELEMENT_POSITION_CACHE_DISTANCE_THRESHOLD_PX,
   ELEMENT_POSITION_THROTTLE_MS,
   POINTER_EVENTS_RESUME_DEBOUNCE_MS,
 } from "../constants.js";
-import { suspendPointerEventsFreeze, resumePointerEventsFreeze } from "./pointer-events-freeze.js";
+import { createElementBounds } from "./create-element-bounds.js";
+import { getAccessibleIframeDocument } from "./get-accessible-iframe-document.js";
+import { getDeepElementAtPoint } from "./get-deep-element-at-point.js";
+import { getDeepFallbackElementAtPoint } from "./get-deep-fallback-element-at-point.js";
+import { getDeepElementsAtPoint } from "./get-deep-elements-at-point.js";
 import { getScopeContainer, isWithinScope } from "./runtime-mode.js";
+import { isIframeElement } from "./is-iframe-element.js";
+import { isPointInsideRect } from "./is-point-inside-rect.js";
+import { isValidGrabbableElement } from "./is-valid-grabbable-element.js";
+import { resumePointerEventsFreeze, suspendPointerEventsFreeze } from "./pointer-events-freeze.js";
 
 interface PositionCache {
   clientX: number;
@@ -14,33 +22,30 @@ interface PositionCache {
   timestamp: number;
 }
 
-interface IFrameHoverCache {
+interface InaccessibleIframePositionCache {
+  bounds: Rect;
   element: HTMLIFrameElement;
-  rect: DOMRect;
   timestamp: number;
 }
 
-let cache: PositionCache | null = null;
-let hoveredIframe: IFrameHoverCache | null = null;
-let resumeTimerId: ReturnType<typeof setTimeout> | null = null;
+let positionCache: PositionCache | null = null;
+let inaccessibleIframePositionCache: InaccessibleIframePositionCache | null = null;
+let pointerEventsResumeTimerId: ReturnType<typeof setTimeout> | null = null;
 
-const isPointInsideRect = (clientX: number, clientY: number, rect: DOMRect): boolean =>
-  clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom;
-
-const scheduleResume = (): void => {
-  if (resumeTimerId !== null) {
-    clearTimeout(resumeTimerId);
+const schedulePointerEventsResume = (): void => {
+  if (pointerEventsResumeTimerId !== null) {
+    clearTimeout(pointerEventsResumeTimerId);
   }
-  resumeTimerId = setTimeout(() => {
-    resumeTimerId = null;
+  pointerEventsResumeTimerId = setTimeout(() => {
+    pointerEventsResumeTimerId = null;
     resumePointerEventsFreeze();
   }, POINTER_EVENTS_RESUME_DEBOUNCE_MS);
 };
 
-const cancelScheduledResume = (): void => {
-  if (resumeTimerId !== null) {
-    clearTimeout(resumeTimerId);
-    resumeTimerId = null;
+const cancelScheduledPointerEventsResume = (): void => {
+  if (pointerEventsResumeTimerId !== null) {
+    clearTimeout(pointerEventsResumeTimerId);
+    pointerEventsResumeTimerId = null;
   }
 };
 
@@ -55,14 +60,14 @@ const isWithinThreshold = (x1: number, y1: number, x2: number, y2: number): bool
 
 export const getElementsAtPoint = (clientX: number, clientY: number): Element[] => {
   if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) return [];
-  cancelScheduledResume();
+  cancelScheduledPointerEventsResume();
   suspendPointerEventsFreeze();
   try {
-    const elements = document.elementsFromPoint(clientX, clientY);
+    const elements = getDeepElementsAtPoint(clientX, clientY);
     if (!getScopeContainer()) return elements;
     return elements.filter(isWithinScope);
   } finally {
-    scheduleResume();
+    schedulePointerEventsResume();
   }
 };
 
@@ -70,48 +75,52 @@ export const getElementAtPosition = (clientX: number, clientY: number): Element 
   if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) return null;
   const now = performance.now();
 
-  // elementFromPoint on the parent document cannot descend into iframes, so
-  // any point within an iframe's rect resolves to the iframe itself. Returning
-  // the cached iframe without calling suspendPointerEventsFreeze lets the
-  // pending resume timer re-enable `html { pointer-events: none }`, which stops
-  // the browser from dispatching pointer events into the iframe's document -
-  // the source of lag on srcdoc iframes running their own React/JIT pipelines.
-  if (hoveredIframe) {
-    const cachedIframe = hoveredIframe.element;
-    const isIframeCacheFresh = now - hoveredIframe.timestamp < ELEMENT_POSITION_THROTTLE_MS;
+  // Inaccessible iframes can only resolve to the iframe element itself. Reusing
+  // its bounds avoids repeating the pointer-events toggle and full hit test on
+  // every move. Accessibility is checked again so a later same-origin navigation
+  // immediately leaves this fast path and resumes deep element detection.
+  if (inaccessibleIframePositionCache) {
+    const cachedIframe = inaccessibleIframePositionCache.element;
+    const isCacheFresh =
+      now - inaccessibleIframePositionCache.timestamp < ELEMENT_POSITION_THROTTLE_MS;
     if (
       cachedIframe.isConnected &&
-      isIframeCacheFresh &&
-      isPointInsideRect(clientX, clientY, hoveredIframe.rect)
+      isCacheFresh &&
+      isPointInsideRect(clientX, clientY, inaccessibleIframePositionCache.bounds) &&
+      !getAccessibleIframeDocument(cachedIframe)
     ) {
       return cachedIframe;
     }
-    hoveredIframe = null;
-    if (cache?.element === cachedIframe) cache = null;
+    inaccessibleIframePositionCache = null;
+    if (positionCache?.element === cachedIframe) positionCache = null;
   }
 
-  if (cache) {
-    const isPositionClose = isWithinThreshold(clientX, clientY, cache.clientX, cache.clientY);
-    const isWithinThrottle = now - cache.timestamp < ELEMENT_POSITION_THROTTLE_MS;
+  if (positionCache) {
+    const isPositionClose = isWithinThreshold(
+      clientX,
+      clientY,
+      positionCache.clientX,
+      positionCache.clientY,
+    );
+    const isWithinThrottle = now - positionCache.timestamp < ELEMENT_POSITION_THROTTLE_MS;
 
-    if (isPositionClose || isWithinThrottle) {
-      return cache.element;
-    }
+    if (isPositionClose || isWithinThrottle) return positionCache.element;
   }
 
   // PERF: suspendPointerEventsFreeze toggles the html { pointer-events: none }
   // stylesheet, which dirties the entire style tree. elementFromPoint then forces
-  // a Recalculate Style. The 100ms debounced resume (scheduleResume) ensures the
+  // a Recalculate Style. The 100ms debounced resume (schedulePointerEventsResume) ensures the
   // toggle is a no-op on rapid subsequent calls. The expensive recalc on those
   // calls comes from host-page CSS animations dirtying styles between frames,
   // which is unavoidable without removing pointer-events: none entirely.
   // Alternatives explored and rejected:
   //   - IntersectionObserver pre-population: adds 1-frame latency to every poll
   //   - event.target fast path: always html/document due to pointer-events: none
-  //   - bounds-check cache: ignores z-index/stacking, causes hover detection misses
+  //   - generic bounds-check cache: ignores z-index/stacking, causing hover
+  //     detection misses; the cache below is limited to inaccessible iframes
   //   - transparent overlay instead of pointer-events: none: leaks CSS-only :hover
   //     dropdowns/tooltips during the hit-test toggle
-  cancelScheduledResume();
+  cancelScheduledPointerEventsResume();
   suspendPointerEventsFreeze();
   try {
     let result: Element | null = null;
@@ -120,37 +129,38 @@ export const getElementAtPosition = (clientX: number, clientY: number): Element 
     // (e.g. a transparent overlay) or out of scope (e.g. an external element
     // overlapping the scoped container) we fall back to elementsFromPoint, which
     // returns the full z-ordered stack, and take the first grabbable in-scope one.
-    const topElement = document.elementFromPoint(clientX, clientY);
+    const topElement = getDeepElementAtPoint(clientX, clientY);
     if (topElement && isValidGrabbableElement(topElement) && isWithinScope(topElement)) {
       result = topElement;
     } else {
-      const elementsAtPoint = document.elementsFromPoint(clientX, clientY);
-      for (const candidateElement of elementsAtPoint) {
-        if (
-          candidateElement !== topElement &&
-          isValidGrabbableElement(candidateElement) &&
-          isWithinScope(candidateElement)
-        ) {
-          result = candidateElement;
-          break;
-        }
-      }
+      result = getDeepFallbackElementAtPoint(clientX, clientY);
     }
 
-    hoveredIframe =
-      result instanceof HTMLIFrameElement
-        ? { element: result, rect: result.getBoundingClientRect(), timestamp: now }
-        : null;
-    cache = { clientX, clientY, element: result, timestamp: now };
+    if (result && isIframeElement(result) && !getAccessibleIframeDocument(result)) {
+      const iframeBounds = createElementBounds(result);
+      inaccessibleIframePositionCache = {
+        element: result,
+        timestamp: now,
+        bounds: {
+          left: iframeBounds.x,
+          top: iframeBounds.y,
+          right: iframeBounds.x + iframeBounds.width,
+          bottom: iframeBounds.y + iframeBounds.height,
+        },
+      };
+    } else {
+      inaccessibleIframePositionCache = null;
+    }
+    positionCache = { clientX, clientY, element: result, timestamp: now };
     return result;
   } finally {
-    scheduleResume();
+    schedulePointerEventsResume();
   }
 };
 
 export const clearElementPositionCache = (): void => {
-  cancelScheduledResume();
+  cancelScheduledPointerEventsResume();
   resumePointerEventsFreeze();
-  cache = null;
-  hoveredIframe = null;
+  positionCache = null;
+  inaccessibleIframePositionCache = null;
 };

--- a/packages/react-grab/src/utils/get-element-computed-style.ts
+++ b/packages/react-grab/src/utils/get-element-computed-style.ts
@@ -1,0 +1,4 @@
+export const getElementComputedStyle = (element: Element): CSSStyleDeclaration => {
+  const ownerWindow = element.ownerDocument.defaultView;
+  return ownerWindow ? ownerWindow.getComputedStyle(element) : window.getComputedStyle(element);
+};

--- a/packages/react-grab/src/utils/get-elements-in-drag.ts
+++ b/packages/react-grab/src/utils/get-elements-in-drag.ts
@@ -11,6 +11,13 @@ import {
 import { isRootElement } from "./is-root-element.js";
 import { isWithinScope } from "./runtime-mode.js";
 import { clampToRange } from "./clamp-to-range.js";
+import { getDeepElementsAtPoint } from "./get-deep-elements-at-point.js";
+import { createElementBounds } from "./create-element-bounds.js";
+import { getComposedParentElement } from "./get-composed-parent-element.js";
+import { compareElementDocumentOrder } from "./compare-element-document-order.js";
+import { getAccessibleIframeDocument } from "./get-accessible-iframe-document.js";
+import { isIframeElement } from "./is-iframe-element.js";
+import { isShadowRoot } from "./is-shadow-root.js";
 
 const calculateIntersectionArea = (rect1: Rect, rect2: Rect): number => {
   const intersectionLeft = Math.max(rect1.left, rect2.left);
@@ -33,15 +40,8 @@ const hasIntersection = (rect1: Rect, rect2: Rect): boolean => {
   );
 };
 
-const sortByDocumentOrder = (elements: Element[]): Element[] => {
-  return elements.sort((leftElement, rightElement) => {
-    if (leftElement === rightElement) return 0;
-    const position = leftElement.compareDocumentPosition(rightElement);
-    if (position & Node.DOCUMENT_POSITION_FOLLOWING) return -1;
-    if (position & Node.DOCUMENT_POSITION_PRECEDING) return 1;
-    return 0;
-  });
-};
+const sortByDocumentOrder = (elements: Element[]): Element[] =>
+  elements.sort(compareElementDocumentOrder);
 
 interface SamplePoint {
   x: number;
@@ -139,7 +139,7 @@ const filterElementsInDrag = (
   suspendPointerEventsFreeze();
   try {
     for (const point of samplePoints) {
-      const elementsAtPoint = document.elementsFromPoint(point.x, point.y);
+      const elementsAtPoint = getDeepElementsAtPoint(point.x, point.y);
       for (const candidateElement of elementsAtPoint) {
         candidates.add(candidateElement);
       }
@@ -148,42 +148,33 @@ const filterElementsInDrag = (
     resumePointerEventsFreeze();
   }
 
-  const validCandidates: Element[] = [];
+  const matchingElements: Element[] = [];
   for (const candidateElement of candidates) {
+    if (isIframeElement(candidateElement) && getAccessibleIframeDocument(candidateElement)) {
+      continue;
+    }
     if (!shouldCheckCoverage && isRootElement(candidateElement)) continue;
     if (!isWithinScope(candidateElement)) continue;
     if (!isValidGrabbableElement(candidateElement)) continue;
-    validCandidates.push(candidateElement);
-  }
 
-  const candidateRects = new Map<Element, DOMRect>();
-  for (const candidateElement of validCandidates) {
-    candidateRects.set(candidateElement, candidateElement.getBoundingClientRect());
-  }
-
-  const matchingElements: Element[] = [];
-
-  for (const candidateElement of validCandidates) {
-    const elementRect = candidateRects.get(candidateElement)!;
-    if (elementRect.width <= 0 || elementRect.height <= 0) continue;
-
-    const elementBounds: Rect = {
-      left: elementRect.left,
-      top: elementRect.top,
-      right: elementRect.left + elementRect.width,
-      bottom: elementRect.top + elementRect.height,
+    const candidateBounds = createElementBounds(candidateElement);
+    if (candidateBounds.width <= 0 || candidateBounds.height <= 0) continue;
+    const bounds: Rect = {
+      left: candidateBounds.x,
+      top: candidateBounds.y,
+      right: candidateBounds.x + candidateBounds.width,
+      bottom: candidateBounds.y + candidateBounds.height,
     };
-
     if (shouldCheckCoverage) {
-      const intersectionArea = calculateIntersectionArea(dragBounds, elementBounds);
-      const elementArea = elementRect.width * elementRect.height;
+      const intersectionArea = calculateIntersectionArea(dragBounds, bounds);
+      const candidateArea = candidateBounds.width * candidateBounds.height;
       const hasMajorityCoverage =
-        elementArea > 0 && intersectionArea / elementArea >= DRAG_SELECTION_COVERAGE_THRESHOLD;
+        intersectionArea / candidateArea >= DRAG_SELECTION_COVERAGE_THRESHOLD;
 
       if (hasMajorityCoverage) {
         matchingElements.push(candidateElement);
       }
-    } else if (hasIntersection(elementBounds, dragBounds)) {
+    } else if (hasIntersection(bounds, dragBounds)) {
       matchingElements.push(candidateElement);
     }
   }
@@ -196,13 +187,35 @@ const removeNestedElements = (elements: Element[]): Element[] => {
   // element's parent chain against a membership Set is O(n·depth) — the
   // previous elements.some(contains) form was O(n²) over the candidate set,
   // which spikes on dense drags (large-drag-selection covers it).
+  // Open shadow hosts are traversal boundaries, so an inner candidate replaces
+  // its host instead of being discarded as an ordinary nested element.
   const elementSet = new Set(elements);
-  return elements.filter((element) => {
-    for (let ancestor = element.parentElement; ancestor; ancestor = ancestor.parentElement) {
-      if (elementSet.has(ancestor)) return false;
+  const selectedElements: Element[] = [];
+  for (let elementIndex = elements.length - 1; elementIndex >= 0; elementIndex -= 1) {
+    const element = elements[elementIndex];
+    if (!elementSet.has(element)) continue;
+
+    let descendant = element;
+    let ancestor = getComposedParentElement(descendant);
+    let hasSelectedAncestor = false;
+    while (ancestor) {
+      const descendantRoot = descendant.getRootNode();
+      if (
+        elementSet.has(ancestor) &&
+        isShadowRoot(descendantRoot) &&
+        descendantRoot.host === ancestor
+      ) {
+        elementSet.delete(ancestor);
+      } else if (elementSet.has(ancestor)) {
+        hasSelectedAncestor = true;
+        break;
+      }
+      descendant = ancestor;
+      ancestor = getComposedParentElement(descendant);
     }
-    return true;
-  });
+    if (!hasSelectedAncestor) selectedElements.push(element);
+  }
+  return selectedElements.reverse();
 };
 
 export const getElementsInDrag = (

--- a/packages/react-grab/src/utils/get-iframe-layout-metrics.ts
+++ b/packages/react-grab/src/utils/get-iframe-layout-metrics.ts
@@ -1,0 +1,67 @@
+import { IFRAME_LAYOUT_METRICS_CACHE_TTL_MS } from "../constants.js";
+
+interface IframeLayoutMetrics {
+  contentOffsetX: number;
+  contentOffsetY: number;
+  height: number;
+  width: number;
+}
+
+interface CachedIframeLayoutMetrics {
+  metrics: IframeLayoutMetrics;
+  timestamp: number;
+}
+
+const layoutMetricsCache = new WeakMap<HTMLIFrameElement, CachedIframeLayoutMetrics>();
+
+const parseCssLength = (value: string): number => {
+  const parsedValue = Number.parseFloat(value);
+  return Number.isFinite(parsedValue) ? parsedValue : 0;
+};
+
+export const getIframeLayoutMetrics = (iframeElement: HTMLIFrameElement): IframeLayoutMetrics => {
+  const now = performance.now();
+  const cachedMetrics = layoutMetricsCache.get(iframeElement);
+  if (cachedMetrics && now - cachedMetrics.timestamp < IFRAME_LAYOUT_METRICS_CACHE_TTL_MS) {
+    return cachedMetrics.metrics;
+  }
+
+  const computedStyle = iframeElement.ownerDocument.defaultView?.getComputedStyle(iframeElement);
+  let metrics: IframeLayoutMetrics;
+
+  if (!computedStyle) {
+    metrics = {
+      contentOffsetX: iframeElement.clientLeft,
+      contentOffsetY: iframeElement.clientTop,
+      height: iframeElement.offsetHeight,
+      width: iframeElement.offsetWidth,
+    };
+  } else {
+    const borderLeftWidth = parseCssLength(computedStyle.borderLeftWidth);
+    const borderRightWidth = parseCssLength(computedStyle.borderRightWidth);
+    const borderTopWidth = parseCssLength(computedStyle.borderTopWidth);
+    const borderBottomWidth = parseCssLength(computedStyle.borderBottomWidth);
+    const paddingLeft = parseCssLength(computedStyle.paddingLeft);
+    const paddingRight = parseCssLength(computedStyle.paddingRight);
+    const paddingTop = parseCssLength(computedStyle.paddingTop);
+    const paddingBottom = parseCssLength(computedStyle.paddingBottom);
+    const computedWidth = parseCssLength(computedStyle.width);
+    const computedHeight = parseCssLength(computedStyle.height);
+    const horizontalInsets = borderLeftWidth + borderRightWidth + paddingLeft + paddingRight;
+    const verticalInsets = borderTopWidth + borderBottomWidth + paddingTop + paddingBottom;
+    const layoutWidth =
+      computedStyle.boxSizing === "border-box" ? computedWidth : computedWidth + horizontalInsets;
+    const layoutHeight =
+      computedStyle.boxSizing === "border-box" ? computedHeight : computedHeight + verticalInsets;
+
+    metrics = {
+      contentOffsetX: borderLeftWidth + paddingLeft,
+      contentOffsetY: borderTopWidth + paddingTop,
+      height: layoutHeight > 0 ? layoutHeight : iframeElement.offsetHeight,
+      width: layoutWidth > 0 ? layoutWidth : iframeElement.offsetWidth,
+    };
+  }
+
+  layoutMetricsCache.set(iframeElement, { metrics, timestamp: now });
+  return metrics;
+};

--- a/packages/react-grab/src/utils/get-iframe-scale.ts
+++ b/packages/react-grab/src/utils/get-iframe-scale.ts
@@ -1,0 +1,2 @@
+export const getIframeScale = (renderedSize: number, layoutSize: number): number =>
+  layoutSize > 0 ? renderedSize / layoutSize : 1;

--- a/packages/react-grab/src/utils/get-parent-react-grab-api.ts
+++ b/packages/react-grab/src/utils/get-parent-react-grab-api.ts
@@ -1,0 +1,11 @@
+import type { ReactGrabAPI } from "../types.js";
+
+export const getParentReactGrabApi = (): ReactGrabAPI | null => {
+  if (typeof window === "undefined" || window.parent === window) return null;
+
+  try {
+    return window.parent.__REACT_GRAB__ ?? null;
+  } catch {
+    return null;
+  }
+};

--- a/packages/react-grab/src/utils/get-preview-text-content.ts
+++ b/packages/react-grab/src/utils/get-preview-text-content.ts
@@ -3,6 +3,7 @@ import {
   PREVIEW_SKIPPED_TEXT_TAGS,
   PREVIEW_TEXT_MAX_LENGTH,
 } from "../constants.js";
+import { isElementNode } from "./is-element-node.js";
 
 const collapseTextContent = (text: string): string => text.replace(/\s+/g, " ").trim();
 
@@ -37,7 +38,7 @@ const collectDescendantText = (
     return remainingCharacterBudget - collapsedText.length;
   }
 
-  if (!(node instanceof Element) || shouldSkipElementText(node)) return remainingCharacterBudget;
+  if (!isElementNode(node) || shouldSkipElementText(node)) return remainingCharacterBudget;
 
   for (const childNode of node.childNodes) {
     remainingCharacterBudget = collectDescendantText(

--- a/packages/react-grab/src/utils/get-shadow-active-element.ts
+++ b/packages/react-grab/src/utils/get-shadow-active-element.ts
@@ -1,6 +1,8 @@
+import { isShadowRoot } from "./is-shadow-root.js";
+
 export const getShadowActiveElement = (node: Node): Element | null => {
   const rootNode = node.getRootNode();
-  if (rootNode instanceof ShadowRoot) {
+  if (isShadowRoot(rootNode)) {
     return rootNode.activeElement;
   }
   return node.ownerDocument?.activeElement ?? document.activeElement;

--- a/packages/react-grab/src/utils/get-window-frame-element.ts
+++ b/packages/react-grab/src/utils/get-window-frame-element.ts
@@ -1,0 +1,8 @@
+export const getWindowFrameElement = (targetWindow: Window | null): Element | null => {
+  if (!targetWindow) return null;
+  try {
+    return targetWindow.frameElement;
+  } catch {
+    return null;
+  }
+};

--- a/packages/react-grab/src/utils/is-document-ancestor-of-element.ts
+++ b/packages/react-grab/src/utils/is-document-ancestor-of-element.ts
@@ -1,0 +1,14 @@
+import { getWindowFrameElement } from "./get-window-frame-element.js";
+
+export const isDocumentAncestorOfElement = (
+  ancestorDocument: Document,
+  element: Element,
+): boolean => {
+  let currentDocument: Document | null = element.ownerDocument;
+  while (currentDocument) {
+    if (currentDocument === ancestorDocument) return true;
+    const parentFrameElement = getWindowFrameElement(currentDocument.defaultView);
+    currentDocument = parentFrameElement?.ownerDocument ?? null;
+  }
+  return false;
+};

--- a/packages/react-grab/src/utils/is-document-node.ts
+++ b/packages/react-grab/src/utils/is-document-node.ts
@@ -1,0 +1,7 @@
+import { DOCUMENT_NODE_TYPE } from "../constants.js";
+
+export const isDocumentNode = (node: unknown): node is Document =>
+  typeof node === "object" &&
+  node !== null &&
+  "nodeType" in node &&
+  node.nodeType === DOCUMENT_NODE_TYPE;

--- a/packages/react-grab/src/utils/is-element-node.ts
+++ b/packages/react-grab/src/utils/is-element-node.ts
@@ -1,0 +1,5 @@
+export const isElementNode = (node: unknown): node is Element =>
+  typeof node === "object" &&
+  node !== null &&
+  "nodeType" in node &&
+  node.nodeType === Node.ELEMENT_NODE;

--- a/packages/react-grab/src/utils/is-element-visible.ts
+++ b/packages/react-grab/src/utils/is-element-visible.ts
@@ -1,3 +1,5 @@
+import { getElementComputedStyle } from "./get-element-computed-style.js";
+
 // checkVisibility avoids materializing a CSSStyleDeclaration per element,
 // which dominated drag-selection profiles on dense DOMs (~35% of self time).
 // Both option spellings are passed: Chrome <108 only understands
@@ -30,8 +32,8 @@ export const isElementVisible = (
     // (opacity-0 row toolbars revealed by .row:hover) reads opacity:0 for the
     // whole session and would become unreachable. Match the element's own
     // opacity only - hit-testability decides the rest.
-    return window.getComputedStyle(element).opacity !== "0";
+    return getElementComputedStyle(element).opacity !== "0";
   }
-  const style = computedStyle ?? window.getComputedStyle(element);
+  const style = computedStyle ?? getElementComputedStyle(element);
   return style.display !== "none" && style.visibility !== "hidden" && style.opacity !== "0";
 };

--- a/packages/react-grab/src/utils/is-event-from-overlay.ts
+++ b/packages/react-grab/src/utils/is-event-from-overlay.ts
@@ -1,8 +1,10 @@
+import { isHtmlElement } from "./is-html-element.js";
+
 export const isEventFromOverlay = (event: Event, attribute: string): boolean => {
   try {
     return event
       .composedPath()
-      .some((target) => target instanceof HTMLElement && target.hasAttribute(attribute));
+      .some((target) => isHtmlElement(target) && target.hasAttribute(attribute));
   } catch {
     return false;
   }

--- a/packages/react-grab/src/utils/is-horizontally-grabbable.ts
+++ b/packages/react-grab/src/utils/is-horizontally-grabbable.ts
@@ -2,7 +2,7 @@ import { MIN_HORIZONTAL_NAV_SIZE_PX } from "../constants.js";
 import type { ElementPredicate } from "../types.js";
 
 const isSvgInternal = (element: Element): boolean =>
-  element instanceof SVGElement && !(element instanceof SVGSVGElement);
+  element.namespaceURI === "http://www.w3.org/2000/svg" && element.tagName !== "svg";
 
 const hasMeaningfulSize = (element: Element): boolean => {
   const rect = element.getBoundingClientRect();

--- a/packages/react-grab/src/utils/is-html-element.ts
+++ b/packages/react-grab/src/utils/is-html-element.ts
@@ -1,0 +1,4 @@
+import { isElementNode } from "./is-element-node.js";
+
+export const isHtmlElement = (element: unknown): element is HTMLElement =>
+  isElementNode(element) && element.namespaceURI === "http://www.w3.org/1999/xhtml";

--- a/packages/react-grab/src/utils/is-iframe-element.ts
+++ b/packages/react-grab/src/utils/is-iframe-element.ts
@@ -1,0 +1,4 @@
+import { isHtmlElement } from "./is-html-element.js";
+
+export const isIframeElement = (element: unknown): element is HTMLIFrameElement =>
+  isHtmlElement(element) && element.tagName === "IFRAME";

--- a/packages/react-grab/src/utils/is-point-inside-rect.ts
+++ b/packages/react-grab/src/utils/is-point-inside-rect.ts
@@ -1,0 +1,4 @@
+import type { Rect } from "../types.js";
+
+export const isPointInsideRect = (clientX: number, clientY: number, rect: Rect): boolean =>
+  clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom;

--- a/packages/react-grab/src/utils/is-react-grab-element.ts
+++ b/packages/react-grab/src/utils/is-react-grab-element.ts
@@ -1,0 +1,9 @@
+import { isReactGrabHost } from "./is-react-grab-host.js";
+import { isShadowRoot } from "./is-shadow-root.js";
+
+export const isReactGrabElement = (element: Element): boolean => {
+  if (isReactGrabHost(element)) return true;
+
+  const rootNode = element.getRootNode();
+  return isShadowRoot(rootNode) && isReactGrabHost(rootNode.host);
+};

--- a/packages/react-grab/src/utils/is-react-grab-host.ts
+++ b/packages/react-grab/src/utils/is-react-grab-host.ts
@@ -1,0 +1,8 @@
+const REACT_GRAB_HOST_ATTRIBUTES = ["data-react-grab", "data-react-grab-demo"];
+
+// Checks both the library and demo host attributes (not just this build's
+// REACT_GRAB_ATTRIBUTE_NAME): when a real instance and the demo build coexist
+// on one page (each with its own host), neither may treat the other's overlay
+// as grabbable page content.
+export const isReactGrabHost = (element: Element): boolean =>
+  REACT_GRAB_HOST_ATTRIBUTES.some((attributeName) => element.hasAttribute(attributeName));

--- a/packages/react-grab/src/utils/is-shadow-root.ts
+++ b/packages/react-grab/src/utils/is-shadow-root.ts
@@ -1,0 +1,4 @@
+export const isShadowRoot = (node: Node): node is ShadowRoot => {
+  const ownerWindow = node.ownerDocument?.defaultView;
+  return Boolean(ownerWindow && node instanceof ownerWindow.ShadowRoot);
+};

--- a/packages/react-grab/src/utils/is-user-ignored-element.ts
+++ b/packages/react-grab/src/utils/is-user-ignored-element.ts
@@ -1,0 +1,11 @@
+import { USER_IGNORE_ATTRIBUTE } from "../constants.js";
+import { getComposedParentElement } from "./get-composed-parent-element.js";
+
+export const isUserIgnoredElement = (element: Element): boolean => {
+  let currentElement: Element | null = element;
+  while (currentElement) {
+    if (currentElement.hasAttribute(USER_IGNORE_ATTRIBUTE)) return true;
+    currentElement = getComposedParentElement(currentElement);
+  }
+  return false;
+};

--- a/packages/react-grab/src/utils/is-valid-grabbable-element.ts
+++ b/packages/react-grab/src/utils/is-valid-grabbable-element.ts
@@ -1,32 +1,14 @@
 import {
   DEV_TOOLS_OVERLAY_Z_INDEX_THRESHOLD,
   OVERLAY_Z_INDEX_THRESHOLD,
-  USER_IGNORE_ATTRIBUTE,
   VIEWPORT_COVERAGE_THRESHOLD,
   VISIBILITY_CACHE_TTL_MS,
 } from "../constants.js";
 import { isElementVisible } from "./is-element-visible.js";
 import { isRootElement } from "./is-root-element.js";
-
-// Checks both the library and demo host attributes (not just this build's
-// REACT_GRAB_ATTRIBUTE_NAME): when a real instance and the demo build coexist
-// on one page (each with its own host), neither may treat the other's overlay
-// as grabbable page content.
-const REACT_GRAB_HOST_ATTRIBUTES = ["data-react-grab", "data-react-grab-demo"];
-
-const hasReactGrabAttribute = (element: Element): boolean =>
-  REACT_GRAB_HOST_ATTRIBUTES.some((attribute) => element.hasAttribute(attribute));
-
-const isReactGrabElement = (element: Element): boolean => {
-  if (hasReactGrabAttribute(element)) return true;
-
-  const rootNode = element.getRootNode();
-  return rootNode instanceof ShadowRoot && hasReactGrabAttribute(rootNode.host);
-};
-
-const isUserIgnoredElement = (element: Element): boolean =>
-  element.hasAttribute(USER_IGNORE_ATTRIBUTE) ||
-  element.closest(`[${USER_IGNORE_ATTRIBUTE}]`) !== null;
+import { getElementComputedStyle } from "./get-element-computed-style.js";
+import { isReactGrabElement } from "./is-react-grab-element.js";
+import { isUserIgnoredElement } from "./is-user-ignored-element.js";
 
 // Dev tools like react-scan create full-viewport canvas overlays with
 // pointer-events:none that elementsFromPoint still returns. Without this
@@ -101,14 +83,16 @@ export const isValidGrabbableElement = (element: Element): boolean => {
   }
 
   const couldBeOverlay =
-    element.clientWidth / window.innerWidth >= VIEWPORT_COVERAGE_THRESHOLD &&
-    element.clientHeight / window.innerHeight >= VIEWPORT_COVERAGE_THRESHOLD;
+    element.clientWidth / (element.ownerDocument.defaultView?.innerWidth ?? window.innerWidth) >=
+      VIEWPORT_COVERAGE_THRESHOLD &&
+    element.clientHeight / (element.ownerDocument.defaultView?.innerHeight ?? window.innerHeight) >=
+      VIEWPORT_COVERAGE_THRESHOLD;
 
   if (couldBeOverlay) {
     // getComputedStyle is deferred to this branch on purpose: it is the
     // expensive call in this function and only viewport-covering elements
     // need the overlay heuristics.
-    const computedStyle = window.getComputedStyle(element);
+    const computedStyle = getElementComputedStyle(element);
     if (isDevToolsOverlay(computedStyle)) {
       return false;
     }

--- a/packages/react-grab/src/utils/observe-same-origin-frame-documents.ts
+++ b/packages/react-grab/src/utils/observe-same-origin-frame-documents.ts
@@ -1,0 +1,197 @@
+import { SAME_ORIGIN_FRAME_ATTRIBUTE } from "../constants.js";
+import { getAccessibleIframeDocument } from "./get-accessible-iframe-document.js";
+import { isElementNode } from "./is-element-node.js";
+import { isIframeElement } from "./is-iframe-element.js";
+import { isReactGrabElement } from "./is-react-grab-element.js";
+
+interface FrameDocumentCallback {
+  (frameDocument: Document): (() => void) | void;
+}
+
+interface ObservedIframe {
+  abortController: AbortController;
+  document: Document | null;
+}
+
+export const observeSameOriginFrameDocuments = (callback: FrameDocumentCallback): (() => void) => {
+  const documentCleanups = new Map<Document, (() => void) | void>();
+  const shadowRootHookCleanups = new Map<Document, () => void>();
+  const rootObservers = new Map<Document | ShadowRoot, MutationObserver>();
+  const observedIframes = new Map<HTMLIFrameElement, ObservedIframe>();
+
+  const cleanupDocument = (targetDocument: Document): void => {
+    const rootObserver = rootObservers.get(targetDocument);
+    if (rootObserver) {
+      rootObserver.disconnect();
+      rootObservers.delete(targetDocument);
+    }
+
+    for (const root of [...rootObservers.keys()]) {
+      if ("host" in root && root.ownerDocument === targetDocument) cleanupRoot(root);
+    }
+
+    for (const iframeElement of [...observedIframes.keys()]) {
+      if (iframeElement.ownerDocument === targetDocument) cleanupIframe(iframeElement);
+    }
+
+    shadowRootHookCleanups.get(targetDocument)?.();
+    shadowRootHookCleanups.delete(targetDocument);
+    documentCleanups.get(targetDocument)?.();
+    documentCleanups.delete(targetDocument);
+  };
+
+  const cleanupRoot = (root: ShadowRoot): void => {
+    const rootObserver = rootObservers.get(root);
+    if (!rootObserver) return;
+    rootObserver.disconnect();
+    rootObservers.delete(root);
+
+    for (const descendantElement of root.querySelectorAll("*")) {
+      cleanupElement(descendantElement);
+    }
+  };
+
+  const cleanupIframe = (iframeElement: HTMLIFrameElement): void => {
+    const observedIframe = observedIframes.get(iframeElement);
+    if (!observedIframe) return;
+    observedIframes.delete(iframeElement);
+    observedIframe.abortController.abort();
+    iframeElement.removeAttribute(SAME_ORIGIN_FRAME_ATTRIBUTE);
+    if (observedIframe.document) cleanupDocument(observedIframe.document);
+  };
+
+  const cleanupElement = (element: Element): void => {
+    if (isIframeElement(element)) cleanupIframe(element);
+    if (element.shadowRoot) cleanupRoot(element.shadowRoot);
+  };
+
+  const cleanupSubtree = (element: Element): void => {
+    for (const descendantElement of element.querySelectorAll("*")) {
+      cleanupElement(descendantElement);
+    }
+    cleanupElement(element);
+  };
+
+  const observeDocument = (targetDocument: Document): void => {
+    if (documentCleanups.has(targetDocument)) return;
+    documentCleanups.set(targetDocument, callback(targetDocument));
+    observeLateShadowRoots(targetDocument);
+    observeRoot(targetDocument);
+  };
+
+  const observeLateShadowRoots = (targetDocument: Document): void => {
+    const elementPrototype = targetDocument.defaultView?.Element.prototype;
+    if (!elementPrototype) return;
+
+    const originalAttachShadow = elementPrototype.attachShadow;
+    const patchedAttachShadow = new Proxy(originalAttachShadow, {
+      apply: (attachShadow, targetElement, argumentList) => {
+        const shadowRoot = Reflect.apply(attachShadow, targetElement, argumentList);
+        if (
+          shadowRoot.mode === "open" &&
+          targetElement.isConnected &&
+          documentCleanups.has(targetDocument)
+        ) {
+          observeRoot(shadowRoot);
+        }
+        return shadowRoot;
+      },
+    });
+
+    elementPrototype.attachShadow = patchedAttachShadow;
+    shadowRootHookCleanups.set(targetDocument, () => {
+      if (elementPrototype.attachShadow === patchedAttachShadow) {
+        elementPrototype.attachShadow = originalAttachShadow;
+      }
+    });
+  };
+
+  const observeIframe = (iframeElement: HTMLIFrameElement): void => {
+    if (observedIframes.has(iframeElement)) return;
+
+    const observedIframe: ObservedIframe = {
+      abortController: new AbortController(),
+      document: null,
+    };
+    observedIframes.set(iframeElement, observedIframe);
+
+    const connectCurrentDocument = (): void => {
+      const frameDocument = getAccessibleIframeDocument(iframeElement);
+      if (observedIframe.document && observedIframe.document !== frameDocument) {
+        cleanupDocument(observedIframe.document);
+      }
+      observedIframe.document = frameDocument;
+
+      if (!frameDocument) {
+        iframeElement.removeAttribute(SAME_ORIGIN_FRAME_ATTRIBUTE);
+        return;
+      }
+
+      iframeElement.setAttribute(SAME_ORIGIN_FRAME_ATTRIBUTE, "");
+      observeDocument(frameDocument);
+    };
+
+    iframeElement.addEventListener("load", connectCurrentDocument, {
+      signal: observedIframe.abortController.signal,
+    });
+    connectCurrentDocument();
+  };
+
+  const observeElement = (element: Element): void => {
+    if (isReactGrabElement(element)) return;
+    if (isIframeElement(element)) observeIframe(element);
+    if (element.shadowRoot) observeRoot(element.shadowRoot);
+  };
+
+  const observeSubtree = (element: Element): void => {
+    observeElement(element);
+    if (isReactGrabElement(element)) return;
+    for (const descendantElement of element.querySelectorAll("*")) {
+      observeElement(descendantElement);
+    }
+  };
+
+  const observeRoot = (root: Document | ShadowRoot): void => {
+    if (rootObservers.has(root)) return;
+
+    const rootWindow = "defaultView" in root ? root.defaultView : root.ownerDocument.defaultView;
+    if (!rootWindow) return;
+
+    const mutationObserver = new rootWindow.MutationObserver((records) => {
+      for (const record of records) {
+        for (const removedNode of record.removedNodes) {
+          if (isElementNode(removedNode)) cleanupSubtree(removedNode);
+        }
+        for (const addedNode of record.addedNodes) {
+          if (isElementNode(addedNode)) observeSubtree(addedNode);
+        }
+      }
+    });
+    rootObservers.set(root, mutationObserver);
+    mutationObserver.observe(root, { childList: true, subtree: true });
+
+    for (const descendantElement of root.querySelectorAll("*")) {
+      observeElement(descendantElement);
+    }
+  };
+
+  observeDocument(document);
+
+  return () => {
+    for (const iframeElement of [...observedIframes.keys()]) {
+      cleanupIframe(iframeElement);
+    }
+    for (const rootObserver of rootObservers.values()) {
+      rootObserver.disconnect();
+    }
+    for (const shadowRootHookCleanup of shadowRootHookCleanups.values()) {
+      shadowRootHookCleanup();
+    }
+    for (const documentCleanup of documentCleanups.values()) {
+      documentCleanup?.();
+    }
+    rootObservers.clear();
+    shadowRootHookCleanups.clear();
+    documentCleanups.clear();
+  };
+};

--- a/packages/react-grab/src/utils/pointer-events-freeze.ts
+++ b/packages/react-grab/src/utils/pointer-events-freeze.ts
@@ -1,11 +1,16 @@
+import { SAME_ORIGIN_FRAME_ATTRIBUTE } from "../constants.js";
 import { createStyleElement } from "./create-style-element.js";
 
 // We apply pointer-events:none on `html` rather than `*` because pointer-events
 // is inherited, so toggling it on a single root element is O(1) style invalidation
 // instead of O(N) for every DOM node, which caused visible lag on dense DOMs
 // like GitHub diff viewers with 10k+ nodes.
+// Same-origin iframe elements stay interactive for native viewport scrolling,
+// while each accessible frame document receives this root freeze too. Their
+// forwarded input can still drive selection without page descendants reacting.
 // @see https://github.com/aidenybai/react-grab/pull/209
-const POINTER_EVENTS_STYLES = "html { pointer-events: none !important; }";
+const POINTER_EVENTS_STYLES = `html { pointer-events: none !important; }
+iframe[${SAME_ORIGIN_FRAME_ATTRIBUTE}] { pointer-events: auto !important; }`;
 
 // Enabled only during a hit-test (between suspend/resume). It must override
 // pointer-events:none that the PAGE applied, not just ours — e.g. Radix (and
@@ -23,26 +28,65 @@ const POINTER_EVENTS_STYLES = "html { pointer-events: none !important; }";
 // an !important rule), and a later-inserted sheet wins our own freeze.
 const HIT_TEST_OVERRIDE_STYLES = "html, body { pointer-events: auto !important; }";
 
-let pointerEventsStyle: HTMLStyleElement | null = null;
-let hitTestOverrideStyle: HTMLStyleElement | null = null;
+interface PointerEventsFreezeStyles {
+  pointerEventsStyle: HTMLStyleElement;
+  hitTestOverrideStyle: HTMLStyleElement;
+}
 
-export const isPointerEventsFreezeInstalled = (): boolean => pointerEventsStyle !== null;
+const registeredDocuments = new Set<Document>();
+const stylesByDocument = new Map<Document, PointerEventsFreezeStyles>();
+let isInstalled = false;
 
-export const installPointerEventsFreeze = (): void => {
-  if (pointerEventsStyle) return;
-  pointerEventsStyle = createStyleElement("data-react-grab-frozen-pseudo", POINTER_EVENTS_STYLES);
-  hitTestOverrideStyle = createStyleElement(
+const installDocumentStyles = (targetDocument: Document): void => {
+  if (stylesByDocument.has(targetDocument)) return;
+
+  const pointerEventsStyle = createStyleElement(
+    "data-react-grab-frozen-pseudo",
+    POINTER_EVENTS_STYLES,
+    targetDocument,
+  );
+  const hitTestOverrideStyle = createStyleElement(
     "data-react-grab-hittest-override",
     HIT_TEST_OVERRIDE_STYLES,
+    targetDocument,
   );
   hitTestOverrideStyle.disabled = true;
+  stylesByDocument.set(targetDocument, { pointerEventsStyle, hitTestOverrideStyle });
+};
+
+const uninstallDocumentStyles = (targetDocument: Document): void => {
+  const styles = stylesByDocument.get(targetDocument);
+  if (!styles) return;
+  styles.pointerEventsStyle.remove();
+  styles.hitTestOverrideStyle.remove();
+  stylesByDocument.delete(targetDocument);
+};
+
+export const isPointerEventsFreezeInstalled = (): boolean => isInstalled;
+
+export const registerPointerEventsFreezeDocument = (targetDocument: Document): (() => void) => {
+  registeredDocuments.add(targetDocument);
+  if (isInstalled) installDocumentStyles(targetDocument);
+
+  return () => {
+    registeredDocuments.delete(targetDocument);
+    uninstallDocumentStyles(targetDocument);
+  };
+};
+
+export const installPointerEventsFreeze = (): void => {
+  if (isInstalled) return;
+  isInstalled = true;
+  registeredDocuments.add(document);
+  for (const targetDocument of registeredDocuments) installDocumentStyles(targetDocument);
 };
 
 export const uninstallPointerEventsFreeze = (): void => {
-  pointerEventsStyle?.remove();
-  pointerEventsStyle = null;
-  hitTestOverrideStyle?.remove();
-  hitTestOverrideStyle = null;
+  if (!isInstalled) return;
+  isInstalled = false;
+  for (const targetDocument of [...stylesByDocument.keys()]) {
+    uninstallDocumentStyles(targetDocument);
+  }
 };
 
 // Writing `.disabled` on a CSSStyleSheet element invalidates the affected
@@ -50,13 +94,17 @@ export const uninstallPointerEventsFreeze = (): void => {
 // so we early-out when the desired state is already in effect. Continuous
 // pointermove hits this hundreds of times per second.
 export const suspendPointerEventsFreeze = (): void => {
-  if (!pointerEventsStyle) return;
-  if (!pointerEventsStyle.disabled) pointerEventsStyle.disabled = true;
-  if (hitTestOverrideStyle?.disabled) hitTestOverrideStyle.disabled = false;
+  if (!isInstalled) return;
+  for (const styles of stylesByDocument.values()) {
+    if (!styles.pointerEventsStyle.disabled) styles.pointerEventsStyle.disabled = true;
+    if (styles.hitTestOverrideStyle.disabled) styles.hitTestOverrideStyle.disabled = false;
+  }
 };
 
 export const resumePointerEventsFreeze = (): void => {
-  if (!pointerEventsStyle) return;
-  if (pointerEventsStyle.disabled) pointerEventsStyle.disabled = false;
-  if (hitTestOverrideStyle && !hitTestOverrideStyle.disabled) hitTestOverrideStyle.disabled = true;
+  if (!isInstalled) return;
+  for (const styles of stylesByDocument.values()) {
+    if (styles.pointerEventsStyle.disabled) styles.pointerEventsStyle.disabled = false;
+    if (!styles.hitTestOverrideStyle.disabled) styles.hitTestOverrideStyle.disabled = true;
+  }
 };

--- a/packages/react-grab/src/utils/runtime-mode.ts
+++ b/packages/react-grab/src/utils/runtime-mode.ts
@@ -1,3 +1,5 @@
+import { getComposedParentElement } from "./get-composed-parent-element.js";
+
 // Scope and mode for the active React Grab instance, held as a singleton so
 // utilities outside the init closure (hit-testing, viewport math) can read them
 // without threading them through every call.
@@ -26,7 +28,12 @@ export const getScopeContainer = (): HTMLElement | null => scopeContainer;
 
 export const isWithinScope = (element: Element | null): boolean => {
   if (!scopeContainer) return true;
-  return element !== null && scopeContainer.contains(element);
+  let currentElement = element;
+  while (currentElement) {
+    if (currentElement === scopeContainer) return true;
+    currentElement = getComposedParentElement(currentElement);
+  }
+  return false;
 };
 
 // A build-time constant, not a function: the bundler replaces

--- a/packages/react-grab/src/utils/scale-border-radius.ts
+++ b/packages/react-grab/src/utils/scale-border-radius.ts
@@ -1,0 +1,21 @@
+import { BORDER_RADIUS_SCALE_PRECISION_DECIMAL_PLACES } from "../constants.js";
+
+const scalePixelValues = (pixelValues: string, scale: number): string =>
+  pixelValues.replace(/([\d.]+)px/g, (_, radiusValue: string) => {
+    const scaledRadius = Number(radiusValue) * Math.abs(scale);
+    const roundedRadius = Number(
+      scaledRadius.toFixed(BORDER_RADIUS_SCALE_PRECISION_DECIMAL_PLACES),
+    );
+    return `${roundedRadius}px`;
+  });
+
+export const scaleBorderRadius = (borderRadius: string, scaleX: number, scaleY: number): string => {
+  const [horizontalRadius, verticalRadius] = borderRadius.split("/").map((value) => value.trim());
+  const scaledHorizontalRadius = scalePixelValues(horizontalRadius, scaleX);
+  const scaledVerticalRadius = scalePixelValues(verticalRadius ?? horizontalRadius, scaleY);
+
+  if (verticalRadius === undefined && scaledHorizontalRadius === scaledVerticalRadius) {
+    return scaledHorizontalRadius;
+  }
+  return `${scaledHorizontalRadius} / ${scaledVerticalRadius}`;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
 
   apps/e2e-app-vite:
     dependencies:
+      '@pierre/diffs':
+        specifier: ^1.2.12
+        version: 1.2.12(@shikijs/themes@4.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -2153,6 +2156,36 @@ packages:
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
 
+  '@pierre/diffs@1.2.12':
+    resolution: {integrity: sha512-pY/gmgWL03WnagqCyCnBi3QtRXUv4hCIY6FYqd5b1ZGaoI6a4Bsji8j+yRl2RfzPh/8Hf19rCl1GE80G6a1cLQ==}
+    peerDependencies:
+      react: 19.2.6
+      react-dom: 19.2.6
+
+  '@pierre/theme@1.1.0':
+    resolution: {integrity: sha512-GC2OWTAfTIIWWYhPCygwG8t2EtePQkRfON4MI2rwIkJylmiyqIttJID2dCL8sUD8cNdEvYkEyfEHHKMeCiDLoQ==}
+    engines: {vscode: ^1.0.0}
+
+  '@pierre/theming@0.0.2':
+    resolution: {integrity: sha512-QM1M4stXfnzfaE8I8YbjXSApV8c+2dBsXJj8eYg9WTpBR/cTmCZIcfGnN4p13iRrYu2Br/R/OJfEL7uR8Qjctw==}
+    peerDependencies:
+      '@pierre/theme': ^1.1.0
+      '@shikijs/themes': ^3.0.0 || ^4.0.0
+      react: 19.2.6
+      react-dom: 19.2.6
+      shiki: ^3.0.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@pierre/theme':
+        optional: true
+      '@shikijs/themes':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      shiki:
+        optional: true
+
   '@playwright/test@1.59.1':
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
@@ -3135,6 +3168,41 @@ packages:
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
 
+  '@shikijs/core@4.3.1':
+    resolution: {integrity: sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@4.3.1':
+    resolution: {integrity: sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-oniguruma@4.3.1':
+    resolution: {integrity: sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/langs@4.3.1':
+    resolution: {integrity: sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/primitive@4.3.1':
+    resolution: {integrity: sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==}
+    engines: {node: '>=20'}
+
+  '@shikijs/themes@4.3.1':
+    resolution: {integrity: sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/transformers@4.3.1':
+    resolution: {integrity: sha512-z6ir0bGDgWcF2FduktEfPgIsdOtIlDiLAjFBgBzE42Q9xHbkkIXZtORHzlLVB71iZP9elEcqKg6keajvOUwE2A==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.3.1':
+    resolution: {integrity: sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==}
+    engines: {node: '>=20'}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@simple-git/args-pathspec@1.0.3':
     resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
 
@@ -3539,6 +3607,9 @@ packages:
   '@types/long@4.0.2':
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
 
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
   '@types/minimatch@3.0.5':
     resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
 
@@ -3723,6 +3794,9 @@ packages:
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
+
+  '@ungap/structured-clone@1.3.3':
+    resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
 
   '@vercel/analytics@2.0.1':
     resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
@@ -4307,6 +4381,9 @@ packages:
   caniuse-lite@1.0.30001792:
     resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -4314,6 +4391,12 @@ packages:
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
@@ -4421,6 +4504,9 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   command-exists@1.2.9:
     resolution: {integrity: sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==}
@@ -4708,6 +4794,10 @@ packages:
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
@@ -5288,6 +5378,12 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   headers-polyfill@5.0.1:
     resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
@@ -5318,6 +5414,9 @@ packages:
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
@@ -5886,6 +5985,9 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
 
+  lru_map@0.4.1:
+    resolution: {integrity: sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==}
+
   lucide-react@1.14.0:
     resolution: {integrity: sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==}
     peerDependencies:
@@ -5923,6 +6025,9 @@ packages:
   md5@2.3.0:
     resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
 
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
@@ -5941,6 +6046,21 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -6248,6 +6368,12 @@ packages:
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
+
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
   open@10.2.0:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
@@ -6567,6 +6693,9 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
@@ -6788,6 +6917,15 @@ packages:
   redux@5.0.1:
     resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
   registry-auth-token@5.1.1:
     resolution: {integrity: sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==}
     engines: {node: '>=14'}
@@ -6982,6 +7120,10 @@ packages:
   shellwords@0.1.1:
     resolution: {integrity: sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==}
 
+  shiki@4.3.1:
+    resolution: {integrity: sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==}
+    engines: {node: '>=20'}
+
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
@@ -7071,6 +7213,9 @@ packages:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   spawn-sync@1.0.15:
     resolution: {integrity: sha512-9DWBgrgYZzNghseho0JOuh+5fg9u6QWhAWa51QC7+U5rCheZ/j1DrEZnyE0RBBRqZ9uEXGPgSSM0nky6burpVw==}
 
@@ -7155,6 +7300,9 @@ packages:
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   stringify-object@5.0.0:
     resolution: {integrity: sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==}
@@ -7373,6 +7521,9 @@ packages:
       tree-sitter:
         optional: true
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
   ts-morph@26.0.0:
     resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
 
@@ -7472,6 +7623,21 @@ packages:
   unique-string@3.0.0:
     resolution: {integrity: sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==}
     engines: {node: '>=12'}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -7590,6 +7756,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
@@ -7827,6 +7999,9 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -8601,7 +8776,7 @@ snapshots:
       '@google/gemini-cli-core': 0.35.3(express@5.2.1)
       '@google/genai': 1.30.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))
       '@iarna/toml': 2.2.5
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       ansi-escapes: 7.3.0
       ansi-regex: 6.2.2
       chalk: 4.1.2
@@ -8657,7 +8832,7 @@ snapshots:
       google-auth-library: 10.6.2
       ws: 8.20.0
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -8996,7 +9171,7 @@ snapshots:
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
       zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -9661,6 +9836,30 @@ snapshots:
       '@parcel/watcher-win32-arm64': 2.5.6
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
+
+  '@pierre/diffs@1.2.12(@shikijs/themes@4.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@pierre/theme': 1.1.0
+      '@pierre/theming': 0.0.2(@pierre/theme@1.1.0)(@shikijs/themes@4.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(shiki@4.3.1)
+      '@shikijs/transformers': 4.3.1
+      diff: 9.0.0
+      hast-util-to-html: 9.0.5
+      lru_map: 0.4.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      shiki: 4.3.1
+    transitivePeerDependencies:
+      - '@shikijs/themes'
+
+  '@pierre/theme@1.1.0': {}
+
+  '@pierre/theming@0.0.2(@pierre/theme@1.1.0)(@shikijs/themes@4.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(shiki@4.3.1)':
+    optionalDependencies:
+      '@pierre/theme': 1.1.0
+      '@shikijs/themes': 4.3.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      shiki: 4.3.1
 
   '@playwright/test@1.59.1':
     dependencies:
@@ -10612,6 +10811,51 @@ snapshots:
       domhandler: 5.0.3
       selderee: 0.11.0
 
+  '@shikijs/core@4.3.1':
+    dependencies:
+      '@shikijs/primitive': 4.3.1
+      '@shikijs/types': 4.3.1
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@4.3.1':
+    dependencies:
+      '@shikijs/types': 4.3.1
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@4.3.1':
+    dependencies:
+      '@shikijs/types': 4.3.1
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@4.3.1':
+    dependencies:
+      '@shikijs/types': 4.3.1
+
+  '@shikijs/primitive@4.3.1':
+    dependencies:
+      '@shikijs/types': 4.3.1
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/themes@4.3.1':
+    dependencies:
+      '@shikijs/types': 4.3.1
+
+  '@shikijs/transformers@4.3.1':
+    dependencies:
+      '@shikijs/core': 4.3.1
+      '@shikijs/types': 4.3.1
+
+  '@shikijs/types@4.3.1':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@simple-git/args-pathspec@1.0.3': {}
 
   '@simple-git/argv-parser@1.1.1':
@@ -11083,6 +11327,10 @@ snapshots:
 
   '@types/long@4.0.2': {}
 
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/minimatch@3.0.5': {}
 
   '@types/node@12.20.55': {}
@@ -11215,6 +11463,8 @@ snapshots:
 
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
+
+  '@ungap/structured-clone@1.3.3': {}
 
   '@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
@@ -11721,12 +11971,18 @@ snapshots:
 
   caniuse-lite@1.0.30001792: {}
 
+  ccount@2.0.1: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
   chalk@5.6.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
 
   chardet@2.1.1: {}
 
@@ -11825,6 +12081,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  comma-separated-tokens@2.0.3: {}
 
   command-exists@1.2.9: {}
 
@@ -12057,6 +12315,8 @@ snapshots:
   devtools-protocol@0.0.1608973: {}
 
   diff@8.0.4: {}
+
+  diff@9.0.0: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -12798,6 +13058,24 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   headers-polyfill@5.0.1:
     dependencies:
       '@types/set-cookie-parser': 2.4.10
@@ -12826,6 +13104,8 @@ snapshots:
       dom-serializer: 2.0.0
       htmlparser2: 8.0.2
       selderee: 0.11.0
+
+  html-void-elements@3.0.0: {}
 
   htmlparser2@8.0.2:
     dependencies:
@@ -13309,6 +13589,8 @@ snapshots:
 
   lru-cache@7.18.3: {}
 
+  lru_map@0.4.1: {}
+
   lucide-react@1.14.0(react@19.2.6):
     dependencies:
       react: 19.2.6
@@ -13341,6 +13623,18 @@ snapshots:
       crypt: 0.0.2
       is-buffer: 1.1.6
 
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.3
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
   media-typer@1.1.0: {}
 
   merge-anything@5.1.7:
@@ -13352,6 +13646,23 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
 
   micromatch@4.0.8:
     dependencies:
@@ -13640,6 +13951,14 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
 
   open@10.2.0:
     dependencies:
@@ -14029,6 +14348,8 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
+  property-information@7.2.0: {}
+
   proto-list@1.2.4: {}
 
   proto3-json-serializer@2.0.2:
@@ -14361,6 +14682,16 @@ snapshots:
 
   redux@5.0.1: {}
 
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
   registry-auth-token@5.1.1:
     dependencies:
       '@pnpm/npm-conf': 3.0.2
@@ -14663,6 +14994,17 @@ snapshots:
 
   shellwords@0.1.1: {}
 
+  shiki@4.3.1:
+    dependencies:
+      '@shikijs/core': 4.3.1
+      '@shikijs/engine-javascript': 4.3.1
+      '@shikijs/engine-oniguruma': 4.3.1
+      '@shikijs/langs': 4.3.1
+      '@shikijs/themes': 4.3.1
+      '@shikijs/types': 4.3.1
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
   side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
@@ -14780,6 +15122,8 @@ snapshots:
 
   source-map@0.7.6: {}
 
+  space-separated-tokens@2.0.2: {}
+
   spawn-sync@1.0.15:
     dependencies:
       concat-stream: 1.6.2
@@ -14869,6 +15213,11 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
 
   stringify-object@5.0.0:
     dependencies:
@@ -15087,6 +15436,8 @@ snapshots:
       node-addon-api: 8.7.0
       node-gyp-build: 4.8.4
 
+  trim-lines@3.0.1: {}
+
   ts-morph@26.0.0:
     dependencies:
       '@ts-morph/common': 0.27.0
@@ -15194,6 +15545,29 @@ snapshots:
     dependencies:
       crypto-random-string: 4.0.0
 
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   universalify@0.1.2: {}
 
   universalify@2.0.1: {}
@@ -15271,6 +15645,16 @@ snapshots:
   validate-npm-package-name@7.0.2: {}
 
   vary@1.1.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   victory-vendor@37.3.6:
     dependencies:
@@ -15647,10 +16031,8 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  zod-to-json-schema@3.25.2(zod@4.4.3):
-    dependencies:
-      zod: 4.4.3
-
   zod@3.25.76: {}
 
   zod@4.4.3: {}
+
+  zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary

- select the deepest accessible element across open Shadow DOM and same-origin iframe boundaries
- preserve composed ancestry, selectors, anchors, bounds, and drag selection across nested roots and scaled frames
- keep same-origin iframe scrolling responsive during selection while caching safe fallback behavior for inaccessible frames
- add realistic Pierre diff, Shadow DOM edge-case, and iframe preview fixtures with focused Playwright coverage

## Tests

- `nr build`
- `nr lint`
- `nr typecheck`
- `nr format`
- `nr test:unit` (106 passed)
- focused iframe and Shadow DOM Playwright suites (8 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core hit-testing, overlay bounds, cross-document event forwarding, and freeze behavior—high regression surface for selection, scrolling, and focus across nested roots.
> 
> **Overview**
> Extends **react-grab** so pointer hit-testing, selection, drag bounds, hierarchy, selectors, and element relinking work through **open Shadow DOM**, **nested slots**, and **same-origin iframes** (with scaled/transform coordinate mapping and inaccessible-frame fallback to the `iframe` element).
> 
> Same-origin child documents **reuse the parent `__REACT_GRAB__` instance**, register dynamically (including iframes inside shadow roots), and while grab is active **forward pointer/keyboard/viewport events** into the top window with converted coordinates; global **animation and pseudo-state freeze** now applies per registered document. `freeze` / `getElementsAtPosition` use the same deep stack as the overlay.
> 
> The Vite e2e app adds **iframe**, **Pierre diff**, and **shadow edge** fixtures plus large Playwright suites; existing e2e helpers are tightened (scoped todo drag targets, edit-panel typing/focus, copy retries, relaxed post-deactivate scroll assertion).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60bb8a959976edd7ea764fe4aa6704a14a52b239. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->