### PR TITLE
fix(react-grab): cancel in-flight copies

### DIFF
--- a/packages/react-grab/e2e/api-methods.spec.ts
+++ b/packages/react-grab/e2e/api-methods.spec.ts
@@ -1,5 +1,15 @@
 import { test, expect } from "./fixtures.js";
 
+interface CopyCancellationCase {
+  method: "deactivate" | "dispose";
+  label: string;
+}
+
+const COPY_CANCELLATION_CASES: CopyCancellationCase[] = [
+  { method: "deactivate", label: "deactivation" },
+  { method: "dispose", label: "disposal" },
+];
+
 test.describe("API Methods", () => {
   test.describe("Activation APIs", () => {
     test("activate() should activate the overlay", async ({ reactGrab }) => {
@@ -207,6 +217,108 @@ test.describe("API Methods", () => {
         getContentCallCount: 1,
       });
     });
+
+    test("keeps a copy completed when deactivated during the clipboard write", async ({
+      reactGrab,
+    }) => {
+      const result = await reactGrab.page.evaluate(async () => {
+        const api = (
+          window as {
+            __REACT_GRAB__?: {
+              copyElement: (element: Element) => Promise<boolean>;
+              deactivate: () => void;
+              registerPlugin: (plugin: {
+                name: string;
+                options: { getContent: () => string };
+              }) => void;
+            };
+          }
+        ).__REACT_GRAB__;
+        const element = document.querySelector("[data-testid='todo-list'] h1");
+        if (!api || !element) throw new Error("React Grab API or test element unavailable");
+
+        api.registerPlugin({
+          name: "copy-commit-test",
+          options: { getContent: () => "content" },
+        });
+        const originalExecCommand = document.execCommand;
+        let copyCommandCount = 0;
+        document.execCommand = () => {
+          copyCommandCount += 1;
+          api.deactivate();
+          return true;
+        };
+
+        try {
+          return { didCopy: await api.copyElement(element), copyCommandCount };
+        } finally {
+          document.execCommand = originalExecCommand;
+        }
+      });
+
+      expect(result).toEqual({ didCopy: true, copyCommandCount: 1 });
+    });
+
+    for (const cancellationCase of COPY_CANCELLATION_CASES) {
+      test(`does not write after ${cancellationCase.label} cancels a pending copy`, async ({
+        reactGrab,
+      }) => {
+        const result = await reactGrab.page.evaluate(async (cancellationMethod) => {
+          const api = (
+            window as {
+              __REACT_GRAB__?: {
+                copyElement: (element: Element) => Promise<boolean>;
+                deactivate: () => void;
+                dispose: () => void;
+                registerPlugin: (plugin: {
+                  name: string;
+                  options: { getContent: () => Promise<string> };
+                }) => void;
+              };
+            }
+          ).__REACT_GRAB__;
+          const element = document.querySelector("[data-testid='todo-list'] h1");
+          if (!api || !element) throw new Error("React Grab API or test element unavailable");
+
+          let resolveContent = (_content: string): void => {};
+          let markContentRequested = (): void => {};
+          const content = new Promise<string>((resolve) => {
+            resolveContent = resolve;
+          });
+          const contentRequested = new Promise<void>((resolve) => {
+            markContentRequested = () => resolve();
+          });
+          api.registerPlugin({
+            name: "pending-copy-test",
+            options: {
+              getContent: () => {
+                markContentRequested();
+                return content;
+              },
+            },
+          });
+
+          const originalExecCommand = document.execCommand;
+          let copyCommandCount = 0;
+          document.execCommand = () => {
+            copyCommandCount += 1;
+            return true;
+          };
+
+          try {
+            const pendingCopy = api.copyElement(element);
+            await contentRequested;
+            api[cancellationMethod]();
+            resolveContent("late content");
+            return { didCopy: await pendingCopy, copyCommandCount };
+          } finally {
+            document.execCommand = originalExecCommand;
+          }
+        }, cancellationCase.method);
+
+        expect(result).toEqual({ didCopy: false, copyCommandCount: 0 });
+      });
+    }
   });
 
   test.describe("Theme via setOptions", () => {

--- a/packages/react-grab/e2e/copy-failure.spec.ts
+++ b/packages/react-grab/e2e/copy-failure.spec.ts
@@ -132,6 +132,87 @@ test.describe("Copy failure feedback", () => {
       .toBe(false);
   });
 
+  test("deactivation cancels a pending retry without restoring its error label", async ({
+    reactGrab,
+  }) => {
+    await forceCopyResult(reactGrab, false);
+
+    await reactGrab.activate();
+    await reactGrab.hoverUntilSelected("li");
+    await reactGrab.clickElement("li");
+    await readErrorView(reactGrab);
+
+    await reactGrab.page.evaluate(() => {
+      const testWindow = window as {
+        __REACT_GRAB__?: {
+          registerPlugin: (plugin: {
+            name: string;
+            options: { getContent: () => Promise<string> };
+          }) => void;
+        };
+        __TEST_RETRY_CONTENT_REQUESTED__?: boolean;
+        __TEST_RETRY_COPY_COMMAND_COUNT__?: number;
+        __TEST_RESOLVE_RETRY_CONTENT__?: (content: string) => void;
+      };
+      const api = testWindow.__REACT_GRAB__;
+      if (!api) throw new Error("React Grab API unavailable");
+
+      let resolveContent = (_content: string): void => {};
+      const content = new Promise<string>((resolve) => {
+        resolveContent = resolve;
+      });
+      api.registerPlugin({
+        name: "pending-retry-test",
+        options: {
+          getContent: () => {
+            testWindow.__TEST_RETRY_CONTENT_REQUESTED__ = true;
+            return content;
+          },
+        },
+      });
+      testWindow.__TEST_RESOLVE_RETRY_CONTENT__ = resolveContent;
+      testWindow.__TEST_RETRY_COPY_COMMAND_COUNT__ = 0;
+      document.execCommand = () => {
+        testWindow.__TEST_RETRY_COPY_COMMAND_COUNT__ =
+          (testWindow.__TEST_RETRY_COPY_COMMAND_COUNT__ ?? 0) + 1;
+        return true;
+      };
+    });
+
+    await clickErrorButton(reactGrab, "data-react-grab-retry");
+    await expect
+      .poll(() =>
+        reactGrab.page.evaluate(
+          () =>
+            (window as { __TEST_RETRY_CONTENT_REQUESTED__?: boolean })
+              .__TEST_RETRY_CONTENT_REQUESTED__,
+        ),
+      )
+      .toBe(true);
+
+    await reactGrab.deactivate();
+    await expect.poll(() => reactGrab.getLabelInstancesInfo()).toEqual([]);
+    await reactGrab.page.evaluate(async () => {
+      (
+        window as {
+          __TEST_RESOLVE_RETRY_CONTENT__?: (content: string) => void;
+        }
+      ).__TEST_RESOLVE_RETRY_CONTENT__?.("late retry content");
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => resolve());
+      });
+    });
+
+    expect(await reactGrab.getLabelInstancesInfo()).toEqual([]);
+    expect(
+      await reactGrab.page.evaluate(
+        () =>
+          (window as { __TEST_RETRY_COPY_COMMAND_COUNT__?: number })
+            .__TEST_RETRY_COPY_COMMAND_COUNT__,
+      ),
+    ).toBe(0);
+  });
+
   test("a failed copy that keeps the overlay open leaves the copying state", async ({
     reactGrab,
   }) => {

--- a/packages/react-grab/e2e/copy-feedback.spec.ts
+++ b/packages/react-grab/e2e/copy-feedback.spec.ts
@@ -316,6 +316,89 @@ test.describe("Copy Feedback Behavior", () => {
       await expect.poll(() => reactGrab.getLabelInstancesInfo()).toEqual([]);
     });
 
+    test("deactivation cancels a copy waiting for content", async ({ reactGrab }) => {
+      await reactGrab.page.evaluate(() => {
+        const testWindow = window as {
+          __REACT_GRAB__?: {
+            registerPlugin: (plugin: {
+              name: string;
+              options: { getContent: () => Promise<string> };
+            }) => void;
+          };
+          __TEST_COPY_CONTENT_REQUESTED__?: boolean;
+          __TEST_COPY_COMMAND_COUNT__?: number;
+          __TEST_RESOLVE_COPY_CONTENT__?: (content: string) => void;
+          __TEST_RESTORE_EXEC_COMMAND__?: () => void;
+        };
+        const api = testWindow.__REACT_GRAB__;
+        if (!api) throw new Error("React Grab API unavailable");
+
+        let resolveContent = (_content: string): void => {};
+        const content = new Promise<string>((resolve) => {
+          resolveContent = resolve;
+        });
+        api.registerPlugin({
+          name: "pending-copy-feedback-test",
+          options: {
+            getContent: () => {
+              testWindow.__TEST_COPY_CONTENT_REQUESTED__ = true;
+              return content;
+            },
+          },
+        });
+        testWindow.__TEST_RESOLVE_COPY_CONTENT__ = resolveContent;
+
+        const originalExecCommand = document.execCommand;
+        testWindow.__TEST_COPY_COMMAND_COUNT__ = 0;
+        document.execCommand = () => {
+          testWindow.__TEST_COPY_COMMAND_COUNT__ =
+            (testWindow.__TEST_COPY_COMMAND_COUNT__ ?? 0) + 1;
+          return true;
+        };
+        testWindow.__TEST_RESTORE_EXEC_COMMAND__ = () => {
+          document.execCommand = originalExecCommand;
+        };
+      });
+
+      await reactGrab.activate();
+      await reactGrab.hoverUntilSelected("li:first-child");
+      await reactGrab.clickElement("li:first-child");
+      await expect
+        .poll(() =>
+          reactGrab.page.evaluate(
+            () =>
+              (window as { __TEST_COPY_CONTENT_REQUESTED__?: boolean })
+                .__TEST_COPY_CONTENT_REQUESTED__,
+          ),
+        )
+        .toBe(true);
+
+      await reactGrab.deactivate();
+      await expect.poll(() => reactGrab.getLabelInstancesInfo()).toEqual([]);
+      await reactGrab.page.evaluate(async () => {
+        (
+          window as {
+            __TEST_RESOLVE_COPY_CONTENT__?: (content: string) => void;
+          }
+        ).__TEST_RESOLVE_COPY_CONTENT__?.("late content");
+        await new Promise<void>((resolve) => {
+          requestAnimationFrame(() => resolve());
+        });
+      });
+
+      expect(await reactGrab.getLabelInstancesInfo()).toEqual([]);
+      expect(
+        await reactGrab.page.evaluate(
+          () => (window as { __TEST_COPY_COMMAND_COUNT__?: number }).__TEST_COPY_COMMAND_COUNT__,
+        ),
+      ).toBe(0);
+      await reactGrab.page.evaluate(() => {
+        (
+          window as { __TEST_RESTORE_EXEC_COMMAND__?: () => void }
+        ).__TEST_RESTORE_EXEC_COMMAND__?.();
+      });
+    });
+
     test("should enter copying state immediately on click", async ({ reactGrab }) => {
       await reactGrab.activate();
       await reactGrab.hoverUntilSelected("li:first-child");

--- a/packages/react-grab/src/core/copy.ts
+++ b/packages/react-grab/src/core/copy.ts
@@ -2,6 +2,7 @@ import { getElementReferenceContext, getStack, getStackContext, resolveSource } 
 import { copyContent } from "../utils/copy-content.js";
 import { normalizeError } from "../utils/normalize-error.js";
 import { getTagName } from "../utils/get-tag-name.js";
+import { ABORTED_PROMISE_RESULT, racePromiseWithAbort } from "../utils/race-promise-with-abort.js";
 import type { StackFrame } from "bippy/source";
 import type { ReactGrabEntry, ReactGrabStackFrame } from "../types.js";
 
@@ -9,6 +10,7 @@ interface CopyFlowOptions {
   getContent?: (elements: Element[]) => Promise<string> | string;
   componentName?: string;
   maxContextLines?: number;
+  signal?: AbortSignal;
 }
 
 interface CopyFlowHooks {
@@ -23,6 +25,14 @@ interface CopyPayload {
   content: string;
   entries?: ReactGrabEntry[];
 }
+
+export interface CopyFlowResult {
+  readonly status: "cancelled" | "failed" | "succeeded";
+}
+
+const CANCELLED_COPY_FLOW_RESULT: CopyFlowResult = {
+  status: "cancelled",
+};
 
 // Strips bippy's raw `source` stack-line text and `args` from the wire payload.
 const formatStackFramePayload = (frame: StackFrame): ReactGrabStackFrame => ({
@@ -100,34 +110,48 @@ export const runCopyFlow = async (
   hooks: CopyFlowHooks,
   elements: Element[],
   prependedPrompt?: string,
-): Promise<boolean> => {
-  await hooks.onBeforeCopy(elements);
+): Promise<CopyFlowResult> => {
+  if (options.signal?.aborted) return CANCELLED_COPY_FLOW_RESULT;
+  const beforeCopyResult = await racePromiseWithAbort(hooks.onBeforeCopy(elements), options.signal);
+  if (beforeCopyResult === ABORTED_PROMISE_RESULT) return CANCELLED_COPY_FLOW_RESULT;
 
   let didCopy = false;
+  let didStartClipboardWrite = false;
   let finalContent = "";
 
   try {
-    const payload: CopyPayload | null = options.getContent
-      ? { content: await options.getContent(elements) }
-      : await buildClipboardPayload(elements, options.maxContextLines);
+    const pendingPayload: Promise<CopyPayload | null> = options.getContent
+      ? Promise.resolve(options.getContent(elements)).then((content) => ({ content }))
+      : buildClipboardPayload(elements, options.maxContextLines);
+    const payload = await racePromiseWithAbort(pendingPayload, options.signal);
+    if (payload === ABORTED_PROMISE_RESULT) return CANCELLED_COPY_FLOW_RESULT;
     const rawContent = payload?.content;
 
     if (rawContent?.trim()) {
-      const transformedContent = await hooks.transformCopyContent(rawContent, elements);
+      const transformedContent = await racePromiseWithAbort(
+        hooks.transformCopyContent(rawContent, elements),
+        options.signal,
+      );
+      if (transformedContent === ABORTED_PROMISE_RESULT) {
+        return CANCELLED_COPY_FLOW_RESULT;
+      }
       finalContent = prependedPrompt
         ? `${prependedPrompt}\n${transformedContent}`
         : transformedContent;
+      didStartClipboardWrite = true;
       didCopy = copyContent(finalContent, {
         componentName: options.componentName,
         entries: getMetadataEntries(payload, finalContent, prependedPrompt),
       });
     }
   } catch (error) {
+    if (!didStartClipboardWrite && options.signal?.aborted) return CANCELLED_COPY_FLOW_RESULT;
     hooks.onCopyError(normalizeError(error));
   }
 
+  if (!didStartClipboardWrite && options.signal?.aborted) return CANCELLED_COPY_FLOW_RESULT;
   if (didCopy) hooks.onCopySuccess(elements, finalContent);
   hooks.onAfterCopy(elements, didCopy);
 
-  return didCopy;
+  return { status: didCopy ? "succeeded" : "failed" };
 };

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -42,7 +42,7 @@ import {
 import { isNextProjectRuntime } from "../utils/is-next-project-runtime.js";
 import { createNoopApi } from "./noop-api.js";
 import { createEventListenerManager } from "./events.js";
-import { runCopyFlow } from "./copy.js";
+import { runCopyFlow, type CopyFlowResult } from "./copy.js";
 import {
   clearElementPositionCache,
   getElementAtPosition,
@@ -152,6 +152,7 @@ import {
 import { freezeUpdates } from "../utils/freeze-updates.js";
 import { generateId } from "../utils/generate-id.js";
 import { reportRecoverableError } from "../utils/report-recoverable-error.js";
+import { ABORTED_PROMISE_RESULT, racePromiseWithAbort } from "../utils/race-promise-with-abort.js";
 import { getNearestEdge } from "../utils/get-nearest-edge.js";
 import { findShortcutAction } from "../utils/action-shortcuts.js";
 import { createKeyboardSelectionController } from "./keyboard-selection.js";
@@ -198,10 +199,14 @@ interface LabeledCopyOptions {
 }
 
 interface CopyRetryEntry {
-  operation: () => Promise<boolean>;
+  operation: (signal: AbortSignal) => Promise<CopyFlowResult>;
   siblingIds: Set<string>;
   shouldDeactivateAfter: boolean;
 }
+
+const CANCELLED_COPY_RESULT: CopyFlowResult = {
+  status: "cancelled",
+};
 
 let hasInited = false;
 const toolbarStateChangeCallbacks = new Set<(state: ToolbarState) => void>();
@@ -250,6 +255,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
   return createRoot((dispose) => {
     let disposed = false;
+    let copyAbortController = new AbortController();
     let pendingCopyMetadataIdentity: object | null = null;
     let disposeRenderer: (() => void) | undefined;
 
@@ -667,6 +673,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           };
         }),
       );
+      if (disposed) return;
 
       window.dispatchEvent(
         new CustomEvent("react-grab:element-selected", {
@@ -690,38 +697,77 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       () => retryCopyByInstanceId.clear(),
     );
 
-    const cancelPendingCopyMetadata = () => {
-      if (!pendingCopyMetadataIdentity) return;
+    const dismissCopyingLabels = (labelInstanceIds: string[]) => {
+      for (const labelInstanceId of labelInstanceIds) {
+        const labelInstance = store.labelInstances.find(
+          (currentInstance) => currentInstance.id === labelInstanceId,
+        );
+        if (labelInstance?.status !== "copying") continue;
+        retryCopyByInstanceId.delete(labelInstanceId);
+        labelController.dismissInstance(labelInstanceId);
+      }
+    };
+
+    const abortCopyOperations = () => {
+      copyAbortController.abort();
+    };
+
+    const getCopySignal = (): AbortSignal => {
+      if (copyAbortController.signal.aborted && !disposed) {
+        copyAbortController = new AbortController();
+      }
+      return copyAbortController.signal;
+    };
+
+    const startCopyOperation = (): AbortSignal => {
+      abortCopyOperations();
+      return getCopySignal();
+    };
+
+    const cancelPendingCopies = () => {
+      abortCopyOperations();
       pendingCopyMetadataIdentity = null;
-      if (current().state === "copying") labelController.clearAll();
+      dismissCopyingLabels(
+        store.labelInstances
+          .filter((labelInstance) => labelInstance.status === "copying")
+          .map((labelInstance) => labelInstance.id),
+      );
     };
 
     const attemptClipboardAndLabel = async (
-      clipboardOperation: () => Promise<boolean>,
+      clipboardOperation: (signal: AbortSignal) => Promise<CopyFlowResult>,
       labelInstanceIds: string[] | null,
-    ): Promise<boolean> => {
-      let didSucceed = false;
+      signal: AbortSignal,
+    ): Promise<CopyFlowResult> => {
+      let copyResult: CopyFlowResult;
       let errorMessage: string | undefined;
 
       try {
-        didSucceed = await clipboardOperation();
-        if (!didSucceed) errorMessage = "Failed to copy";
+        copyResult = await clipboardOperation(signal);
+        if (copyResult.status === "cancelled") return copyResult;
+        if (copyResult.status === "failed") errorMessage = "Failed to copy";
       } catch (error) {
+        if (signal.aborted) return CANCELLED_COPY_RESULT;
+        copyResult = { status: "failed" };
         errorMessage = normalizeErrorMessage(error, "Action failed");
       }
 
       if (labelInstanceIds) {
         for (const labelInstanceId of labelInstanceIds) {
-          labelController.updateAfterCopy(labelInstanceId, didSucceed, errorMessage);
+          labelController.updateAfterCopy(
+            labelInstanceId,
+            copyResult.status === "succeeded",
+            errorMessage,
+          );
         }
       }
 
-      return didSucceed;
+      return copyResult;
     };
 
     const registerCopyRetry = (
       didSucceed: boolean,
-      clipboardOperation: () => Promise<boolean>,
+      clipboardOperation: (signal: AbortSignal) => Promise<CopyFlowResult>,
       labelInstanceIds: string[],
       shouldDeactivateAfter: boolean,
     ) => {
@@ -743,16 +789,24 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
 
     const executeCopyOperation = async (
-      clipboardOperation: () => Promise<boolean>,
+      clipboardOperation: (signal: AbortSignal) => Promise<CopyFlowResult>,
       labelInstanceIds: string[] | null,
       shouldDeactivateAfter?: boolean,
-    ) => {
+      signal: AbortSignal = startCopyOperation(),
+    ): Promise<boolean> => {
+      if (signal.aborted) return false;
       clearCopyFeedbackCooldown();
       if (current().state !== "copying") {
         actions.startCopy();
       }
 
-      const didSucceed = await attemptClipboardAndLabel(clipboardOperation, labelInstanceIds);
+      const copyResult = await attemptClipboardAndLabel(
+        clipboardOperation,
+        labelInstanceIds,
+        signal,
+      );
+      if (copyResult.status === "cancelled") return false;
+      const didSucceed = copyResult.status === "succeeded";
 
       if (labelInstanceIds) {
         registerCopyRetry(
@@ -763,7 +817,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         );
       }
 
-      if (current().state !== "copying") return;
+      if (current().state !== "copying") return true;
 
       if (didSucceed) {
         actions.completeCopy();
@@ -781,6 +835,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         actions.activate();
         actions.unfreeze();
       }
+      return true;
     };
 
     const handleRetryInstance = (instanceId: string) => {
@@ -794,7 +849,11 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       // Route through the full copy path (not just the clipboard attempt) so a
       // recovered copy runs the same completion side effects as a first-try
       // success: completeCopy, re-activate or deactivate, and feedback cooldown.
-      void executeCopyOperation(entry.operation, idsToRetry, entry.shouldDeactivateAfter);
+      void executeCopyOperation(entry.operation, idsToRetry, entry.shouldDeactivateAfter).then(
+        (didComplete) => {
+          if (!didComplete) dismissCopyingLabels(idsToRetry);
+        },
+      );
     };
 
     const handleAcknowledgeErrorInstance = (instanceId: string) => {
@@ -805,6 +864,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
 
     const copyResolvedElements = (
       elements: Element[],
+      signal: AbortSignal,
       extraPrompt?: string,
       resolvedComponentName?: string,
     ) => {
@@ -819,6 +879,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           getContent: pluginRegistry.store.options.getContent,
           componentName: elementName,
           maxContextLines: pluginRegistry.store.options.maxContextLines,
+          signal,
         },
         pluginRegistry.hooks,
         elements,
@@ -830,8 +891,9 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       targetElements: Element[],
       extraPrompt?: string,
       resolvedComponentName?: string,
-    ): Promise<boolean> => {
-      if (targetElements.length === 0) return false;
+      signal: AbortSignal = getCopySignal(),
+    ): Promise<CopyFlowResult> => {
+      if (targetElements.length === 0 || signal.aborted) return CANCELLED_COPY_RESULT;
 
       const unhandledElements: Element[] = [];
       const pendingResults: Promise<boolean>[] = [];
@@ -848,43 +910,72 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         }
       }
       await waitUntilNextFrame();
+      if (signal.aborted) return CANCELLED_COPY_RESULT;
 
-      let didCopy = true;
+      let copyResult: CopyFlowResult | undefined;
       if (unhandledElements.length > 0) {
-        didCopy = await copyResolvedElements(unhandledElements, extraPrompt, resolvedComponentName);
+        copyResult = await copyResolvedElements(
+          unhandledElements,
+          signal,
+          extraPrompt,
+          resolvedComponentName,
+        );
+        if (copyResult.status === "cancelled") return copyResult;
       }
       if (pendingResults.length > 0) {
-        const results = await Promise.all(pendingResults);
+        const results = await racePromiseWithAbort(Promise.all(pendingResults), signal);
+        if (results === ABORTED_PROMISE_RESULT) {
+          return copyResult?.status === "succeeded" ? copyResult : CANCELLED_COPY_RESULT;
+        }
         if (!results.every(Boolean)) {
           throw new CopyFailedError();
         }
       }
-      void notifyElementsSelected(targetElements);
-      return didCopy;
+      if (signal.aborted && !copyResult) return CANCELLED_COPY_RESULT;
+      void notifyElementsSelected(targetElements).catch((error) => {
+        reportRecoverableError(
+          new RecoverableError("Element selection notification failed", error),
+        );
+      });
+      return copyResult ?? { status: "succeeded" };
     };
 
     const runLabeledCopy = (copy: LabeledCopyOptions) => {
+      const signal = startCopyOperation();
       const metadataIdentity = {};
       let didStartCopyOperation = false;
       pendingCopyMetadataIdentity = metadataIdentity;
       void getNearestComponentName(copy.primaryElement)
         .then(async (componentName) => {
-          if (disposed || pendingCopyMetadataIdentity !== metadataIdentity) return;
+          if (signal.aborted || pendingCopyMetadataIdentity !== metadataIdentity) {
+            dismissCopyingLabels(copy.labelInstanceIds);
+            return;
+          }
           pendingCopyMetadataIdentity = null;
           didStartCopyOperation = true;
-          await executeCopyOperation(
-            () =>
+          const didComplete = await executeCopyOperation(
+            (copySignal) =>
               copyElementsToClipboard(
                 copy.targetElements,
                 copy.extraPrompt,
                 componentName ?? undefined,
+                copySignal,
               ),
             copy.labelInstanceIds.length > 0 ? copy.labelInstanceIds : null,
             copy.shouldDeactivateAfter,
+            signal,
           );
-          copy.onComplete?.();
+          if (didComplete) {
+            copy.onComplete?.();
+          } else {
+            dismissCopyingLabels(copy.labelInstanceIds);
+          }
         })
         .catch((error) => {
+          if (signal.aborted) {
+            dismissCopyingLabels(copy.labelInstanceIds);
+            return;
+          }
           if (
             disposed ||
             (!didStartCopyOperation && pendingCopyMetadataIdentity !== metadataIdentity)
@@ -898,14 +989,16 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           if (copy.labelInstanceIds.length > 0) {
             registerCopyRetry(
               false,
-              () =>
-                getNearestComponentName(copy.primaryElement).then((componentName) =>
-                  copyElementsToClipboard(
+              (retrySignal) =>
+                getNearestComponentName(copy.primaryElement).then((componentName) => {
+                  if (retrySignal.aborted) return CANCELLED_COPY_RESULT;
+                  return copyElementsToClipboard(
                     copy.targetElements,
                     copy.extraPrompt,
                     componentName ?? undefined,
-                  ),
-                ),
+                    retrySignal,
+                  );
+                }),
               copy.labelInstanceIds,
               Boolean(copy.shouldDeactivateAfter),
             );
@@ -1609,7 +1702,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
 
     const deactivateRenderer = () => {
-      cancelPendingCopyMetadata();
+      cancelPendingCopies();
       const wasDragging = isDragging();
       const previousFocused = store.previouslyFocusedElement;
       stopSpaceDragRepositioning();
@@ -1649,8 +1742,10 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       if (isHoldingKeys()) {
         actions.releaseHold();
       }
-      if (isActivated()) {
+      if (isActivated() || isCopying()) {
         deactivateRenderer();
+      } else {
+        cancelPendingCopies();
       }
       clearCopyFeedbackCooldown();
     };
@@ -1788,6 +1883,10 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     };
 
     const handleActivateAction = (actionId: string) => {
+      if (isCopying()) {
+        deactivateRenderer();
+        return;
+      }
       if (isActivated()) {
         // While still choosing an element, clicking a different action switches
         // the pending action in place instead of tearing down selection mode;
@@ -2738,6 +2837,11 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
           event.preventDefault();
           event.stopPropagation();
           handleInputCancel();
+          return;
+        }
+
+        if (event.key === "Escape" && isCopying()) {
+          deactivateRenderer();
           return;
         }
 
@@ -4093,7 +4197,8 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     const copyElementAPI = async (elements: Element | Element[]): Promise<boolean> => {
       const elementsArray = Array.isArray(elements) ? elements : [elements];
       if (elementsArray.length === 0) return false;
-      return await copyResolvedElements(elementsArray);
+      const copyResult = await copyResolvedElements(elementsArray, getCopySignal());
+      return copyResult.status === "succeeded";
     };
 
     const api: ReactGrabAPI = {
@@ -4106,10 +4211,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       deactivate: () => {
         if (isActivated() || isCopying()) {
           deactivateRenderer();
+        } else {
+          cancelPendingCopies();
         }
       },
       toggle: () => {
-        if (isActivated()) {
+        if (isActivated() || isCopying()) {
           deactivateRenderer();
         } else if (isEnabled()) {
           toggleActivate();
@@ -4163,13 +4270,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         forceDeactivateAll();
         dismissAllPopups();
         actions.clearGrabbedBoxes();
-        cancelPendingCopyMetadata();
         labelController.clearAll();
         actions.setSelectionSource(null, null);
       },
       dispose: () => {
         disposed = true;
-        cancelPendingCopyMetadata();
+        cancelPendingCopies();
         labelController.clearAll();
         hasInited = false;
         disposeRenderer?.();

--- a/packages/react-grab/src/utils/race-promise-with-abort.ts
+++ b/packages/react-grab/src/utils/race-promise-with-abort.ts
@@ -1,0 +1,21 @@
+export const ABORTED_PROMISE_RESULT = Symbol("aborted-promise-result");
+
+export const racePromiseWithAbort = async <Result>(
+  promise: Promise<Result>,
+  signal?: AbortSignal,
+): Promise<Result | typeof ABORTED_PROMISE_RESULT> => {
+  if (!signal) return promise;
+  if (signal.aborted) return ABORTED_PROMISE_RESULT;
+
+  let resolveAbort = (): void => {};
+  const aborted = new Promise<typeof ABORTED_PROMISE_RESULT>((resolve) => {
+    resolveAbort = () => resolve(ABORTED_PROMISE_RESULT);
+  });
+  signal.addEventListener("abort", resolveAbort, { once: true });
+
+  try {
+    return await Promise.race([promise, aborted]);
+  } finally {
+    signal.removeEventListener("abort", resolveAbort);
+  }
+};

--- a/packages/react-grab/tests/copy-flow.test.ts
+++ b/packages/react-grab/tests/copy-flow.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import { runCopyFlow } from "../src/core/copy.js";
+
+const createHooks = () => ({
+  onBeforeCopy: vi.fn(async () => {}),
+  transformCopyContent: vi.fn(async (content: string) => content),
+  onAfterCopy: vi.fn(),
+  onCopySuccess: vi.fn(),
+  onCopyError: vi.fn(),
+});
+
+describe("runCopyFlow", () => {
+  it("stops after content resolves when the copy was cancelled", async () => {
+    const abortController = new AbortController();
+    const content = Promise.withResolvers<string>();
+    const contentRequested = Promise.withResolvers<void>();
+    const hooks = createHooks();
+    const pendingCopy = runCopyFlow(
+      {
+        getContent: () => {
+          contentRequested.resolve();
+          return content.promise;
+        },
+        signal: abortController.signal,
+      },
+      hooks,
+      [Object.create(null)],
+    );
+
+    await contentRequested.promise;
+    abortController.abort();
+
+    expect(await pendingCopy).toEqual({ status: "cancelled" });
+    content.resolve("late content");
+    expect(hooks.transformCopyContent).not.toHaveBeenCalled();
+    expect(hooks.onCopySuccess).not.toHaveBeenCalled();
+    expect(hooks.onCopyError).not.toHaveBeenCalled();
+    expect(hooks.onAfterCopy).not.toHaveBeenCalled();
+  });
+
+  it("stops before writing when a transform resolves after cancellation", async () => {
+    const abortController = new AbortController();
+    const transformedContent = Promise.withResolvers<string>();
+    const transformStarted = Promise.withResolvers<void>();
+    const hooks = createHooks();
+    hooks.transformCopyContent.mockImplementation(() => {
+      transformStarted.resolve();
+      return transformedContent.promise;
+    });
+    const pendingCopy = runCopyFlow(
+      {
+        getContent: () => "content",
+        signal: abortController.signal,
+      },
+      hooks,
+      [Object.create(null)],
+    );
+
+    await transformStarted.promise;
+    abortController.abort();
+
+    expect(await pendingCopy).toEqual({ status: "cancelled" });
+    transformedContent.resolve("late transformed content");
+    expect(hooks.onCopySuccess).not.toHaveBeenCalled();
+    expect(hooks.onCopyError).not.toHaveBeenCalled();
+    expect(hooks.onAfterCopy).not.toHaveBeenCalled();
+  });
+
+  it("treats empty content as cancelled when abort wins before continuation", async () => {
+    const abortController = new AbortController();
+    const content = Promise.withResolvers<string>();
+    const hooks = createHooks();
+    const pendingCopy = runCopyFlow(
+      {
+        getContent: () => content.promise,
+        signal: abortController.signal,
+      },
+      hooks,
+      [Object.create(null)],
+    );
+
+    content.resolve("");
+    abortController.abort();
+
+    expect(await pendingCopy).toEqual({ status: "cancelled" });
+    expect(hooks.onCopyError).not.toHaveBeenCalled();
+    expect(hooks.onAfterCopy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-grab/tests/race-promise-with-abort.test.ts
+++ b/packages/react-grab/tests/race-promise-with-abort.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  ABORTED_PROMISE_RESULT,
+  racePromiseWithAbort,
+} from "../src/utils/race-promise-with-abort.js";
+
+describe("racePromiseWithAbort", () => {
+  it("returns a completed result", async () => {
+    const abortController = new AbortController();
+
+    await expect(
+      racePromiseWithAbort(Promise.resolve("completed"), abortController.signal),
+    ).resolves.toBe("completed");
+  });
+
+  it("stops waiting when aborted", async () => {
+    const abortController = new AbortController();
+    const pendingResult = Promise.withResolvers<string>();
+    const result = racePromiseWithAbort(pendingResult.promise, abortController.signal);
+
+    abortController.abort();
+
+    await expect(result).resolves.toBe(ABORTED_PROMISE_RESULT);
+  });
+});


### PR DESCRIPTION
## Motivation

Deactivating or disposing React Grab stopped the UI, but an async copy could keep running and write stale content later. Cancellation is expected control flow, so it should not be reported as an error.

## Example

A plugin starts a slow `getContent()` request. The user presses Escape before it resolves. Previously, the late result could still overwrite the clipboard and restore copy feedback; now the copy ends silently.

## Changes

- Abort copy preparation on Escape, deactivate, disable, reset, or dispose.
- Distinguish `cancelled`, `failed`, and `succeeded` outcomes.
- Preserve a clipboard write that already committed synchronously.
- Stop waiting on plugin copy promises after cancellation.
- Dismiss only in-progress labels, preserving completed feedback.

## Validation

- `nr build`
- `nr test:unit` (111 tests)
- focused Playwright copy/API suite (36 tests)
- `nr lint`
- `nr typecheck`
- `nr format:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches clipboard timing and copy state machine paths (retry, labels, deactivate); regressions could strand the overlay or drop successful writes, but behavior is heavily tested.
> 
> **Overview**
> **In-flight copy operations can now be aborted** when the user leaves copy mode or tears down React Grab, so late async plugin work no longer writes to the clipboard or revives copy UI.
> 
> Copy outcomes are modeled as **`cancelled`**, **`failed`**, or **`succeeded`** (replacing a bare boolean from `runCopyFlow`). A shared **`racePromiseWithAbort`** helper stops waiting on `getContent`, transforms, and plugin promises once an **`AbortSignal`** fires. **Synchronous clipboard writes that already started** still count as success even if deactivate runs inside `execCommand`.
> 
> The core wires a **`copyAbortController`** through labeled copies, retries, and `copyElement`. **Deactivate, dispose, reset, Escape while copying**, and related API paths call **`cancelPendingCopies`**, which aborts the signal and **dismisses only labels still in `copying`** (completed or error feedback is left alone). Retries and pending metadata paths dismiss in-progress labels when cancellation wins.
> 
> Coverage adds unit tests for the abort helper and copy flow, plus Playwright cases for pending copy/retry cancellation and commit-during-write behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc77a455d1f7f3e59d9bf4def13c194ee2ada0ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->