### PR TITLE
fix(react-grab): isolate action failures

### DIFF
--- a/packages/react-grab/e2e/context-menu.spec.ts
+++ b/packages/react-grab/e2e/context-menu.spec.ts
@@ -642,6 +642,44 @@ test.describe("Context Menu", () => {
       expect(isDisabled).toBe(true);
     });
 
+    test("disabled action should not run through its keyboard shortcut", async ({ reactGrab }) => {
+      await reactGrab.page.evaluate(() => {
+        const api = (
+          window as {
+            __REACT_GRAB__?: {
+              unregisterPlugin: (name: string) => void;
+              registerPlugin: (plugin: Record<string, unknown>) => void;
+            };
+          }
+        ).__REACT_GRAB__;
+
+        api?.unregisterPlugin("disabled-shortcut-action");
+        api?.registerPlugin({
+          name: "disabled-shortcut-action",
+          actions: [
+            {
+              id: "disabled-shortcut-action",
+              label: "Disabled Shortcut Action",
+              enabled: false,
+              shortcut: "K",
+              onAction: () => {
+                (window as { __disabledShortcutCalled?: boolean }).__disabledShortcutCalled = true;
+              },
+            },
+          ],
+        });
+      });
+
+      await reactGrab.activate();
+      await reactGrab.hoverUntilSelected("li:first-child");
+      await reactGrab.pressModifierKeyCombo("k");
+
+      const actionCalled = await reactGrab.page.evaluate(
+        () => (window as { __disabledShortcutCalled?: boolean }).__disabledShortcutCalled ?? false,
+      );
+      expect(actionCalled).toBe(false);
+    });
+
     test("action enabled function should receive context", async ({ reactGrab }) => {
       await reactGrab.page.evaluate(() => {
         const api = (

--- a/packages/react-grab/src/components/context-menu.tsx
+++ b/packages/react-grab/src/components/context-menu.tsx
@@ -34,6 +34,7 @@ import { suppressMenuEvent } from "../utils/suppress-menu-event.js";
 import { registerOverlayDismiss } from "../utils/register-overlay-dismiss.js";
 import { ignoreRealInput } from "../utils/runtime-mode.js";
 import { findShortcutAction } from "../utils/action-shortcuts.js";
+import { executeContextMenuAction } from "../utils/execute-context-menu-action.js";
 
 interface ContextMenuProps {
   position: Position | null;
@@ -158,7 +159,7 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
       label: action.label,
       action: () => {
         if (context) {
-          action.onAction(context);
+          executeContextMenuAction(action, context);
         }
       },
       enabled: resolveActionEnabled(action, context),
@@ -242,10 +243,9 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
 
       const runActionIfAllowed = (action: ContextMenuAction) => {
         if (!context) return;
-        if (!resolveActionEnabled(action, context)) return;
+        if (!executeContextMenuAction(action, context)) return;
         event.preventDefault();
         event.stopPropagation();
-        action.onAction(context);
         props.onHide();
       };
 
@@ -324,7 +324,9 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
                 event.stopPropagation();
                 if (props.hasFilePath && props.actionContext) {
                   const openAction = props.actions?.find((action) => action.id === "open");
-                  openAction?.onAction(props.actionContext);
+                  if (openAction) {
+                    executeContextMenuAction(openAction, props.actionContext);
+                  }
                 }
               }}
               shrink

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -153,6 +153,7 @@ import { logRecoverableError } from "../utils/log-recoverable-error.js";
 import { getNearestEdge } from "../utils/get-nearest-edge.js";
 import { findShortcutAction } from "../utils/action-shortcuts.js";
 import { createKeyboardSelectionController } from "./keyboard-selection.js";
+import { executeContextMenuAction } from "../utils/execute-context-menu-action.js";
 
 const builtInPlugins = [copyPlugin, editPlugin, commentPlugin, openPlugin];
 
@@ -1739,7 +1740,10 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       actions.clearInputText();
       actions.exitPromptMode();
       clearPendingToolbarSelection();
-      action.onAction(buildImmediateActionContext(element, position));
+      const context = buildImmediateActionContext(element, position);
+      if (!executeContextMenuAction(action, context)) {
+        openContextMenu(element, position);
+      }
       return true;
     };
 
@@ -1811,7 +1815,10 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         return;
       }
 
-      action.onAction(buildImmediateActionContext(element, position));
+      const context = buildImmediateActionContext(element, position);
+      if (!executeContextMenuAction(action, context)) {
+        openContextMenu(element, position);
+      }
     };
 
     const handleComment = () => {
@@ -2466,7 +2473,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       }
 
       const position = { x: pointer().x, y: pointer().y };
-      action.onAction(buildImmediateActionContext(element, position));
+      const context = buildImmediateActionContext(element, position);
+      if (!executeContextMenuAction(action, context)) return false;
 
       event.preventDefault();
       event.stopImmediatePropagation();

--- a/packages/react-grab/src/utils/execute-context-menu-action.ts
+++ b/packages/react-grab/src/utils/execute-context-menu-action.ts
@@ -1,0 +1,23 @@
+import type { ContextMenuAction, ContextMenuActionContext } from "../types.js";
+import { resolveActionEnabled } from "./resolve-action-enabled.js";
+import { logRecoverableError } from "./log-recoverable-error.js";
+
+export const executeContextMenuAction = (
+  action: ContextMenuAction,
+  context: ContextMenuActionContext,
+): boolean => {
+  if (!resolveActionEnabled(action, context)) return false;
+
+  try {
+    const pendingAction = action.onAction(context);
+    if (pendingAction) {
+      void pendingAction.catch((error: unknown) => {
+        logRecoverableError(`Action "${action.id}" failed`, error);
+      });
+    }
+  } catch (error) {
+    logRecoverableError(`Action "${action.id}" failed`, error);
+  }
+
+  return true;
+};

--- a/packages/react-grab/src/utils/resolve-action-enabled.ts
+++ b/packages/react-grab/src/utils/resolve-action-enabled.ts
@@ -1,4 +1,5 @@
 import type { ActionContext, ContextMenuAction } from "../types.js";
+import { logRecoverableError } from "./log-recoverable-error.js";
 
 const resolveBooleanEnabled = (enabled: boolean | undefined): boolean => enabled ?? true;
 
@@ -11,7 +12,12 @@ export const resolveActionEnabled = (
       return false;
     }
 
-    return action.enabled(context);
+    try {
+      return action.enabled(context);
+    } catch (error) {
+      logRecoverableError(`Action "${action.id}" enabled check failed`, error);
+      return false;
+    }
   }
 
   return resolveBooleanEnabled(action.enabled);

