### PR TITLE
fix(react-grab): snapshot plugin hook dispatch

### DIFF
--- a/packages/react-grab/src/core/plugin-registry.ts
+++ b/packages/react-grab/src/core/plugin-registry.ts
@@ -60,6 +60,7 @@ type HookName = keyof PluginHooks;
 
 const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
   const plugins = new Map<string, RegisteredPlugin>();
+  let registeredPluginSnapshot: readonly RegisteredPlugin[] = [];
   const directOptionOverrides: Partial<OptionsState> = {};
   let isDisposed = false;
 
@@ -106,7 +107,7 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
   };
 
   const recomputeStore = () => {
-    applyPluginStoreState(createPluginStoreState(plugins.values()));
+    applyPluginStoreState(createPluginStoreState(registeredPluginSnapshot));
   };
 
   const setOption = <OptionKey extends keyof OptionsState>(
@@ -191,6 +192,7 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     }
 
     plugins.set(plugin.name, registeredPlugin);
+    registeredPluginSnapshot = Array.from(plugins.values());
     applyPluginStoreState(nextStore);
     if (previousPlugin) cleanupPlugin(previousPlugin);
   };
@@ -201,6 +203,7 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     if (!registered) return;
 
     plugins.delete(name);
+    registeredPluginSnapshot = Array.from(plugins.values());
     cleanupPlugin(registered);
     recomputeStore();
   };
@@ -209,21 +212,22 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     if (isDisposed) return;
     isDisposed = true;
 
-    const registeredPlugins = Array.from(plugins.values());
+    const pluginsToCleanup = registeredPluginSnapshot;
     plugins.clear();
-    registeredPlugins.forEach(cleanupPlugin);
+    registeredPluginSnapshot = [];
+    pluginsToCleanup.forEach(cleanupPlugin);
     recomputeStore();
   };
 
   const getPluginNames = (): string[] => {
-    return Array.from(plugins.keys());
+    return registeredPluginSnapshot.map(({ plugin }) => plugin.name);
   };
 
   const callHook = <K extends HookName>(
     hookName: K,
     ...args: Parameters<NonNullable<PluginHooks[K]>>
   ): void => {
-    for (const { plugin, config } of plugins.values()) {
+    for (const { plugin, config } of registeredPluginSnapshot) {
       const hook = config.hooks?.[hookName] as
         | ((...hookArgs: Parameters<NonNullable<PluginHooks[K]>>) => void | Promise<void>)
         | undefined;
@@ -247,7 +251,7 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     ...args: Parameters<NonNullable<PluginHooks[K]>>
   ): boolean => {
     let handled = false;
-    for (const { plugin, config } of plugins.values()) {
+    for (const { plugin, config } of registeredPluginSnapshot) {
       const hook = config.hooks?.[hookName] as
         | ((...hookArgs: Parameters<NonNullable<PluginHooks[K]>>) => boolean | void)
         | undefined;
@@ -269,7 +273,7 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     hookName: K,
     ...args: Parameters<NonNullable<PluginHooks[K]>>
   ): Promise<void> => {
-    for (const { plugin, config } of plugins.values()) {
+    for (const { plugin, config } of registeredPluginSnapshot) {
       const hook = config.hooks?.[hookName] as
         | ((
             ...hookArgs: Parameters<NonNullable<PluginHooks[K]>>
@@ -291,7 +295,7 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     ...extraArgs: unknown[]
   ): Promise<T> => {
     let result = initialValue;
-    for (const { plugin, config } of plugins.values()) {
+    for (const { plugin, config } of registeredPluginSnapshot) {
       const hook = config.hooks?.[hookName] as
         | ((value: T, ...hookArgs: unknown[]) => T | Promise<T>)
         | undefined;
@@ -312,7 +316,7 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     ...extraArgs: unknown[]
   ): T => {
     let result = initialValue;
-    for (const { plugin, config } of plugins.values()) {
+    for (const { plugin, config } of registeredPluginSnapshot) {
       const hook = config.hooks?.[hookName] as
         | ((value: T, ...hookArgs: unknown[]) => T)
         | undefined;
@@ -336,7 +340,7 @@ const createPluginRegistry = (initialOptions: SettableOptions = {}) => {
     ): { wasIntercepted: boolean; pendingResult?: Promise<boolean> } => {
       let wasIntercepted = false;
       const pendingResults: Promise<boolean>[] = [];
-      for (const { plugin, config } of plugins.values()) {
+      for (const { plugin, config } of registeredPluginSnapshot) {
         const hook = config.hooks?.onElementSelect;
         if (hook) {
           try {

--- a/packages/react-grab/tests/plugin-registry.test.ts
+++ b/packages/react-grab/tests/plugin-registry.test.ts
@@ -426,4 +426,41 @@ describe("createPluginRegistry", () => {
     );
     warning.mockRestore();
   });
+
+  it("uses one plugin snapshot for each hook dispatch", () => {
+    const registry = createPluginRegistry();
+    const api = createNoopApi();
+    const lateHook = vi.fn();
+    const registeringHook = vi.fn(() => {
+      registry.register({ name: "late", hooks: { onActivate: lateHook } }, api);
+    });
+    registry.register({ name: "registering", hooks: { onActivate: registeringHook } }, api);
+
+    registry.hooks.onActivate();
+
+    expect(registeringHook).toHaveBeenCalledOnce();
+    expect(lateHook).not.toHaveBeenCalled();
+
+    registry.hooks.onActivate();
+
+    expect(lateHook).toHaveBeenCalledOnce();
+  });
+
+  it("does not revisit a plugin that replaces itself during dispatch", () => {
+    const registry = createPluginRegistry();
+    const api = createNoopApi();
+    const selfReplacingHook = vi.fn(() => {
+      if (selfReplacingHook.mock.calls.length === 1) {
+        registry.register(
+          { name: "self-replacing", hooks: { onActivate: selfReplacingHook } },
+          api,
+        );
+      }
+    });
+    registry.register({ name: "self-replacing", hooks: { onActivate: selfReplacingHook } }, api);
+
+    registry.hooks.onActivate();
+
+    expect(selfReplacingHook).toHaveBeenCalledOnce();
+  });
 });


### PR DESCRIPTION
Depends on #556.

## Motivation

Hook dispatch iterated the live plugin map. Registering or replacing a plugin from inside a hook changed that same iterator, so a self-replacing hook could run repeatedly and a newly added plugin could receive an event that started before it existed.

## Example

An `onActivate` hook hot-replaces itself. Previously the replacement could be visited again during the same activation; now each activation uses the plugin list that existed when it began.

## Changes

- Maintain an immutable registry snapshot updated only when membership changes.
- Dispatch hooks and recompute options from the captured snapshot.
- Avoid per-hover or per-hook snapshot allocations.

## Validation

- `nr build`
- `nr test:unit` (113 tests)
- `nr lint`
- `nr typecheck`
- `nr format:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit edc68c31872a100a2470f62727617eb3b819a6d6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->