### PR TITLE
fix(react-grab): isolate extension failures

### DIFF
--- a/packages/react-grab/e2e/context-menu.spec.ts
+++ b/packages/react-grab/e2e/context-menu.spec.ts
@@ -642,6 +642,44 @@ test.describe("Context Menu", () => {
       expect(isDisabled).toBe(true);
     });
 
+    test("disabled action should not run through its keyboard shortcut", async ({ reactGrab }) => {
+      await reactGrab.page.evaluate(() => {
+        const api = (
+          window as {
+            __REACT_GRAB__?: {
+              unregisterPlugin: (name: string) => void;
+              registerPlugin: (plugin: Record<string, unknown>) => void;
+            };
+          }
+        ).__REACT_GRAB__;
+
+        api?.unregisterPlugin("disabled-shortcut-action");
+        api?.registerPlugin({
+          name: "disabled-shortcut-action",
+          actions: [
+            {
+              id: "disabled-shortcut-action",
+              label: "Disabled Shortcut Action",
+              enabled: false,
+              shortcut: "K",
+              onAction: () => {
+                (window as { __disabledShortcutCalled?: boolean }).__disabledShortcutCalled = true;
+              },
+            },
+          ],
+        });
+      });
+
+      await reactGrab.activate();
+      await reactGrab.hoverUntilSelected("li:first-child");
+      await reactGrab.pressModifierKeyCombo("k");
+
+      const actionCalled = await reactGrab.page.evaluate(
+        () => (window as { __disabledShortcutCalled?: boolean }).__disabledShortcutCalled ?? false,
+      );
+      expect(actionCalled).toBe(false);
+    });
+
     test("action enabled function should receive context", async ({ reactGrab }) => {
       await reactGrab.page.evaluate(() => {
         const api = (

--- a/packages/react-grab/src/components/context-menu.tsx
+++ b/packages/react-grab/src/components/context-menu.tsx
@@ -34,6 +34,7 @@ import { suppressMenuEvent } from "../utils/suppress-menu-event.js";
 import { registerOverlayDismiss } from "../utils/register-overlay-dismiss.js";
 import { ignoreRealInput } from "../utils/runtime-mode.js";
 import { findShortcutAction } from "../utils/action-shortcuts.js";
+import { executeContextMenuAction } from "../utils/execute-context-menu-action.js";
 
 interface ContextMenuProps {
   position: Position | null;
@@ -158,7 +159,7 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
       label: action.label,
       action: () => {
         if (context) {
-          action.onAction(context);
+          executeContextMenuAction(action, context);
         }
       },
       enabled: resolveActionEnabled(action, context),
@@ -242,10 +243,9 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
 
       const runActionIfAllowed = (action: ContextMenuAction) => {
         if (!context) return;
-        if (!resolveActionEnabled(action, context)) return;
+        if (!executeContextMenuAction(action, context)) return;
         event.preventDefault();
         event.stopPropagation();
-        action.onAction(context);
         props.onHide();
       };
 
@@ -324,7 +324,9 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
                 event.stopPropagation();
                 if (props.hasFilePath && props.actionContext) {
                   const openAction = props.actions?.find((action) => action.id === "open");
-                  openAction?.onAction(props.actionContext);
+                  if (openAction) {
+                    executeContextMenuAction(openAction, props.actionContext);
+                  }
                 }
               }}
               shrink

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -153,6 +153,7 @@ import { logRecoverableError } from "../utils/log-recoverable-error.js";
 import { getNearestEdge } from "../utils/get-nearest-edge.js";
 import { findShortcutAction } from "../utils/action-shortcuts.js";
 import { createKeyboardSelectionController } from "./keyboard-selection.js";
+import { executeContextMenuAction } from "../utils/execute-context-menu-action.js";
 
 const builtInPlugins = [copyPlugin, editPlugin, commentPlugin, openPlugin];
 
@@ -1739,7 +1740,10 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       actions.clearInputText();
       actions.exitPromptMode();
       clearPendingToolbarSelection();
-      action.onAction(buildImmediateActionContext(element, position));
+      const context = buildImmediateActionContext(element, position);
+      if (!executeContextMenuAction(action, context)) {
+        openContextMenu(element, position);
+      }
       return true;
     };
 
@@ -1811,7 +1815,10 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         return;
       }
 
-      action.onAction(buildImmediateActionContext(element, position));
+      const context = buildImmediateActionContext(element, position);
+      if (!executeContextMenuAction(action, context)) {
+        openContextMenu(element, position);
+      }
     };
 
     const handleComment = () => {
@@ -2466,7 +2473,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       }
 
       const position = { x: pointer().x, y: pointer().y };
-      action.onAction(buildImmediateActionContext(element, position));
+      const context = buildImmediateActionContext(element, position);
+      if (!executeContextMenuAction(action, context)) return false;
 
       event.preventDefault();
       event.stopImmediatePropagation();

--- a/packages/react-grab/src/core/plugin-registry.ts
+++ b/packages/react-grab/src/core/plugin-registry.ts
@@ -1,3 +1,4 @@
+import { getOwner, onCleanup } from "solid-js";
 import { createStore } from "solid-js/store";
 import type {
   Position,
@@ -21,6 +22,7 @@ import type {
 } from "../types.js";
 import { DEFAULT_THEME, deepMergeTheme } from "./theme.js";
 import { DEFAULT_KEY_HOLD_DURATION_MS, DEFAULT_MAX_CONTEXT_LINES } from "../constants.js";
+import { logRecoverableError } from "../utils/log-recoverable-error.js";
 
 interface RegisteredPlugin {
   plugin: Plugin;
@@ -58,6 +60,7 @@ type HookName = keyof PluginHooks;
 const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
   const plugins = new Map<string, RegisteredPlugin>();
   const directOptionOverrides: Partial<OptionsState> = {};
+  let isDisposed = false;
 
   const [store, setStore] = createStore<PluginStoreState>({
     theme: DEFAULT_THEME,
@@ -112,6 +115,7 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
   ];
 
   const setOptions = (optionUpdates: SettableOptions) => {
+    if (isDisposed) return;
     for (const optionKey of SETTABLE_OPTION_KEYS) {
       if (optionUpdates[optionKey] !== undefined) {
         setOption(optionKey, optionUpdates[optionKey]!);
@@ -120,6 +124,7 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
   };
 
   const register = (plugin: Plugin, api: ReactGrabAPI) => {
+    if (isDisposed) return;
     if (plugins.has(plugin.name)) {
       unregister(plugin.name);
     }
@@ -148,15 +153,32 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     recomputeStore();
   };
 
+  const cleanupPlugin = ({ plugin, config }: RegisteredPlugin) => {
+    try {
+      config.cleanup?.();
+    } catch (error) {
+      logRecoverableError(`Plugin cleanup failed for "${plugin.name}"`, error);
+    }
+  };
+
   const unregister = (name: string) => {
+    if (isDisposed) return;
     const registered = plugins.get(name);
     if (!registered) return;
 
-    if (registered.config.cleanup) {
-      registered.config.cleanup();
-    }
-
     plugins.delete(name);
+    cleanupPlugin(registered);
+    recomputeStore();
+  };
+
+  const dispose = () => {
+    if (isDisposed) return;
+    isDisposed = true;
+
+    const registeredPlugins = Array.from(plugins.values());
+    plugins.clear();
+    registeredPlugins.forEach(cleanupPlugin);
+
     recomputeStore();
   };
 
@@ -168,12 +190,19 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     hookName: K,
     ...args: Parameters<NonNullable<PluginHooks[K]>>
   ): void => {
-    for (const { config } of plugins.values()) {
+    for (const { plugin, config } of plugins.values()) {
       const hook = config.hooks?.[hookName] as
         | ((...hookArgs: Parameters<NonNullable<PluginHooks[K]>>) => void)
         | undefined;
       if (hook) {
-        hook(...args);
+        try {
+          hook(...args);
+        } catch (error) {
+          logRecoverableError(
+            `Plugin hook "${String(hookName)}" failed for "${plugin.name}"`,
+            error,
+          );
+        }
       }
     }
   };
@@ -183,14 +212,21 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     ...args: Parameters<NonNullable<PluginHooks[K]>>
   ): boolean => {
     let handled = false;
-    for (const { config } of plugins.values()) {
+    for (const { plugin, config } of plugins.values()) {
       const hook = config.hooks?.[hookName] as
         | ((...hookArgs: Parameters<NonNullable<PluginHooks[K]>>) => boolean | void)
         | undefined;
       if (hook) {
-        const result = hook(...args);
-        if (result === true) {
-          handled = true;
+        try {
+          const result = hook(...args);
+          if (result === true) {
+            handled = true;
+          }
+        } catch (error) {
+          logRecoverableError(
+            `Plugin hook "${String(hookName)}" failed for "${plugin.name}"`,
+            error,
+          );
         }
       }
     }
@@ -255,19 +291,36 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
       element: Element,
     ): { wasIntercepted: boolean; pendingResult?: Promise<boolean> } => {
       let wasIntercepted = false;
-      let pendingResult: Promise<boolean> | undefined;
-      for (const { config } of plugins.values()) {
+      const pendingResults: Promise<boolean>[] = [];
+      for (const { plugin, config } of plugins.values()) {
         const hook = config.hooks?.onElementSelect;
         if (hook) {
-          const result = hook(element);
-          if (result === true) {
+          try {
+            const result = hook(element);
+            if (result) {
+              wasIntercepted = true;
+              if (result === true) continue;
+              pendingResults.push(
+                result.catch((error) => {
+                  logRecoverableError(
+                    `Plugin hook "onElementSelect" failed for "${plugin.name}"`,
+                    error,
+                  );
+                  return false;
+                }),
+              );
+            }
+          } catch (error) {
             wasIntercepted = true;
-          } else if (result instanceof Promise) {
-            wasIntercepted = true;
-            pendingResult = result;
+            logRecoverableError(`Plugin hook "onElementSelect" failed for "${plugin.name}"`, error);
+            pendingResults.push(Promise.resolve(false));
           }
         }
       }
+      const pendingResult =
+        pendingResults.length > 0
+          ? Promise.all(pendingResults).then((results) => results.every(Boolean))
+          : undefined;
       return { wasIntercepted, pendingResult };
     },
     onDragStart: (startX: number, startY: number) => callHook("onDragStart", startX, startY),
@@ -308,11 +361,16 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
       callHookReduceSync("transformOpenFileUrl", url, filePath, lineNumber),
   };
 
+  if (getOwner()) {
+    onCleanup(dispose);
+  }
+
   return {
     register,
     unregister,
     getPluginNames,
     setOptions,
+    dispose,
     store,
     hooks,
   };

--- a/packages/react-grab/src/utils/execute-context-menu-action.ts
+++ b/packages/react-grab/src/utils/execute-context-menu-action.ts
@@ -1,0 +1,23 @@
+import type { ContextMenuAction, ContextMenuActionContext } from "../types.js";
+import { resolveActionEnabled } from "./resolve-action-enabled.js";
+import { logRecoverableError } from "./log-recoverable-error.js";
+
+export const executeContextMenuAction = (
+  action: ContextMenuAction,
+  context: ContextMenuActionContext,
+): boolean => {
+  if (!resolveActionEnabled(action, context)) return false;
+
+  try {
+    const pendingAction = action.onAction(context);
+    if (pendingAction) {
+      void pendingAction.catch((error: unknown) => {
+        logRecoverableError(`Action "${action.id}" failed`, error);
+      });
+    }
+  } catch (error) {
+    logRecoverableError(`Action "${action.id}" failed`, error);
+  }
+
+  return true;
+};

--- a/packages/react-grab/src/utils/resolve-action-enabled.ts
+++ b/packages/react-grab/src/utils/resolve-action-enabled.ts
@@ -1,4 +1,5 @@
 import type { ActionContext, ContextMenuAction } from "../types.js";
+import { logRecoverableError } from "./log-recoverable-error.js";
 
 const resolveBooleanEnabled = (enabled: boolean | undefined): boolean => enabled ?? true;
 
@@ -11,7 +12,12 @@ export const resolveActionEnabled = (
       return false;
     }
 
-    return action.enabled(context);
+    try {
+      return action.enabled(context);
+    } catch (error) {
+      logRecoverableError(`Action "${action.id}" enabled check failed`, error);
+      return false;
+    }
   }
 
   return resolveBooleanEnabled(action.enabled);

--- a/packages/react-grab/tests/execute-context-menu-action.test.ts
+++ b/packages/react-grab/tests/execute-context-menu-action.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import type { ContextMenuActionContext } from "../src/types.js";
+import { executeContextMenuAction } from "../src/utils/execute-context-menu-action.js";
+
+const createContext = (): ContextMenuActionContext => ({
+  element: Object.create(null),
+  elements: [],
+  hooks: {
+    transformHtmlContent: async (html) => html,
+    onOpenFile: () => false,
+    transformOpenFileUrl: (url) => url,
+  },
+  performWithFeedback: async () => {},
+  hideContextMenu: () => {},
+  cleanup: () => {},
+});
+
+describe("executeContextMenuAction", () => {
+  it("contains enabled predicate failures and skips the action", () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const onAction = vi.fn();
+
+    const didExecute = executeContextMenuAction(
+      {
+        id: "throwing-enabled",
+        label: "Throwing Enabled",
+        enabled: () => {
+          throw new Error("enabled failed");
+        },
+        onAction,
+      },
+      createContext(),
+    );
+
+    expect(didExecute).toBe(false);
+    expect(onAction).not.toHaveBeenCalled();
+    expect(warning).toHaveBeenCalledOnce();
+    warning.mockRestore();
+  });
+});

--- a/packages/react-grab/tests/plugin-registry.test.ts
+++ b/packages/react-grab/tests/plugin-registry.test.ts
@@ -1,0 +1,135 @@
+import { createRoot } from "solid-js";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { createNoopApi } from "../src/core/noop-api.js";
+import { createPluginRegistry } from "../src/core/plugin-registry.js";
+
+const createElement = (): Element => Object.create(null);
+
+describe("createPluginRegistry", () => {
+  it("aggregates every asynchronous element selection result", async () => {
+    const registry = createPluginRegistry();
+    const firstHook = vi.fn(() => Promise.resolve(true));
+    const secondHook = vi.fn(() => Promise.resolve(false));
+
+    registry.register({ name: "first", hooks: { onElementSelect: firstHook } }, createNoopApi());
+    registry.register({ name: "second", hooks: { onElementSelect: secondHook } }, createNoopApi());
+
+    const result = registry.hooks.onElementSelect(createElement());
+
+    expect(result.wasIntercepted).toBe(true);
+    expect(await result.pendingResult).toBe(false);
+    expect(firstHook).toHaveBeenCalledOnce();
+    expect(secondHook).toHaveBeenCalledOnce();
+  });
+
+  it("turns rejected and thrown element selection hooks into failed results", async () => {
+    const registry = createPluginRegistry();
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    registry.register(
+      {
+        name: "rejecting",
+        hooks: { onElementSelect: () => Promise.reject(new Error("rejected")) },
+      },
+      createNoopApi(),
+    );
+    registry.register(
+      {
+        name: "throwing",
+        hooks: {
+          onElementSelect: () => {
+            throw new Error("thrown");
+          },
+        },
+      },
+      createNoopApi(),
+    );
+
+    const result = registry.hooks.onElementSelect(createElement());
+
+    expect(result.wasIntercepted).toBe(true);
+    expect(await result.pendingResult).toBe(false);
+    expect(warning).toHaveBeenCalledTimes(2);
+    warning.mockRestore();
+  });
+
+  it("removes a plugin even when its cleanup throws", () => {
+    const registry = createPluginRegistry();
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    registry.register(
+      {
+        name: "failing-cleanup",
+        actions: [{ id: "removed", label: "Removed", onAction: () => {} }],
+        setup: () => ({
+          cleanup: () => {
+            throw new Error("cleanup failed");
+          },
+        }),
+      },
+      createNoopApi(),
+    );
+
+    registry.unregister("failing-cleanup");
+
+    expect(registry.getPluginNames()).toEqual([]);
+    expect(registry.store.actions).toEqual([]);
+    expect(warning).toHaveBeenCalledOnce();
+    warning.mockRestore();
+  });
+
+  it("cleans every plugin when its Solid owner is disposed", () => {
+    const firstCleanup = vi.fn(() => {
+      throw new Error("cleanup failed");
+    });
+    const secondCleanup = vi.fn();
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const ownedRegistry = createRoot((disposeOwner) => {
+      const registry = createPluginRegistry();
+      registry.register(
+        { name: "first", setup: () => ({ cleanup: firstCleanup }) },
+        createNoopApi(),
+      );
+      registry.register(
+        { name: "second", setup: () => ({ cleanup: secondCleanup }) },
+        createNoopApi(),
+      );
+      return { registry, disposeOwner };
+    });
+
+    ownedRegistry.disposeOwner();
+
+    expect(firstCleanup).toHaveBeenCalledOnce();
+    expect(secondCleanup).toHaveBeenCalledOnce();
+    expect(ownedRegistry.registry.getPluginNames()).toEqual([]);
+    ownedRegistry.registry.register({ name: "late" }, createNoopApi());
+    expect(ownedRegistry.registry.getPluginNames()).toEqual([]);
+    expect(warning).toHaveBeenCalledOnce();
+    warning.mockRestore();
+  });
+
+  it("isolates notification hook failures between plugins", () => {
+    const registry = createPluginRegistry();
+    const laterHook = vi.fn();
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    registry.register(
+      {
+        name: "throwing",
+        hooks: {
+          onActivate: () => {
+            throw new Error("hook failed");
+          },
+        },
+      },
+      createNoopApi(),
+    );
+    registry.register({ name: "later", hooks: { onActivate: laterHook } }, createNoopApi());
+
+    registry.hooks.onActivate();
+
+    expect(laterHook).toHaveBeenCalledOnce();
+    expect(warning).toHaveBeenCalledOnce();
+    warning.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- contain plugin hook and cleanup failures so one extension cannot break the runtime or another plugin
- aggregate asynchronous selection hooks and clean plugins with their Solid owner
- centralize safe context-menu action execution, including disabled shortcuts and rejected actions

## Validation
- `nr format`
- `nr build`
- `E2E_ENVIRONMENT=vite-plus-development nr --filter react-grab test -- e2e/context-menu.spec.ts` (100 unit + 36 focused E2E passed)
- `nr lint`
- `nr typecheck`

This replaces the extension-boundary portion of #534.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches central plugin hook dispatch and all context-menu/shortcut action paths; behavior changes for multi-plugin async selection and when actions are disabled or throw, though failures are intentionally contained.
> 
> **Overview**
> Hardens **react-grab** so a buggy third-party plugin cannot take down the overlay or other extensions.
> 
> **Plugin registry** wraps hook invocations and plugin `cleanup` in try/catch with `logRecoverableError`, so one plugin’s thrown hook no longer aborts the rest. `onElementSelect` now collects **all** async hook promises and resolves `pendingResult` with `Promise.all(...).every(Boolean)` instead of keeping only the last promise. Registry **`dispose`** runs every cleanup, sets a disposed flag (blocking further register/setOptions), and hooks **`onCleanup(dispose)`** when created under a Solid owner.
> 
> **Context menu actions** go through new **`executeContextMenuAction`**, which respects `enabled` (including try/catch around function `enabled`), runs `onAction` safely, and logs rejected promises. Call sites in the context menu, core toolbar/shortcut paths use its boolean return: when execution is skipped (disabled/failed enabled check), toolbar flows **open the context menu** instead of silently doing nothing. **`resolveActionEnabled`** also catches throws from dynamic `enabled` and treats them as disabled.
> 
> Adds unit tests for the registry and executor plus an E2E case that **disabled actions ignore keyboard shortcuts**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9b31cf36da6b9c50820c5401ff36f8f8dcd97fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates extension failures in `react-grab` so one plugin or action can’t crash the runtime or other plugins. Centralizes safe context‑menu action execution and blocks disabled shortcuts.

- **Bug Fixes**
  - Contain plugin hook and cleanup errors; unregister always succeeds and all plugins are disposed with their Solid owner.
  - Aggregate async `onElementSelect` results across plugins; thrown/rejected hooks are treated as false and a combined result is returned.
  - Centralize action execution via `executeContextMenuAction` (checks `enabled`, catches sync/async failures); disabled actions no longer run via shortcuts, and the menu reopens when execution is blocked.
  - Add tests for registry isolation and action execution; new E2E ensures disabled shortcut actions don’t run.

<sup>Written for commit d9b31cf36da6b9c50820c5401ff36f8f8dcd97fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