--- a/packages/react-grab/tests/execute-context-menu-action.test.ts
+++ b/packages/react-grab/tests/execute-context-menu-action.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import type { ContextMenuActionContext } from "../src/types.js";
+import { executeContextMenuAction } from "../src/utils/execute-context-menu-action.js";
+
+const createContext = (): ContextMenuActionContext => ({
+  element: Object.create(null),
+  elements: [],
+  hooks: {
+    transformHtmlContent: async (html) => html,
+    onOpenFile: () => false,
+    transformOpenFileUrl: (url) => url,
+  },
+  performWithFeedback: async () => {},
+  hideContextMenu: () => {},
+  cleanup: () => {},
+});
+
+describe("executeContextMenuAction", () => {
+  it("contains enabled predicate failures and skips the action", () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const onAction = vi.fn();
+
+    const didExecute = executeContextMenuAction(
+      {
+        id: "throwing-enabled",
+        label: "Throwing Enabled",
+        enabled: () => {
+          throw new Error("enabled failed");
+        },
+        onAction,
+      },
+      createContext(),
+    );
+
+    expect(didExecute).toBe(false);
+    expect(onAction).not.toHaveBeenCalled();
+    expect(warning).toHaveBeenCalledOnce();
+    warning.mockRestore();
+  });
+
+  it("contains synchronous action failures after accepting the action", () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const didExecute = executeContextMenuAction(
+      {
+        id: "throwing-action",
+        label: "Throwing Action",
+        onAction: () => {
+          throw new Error("action failed");
+        },
+      },
+      createContext(),
+    );
+
+    expect(didExecute).toBe(true);
+    expect(warning).toHaveBeenCalledOnce();
+    warning.mockRestore();
+  });
+
+  it("contains asynchronous action failures", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const didExecute = executeContextMenuAction(
+      {
+        id: "rejecting-action",
+        label: "Rejecting Action",
+        onAction: () => Promise.reject(new Error("action failed")),
+      },
+      createContext(),
+    );
+    await Promise.resolve();
+
+    expect(didExecute).toBe(true);
+    expect(warning).toHaveBeenCalledOnce();
+    warning.mockRestore();
+  });
+});


### PR DESCRIPTION
## Motivation

Custom actions can be disabled, throw synchronously, or reject asynchronously. Menu, toolbar, and shortcut paths should handle those cases consistently.

## Example

A plugin action is disabled but still has a keyboard shortcut. Pressing the shortcut must not execute it; if its enabled predicate throws, the overlay must remain usable.

## Changes

- execute every action through one safe helper
- treat failed enabled predicates as disabled
- contain synchronous and asynchronous action failures
- make toolbar, menu, and shortcut fallback behavior consistent

## Validation

- format, build, action-executor unit tests, lint, and typecheck
- E2E coverage for disabled shortcuts
- full GitHub CI and performance checks