### PR TITLE
fix(react-grab): isolate toolbar state subscribers

### DIFF
--- a/packages/react-grab/e2e/api-methods.spec.ts
+++ b/packages/react-grab/e2e/api-methods.spec.ts
@@ -354,6 +354,35 @@ test.describe("API Methods", () => {
     });
   });
 
+  test.describe("Toolbar state", () => {
+    test("isolates throwing state subscribers", async ({ reactGrab }) => {
+      const result = await reactGrab.page.evaluate(() => {
+        const api = (
+          window as {
+            __REACT_GRAB__?: {
+              onToolbarStateChange: (callback: (state: { collapsed: boolean }) => void) => void;
+              setToolbarState: (state: { collapsed: boolean }) => void;
+            };
+          }
+        ).__REACT_GRAB__;
+        if (!api) throw new Error("React Grab API unavailable");
+
+        let receivedCollapsed: boolean | undefined;
+        api.onToolbarStateChange(() => {
+          throw new Error("subscriber failed");
+        });
+        api.onToolbarStateChange((state) => {
+          receivedCollapsed = state.collapsed;
+        });
+
+        api.setToolbarState({ collapsed: true });
+        return receivedCollapsed;
+      });
+
+      expect(result).toBe(true);
+    });
+  });
+
   test.describe("maxContextLines via setOptions", () => {
     test("raising maxContextLines surfaces more source lines than the compact default", async ({
       reactGrab,

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -157,6 +157,7 @@ import { getNearestEdge } from "../utils/get-nearest-edge.js";
 import { findShortcutAction } from "../utils/action-shortcuts.js";
 import { createKeyboardSelectionController } from "./keyboard-selection.js";
 import { executeContextMenuAction } from "../utils/execute-context-menu-action.js";
+import { notifyToolbarStateChangeSubscribers } from "../utils/notify-toolbar-state-change-subscribers.js";
 
 const builtInPlugins = [copyPlugin, editPlugin, commentPlugin, openPlugin];
 
@@ -427,9 +428,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       };
       saveToolbarState(newState);
       setCurrentToolbarState(newState);
-      for (const callback of toolbarStateChangeCallbacks) {
-        callback(newState);
-      }
+      notifyToolbarStateChangeSubscribers(toolbarStateChangeCallbacks, newState);
     };
 
     const clearHoldTimer = () => {
@@ -4150,7 +4149,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
                       dismissAllPopups();
                     }
                   }
-                  toolbarStateChangeCallbacks.forEach((callback) => callback(state));
+                  notifyToolbarStateChangeSubscribers(toolbarStateChangeCallbacks, state);
                 }}
                 onSubscribeToToolbarStateChanges={(callback) => {
                   toolbarStateChangeCallbacks.add(callback);
@@ -4256,7 +4255,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
             dismissAllPopups();
           }
         }
