### PR TITLE
fix(react-grab): isolate label button keys

### DIFF
--- a/packages/react-grab/e2e/copy-failure.spec.ts
+++ b/packages/react-grab/e2e/copy-failure.spec.ts
@@ -46,6 +46,22 @@ const clickErrorButton = async (
   );
 };
 
+const focusErrorButton = async (
+  reactGrab: { page: import("@playwright/test").Page },
+  buttonAttribute: string,
+): Promise<void> => {
+  await reactGrab.page.evaluate(
+    ({ attrName, target }) => {
+      const host = document.querySelector(`[${attrName}]`);
+      const root = host?.shadowRoot?.querySelector(`[${attrName}]`);
+      const button = root?.querySelector<HTMLButtonElement>(`[${target}]`);
+      if (!button) throw new Error(`Error button [${target}] not found`);
+      button.focus();
+    },
+    { attrName: ATTRIBUTE_NAME, target: buttonAttribute },
+  );
+};
+
 const isErrorViewGone = (reactGrab: { page: import("@playwright/test").Page }) =>
   reactGrab.page.evaluate((attrName) => {
     const host = document.querySelector(`[${attrName}]`);
@@ -167,5 +183,20 @@ test.describe("Copy failure feedback", () => {
     await expect.poll(() => isErrorViewGone(reactGrab), { timeout: 5000 }).toBe(true);
     const instances = await reactGrab.getLabelInstancesInfo();
     expect(instances.some((instance) => instance.status === "error")).toBe(false);
+  });
+
+  test("Enter on the focused Ok button acknowledges instead of retrying", async ({ reactGrab }) => {
+    await forceCopyResult(reactGrab, false);
+
+    await reactGrab.activate();
+    await reactGrab.hoverUntilSelected("li");
+    await reactGrab.clickElement("li");
+    await readErrorView(reactGrab);
+    await focusErrorButton(reactGrab, "data-react-grab-error-ok");
+    await expect.poll(() => isErrorViewGone(reactGrab)).toBe(false);
+
+    await reactGrab.page.keyboard.press("Enter");
+
+    await expect.poll(() => isErrorViewGone(reactGrab), { timeout: 5000 }).toBe(true);
   });
 });

--- a/packages/react-grab/e2e/keyboard-navigation.spec.ts
+++ b/packages/react-grab/e2e/keyboard-navigation.spec.ts
@@ -393,6 +393,22 @@ test.describe("Keyboard Navigation", () => {
     expect(await reactGrab.getClipboardContent()).toBe("");
   });
 
+  test("Enter on the focused More options button opens the completed-item menu", async ({
+    reactGrab,
+  }) => {
+    await reactGrab.activate();
+    await reactGrab.hoverUntilSelected("[data-testid='todo-list'] li:first-child");
+    await reactGrab.clickElement("[data-testid='todo-list'] li:first-child");
+    await expect.poll(() => reactGrab.getLabelStatusText(), { timeout: 2000 }).toBe("Copied");
+
+    const moreOptionsButton = reactGrab.page.locator("[data-react-grab-more-options]");
+    await expect(moreOptionsButton).toHaveAccessibleName("More options");
+    await moreOptionsButton.focus();
+    await reactGrab.page.keyboard.press("Enter");
+
+    await expect.poll(() => reactGrab.isContextMenuVisible()).toBe(true);
+  });
+
   test("arrow keys continue navigation while the discard-selection prompt is open", async ({
     reactGrab,
   }) => {

--- a/packages/react-grab/src/components/selection-label/completion-view.tsx
+++ b/packages/react-grab/src/components/selection-label/completion-view.tsx
@@ -2,6 +2,7 @@ import { createSignal, onCleanup, Show, type Component } from "solid-js";
 import type { CompletionViewProps } from "../../types.js";
 import { FEEDBACK_DURATION_MS, FADE_DURATION_MS } from "../../constants.js";
 import { createConfirmationKeyboard } from "../../utils/create-confirmation-keyboard.js";
+import { isEventFromOverlay } from "../../utils/is-event-from-overlay.js";
 import { IconReturn } from "../icons/icon-return.jsx";
 import { IconEllipsis } from "../icons/icon-ellipsis.jsx";
 import { cn } from "../../utils/cn.js";
@@ -16,8 +17,10 @@ interface MoreOptionsButtonProps {
 const MoreOptionsButton: Component<MoreOptionsButtonProps> = (props) => {
   return (
     <button
+      type="button"
       data-react-grab-ignore-events
       data-react-grab-more-options
+      aria-label="More options"
       class={cn(
         buttonVariants({ variant: "ghost" }),
         "group size-4 text-[var(--rg-text-secondary)] hover:text-[var(--rg-text-primary)]",
@@ -33,7 +36,11 @@ const MoreOptionsButton: Component<MoreOptionsButtonProps> = (props) => {
         props.onClick();
       }}
     >
-      <IconEllipsis size={14} class="opacity-50 group-hover:opacity-100 transition-opacity" />
+      <IconEllipsis
+        size={14}
+        aria-hidden="true"
+        class="opacity-50 group-hover:opacity-100 transition-opacity"
+      />
     </button>
   );
 };
@@ -67,6 +74,13 @@ export const CompletionView: Component<CompletionViewProps> = (props) => {
 
   const { claimFocus } = createConfirmationKeyboard({
     onEnter: (event) => {
+      if (isEventFromOverlay(event, "data-react-grab-more-options")) {
+        event.preventDefault();
+        event.stopPropagation();
+        handleShowContextMenu();
+        return;
+      }
+      if (isEventFromOverlay(event, "data-react-grab-context-menu")) return;
       event.preventDefault();
       event.stopPropagation();
       handleAccept();

--- a/packages/react-grab/src/components/selection-label/error-view.tsx
+++ b/packages/react-grab/src/components/selection-label/error-view.tsx
@@ -1,6 +1,7 @@
 import { Show, type Component } from "solid-js";
 import type { ErrorViewProps } from "../../types.js";
 import { createConfirmationKeyboard } from "../../utils/create-confirmation-keyboard.js";
+import { isEventFromOverlay } from "../../utils/is-event-from-overlay.js";
 import { IconRetry } from "../icons/icon-retry.jsx";
 import { Button } from "../ui/button.js";
 import { BottomSection } from "./bottom-section.js";
@@ -8,6 +9,12 @@ import { BottomSection } from "./bottom-section.js";
 export const ErrorView: Component<ErrorViewProps> = (props) => {
   const { claimFocus } = createConfirmationKeyboard({
     onEnter: (event) => {
+      if (isEventFromOverlay(event, "data-react-grab-error-ok")) {
+        event.preventDefault();
+        event.stopPropagation();
+        props.onAcknowledge?.();
+        return;
+      }
       event.preventDefault();
       event.stopPropagation();
       props.onRetry?.();


### PR DESCRIPTION
## Motivation

The label-wide Enter shortcut could intercept Enter presses intended for a focused button. Keyboard users could trigger the wrong action.

## Example

Focus the error label Ok button and press Enter. The surrounding confirmation handler retries the copy instead of acknowledging the error.

## Changes

- route Enter on Ok directly to acknowledgement
- route Enter on More options directly to its menu
- leave context-menu key events to the menu
- add explicit button and accessible-name semantics

## Validation

- format, build, unit tests, lint, and typecheck
- focused copy-failure and keyboard-navigation E2E coverage
- full GitHub CI and performance checks