### PR TITLE
fix(react-grab): cancel stale copy feedback

### DIFF
--- a/packages/react-grab/e2e/copy-feedback.spec.ts
+++ b/packages/react-grab/e2e/copy-feedback.spec.ts
@@ -295,6 +295,27 @@ test.describe("Copy Feedback Behavior", () => {
   });
 
   test.describe("Immediate Grabbing Feedback", () => {
+    test("deactivation clears feedback waiting for component metadata", async ({ reactGrab }) => {
+      await reactGrab.page.evaluate(() => {
+        window.fetch = () => new Promise<Response>(() => {});
+      });
+
+      await reactGrab.activate();
+      await reactGrab.hoverUntilSelected("li:first-child");
+      await reactGrab.clickElement("li:first-child");
+
+      await expect
+        .poll(async () => {
+          const instances = await reactGrab.getLabelInstancesInfo();
+          return instances.some((instance) => instance.status === "copying");
+        })
+        .toBe(true);
+
+      await reactGrab.deactivate();
+
+      await expect.poll(() => reactGrab.getLabelInstancesInfo()).toEqual([]);
+    });
+
     test("should enter copying state immediately on click", async ({ reactGrab }) => {
       await reactGrab.activate();
       await reactGrab.hoverUntilSelected("li:first-child");

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -247,6 +247,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
   return createRoot((dispose) => {
     let disposed = false;
+    let pendingCopyMetadataIdentity: object | null = null;
     let disposeRenderer: (() => void) | undefined;
 
     const pluginRegistry = createPluginRegistry(settableOptions);
@@ -673,6 +674,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       () => retryCopyByInstanceId.clear(),
     );
 
+    const cancelPendingCopyMetadata = () => {
+      if (!pendingCopyMetadataIdentity) return;
+      pendingCopyMetadataIdentity = null;
+      if (current().state === "copying") labelController.clearAll();
+    };
+
     const attemptClipboardAndLabel = async (
       clipboardOperation: () => Promise<boolean>,
       labelInstanceIds: string[] | null,
@@ -841,8 +848,14 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
 
     const runLabeledCopy = (copy: LabeledCopyOptions) => {
+      const metadataIdentity = {};
+      let didStartCopyOperation = false;
+      pendingCopyMetadataIdentity = metadataIdentity;
       void getNearestComponentName(copy.primaryElement)
         .then(async (componentName) => {
+          if (disposed || pendingCopyMetadataIdentity !== metadataIdentity) return;
+          pendingCopyMetadataIdentity = null;
+          didStartCopyOperation = true;
           await executeCopyOperation(
             () =>
               copyElementsToClipboard(
@@ -856,6 +869,11 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           copy.onComplete?.();
         })
         .catch((error) => {
+          if (
+            disposed ||
+            (!didStartCopyOperation && pendingCopyMetadataIdentity !== metadataIdentity)
+          )
+            return;
           logRecoverableError("Copy operation failed", error);
           const normalizedMessage = normalizeErrorMessage(error, "Action failed");
           for (const labelInstanceId of copy.labelInstanceIds) {
@@ -883,6 +901,11 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
               actions.activate();
               actions.unfreeze();
             }
+          }
+        })
+        .finally(() => {
+          if (pendingCopyMetadataIdentity === metadataIdentity) {
+            pendingCopyMetadataIdentity = null;
           }
         });
     };
@@ -1569,6 +1592,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
 
     const deactivateRenderer = () => {
+      cancelPendingCopyMetadata();
       const wasDragging = isDragging();
       const previousFocused = store.previouslyFocusedElement;
       stopSpaceDragRepositioning();
@@ -4084,11 +4108,14 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         forceDeactivateAll();
         dismissAllPopups();
         actions.clearGrabbedBoxes();
-        actions.clearLabelInstances();
+        cancelPendingCopyMetadata();
+        labelController.clearAll();
         actions.setSelectionSource(null, null);
       },
       dispose: () => {
         disposed = true;
+        cancelPendingCopyMetadata();
+        labelController.clearAll();
         hasInited = false;
         disposeRenderer?.();
         stopToolbarMenuTracking?.();


### PR DESCRIPTION
## Motivation

Async component metadata can finish after a copy is no longer current. Without cancellation, an old copy can change or clear feedback that belongs to a newer interaction.

## Example

Start a copy, deactivate React Grab before metadata resolves, then start another copy. The first request finishes late and updates the current label.

## Changes

- identify the copy that owns pending metadata
- ignore results from an older copy or disposed instance
- clear only feedback that is still pending

## Validation

- format, build, unit tests, lint, and typecheck
- focused copy-feedback E2E coverage
- full GitHub CI and performance checks