### PR TITLE
fix(react-grab): release source fetch slots on throws

### DIFF
--- a/packages/react-grab/src/utils/source-fetch-queue.ts
+++ b/packages/react-grab/src/utils/source-fetch-queue.ts
@@ -52,12 +52,11 @@ export const runQueuedSourceFetch = async <T>(
     }, timeoutMs);
   });
 
-  const taskPromise = task(controller.signal);
-  // Swallow a late rejection from a fetch that already lost the timeout race, so
-  // an aborted request never surfaces as an unhandled rejection.
-  taskPromise.catch(() => {});
-
   try {
+    const taskPromise = task(controller.signal);
+    // Swallow a late rejection from a fetch that already lost the timeout race, so
+    // an aborted request never surfaces as an unhandled rejection.
+    taskPromise.catch(() => {});
     return await Promise.race([taskPromise, timeout]);
   } finally {
     clearTimeout(timeoutId);

--- a/packages/react-grab/tests/source-fetch-queue.test.ts
+++ b/packages/react-grab/tests/source-fetch-queue.test.ts
@@ -195,4 +195,29 @@ describe("runQueuedSourceFetch", () => {
     expect(await laterResult).toBe("later");
     expect(laterStarted).toBe(true);
   });
+
+  it("releases a slot when a task throws synchronously", async () => {
+    const failures = Array.from({ length: 3 }, () =>
+      runQueuedSourceFetch(
+        () => {
+          throw new Error("fetch failed");
+        },
+        "fallback",
+        TEST_TIMEOUT_MS,
+      ).catch((error: unknown) => error),
+    );
+
+    const laterResult = runQueuedSourceFetch(
+      () => Promise.resolve("later"),
+      "fallback",
+      TEST_TIMEOUT_MS,
+    );
+
+    expect(await Promise.all(failures)).toEqual([
+      new Error("fetch failed"),
+      new Error("fetch failed"),
+      new Error("fetch failed"),
+    ]);
+    expect(await laterResult).toBe("later");
+  });
 });


### PR DESCRIPTION
## Motivation

A queued source task can throw synchronously before returning its promise. Because that call happened before the queue's `finally`, its concurrency slot was never released. Three such failures could permanently block every later source lookup.

## Example

Before: a task throws while starting, the caller receives the error, but the queue still counts the task as active forever.

After: task startup runs inside the existing `try`/`finally`, so the slot is released whether the task throws, rejects, resolves, or times out.

## Changes

- Move task invocation under the existing slot-release boundary.
- Add a regression test that fills all three slots with synchronous throws and verifies a later task still runs.

## Validation

- `nr build`
- `nr test:unit -- source-fetch-queue.test.ts` (107 tests)
- `nr lint`
- `nr typecheck`
- `nr format:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow fix in the source-fetch queue with a targeted unit test; no auth or data-path changes, but it unblocks a real concurrency deadlock in source resolution.
> 
> **Overview**
> Fixes a **deadlock** in `runQueuedSourceFetch` when a queued task **throws before returning a promise**. Previously `task()` ran outside the `try`/`finally` that calls `releaseSlot()`, so a synchronous throw could leave a concurrency slot occupied permanently; three such failures could block all later source lookups (hover/copy stack resolution in `context.ts`).
> 
> **`task(controller.signal)`** and the late-rejection `.catch()` are now inside the existing **`try`/`finally`**, so slots are released on synchronous throw, async reject, resolve, or timeout—matching behavior already covered for async rejections.
> 
> Adds a regression test that fills all three slots with synchronous throws and asserts a fourth task still runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e992ab8d5309ac8f11bfdb618571c8d301f18a37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a concurrency slot leak in `react-grab`’s source fetch queue when a task throws synchronously. Slots now always release, preventing the queue from blocking after failures.

- **Bug Fixes**
  - Run task invocation inside the existing try/finally so the slot releases on throw/reject/resolve/timeout.
  - Add a regression test that fills all three slots with sync throws and confirms a later task runs.

<sup>Written for commit e992ab8d5309ac8f11bfdb618571c8d301f18a37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

