### PR TITLE
fix(react-grab): snapshot frozen animation inputs

### DIFF
--- a/packages/react-grab/src/utils/freeze-animations.ts
+++ b/packages/react-grab/src/utils/freeze-animations.ts
@@ -137,9 +137,10 @@ export const freezeAllAnimations = (elements: Element[]): void => {
   if (areElementsSame(elements, lastInputElements)) return;
 
   unfreezeAllAnimations();
-  lastInputElements = [...elements];
+  const elementSnapshot = [...elements];
+  lastInputElements = elementSnapshot;
   ensureStylesInjected();
-  frozenElements = elements;
+  frozenElements = elementSnapshot;
   frozenSvgElements = collectFrozenSvgElements(frozenElements);
   pauseSvgAnimations(frozenSvgElements);
 


### PR DESCRIPTION
## Motivation

The element array passed into animation freezing belongs to the caller. Keeping that same mutable array lets later caller changes alter React Grab cleanup state.

## Example

A caller freezes elements using an array and then empties the array. React Grab must still remember which original elements need to be unfrozen.

## Changes

- take one private snapshot of the input elements
- reuse that snapshot for equality checks, freezing, and cleanup

## Validation

- format, build, unit tests, lint, and typecheck
- full GitHub CI and performance checks