### PR TITLE
fix(react-grab): isolate plugin lifecycles

### DIFF
--- a/packages/react-grab/src/core/plugin-registry.ts
+++ b/packages/react-grab/src/core/plugin-registry.ts
@@ -1,3 +1,4 @@
+import { getOwner, onCleanup } from "solid-js";
 import { createStore } from "solid-js/store";
 import type {
   Position,
@@ -21,6 +22,7 @@ import type {
 } from "../types.js";
 import { DEFAULT_THEME, deepMergeTheme } from "./theme.js";
 import { DEFAULT_KEY_HOLD_DURATION_MS, DEFAULT_MAX_CONTEXT_LINES } from "../constants.js";
+import { logRecoverableError } from "../utils/log-recoverable-error.js";
 
 interface RegisteredPlugin {
   plugin: Plugin;
@@ -58,6 +60,7 @@ type HookName = keyof PluginHooks;
 const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
   const plugins = new Map<string, RegisteredPlugin>();
   const directOptionOverrides: Partial<OptionsState> = {};
+  let isDisposed = false;
 
   const [store, setStore] = createStore<PluginStoreState>({
     theme: DEFAULT_THEME,
@@ -112,6 +115,7 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
   ];
 
   const setOptions = (optionUpdates: SettableOptions) => {
+    if (isDisposed) return;
     for (const optionKey of SETTABLE_OPTION_KEYS) {
       if (optionUpdates[optionKey] !== undefined) {
         setOption(optionKey, optionUpdates[optionKey]!);
@@ -120,6 +124,7 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
   };
 
   const register = (plugin: Plugin, api: ReactGrabAPI) => {
+    if (isDisposed) return;
     if (plugins.has(plugin.name)) {
       unregister(plugin.name);
     }
@@ -148,15 +153,34 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     recomputeStore();
   };
 
+  const cleanupPlugin = ({ plugin, config }: RegisteredPlugin) => {
+    try {
+      const cleanupResult = config.cleanup?.();
+      void Promise.resolve(cleanupResult).catch((error) => {
+        logRecoverableError(`Plugin cleanup failed for "${plugin.name}"`, error);
+      });
+    } catch (error) {
+      logRecoverableError(`Plugin cleanup failed for "${plugin.name}"`, error);
+    }
+  };
+
   const unregister = (name: string) => {
+    if (isDisposed) return;
     const registered = plugins.get(name);
     if (!registered) return;
 
-    if (registered.config.cleanup) {
-      registered.config.cleanup();
-    }
-
     plugins.delete(name);
+    cleanupPlugin(registered);
+    recomputeStore();
+  };
+
+  const dispose = () => {
+    if (isDisposed) return;
+    isDisposed = true;
+
+    const registeredPlugins = Array.from(plugins.values());
+    plugins.clear();
+    registeredPlugins.forEach(cleanupPlugin);
     recomputeStore();
   };
 
@@ -168,12 +192,19 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     hookName: K,
     ...args: Parameters<NonNullable<PluginHooks[K]>>
   ): void => {
-    for (const { config } of plugins.values()) {
+    for (const { plugin, config } of plugins.values()) {
       const hook = config.hooks?.[hookName] as
         | ((...hookArgs: Parameters<NonNullable<PluginHooks[K]>>) => void)
         | undefined;
       if (hook) {
-        hook(...args);
+        try {
+          hook(...args);
+        } catch (error) {
+          logRecoverableError(
+            `Plugin hook "${String(hookName)}" failed for "${plugin.name}"`,
+            error,
+          );
+        }
       }
     }
   };
@@ -183,14 +214,21 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     ...args: Parameters<NonNullable<PluginHooks[K]>>
   ): boolean => {
     let handled = false;
-    for (const { config } of plugins.values()) {
+    for (const { plugin, config } of plugins.values()) {
       const hook = config.hooks?.[hookName] as
         | ((...hookArgs: Parameters<NonNullable<PluginHooks[K]>>) => boolean | void)
         | undefined;
       if (hook) {
-        const result = hook(...args);
-        if (result === true) {
-          handled = true;
+        try {
+          const result = hook(...args);
+          if (result === true) {
+            handled = true;
+          }
+        } catch (error) {
+          logRecoverableError(
+            `Plugin hook "${String(hookName)}" failed for "${plugin.name}"`,
+            error,
+          );
         }
       }
     }
@@ -201,14 +239,21 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     hookName: K,
     ...args: Parameters<NonNullable<PluginHooks[K]>>
   ): Promise<void> => {
-    for (const { config } of plugins.values()) {
+    for (const { plugin, config } of plugins.values()) {
       const hook = config.hooks?.[hookName] as
         | ((
             ...hookArgs: Parameters<NonNullable<PluginHooks[K]>>
           ) => ReturnType<NonNullable<PluginHooks[K]>>)
         | undefined;
       if (hook) {
-        await hook(...args);
+        try {
+          await hook(...args);
+        } catch (error) {
+          logRecoverableError(
+            `Plugin hook "${String(hookName)}" failed for "${plugin.name}"`,
+            error,
+          );
+        }
       }
     }
   };
@@ -219,12 +264,19 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     ...extraArgs: unknown[]
   ): Promise<T> => {
     let result = initialValue;
-    for (const { config } of plugins.values()) {
+    for (const { plugin, config } of plugins.values()) {
       const hook = config.hooks?.[hookName] as
         | ((value: T, ...hookArgs: unknown[]) => T | Promise<T>)
         | undefined;
       if (hook) {
-        result = await hook(result, ...extraArgs);
+        try {
+          result = await hook(result, ...extraArgs);
+        } catch (error) {
+          logRecoverableError(
+            `Plugin hook "${String(hookName)}" failed for "${plugin.name}"`,
+            error,
+          );
+        }
       }
     }
     return result;
@@ -236,12 +288,19 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     ...extraArgs: unknown[]
   ): T => {
     let result = initialValue;
-    for (const { config } of plugins.values()) {
+    for (const { plugin, config } of plugins.values()) {
       const hook = config.hooks?.[hookName] as
         | ((value: T, ...hookArgs: unknown[]) => T)
         | undefined;
       if (hook) {
-        result = hook(result, ...extraArgs);
+        try {
+          result = hook(result, ...extraArgs);
+        } catch (error) {
+          logRecoverableError(
+            `Plugin hook "${String(hookName)}" failed for "${plugin.name}"`,
+            error,
+          );
+        }
       }
     }
     return result;
@@ -255,19 +314,34 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
       element: Element,
     ): { wasIntercepted: boolean; pendingResult?: Promise<boolean> } => {
       let wasIntercepted = false;
-      let pendingResult: Promise<boolean> | undefined;
-      for (const { config } of plugins.values()) {
+      const pendingResults: Promise<boolean>[] = [];
+      for (const { plugin, config } of plugins.values()) {
         const hook = config.hooks?.onElementSelect;
         if (hook) {
-          const result = hook(element);
-          if (result === true) {
-            wasIntercepted = true;
-          } else if (result instanceof Promise) {
-            wasIntercepted = true;
-            pendingResult = result;
+          try {
+            const result = hook(element);
+            if (result) {
+              wasIntercepted = true;
+              if (result === true) continue;
+              pendingResults.push(
+                result.catch((error) => {
+                  logRecoverableError(
+                    `Plugin hook "onElementSelect" failed for "${plugin.name}"`,
+                    error,
+                  );
+                  return false;
+                }),
+              );
+            }
+          } catch (error) {
+            logRecoverableError(`Plugin hook "onElementSelect" failed for "${plugin.name}"`, error);
           }
         }
       }
+      const pendingResult =
+        pendingResults.length > 0
+          ? Promise.all(pendingResults).then((results) => results.every(Boolean))
+          : undefined;
       return { wasIntercepted, pendingResult };
     },
     onDragStart: (startX: number, startY: number) => callHook("onDragStart", startX, startY),
@@ -308,11 +382,16 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
       callHookReduceSync("transformOpenFileUrl", url, filePath, lineNumber),
   };
 
+  if (getOwner()) {
+    onCleanup(dispose);
+  }
+
   return {
     register,
     unregister,
     getPluginNames,
     setOptions,
+    dispose,
     store,
     hooks,
   };

--- a/packages/react-grab/src/core/plugins/create-pending-selection-plugin.ts
+++ b/packages/react-grab/src/core/plugins/create-pending-selection-plugin.ts
@@ -7,7 +7,7 @@ type ContextMenuActionFactory =
 interface PendingSelectionPluginConfig {
   name: string;
   contextMenuAction: ContextMenuActionFactory;
-  cleanup?: () => void;
+  cleanup?: () => undefined;
 }
 
 export const createPendingSelectionPlugin = (config: PendingSelectionPluginConfig): Plugin => ({

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -367,7 +367,7 @@ export interface PluginConfig {
   options?: SettableOptions;
   actions?: ContextMenuAction[];
   hooks?: PluginHooks;
-  cleanup?: () => void;
+  cleanup?: () => undefined;
 }
 
 export interface Plugin {

--- a/packages/react-grab/tests/plugin-registry.test.ts
+++ b/packages/react-grab/tests/plugin-registry.test.ts
@@ -1,0 +1,241 @@
+import { createRoot } from "solid-js";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { createNoopApi } from "../src/core/noop-api.js";
+import { createPluginRegistry } from "../src/core/plugin-registry.js";
+import type { PluginConfig } from "../src/types.js";
+
+const createElement = (): Element => Object.create(null);
+
+describe("createPluginRegistry", () => {
+  it("aggregates every asynchronous element selection result", async () => {
+    const registry = createPluginRegistry();
+    const firstHook = vi.fn(() => Promise.resolve(true));
+    const secondHook = vi.fn(() => Promise.resolve(false));
+
+    registry.register({ name: "first", hooks: { onElementSelect: firstHook } }, createNoopApi());
+    registry.register({ name: "second", hooks: { onElementSelect: secondHook } }, createNoopApi());
+
+    const result = registry.hooks.onElementSelect(createElement());
+
+    expect(result.wasIntercepted).toBe(true);
+    expect(await result.pendingResult).toBe(false);
+    expect(firstHook).toHaveBeenCalledOnce();
+    expect(secondHook).toHaveBeenCalledOnce();
+  });
+
+  it("turns rejected element selection hooks into failed results", async () => {
+    const registry = createPluginRegistry();
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    registry.register(
+      {
+        name: "rejecting",
+        hooks: { onElementSelect: () => Promise.reject(new Error("rejected")) },
+      },
+      createNoopApi(),
+    );
+    const result = registry.hooks.onElementSelect(createElement());
+
+    expect(result.wasIntercepted).toBe(true);
+    expect(await result.pendingResult).toBe(false);
+    expect(warning).toHaveBeenCalledOnce();
+    warning.mockRestore();
+  });
+
+  it("does not let thrown element selection hooks block defaults", () => {
+    const registry = createPluginRegistry();
+    const laterHook = vi.fn();
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    registry.register(
+      {
+        name: "throwing",
+        hooks: {
+          onElementSelect: () => {
+            throw new Error("thrown");
+          },
+        },
+      },
+      createNoopApi(),
+    );
+    registry.register({ name: "later", hooks: { onElementSelect: laterHook } }, createNoopApi());
+
+    const result = registry.hooks.onElementSelect(createElement());
+
+    expect(result.wasIntercepted).toBe(false);
+    expect(result.pendingResult).toBeUndefined();
+    expect(laterHook).toHaveBeenCalledOnce();
+    expect(warning).toHaveBeenCalledOnce();
+    warning.mockRestore();
+  });
+
+  it("removes a plugin even when its cleanup throws", () => {
+    const registry = createPluginRegistry();
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    registry.register(
+      {
+        name: "failing-cleanup",
+        actions: [{ id: "removed", label: "Removed", onAction: () => {} }],
+        setup: () => ({
+          cleanup: () => {
+            throw new Error("cleanup failed");
+          },
+        }),
+      },
+      createNoopApi(),
+    );
+
+    registry.unregister("failing-cleanup");
+
+    expect(registry.getPluginNames()).toEqual([]);
+    expect(registry.store.actions).toEqual([]);
+    expect(warning).toHaveBeenCalledOnce();
+    warning.mockRestore();
+  });
+
+  it("observes invalid asynchronous cleanup failures", async () => {
+    const registry = createPluginRegistry();
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const config: PluginConfig = { cleanup: () => undefined };
+    Reflect.set(config, "cleanup", () => Promise.reject(new Error("cleanup failed")));
+
+    registry.register(
+      {
+        name: "failing-cleanup",
+        setup: () => config,
+      },
+      createNoopApi(),
+    );
+
+    registry.unregister("failing-cleanup");
+    await Promise.resolve();
+
+    expect(warning).toHaveBeenCalledOnce();
+    warning.mockRestore();
+  });
+
+  it("cleans every plugin when its Solid owner is disposed", () => {
+    const firstCleanup = vi.fn(() => {
+      throw new Error("cleanup failed");
+    });
+    const secondCleanup = vi.fn(() => undefined);
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const ownedRegistry = createRoot((disposeOwner) => {
+      const registry = createPluginRegistry();
+      registry.register(
+        { name: "first", setup: () => ({ cleanup: firstCleanup }) },
+        createNoopApi(),
+      );
+      registry.register(
+        { name: "second", setup: () => ({ cleanup: secondCleanup }) },
+        createNoopApi(),
+      );
+      return { registry, disposeOwner };
+    });
+
+    ownedRegistry.disposeOwner();
+
+    expect(firstCleanup).toHaveBeenCalledOnce();
+    expect(secondCleanup).toHaveBeenCalledOnce();
+    expect(ownedRegistry.registry.getPluginNames()).toEqual([]);
+    expect(ownedRegistry.registry.store.actions).toEqual([]);
+    ownedRegistry.registry.register({ name: "late" }, createNoopApi());
+    expect(ownedRegistry.registry.getPluginNames()).toEqual([]);
+    expect(warning).toHaveBeenCalledOnce();
+    warning.mockRestore();
+  });
+
+  it("isolates asynchronous notification hook failures between plugins", async () => {
+    const registry = createPluginRegistry();
+    const laterHook = vi.fn();
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    registry.register(
+      {
+        name: "rejecting",
+        hooks: { onBeforeCopy: () => Promise.reject(new Error("hook failed")) },
+      },
+      createNoopApi(),
+    );
+    registry.register({ name: "later", hooks: { onBeforeCopy: laterHook } }, createNoopApi());
+
+    await registry.hooks.onBeforeCopy([]);
+
+    expect(laterHook).toHaveBeenCalledOnce();
+    expect(warning).toHaveBeenCalledOnce();
+    warning.mockRestore();
+  });
+
+  it("preserves transformation results after plugin failures", async () => {
+    const registry = createPluginRegistry();
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    registry.register(
+      {
+        name: "first",
+        hooks: {
+          transformCopyContent: (content) => `${content}-first`,
+          transformOpenFileUrl: (url) => `${url}?first`,
+        },
+      },
+      createNoopApi(),
+    );
+    registry.register(
+      {
+        name: "throwing",
+        hooks: {
+          transformCopyContent: () => Promise.reject(new Error("async failure")),
+          transformOpenFileUrl: () => {
+            throw new Error("sync failure");
+          },
+        },
+      },
+      createNoopApi(),
+    );
+    registry.register(
+      {
+        name: "last",
+        hooks: {
+          transformCopyContent: (content) => `${content}-last`,
+          transformOpenFileUrl: (url) => `${url}&last`,
+        },
+      },
+      createNoopApi(),
+    );
+
+    await expect(registry.hooks.transformCopyContent("content", [])).resolves.toBe(
+      "content-first-last",
+    );
+    expect(registry.hooks.transformOpenFileUrl("file://path", "path")).toBe(
+      "file://path?first&last",
+    );
+    expect(warning).toHaveBeenCalledTimes(2);
+    warning.mockRestore();
+  });
+
+  it("isolates notification hook failures between plugins", () => {
+    const registry = createPluginRegistry();
+    const laterHook = vi.fn();
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    registry.register(
+      {
+        name: "throwing",
+        hooks: {
+          onActivate: () => {
+            throw new Error("hook failed");
+          },
+        },
+      },
+      createNoopApi(),
+    );
+    registry.register({ name: "later", hooks: { onActivate: laterHook } }, createNoopApi());
+
+    registry.hooks.onActivate();
+
+    expect(laterHook).toHaveBeenCalledOnce();
+    expect(warning).toHaveBeenCalledOnce();
+    warning.mockRestore();
+  });
+});


### PR DESCRIPTION
## Motivation

Plugins are external extension points. One plugin throwing or rejecting should not prevent later plugins from running or leave the registry partially disposed.

## Example

Plugin A throws while observing an element selection. The default copy path and Plugin B should still run instead of treating the crash as an intentional interception.

## Changes

- isolate synchronous and asynchronous hook failures
- preserve the previous value when a transform hook fails
- keep cleanup synchronous so same-name replacement cannot race old cleanup
- defensively observe invalid asynchronous cleanup rejections from untyped plugins
- let synchronous selection-hook failures fall through to default behavior
- aggregate all asynchronous selection results
- dispose owned registries once and reject late mutations

## Validation

- format, build, 103 unit tests, lint, and typecheck
- full functional GitHub CI
- performance rerun in progress