-        toolbarStateChangeCallbacks.forEach((callback) => callback(newState));
+        notifyToolbarStateChangeSubscribers(toolbarStateChangeCallbacks, newState);
       },
       onToolbarStateChange: (callback: (state: ToolbarState) => void) => {
         toolbarStateChangeCallbacks.add(callback);

--- a/packages/react-grab/src/utils/notify-toolbar-state-change-subscribers.ts
+++ b/packages/react-grab/src/utils/notify-toolbar-state-change-subscribers.ts
@@ -1,0 +1,20 @@
+import { RecoverableError } from "../errors.js";
+import type { ToolbarState } from "../types.js";
+import { reportRecoverableError } from "./report-recoverable-error.js";
+
+const reportSubscriberError = (error: unknown): void => {
+  reportRecoverableError(new RecoverableError("Toolbar state change subscriber failed", error));
+};
+
+export const notifyToolbarStateChangeSubscribers = (
+  subscribers: ReadonlySet<(state: ToolbarState) => void>,
+  state: ToolbarState,
+): void => {
+  for (const subscriber of subscribers) {
+    try {
+      void Promise.resolve(subscriber(state)).catch(reportSubscriberError);
+    } catch (error) {
+      reportSubscriberError(error);
+    }
+  }
+};

--- a/packages/react-grab/tests/notify-toolbar-state-change-subscribers.test.ts
+++ b/packages/react-grab/tests/notify-toolbar-state-change-subscribers.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import type { ToolbarState } from "../src/types.js";
+import { notifyToolbarStateChangeSubscribers } from "../src/utils/notify-toolbar-state-change-subscribers.js";
+
+const TOOLBAR_STATE: ToolbarState = {
+  edge: "bottom",
+  ratio: 0.5,
+  collapsed: false,
+  enabled: true,
+  defaultAction: "copy",
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("notifyToolbarStateChangeSubscribers", () => {
+  it("reports a throwing subscriber and continues notifying", () => {
+    const subscriberError = new Error("subscriber failed");
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const nextSubscriber = vi.fn();
+
+    notifyToolbarStateChangeSubscribers(
+      new Set([
+        () => {
+          throw subscriberError;
+        },
+        nextSubscriber,
+      ]),
+      TOOLBAR_STATE,
+    );
+
+    expect(nextSubscriber).toHaveBeenCalledWith(TOOLBAR_STATE);
+    expect(warning).toHaveBeenCalledWith(
+      "[react-grab]",
+      expect.objectContaining({ cause: subscriberError }),
+    );
+  });
+
+  it("reports an asynchronously rejected subscriber", async () => {
+    const subscriberError = new Error("subscriber rejected");
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    notifyToolbarStateChangeSubscribers(
+      new Set([
+        async () => {
+          throw subscriberError;
+        },
+      ]),
+      TOOLBAR_STATE,
+    );
+    await Promise.resolve();
+
+    expect(warning).toHaveBeenCalledWith(
+      "[react-grab]",
+      expect.objectContaining({ cause: subscriberError }),
+    );
+  });
+});


### PR DESCRIPTION
Depends on #551.

## Motivation

Toolbar state is committed before subscribers are notified. If one public subscriber throws or rejects, later subscribers—including React Grab’s internal toolbar sync—must still receive the new state.

## Example

A broken analytics listener throws while observing `collapsed: true`. The toolbar should still collapse, and the listener failure should be reported as recoverable.

## Changes

- Route all three toolbar notification paths through one focused notifier.
- Isolate synchronous throws and asynchronous rejections per subscriber.
- Report failures through the recoverable-error boundary from #551.

## Validation

- `nr build`
- `nr test:unit` (108 tests)
- `E2E_ENVIRONMENT=vite-plus-development nr test -- e2e/api-methods.spec.ts` (26 tests)
- `nr lint`
- `nr typecheck`
- `nr format:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to observer notification only; state commit behavior is unchanged and covered by new unit and e2e tests.
> 
> **Overview**
> **Toolbar state notifications** no longer stop when a single `onToolbarStateChange` listener throws or returns a rejected promise. State is still saved and applied first; only the fan-out to subscribers is hardened.
> 
> All three notification paths (`updateToolbarState`, renderer `onToolbarStateChange`, and `setToolbarState` on the public API) now go through **`notifyToolbarStateChangeSubscribers`**, which notifies each callback in isolation and routes failures through **`reportRecoverableError`** as a recoverable subscriber error.
> 
> Unit tests cover sync throws and async rejections; an e2e case asserts a throwing first subscriber does not block a second subscriber from seeing `collapsed: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65ec2a2e4147ef8a2ae3b51d29b7343b63d1d6d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates `react-grab` toolbar state subscribers so a failing `onToolbarStateChange` listener never blocks others. Toolbar updates always apply, and failures are reported as recoverable.

- **Bug Fixes**
  - Added `notifyToolbarStateChangeSubscribers` to run each listener in isolation and catch sync/async errors.
  - Commit toolbar state before notifying; continue notifying even when a subscriber fails.
  - Added unit tests for throws/rejections and an e2e test for a throwing subscriber.

- **Refactors**
  - Replaced direct callback iteration with `notifyToolbarStateChangeSubscribers` at all toolbar notification sites.

<sup>Written for commit 65ec2a2e4147ef8a2ae3b51d29b7343b63d1d6d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

