### PR TITLE
fix(react-grab): preserve label identity

### DIFF
--- a/packages/react-grab/e2e/shift-multi-select.spec.ts
+++ b/packages/react-grab/e2e/shift-multi-select.spec.ts
@@ -203,6 +203,75 @@ test.describe("Shift Multi-Select", () => {
     await reactGrab.page.keyboard.up("Shift");
   });
 
+  test("should preserve frozen and copied labels across viewport updates", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.activate();
+
+    const firstItem = reactGrab.page.locator("[data-testid='todo-list'] li").first();
+    const secondItem = reactGrab.page.locator("[data-testid='todo-list'] li").nth(1);
+    const firstBox = await firstItem.boundingBox();
+    const secondBox = await secondItem.boundingBox();
+    if (!firstBox || !secondBox) throw new Error("Could not get bounding boxes");
+
+    await reactGrab.page.keyboard.up("Shift");
+    await reactGrab.page.keyboard.down("Shift");
+    await reactGrab.page.mouse.click(
+      firstBox.x + firstBox.width / 2,
+      firstBox.y + firstBox.height / 2,
+    );
+    await reactGrab.page.mouse.click(
+      secondBox.x + secondBox.width / 2,
+      secondBox.y + secondBox.height / 2,
+    );
+    await expect
+      .poll(async () =>
+        reactGrab.page.evaluate(() => {
+          const host = document.querySelector("[data-react-grab]");
+          return (
+            host?.shadowRoot?.querySelectorAll("[data-react-grab-selection-label]").length ?? 0
+          );
+        }),
+      )
+      .toBe(SHIFT_LABEL_ANCHORED_COUNT);
+
+    const didPreserveLabelInstance = await reactGrab.page.evaluate(async () => {
+      const host = document.querySelector("[data-react-grab]");
+      const initialLabel = host?.shadowRoot?.querySelector("[data-react-grab-selection-label]");
+      if (!initialLabel) throw new Error("Could not find frozen label");
+
+      window.dispatchEvent(new Event("scroll"));
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+      const currentLabel = host?.shadowRoot?.querySelector("[data-react-grab-selection-label]");
+      return currentLabel === initialLabel;
+    });
+
+    expect(didPreserveLabelInstance).toBe(true);
+    await reactGrab.page.keyboard.up("Shift");
+
+    await expect
+      .poll(async () => {
+        const instances = await reactGrab.getLabelInstancesInfo();
+        return instances.filter((instance) => instance.status === "copied").length;
+      })
+      .toBe(SHIFT_LABEL_ANCHORED_COUNT);
+
+    const didPreserveCopiedLabel = await reactGrab.page.evaluate(async () => {
+      const host = document.querySelector("[data-react-grab]");
+      const initialLabel = host?.shadowRoot?.querySelector("[data-react-grab-selection-label]");
+      if (!initialLabel) throw new Error("Could not find copied label");
+
+      window.dispatchEvent(new Event("scroll"));
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+      const currentLabel = host?.shadowRoot?.querySelector("[data-react-grab-selection-label]");
+      return currentLabel === initialLabel;
+    });
+
+    expect(didPreserveCopiedLabel).toBe(true);
+  });
+
   test("should keep every shift-selected label anchored to its click position", async ({
     reactGrab,
   }) => {

--- a/packages/react-grab/src/components/renderer.tsx
+++ b/packages/react-grab/src/components/renderer.tsx
@@ -1,4 +1,4 @@
-import { Index, Show, type Component } from "solid-js";
+import { For, Show, type Component } from "solid-js";
 import type { ReactGrabRendererProps } from "../types.js";
 import { DEFAULT_ACTION_ID } from "../constants.js";
 import { requestOpenFile } from "../utils/open-file.js";
@@ -26,20 +26,26 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
         labelInstances={props.labelInstances}
       />
       <FrozenGlow visible={props.isFrozen ?? false} />
-      <Show when={props.selectionLabelVisible && (props.frozenLabelEntries?.length ?? 0) > 0}>
-        <Index each={props.frozenLabelEntries ?? []}>
-          {(entry, entryIndex) => (
-            <SelectionLabel
-              tagName={entry().tagName}
-              componentName={entry().componentName}
-              selectionBounds={entry().bounds}
-              mouseX={entry().mouseX}
-              visible={true}
-              shouldToggleExpandOnClick={entryIndex === 0}
-              onToggleExpand={entryIndex === 0 ? props.onToggleExpand : undefined}
-            />
+      <Show
+        when={props.selectionLabelVisible && (props.frozenLabelEntryAccessors?.length ?? 0) > 0}
+      >
+        <For each={props.frozenLabelEntryAccessors ?? []}>
+          {(entryAccessor, entryIndex) => (
+            <Show when={entryAccessor.read()}>
+              {(entry) => (
+                <SelectionLabel
+                  tagName={entry().tagName}
+                  componentName={entry().componentName}
+                  selectionBounds={entry().bounds}
+                  mouseX={entry().mouseX}
+                  visible={true}
+                  shouldToggleExpandOnClick={entryIndex() === 0}
+                  onToggleExpand={entryIndex() === 0 ? props.onToggleExpand : undefined}
+                />
+              )}
+            </Show>
           )}
-        </Index>
+        </For>
       </Show>
       <Show when={props.selectionLabelVisible && props.pendingShiftPreviewEntry}>
         {(pendingEntry) => (
@@ -56,7 +62,7 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
         when={
           props.selectionLabelVisible &&
           props.selectionBounds &&
-          (props.frozenLabelEntries?.length ?? 0) === 0
+          (props.frozenLabelEntryAccessors?.length ?? 0) === 0
         }
       >
         <SelectionLabel
@@ -84,38 +90,42 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
           isContextMenuOpen={props.contextMenuPosition !== null}
         />
       </Show>
-      <Index each={props.labelInstances ?? []}>
-        {(instance) => (
-          <SelectionLabel
-            tagName={instance().tagName}
-            componentName={instance().componentName}
-            elementsCount={instance().elementsCount}
-            selectionBounds={instance().bounds}
-            mouseX={instance().mouseX}
-            visible={true}
-            status={instance().status}
-            statusText={instance().statusText}
-            isPromptMode={instance().isPromptMode}
-            inputValue={instance().inputValue}
-            error={instance().errorMessage}
-            hideArrow={instance().hideArrow}
-            onShowContextMenu={(() => {
-              const currentInstance = instance();
-              const hasCompletedStatus =
-                currentInstance.status === "copied" || currentInstance.status === "fading";
-              if (!hasCompletedStatus || !isElementConnected(currentInstance.element)) {
-                return undefined;
-              }
-              return () => props.onShowContextMenuInstance?.(currentInstance.id);
-            })()}
-            onRetry={() => props.onRetryInstance?.(instance().id)}
-            onAcknowledgeError={() => props.onAcknowledgeErrorInstance?.(instance().id)}
-            onHoverChange={(isHovered) =>
-              props.onLabelInstanceHoverChange?.(instance().id, isHovered)
-            }
-          />
+      <For each={props.labelInstanceAccessors ?? []}>
+        {(instanceAccessor) => (
+          <Show when={instanceAccessor.read()}>
+            {(instance) => (
+              <SelectionLabel
+                tagName={instance().tagName}
+                componentName={instance().componentName}
+                elementsCount={instance().elementsCount}
+                selectionBounds={instance().bounds}
+                mouseX={instance().mouseX}
+                visible={true}
+                status={instance().status}
+                statusText={instance().statusText}
+                isPromptMode={instance().isPromptMode}
+                inputValue={instance().inputValue}
+                error={instance().errorMessage}
+                hideArrow={instance().hideArrow}
+                onShowContextMenu={(() => {
+                  const currentInstance = instance();
+                  const hasCompletedStatus =
+                    currentInstance.status === "copied" || currentInstance.status === "fading";
+                  if (!hasCompletedStatus || !isElementConnected(currentInstance.element)) {
+                    return undefined;
+                  }
+                  return () => props.onShowContextMenuInstance?.(currentInstance.id);
+                })()}
+                onRetry={() => props.onRetryInstance?.(instance().id)}
+                onAcknowledgeError={() => props.onAcknowledgeErrorInstance?.(instance().id)}
+                onHoverChange={(isHovered) =>
+                  props.onLabelInstanceHoverChange?.(instance().id, isHovered)
+                }
+              />
+            )}
+          </Show>
         )}
-      </Index>
+      </For>
       <Show when={props.toolbarVisible !== false}>
         <Toolbar
           isActive={props.isActive}

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -116,6 +116,8 @@ import type {
   HierarchyState,
   HierarchyEntry,
   FrozenLabelEntry,
+  FrozenLabelEntryAccessor,
+  SelectionLabelInstanceAccessor,
   PerformWithFeedbackOptions,
   SettableOptions,
   SourceInfo,
@@ -1269,31 +1271,32 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       return frozenElementsBounds();
     });
 
-    const frozenLabelEntryAccessors = mapArray(
+    const allFrozenLabelEntryAccessors = mapArray(
       () => store.frozenElements,
       (element) => {
         const tagName = getTagName(element) || "element";
         const componentName = getComponentDisplayName(element) ?? undefined;
-        return createMemo<FrozenLabelEntry | null>(() => {
-          void viewportVersion();
-          if (!isElementConnected(element)) return null;
-          const bounds = createElementBounds(element);
-          const anchorRatio = shiftSelectionLabelAnchorRatioByElement.get(element);
-          const mouseX =
-            anchorRatio === undefined ? undefined : bounds.x + bounds.width * anchorRatio;
-          return { tagName, componentName, bounds, mouseX };
-        });
+        return {
+          read: createMemo<FrozenLabelEntry | null>(() => {
+            void viewportVersion();
+            if (!isElementConnected(element)) return null;
+            const bounds = createElementBounds(element);
+            const anchorRatio = shiftSelectionLabelAnchorRatioByElement.get(element);
+            const mouseX =
+              anchorRatio === undefined ? undefined : bounds.x + bounds.width * anchorRatio;
+            return { tagName, componentName, bounds, mouseX };
+          }),
+        };
       },
     );
 
-    const frozenLabelEntries = createMemo((): FrozenLabelEntry[] => {
+    const visibleFrozenLabelEntryAccessors = createMemo((): FrozenLabelEntryAccessor[] => {
       if (isPromptMode() || store.frozenElements.length < 2) return [];
-      const entries: FrozenLabelEntry[] = [];
-      for (const readEntry of frozenLabelEntryAccessors()) {
-        const entry = readEntry();
-        if (entry !== null) entries.push(entry);
+      const entryAccessors: FrozenLabelEntryAccessor[] = [];
+      for (const entryAccessor of allFrozenLabelEntryAccessors()) {
+        if (entryAccessor.read() !== null) entryAccessors.push(entryAccessor);
       }
-      return entries;
+      return entryAccessors;
     });
 
     const pendingShiftPreviewEntry = createMemo((): FrozenLabelEntry | null => {
@@ -3443,6 +3446,31 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       return store.labelInstances.map(recomputeLabelInstance);
     });
 
+    const computedLabelInstanceById = createMemo(
+      () => new Map(computedLabelInstances().map((instance) => [instance.id, instance])),
+    );
+
+    const labelInstanceAccessorById = new Map<string, SelectionLabelInstanceAccessor>();
+    const labelInstanceAccessors = createMemo((): SelectionLabelInstanceAccessor[] => {
+      const currentInstances = computedLabelInstances();
+      const currentInstanceIds = new Set(currentInstances.map((instance) => instance.id));
+      for (const instanceId of labelInstanceAccessorById.keys()) {
+        if (!currentInstanceIds.has(instanceId)) labelInstanceAccessorById.delete(instanceId);
+      }
+
+      return currentInstances.map((instance) => {
+        const cachedAccessor = labelInstanceAccessorById.get(instance.id);
+        if (cachedAccessor) return cachedAccessor;
+
+        const instanceId = instance.id;
+        const instanceAccessor: SelectionLabelInstanceAccessor = {
+          read: () => computedLabelInstanceById().get(instanceId) ?? null,
+        };
+        labelInstanceAccessorById.set(instanceId, instanceAccessor);
+        return instanceAccessor;
+      });
+    });
+
     const computedGrabbedBoxes = createMemo(() => {
       if (!isThemeEnabled()) return [];
       if (!pluginRegistry.store.theme.grabbedBoxes.enabled) return [];
@@ -3906,7 +3934,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
                   store.frozenElements.length > 0 || dragPreviewBounds().length > 0
                 }
                 selectionElementsCount={store.frozenElements.length}
-                frozenLabelEntries={frozenLabelEntries()}
+                frozenLabelEntryAccessors={visibleFrozenLabelEntryAccessors()}
                 pendingShiftPreviewEntry={pendingShiftPreviewEntry() ?? undefined}
                 selectionFilePath={store.selectionFilePath ?? undefined}
                 selectionLineNumber={store.selectionLineNumber ?? undefined}
@@ -3917,6 +3945,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
                 hierarchyState={hierarchyState()}
                 hierarchyMenuPosition={hierarchyMenuPosition()}
                 labelInstances={computedLabelInstances()}
+                labelInstanceAccessors={labelInstanceAccessors()}
                 dragVisible={dragVisible()}
                 dragBounds={dragBounds()}
                 grabbedBoxes={computedGrabbedBoxes()}

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -525,13 +525,21 @@ export interface FrozenLabelEntry {
   mouseX?: number;
 }
 
+export interface FrozenLabelEntryAccessor {
+  read: () => FrozenLabelEntry | null;
+}
+
+export interface SelectionLabelInstanceAccessor {
+  read: () => SelectionLabelInstance | null;
+}
+
 export interface ReactGrabRendererProps {
   selectionVisible?: boolean;
   selectionBounds?: OverlayBounds;
   selectionBoundsMultiple?: OverlayBounds[];
   selectionShouldSnap?: boolean;
   selectionElementsCount?: number;
-  frozenLabelEntries?: FrozenLabelEntry[];
+  frozenLabelEntryAccessors?: FrozenLabelEntryAccessor[];
   pendingShiftPreviewEntry?: FrozenLabelEntry;
   selectionFilePath?: string;
   selectionLineNumber?: number;
@@ -542,6 +550,7 @@ export interface ReactGrabRendererProps {
   hierarchyState?: HierarchyState;
   hierarchyMenuPosition?: DropdownAnchor | null;
   labelInstances?: SelectionLabelInstance[];
+  labelInstanceAccessors?: SelectionLabelInstanceAccessor[];
   dragVisible?: boolean;
   dragBounds?: OverlayBounds;
   grabbedBoxes?: Array<{


### PR DESCRIPTION
## Motivation

Selection labels represent logical items with stable IDs, but viewport updates produced new objects. Solid treated those objects as new rows and remounted the labels.

## Example

Copy an element and then scroll. The copied label is rebuilt, resetting its local animation or completion state even though it represents the same copy.

## Changes

- keep stable accessors keyed by label ID
- render object collections with Solid For and reactive Show boundaries
- index current label values for constant-time reads
- cover frozen and copied labels across viewport updates

## Validation

- format, build, unit tests, lint, and typecheck
- focused shift-selection and label-identity E2E coverage
- full GitHub CI and performance checks