### PR TITLE
fix(react-grab): make plugin registration atomic

### DIFF
--- a/packages/react-grab/src/core/plugin-registry.ts
+++ b/packages/react-grab/src/core/plugin-registry.ts
@@ -22,7 +22,7 @@ import type {
 } from "../types.js";
 import { DEFAULT_THEME, deepMergeTheme } from "./theme.js";
 import { DEFAULT_KEY_HOLD_DURATION_MS, DEFAULT_MAX_CONTEXT_LINES } from "../constants.js";
-import { PluginCleanupError, PluginHookError } from "../errors.js";
+import { PluginCleanupError, PluginHookError, PluginSetupError } from "../errors.js";
 import { reportRecoverableError } from "../utils/report-recoverable-error.js";
 
 interface RegisteredPlugin {
@@ -69,12 +69,14 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     actions: [],
   });
 
-  const recomputeStore = () => {
+  const createPluginStoreState = (
+    registeredPlugins: Iterable<RegisteredPlugin>,
+  ): PluginStoreState => {
     let mergedTheme: Required<Theme> = DEFAULT_THEME;
     let mergedOptions: OptionsState = { ...DEFAULT_OPTIONS, ...initialOptions };
     const allContextMenuActions: ContextMenuAction[] = [];
 
-    for (const { config } of plugins.values()) {
+    for (const { config } of registeredPlugins) {
       if (config.theme) {
         mergedTheme = deepMergeTheme(mergedTheme, config.theme);
       }
@@ -90,11 +92,21 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
       }
     }
 
-    mergedOptions = { ...mergedOptions, ...directOptionOverrides };
+    return {
+      theme: mergedTheme,
+      options: mergedOptions,
+      actions: allContextMenuActions,
+    };
+  };
 
-    setStore("theme", mergedTheme);
-    setStore("options", mergedOptions);
-    setStore("actions", allContextMenuActions);
+  const applyPluginStoreState = (nextStore: PluginStoreState): void => {
+    setStore("theme", nextStore.theme);
+    setStore("options", { ...nextStore.options, ...directOptionOverrides });
+    setStore("actions", nextStore.actions);
+  };
+
+  const recomputeStore = () => {
+    applyPluginStoreState(createPluginStoreState(plugins.values()));
   };
 
   const setOption = <OptionKey extends keyof OptionsState>(
@@ -124,36 +136,6 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     }
   };
 
-  const register = (plugin: Plugin, api: ReactGrabAPI) => {
-    if (isDisposed) return;
-    if (plugins.has(plugin.name)) {
-      unregister(plugin.name);
-    }
-
-    const config: PluginConfig = plugin.setup?.(api, hooks) ?? {};
-
-    if (plugin.theme) {
-      config.theme = config.theme
-        ? deepMergeTheme(deepMergeTheme(DEFAULT_THEME, plugin.theme), config.theme)
-        : plugin.theme;
-    }
-
-    if (plugin.actions) {
-      config.actions = [...plugin.actions, ...(config.actions ?? [])];
-    }
-
-    if (plugin.hooks) {
-      config.hooks = config.hooks ? { ...plugin.hooks, ...config.hooks } : plugin.hooks;
-    }
-
-    if (plugin.options) {
-      config.options = config.options ? { ...plugin.options, ...config.options } : plugin.options;
-    }
-
-    plugins.set(plugin.name, { plugin, config });
-    recomputeStore();
-  };
-
   const cleanupPlugin = ({ plugin, config }: RegisteredPlugin) => {
     try {
       const cleanupResult = config.cleanup?.();
@@ -163,6 +145,54 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     } catch (error) {
       reportRecoverableError(new PluginCleanupError(plugin.name, error));
     }
+  };
+
+  const preparePluginConfig = (plugin: Plugin, api: ReactGrabAPI): PluginConfig => {
+    let setupConfig: PluginConfig | undefined;
+    try {
+      setupConfig = plugin.setup?.(api, hooks) ?? {};
+      const cleanup = setupConfig.cleanup?.bind(setupConfig);
+      return {
+        ...setupConfig,
+        cleanup,
+        theme: plugin.theme
+          ? setupConfig.theme
+            ? deepMergeTheme(deepMergeTheme(DEFAULT_THEME, plugin.theme), setupConfig.theme)
+            : plugin.theme
+          : setupConfig.theme,
+        options: plugin.options
+          ? { ...plugin.options, ...setupConfig.options }
+          : setupConfig.options,
+        actions: plugin.actions
+          ? [...plugin.actions, ...(setupConfig.actions ?? [])]
+          : setupConfig.actions,
+        hooks: plugin.hooks ? { ...plugin.hooks, ...setupConfig.hooks } : setupConfig.hooks,
+      };
+    } catch (error) {
+      if (setupConfig) cleanupPlugin({ plugin, config: setupConfig });
+      throw new PluginSetupError(plugin.name, error);
+    }
+  };
+
+  const register = (plugin: Plugin, api: ReactGrabAPI) => {
+    if (isDisposed) return;
+
+    const config = preparePluginConfig(plugin, api);
+    const registeredPlugin = { plugin, config };
+    const previousPlugin = plugins.get(plugin.name);
+    const nextPlugins = new Map(plugins);
+    nextPlugins.set(plugin.name, registeredPlugin);
+    let nextStore: PluginStoreState;
+    try {
+      nextStore = createPluginStoreState(nextPlugins.values());
+    } catch (error) {
+      cleanupPlugin(registeredPlugin);
+      throw new PluginSetupError(plugin.name, error);
+    }
+
+    plugins.set(plugin.name, registeredPlugin);
+    applyPluginStoreState(nextStore);
+    if (previousPlugin) cleanupPlugin(previousPlugin);
   };
 
   const unregister = (name: string) => {

--- a/packages/react-grab/src/errors.ts
+++ b/packages/react-grab/src/errors.ts
@@ -41,6 +41,16 @@ export class PluginCleanupError extends RecoverableError {
   }
 }
 
