### PR TITLE
fix(react-grab): observe async plugin hooks

### DIFF
--- a/packages/react-grab/src/core/plugin-registry.ts
+++ b/packages/react-grab/src/core/plugin-registry.ts
@@ -195,11 +195,16 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
   ): void => {
     for (const { plugin, config } of plugins.values()) {
       const hook = config.hooks?.[hookName] as
-        | ((...hookArgs: Parameters<NonNullable<PluginHooks[K]>>) => void)
+        | ((...hookArgs: Parameters<NonNullable<PluginHooks[K]>>) => void | Promise<void>)
         | undefined;
       if (hook) {
         try {
-          hook(...args);
+          const pendingResult = hook(...args);
+          if (pendingResult) {
+            void Promise.resolve(pendingResult).catch((error) => {
+              reportRecoverableError(new PluginHookError(plugin.name, String(hookName), error));
+            });
+          }
         } catch (error) {
           reportRecoverableError(new PluginHookError(plugin.name, String(hookName), error));
         }

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -326,32 +326,32 @@ export interface PerformWithFeedbackOptions {
 }
 
 export interface PluginHooks {
-  onActivate?: () => void;
-  onDeactivate?: () => void;
-  onElementHover?: (element: Element) => void;
+  onActivate?: () => void | Promise<void>;
+  onDeactivate?: () => void | Promise<void>;
+  onElementHover?: (element: Element) => void | Promise<void>;
   onElementSelect?: (element: Element) => boolean | void | Promise<boolean>;
-  onDragStart?: (startX: number, startY: number) => void;
-  onDragEnd?: (elements: Element[], bounds: DragRect) => void;
+  onDragStart?: (startX: number, startY: number) => void | Promise<void>;
+  onDragEnd?: (elements: Element[], bounds: DragRect) => void | Promise<void>;
   onBeforeCopy?: (elements: Element[]) => void | Promise<void>;
   transformCopyContent?: (content: string, elements: Element[]) => string | Promise<string>;
-  onAfterCopy?: (elements: Element[], success: boolean) => void;
-  onCopySuccess?: (elements: Element[], content: string) => void;
-  onCopyError?: (error: Error) => void;
-  onStateChange?: (state: ReactGrabState) => void;
-  onPromptModeChange?: (isPromptMode: boolean, context: PromptModeContext) => void;
+  onAfterCopy?: (elements: Element[], success: boolean) => void | Promise<void>;
+  onCopySuccess?: (elements: Element[], content: string) => void | Promise<void>;
+  onCopyError?: (error: Error) => void | Promise<void>;
+  onStateChange?: (state: ReactGrabState) => void | Promise<void>;
+  onPromptModeChange?: (isPromptMode: boolean, context: PromptModeContext) => void | Promise<void>;
   onSelectionBox?: (
     visible: boolean,
     bounds: OverlayBounds | null,
     element: Element | null,
-  ) => void;
-  onDragBox?: (visible: boolean, bounds: OverlayBounds | null) => void;
-  onGrabbedBox?: (bounds: OverlayBounds, element: Element) => void;
+  ) => void | Promise<void>;
+  onDragBox?: (visible: boolean, bounds: OverlayBounds | null) => void | Promise<void>;
+  onGrabbedBox?: (bounds: OverlayBounds, element: Element) => void | Promise<void>;
   onElementLabel?: (
     visible: boolean,
     variant: ElementLabelVariant,
     context: ElementLabelContext,
-  ) => void;
-  onContextMenu?: (element: Element, position: Position) => void;
+  ) => void | Promise<void>;
+  onContextMenu?: (element: Element, position: Position) => void | Promise<void>;
   onOpenFile?: (filePath: string, lineNumber?: number) => boolean | void;
   transformHtmlContent?: (html: string, elements: Element[]) => string | Promise<string>;
   transformAgentContext?: (

--- a/packages/react-grab/tests/plugin-registry.test.ts
+++ b/packages/react-grab/tests/plugin-registry.test.ts
@@ -245,4 +245,38 @@ describe("createPluginRegistry", () => {
     expect(warning).toHaveBeenCalledOnce();
     warning.mockRestore();
   });
+
+  it("observes asynchronous notification hook failures", async () => {
+    const registry = createPluginRegistry();
+    const laterHook = vi.fn();
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const hookError = new Error("hook failed");
+
+    registry.register(
+      {
+        name: "rejecting",
+        hooks: {
+          onActivate: async () => {
+            throw hookError;
+          },
+        },
+      },
+      createNoopApi(),
+    );
+    registry.register({ name: "later", hooks: { onActivate: laterHook } }, createNoopApi());
+
+    registry.hooks.onActivate();
+    await Promise.resolve();
+
+    expect(laterHook).toHaveBeenCalledOnce();
+    expect(warning).toHaveBeenCalledWith(
+      "[react-grab]",
+      expect.objectContaining({
+        cause: hookError,
+        hookName: "onActivate",
+        pluginName: "rejecting",
+      }) satisfies Partial<PluginHookError>,
+    );
+    warning.mockRestore();
+  });
 });


### PR DESCRIPTION
Depends on #551.

## Motivation

Notification hooks were isolated only when they threw synchronously. TypeScript accepts async implementations of void callbacks, so a rejected `onActivate`, `onStateChange`, or hover hook became an unhandled rejection.

## Example

An async analytics `onActivate` hook rejects. React Grab should still notify later plugins and report one structured `PluginHookError`.

## Changes

- Explicitly allow async notification hooks.
- Observe and report returned promises without awaiting or blocking later plugins.
- Avoid promise allocation when ordinary synchronous hooks return nothing.

## Validation

- `nr build`
- `nr test:unit` (107 tests)
- `nr lint`
- `nr typecheck`
- `nr format:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized plugin-registry error handling and type widening; behavior change is catching previously unhandled async rejections without blocking the hook chain.
> 
> **Overview**
> **Plugin notification hooks** (`onActivate`, overlay/drag/copy/state hooks, etc.) can now return promises without causing unhandled rejections.
> 
> `callHook` still invokes every registered plugin in order and does not await async work, but when a hook returns a value it **attaches a `.catch`** that reports a structured `PluginHookError` (same path as synchronous throws). Sync hooks that return `undefined` skip extra `Promise` wrapping.
> 
> `PluginHooks` types are updated so those notification callbacks explicitly allow `void | Promise<void>`; selector/transform hooks with other return shapes are unchanged.
> 
> A unit test confirms a rejecting async `onActivate` still runs later plugins and logs the expected error metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46d375c44a581dbb4c75c698aaaa58b3d94933ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unhandled promise rejections from async plugin notification hooks in `react-grab`. Async hooks are now observed, report a structured `PluginHookError`, and do not block later plugins.

- **Bug Fixes**
  - Observe and report rejections from async notification hooks without awaiting (e.g., `onActivate`, hover/drag/overlay/copy/state hooks).
  - Widen `PluginHooks` so notification hooks accept `void | Promise<void>`; other return types unchanged.
  - Avoid extra promises for sync hooks and add a unit test confirming later hooks still run and errors are reported.

<sup>Written for commit 46d375c44a581dbb4c75c698aaaa58b3d94933ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

