### PR TITLE
fix(react-grab): preserve function options

### DIFF
--- a/packages/react-grab/e2e/api-methods.spec.ts
+++ b/packages/react-grab/e2e/api-methods.spec.ts
@@ -165,6 +165,48 @@ test.describe("API Methods", () => {
       });
       expect(success).toBe(true);
     });
+
+    test("preserves a getContent callback passed to setOptions", async ({ reactGrab }) => {
+      const result = await reactGrab.page.evaluate(async () => {
+        const api = (
+          window as {
+            __REACT_GRAB__?: {
+              copyElement: (element: Element) => Promise<boolean>;
+              setOptions: (options: { getContent: () => string }) => void;
+            };
+          }
+        ).__REACT_GRAB__;
+        const element = document.querySelector("[data-testid='todo-list'] h1");
+        if (!api || !element) throw new Error("React Grab API or test element unavailable");
+
+        let getContentCallCount = 0;
+        api.setOptions({
+          getContent: () => {
+            getContentCallCount += 1;
+            return "custom content";
+          },
+        });
+        const callCountBeforeCopy = getContentCallCount;
+        const originalExecCommand = document.execCommand;
+        document.execCommand = () => true;
+
+        try {
+          return {
+            callCountBeforeCopy,
+            didCopy: await api.copyElement(element),
+            getContentCallCount,
+          };
+        } finally {
+          document.execCommand = originalExecCommand;
+        }
+      });
+
+      expect(result).toEqual({
+        callCountBeforeCopy: 0,
+        didCopy: true,
+        getContentCallCount: 1,
+      });
+    });
   });
 
   test.describe("Theme via setOptions", () => {

--- a/packages/react-grab/src/core/plugin-registry.ts
+++ b/packages/react-grab/src/core/plugin-registry.ts
@@ -101,7 +101,7 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     optionValue: OptionsState[OptionKey],
   ) => {
     directOptionOverrides[optionKey] = optionValue;
-    setStore("options", optionKey, optionValue);
+    setStore("options", optionKey, () => optionValue);
   };
 
   const SETTABLE_OPTION_KEYS: Array<keyof OptionsState> = [


### PR DESCRIPTION
## Motivation

Solid treats function values passed to a store setter as updater callbacks. `setOptions({ getContent })` therefore executed `getContent` immediately and stored its return value instead of the function.

## Example

Calling `setOptions({ getContent: () => "custom" })` ran the callback during setup. A later `copyElement()` then tried to call the stored string and returned `false`.

## Changes

Wrap option writes so Solid stores the supplied value without invoking function-valued options.

## Validation

- regression test verifies `getContent` is not called until copying and runs exactly once
- `nr build`
- API Playwright suite (26 tests)
- `nr lint`
- `nr typecheck`
- `nr format:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted fix in option persistence plus an e2e test; no auth or data-path changes.
> 
> **Overview**
> Fixes **function-valued options** (notably `getContent`) being broken when set through `setOptions`.
> 
> Solid’s store setter treats a function as an updater and runs it immediately, so `setOptions({ getContent: () => ... })` stored the callback’s return value instead of the function and broke `copyElement()`. Per-option writes now use `setStore("options", optionKey, () => optionValue)` so the supplied value is stored as-is.
> 
> Adds a Playwright regression test: `getContent` is not invoked during `setOptions`, runs once on copy, and copy succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4054f083b61e2acd047192d3faf338b8d512672e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves function-valued options in `react-grab` so `setOptions({ getContent })` stores the function instead of calling it. This prevents early execution and ensures `copyElement` calls `getContent` once at copy time.

- **Bug Fixes**
  - Write options via `setStore("options", key, () => value)` to store functions without invoking them.
  - Added an e2e test to confirm `getContent` is not called before copying and runs exactly once.

<sup>Written for commit 4054f083b61e2acd047192d3faf338b8d512672e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