+export class PluginSetupError extends ReactGrabError {
+  readonly pluginName: string;
+
+  constructor(pluginName: string, cause: unknown) {
+    super(`Plugin setup failed for "${pluginName}"`, { cause });
+    this.name = "PluginSetupError";
+    this.pluginName = pluginName;
+  }
+}
+
 export class ContextMenuActionError extends RecoverableError {
   readonly actionId: string;
 

--- a/packages/react-grab/src/index.ts
+++ b/packages/react-grab/src/index.ts
@@ -9,6 +9,7 @@ export { commentPlugin } from "./core/plugins/comment.js";
 export { openPlugin } from "./core/plugins/open.js";
 export { FreezeError } from "./errors.js";
 export { generateSnippet } from "./utils/generate-snippet.js";
+export { PluginSetupError, ReactGrabError } from "./errors.js";
 export type {
   Options,
   ReactGrabAPI,

--- a/packages/react-grab/tests/plugin-registry.test.ts
+++ b/packages/react-grab/tests/plugin-registry.test.ts
@@ -2,7 +2,7 @@ import { createRoot } from "solid-js";
 import { describe, expect, it, vi } from "vite-plus/test";
 import { createNoopApi } from "../src/core/noop-api.js";
 import { createPluginRegistry } from "../src/core/plugin-registry.js";
-import { PluginHookError } from "../src/errors.js";
+import { PluginHookError, PluginSetupError } from "../src/errors.js";
 import type { PluginConfig } from "../src/types.js";
 
 const createElement = (): Element => Object.create(null);
@@ -120,6 +120,153 @@ describe("createPluginRegistry", () => {
 
     expect(warning).toHaveBeenCalledOnce();
     warning.mockRestore();
+  });
+
+  it("keeps the current plugin when its replacement setup fails", () => {
+    const registry = createPluginRegistry();
+    const cleanup = vi.fn();
+    const setupError = new Error("setup failed");
+    registry.register(
+      {
+        name: "replaceable",
+        actions: [{ id: "current", label: "Current", onAction: () => {} }],
+        setup: () => ({ cleanup }),
+      },
+      createNoopApi(),
+    );
+
+    let replacementError: unknown;
+    try {
+      registry.register(
+        {
+          name: "replaceable",
+          setup: () => {
+            throw setupError;
+          },
+        },
+        createNoopApi(),
+      );
+    } catch (error) {
+      replacementError = error;
+    }
+    expect(replacementError).toBeInstanceOf(PluginSetupError);
+    expect(replacementError).toMatchObject({
+      pluginName: "replaceable",
+      cause: setupError,
+    });
+    expect(registry.getPluginNames()).toEqual(["replaceable"]);
+    expect(registry.store.actions.map((action) => action.id)).toEqual(["current"]);
+    expect(cleanup).not.toHaveBeenCalled();
+  });
+
+  it("merges frozen setup config without mutating it", () => {
+    const registry = createPluginRegistry();
+    const setupConfig = Object.freeze<PluginConfig>({
+      actions: [{ id: "setup", label: "Setup", onAction: () => {} }],
+    });
+
+    registry.register(
+      {
+        name: "frozen-config",
+        actions: [{ id: "plugin", label: "Plugin", onAction: () => {} }],
+        setup: () => setupConfig,
+      },
+      createNoopApi(),
+    );
+
+    expect(registry.store.actions.map((action) => action.id)).toEqual(["plugin", "setup"]);
+    expect(setupConfig.actions?.map((action) => action.id)).toEqual(["setup"]);
+  });
+
+  it("preserves non-enumerable setup cleanup", () => {
+    const registry = createPluginRegistry();
+    const cleanup = vi.fn();
+    const setupConfig: PluginConfig = {};
+    Object.defineProperty(setupConfig, "cleanup", { value: cleanup });
+
+    registry.register(
+      { name: "non-enumerable-cleanup", setup: () => setupConfig },
+      createNoopApi(),
+    );
+    registry.unregister("non-enumerable-cleanup");
+
+    expect(cleanup).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the current plugin when replacement store preparation fails", () => {
+    const registry = createPluginRegistry();
+    const currentCleanup = vi.fn();
+    const replacementCleanup = vi.fn();
+    const mergeError = new Error("theme merge failed");
+    const invalidTheme = {};
+    Object.defineProperty(invalidTheme, "elementLabel", {
+      enumerable: true,
+      get: () => {
+        throw mergeError;
+      },
+    });
+    registry.register(
+      {
+        name: "replaceable",
+        actions: [{ id: "current", label: "Current", onAction: () => {} }],
+        setup: () => ({ cleanup: currentCleanup }),
+      },
+      createNoopApi(),
+    );
+
+    expect(() =>
+      registry.register(
+        {
+          name: "replaceable",
+          setup: () => ({ cleanup: replacementCleanup, theme: invalidTheme }),
+        },
+        createNoopApi(),
+      ),
+    ).toThrow(PluginSetupError);
+    expect(registry.getPluginNames()).toEqual(["replaceable"]);
+    expect(registry.store.actions.map((action) => action.id)).toEqual(["current"]);
+    expect(currentCleanup).not.toHaveBeenCalled();
+    expect(replacementCleanup).toHaveBeenCalledOnce();
+  });
+
+  it("preserves plugin precedence when replacing by name", () => {
+    const registry = createPluginRegistry();
+    const api = createNoopApi();
+    registry.register(
+      {
+        name: "first",
+        actions: [{ id: "first", label: "First", onAction: () => {} }],
+      },
+      api,
+    );
+    registry.register(
+      {
+        name: "second",
+        actions: [{ id: "second", label: "Second", onAction: () => {} }],
+      },
+      api,
+    );
+
+    registry.register(
+      {
+        name: "first",
+        actions: [{ id: "replacement", label: "Replacement", onAction: () => {} }],
+      },
+      api,
+    );
+    registry.register(
+      {
+        name: "third",
+        actions: [{ id: "third", label: "Third", onAction: () => {} }],
+      },
+      api,
+    );
+
+    expect(registry.store.actions.map((action) => action.id)).toEqual([
+      "replacement",
+      "second",
+      "third",
+    ]);
   });
 
   it("cleans every plugin when its Solid owner is disposed", () => {


### PR DESCRIPTION
Depends on #551.

## Motivation

Replacing a plugin removed and cleaned up the working version before the replacement setup and configuration merge succeeded. Registration also mutated the config returned by plugin setup.

## Example

A working editor plugin is hot-replaced, but the new setup or theme merge throws. Previously the old plugin disappeared; now `registerPlugin()` throws `PluginSetupError` and the old plugin remains active. Frozen/shared configs and non-enumerable cleanup methods work too.

## Changes

- Prepare the complete next config and store before changing registry state.
- Merge into a fresh config instead of mutating plugin-owned data.
- Preserve and bind setup cleanup methods.
- Clean partially prepared replacements when staging fails.
- Export `ReactGrabError` and `PluginSetupError` for caller-side handling.

## Validation

- `nr build`
- `nr test:unit` (111 tests)
- `nr lint`
- `nr typecheck`
- `nr format:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core plugin lifecycle and hot-replace behavior; failures now throw instead of silently dropping plugins, which callers must handle but reduces broken runtime state.
> 
> **Overview**
> **Plugin registration is now all-or-nothing.** `register` builds the merged config and aggregated store on a staging copy before touching the live registry, so a failed hot-replace no longer unregisters and cleans up the working plugin first.
> 
> Setup is centralized in `preparePluginConfig`, which merges theme/options/actions/hooks into a **new** object (no mutation of frozen or shared `setup()` return values), binds `cleanup` to the setup config, and wraps failures in **`PluginSetupError`**. If store merge fails after setup ran, the partial replacement is cleaned up and the previous plugin stays active.
> 
> **`PluginSetupError`** and **`ReactGrabError`** are exported from the package entry for callers to handle registration failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cf985dc6db1a4abe541c1379d4f13ad530d9dda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->