### PR TITLE
fix(react-grab): flush queued plugins

### DIFF
--- a/packages/react-grab/src/errors.ts
+++ b/packages/react-grab/src/errors.ts
@@ -41,11 +41,11 @@ export class PluginCleanupError extends RecoverableError {
   }
 }
 
-export class PluginSetupError extends ReactGrabError {
+export class PluginSetupError extends RecoverableError {
   readonly pluginName: string;
 
   constructor(pluginName: string, cause: unknown) {
-    super(`Plugin setup failed for "${pluginName}"`, { cause });
+    super(`Plugin setup failed for "${pluginName}"`, cause);
     this.name = "PluginSetupError";
     this.pluginName = pluginName;
   }

--- a/packages/react-grab/src/global-api.ts
+++ b/packages/react-grab/src/global-api.ts
@@ -1,0 +1,53 @@
+import { PluginSetupError } from "./errors.js";
+import type { Plugin, ReactGrabAPI } from "./types.js";
+import { reportRecoverableError } from "./utils/report-recoverable-error.js";
+
+let globalApi: ReactGrabAPI | null = null;
+const pendingPlugins = new Map<string, Plugin>();
+
+export const getGlobalApi = (): ReactGrabAPI | null => {
+  if (typeof window === "undefined") return globalApi;
+  return window.__REACT_GRAB__ ?? globalApi ?? null;
+};
+
+export const setGlobalApi = (api: ReactGrabAPI | null): void => {
+  globalApi = api;
+  if (typeof window !== "undefined") {
+    if (api) {
+      window.__REACT_GRAB__ = api;
+    } else {
+      delete window.__REACT_GRAB__;
+    }
+  }
+
+  if (!api) return;
+
+  for (const [pluginName, plugin] of pendingPlugins) {
+    pendingPlugins.delete(pluginName);
+    try {
+      api.registerPlugin(plugin);
+    } catch (error) {
+      reportRecoverableError(
+        error instanceof PluginSetupError ? error : new PluginSetupError(pluginName, error),
+      );
+    }
+  }
+};
+
+export const registerPlugin = (plugin: Plugin): void => {
+  const api = getGlobalApi();
+  if (api) {
+    api.registerPlugin(plugin);
+    return;
+  }
+  pendingPlugins.set(plugin.name, plugin);
+};
+
+export const unregisterPlugin = (name: string): void => {
+  const api = getGlobalApi();
+  if (api) {
+    api.unregisterPlugin(name);
+    return;
+  }
+  pendingPlugins.delete(name);
+};

--- a/packages/react-grab/src/index.ts
+++ b/packages/react-grab/src/index.ts
@@ -41,7 +41,10 @@ export type {
 } from "./types.js";
 
 import { init } from "./core/index.js";
-import type { Plugin, ReactGrabAPI } from "./types.js";
+import { getGlobalApi, setGlobalApi } from "./global-api.js";
+import type { ReactGrabAPI } from "./types.js";
+
+export { getGlobalApi, setGlobalApi, registerPlugin, unregisterPlugin } from "./global-api.js";
 
 declare global {
   interface Window {
@@ -50,63 +53,11 @@ declare global {
   }
 }
 
-let globalApi: ReactGrabAPI | null = null;
-
-export const getGlobalApi = (): ReactGrabAPI | null => {
-  if (typeof window === "undefined") return globalApi;
-  return window.__REACT_GRAB__ ?? globalApi ?? null;
-};
-
-export const setGlobalApi = (api: ReactGrabAPI | null): void => {
-  globalApi = api;
-  if (typeof window !== "undefined") {
-    if (api) {
-      window.__REACT_GRAB__ = api;
-    } else {
-      delete window.__REACT_GRAB__;
-    }
-  }
-};
-
-const pendingPlugins: Plugin[] = [];
-
-const flushPendingPlugins = (api: ReactGrabAPI): void => {
-  while (pendingPlugins.length > 0) {
-    const plugin = pendingPlugins.shift();
-    if (plugin) {
-      api.registerPlugin(plugin);
-    }
-  }
-};
-
-export const registerPlugin = (plugin: Plugin): void => {
-  const api = getGlobalApi();
-  if (api) {
-    api.registerPlugin(plugin);
-    return;
-  }
-  pendingPlugins.push(plugin);
-};
-
-export const unregisterPlugin = (name: string): void => {
-  const api = getGlobalApi();
-  if (api) {
-    api.unregisterPlugin(name);
-    return;
-  }
-  const pendingIndex = pendingPlugins.findIndex((pendingPlugin) => pendingPlugin.name === name);
-  if (pendingIndex !== -1) {
-    pendingPlugins.splice(pendingIndex, 1);
-  }
-};
-
 if (typeof window !== "undefined" && !window.__REACT_GRAB_DISABLED__) {
   if (window.__REACT_GRAB__) {
-    globalApi = window.__REACT_GRAB__;
+    setGlobalApi(window.__REACT_GRAB__);
   } else {
-    globalApi = init();
-    window.__REACT_GRAB__ = globalApi;
+    setGlobalApi(init());
   }
-  flushPendingPlugins(globalApi);
-  window.dispatchEvent(new CustomEvent("react-grab:init", { detail: globalApi }));
+  window.dispatchEvent(new CustomEvent("react-grab:init", { detail: getGlobalApi() }));
 }

--- a/packages/react-grab/tests/global-plugin-registry.test.ts
+++ b/packages/react-grab/tests/global-plugin-registry.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { createNoopApi } from "../src/core/noop-api.js";
+import { PluginSetupError } from "../src/errors.js";
+import { getGlobalApi, registerPlugin, setGlobalApi, unregisterPlugin } from "../src/global-api.js";
+import type { Plugin, ReactGrabAPI } from "../src/types.js";
+
+const PLUGIN_NAMES = ["first", "second", "failing"];
+
+const createApi = (registerPluginImplementation: ReactGrabAPI["registerPlugin"]): ReactGrabAPI => ({
+  ...createNoopApi(),
+  registerPlugin: registerPluginImplementation,
+});
+
+afterEach(() => {
+  setGlobalApi(null);
+  for (const pluginName of PLUGIN_NAMES) unregisterPlugin(pluginName);
+  vi.restoreAllMocks();
+});
+
+describe("global plugin registration", () => {
+  it("flushes queued plugins when an API is attached", () => {
+    const plugin: Plugin = { name: "first" };
+    const apiRegisterPlugin = vi.fn();
+    const api = createApi(apiRegisterPlugin);
+
+    registerPlugin(plugin);
+    setGlobalApi(api);
+
+    expect(getGlobalApi()).toBe(api);
+    expect(apiRegisterPlugin).toHaveBeenCalledWith(plugin);
+  });
+
+  it("queues only the latest plugin with each name", () => {
+    const firstPlugin: Plugin = { name: "first", actions: [] };
+    const replacementPlugin: Plugin = { name: "first", hooks: {} };
+    const secondPlugin: Plugin = { name: "second" };
+    const apiRegisterPlugin = vi.fn();
+
+    registerPlugin(firstPlugin);
+    registerPlugin(secondPlugin);
+    registerPlugin(replacementPlugin);
+    setGlobalApi(createApi(apiRegisterPlugin));
+
+    expect(apiRegisterPlugin.mock.calls).toEqual([[replacementPlugin], [secondPlugin]]);
+  });
+
+  it("fully removes a queued plugin by name", () => {
+    const apiRegisterPlugin = vi.fn();
+
+    registerPlugin({ name: "first" });
+    registerPlugin({ name: "first", hooks: {} });
+    unregisterPlugin("first");
+    setGlobalApi(createApi(apiRegisterPlugin));
+
+    expect(apiRegisterPlugin).not.toHaveBeenCalled();
+  });
+
+  it("reports a queued setup failure and continues flushing", () => {
+    const setupCause = new Error("setup failed");
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const apiRegisterPlugin = vi.fn<ReactGrabAPI["registerPlugin"]>((plugin) => {
+      if (plugin.name === "failing") throw setupCause;
+    });
+    const laterPlugin: Plugin = { name: "second" };
+    const api = createApi(apiRegisterPlugin);
+
+    registerPlugin({ name: "failing" });
+    registerPlugin(laterPlugin);
+    setGlobalApi(api);
+
+    expect(getGlobalApi()).toBe(api);
+    expect(apiRegisterPlugin).toHaveBeenLastCalledWith(laterPlugin);
+    expect(warning).toHaveBeenCalledWith("[react-grab]", expect.any(PluginSetupError));
+    expect(warning.mock.calls[0]?.[1]).toMatchObject({
+      pluginName: "failing",
+      cause: setupCause,
+    });
+  });
+});


### PR DESCRIPTION
Depends on #556.

## Motivation

Plugins queued before an API exists were never flushed by `setGlobalApi()`, which is the attachment path used by SSR, disabled auto-init, and manual initialization. The array queue also initialized obsolete same-name plugins.

## Example

An integration queues editor plugin v1, then v2, before attaching a manually created API. Previously neither version loaded. Now only v2 loads, at the original plugin position.

## Changes

- Move global API attachment and queued registration into one focused module.
- Flush queued plugins whenever a non-null API is attached.
- Key pending plugins by name so the latest definition wins without changing order.
- Report a deferred `PluginSetupError` once and continue loading later plugins.
- Keep live registration failures throwable to their caller.

## Validation

- `nr build`
- `nr test:unit` (115 tests)
- `nr lint`
- `nr typecheck`
- `nr format:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches plugin bootstrap timing for SSR/manual init paths; behavior change is intentional but affects when plugins load and how duplicate names resolve.
> 
> **Overview**
> Fixes **plugins registered before the global API exists** never loading when the API is attached via `setGlobalApi()` (SSR, disabled auto-init, manual init). Global API wiring and the pending-plugin queue now live in **`global-api.ts`**, re-exported from `index.ts`.
> 
> **`setGlobalApi(non-null)`** flushes the queue by calling `registerPlugin` on each pending plugin. Pending entries use a **`Map` keyed by plugin name** so re-queues replace older definitions while **insertion order** is preserved. **`unregisterPlugin`** removes queued entries by name before attach.
> 
> During flush, setup failures are **`reportRecoverableError`** as `PluginSetupError` and **later queued plugins still register**; direct `registerPlugin` when an API already exists is unchanged (errors still propagate to the caller). **`PluginSetupError`** now extends **`RecoverableError`** with the same `cause` pattern as other plugin errors.
> 
> Adds unit tests for flush-on-attach, name dedupe, queued unregister, and recoverable setup failure + continue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1d98a9d32bbce80c52fd0ff13e7ec2867476418. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes plugin queuing in `react-grab`: plugins queued before the API exists now flush when `setGlobalApi()` attaches a non‑null API, de‑duplicated by name so the latest wins without reordering. This unblocks SSR, disabled auto‑init, and manual init, and reports setup failures without stopping later plugins.

- **Bug Fixes**
  - Flush queued plugins on `setGlobalApi(non-null)`.
  - Queue uses a `Map` keyed by name; latest definition replaces, insertion order kept.
  - `unregisterPlugin` removes queued entries by name before attach.
  - Wrap/emit deferred setup failures as `PluginSetupError` (now extends `RecoverableError`) and continue; live registration still throws.
  - Centralize global API + queue in `global-api.ts`; re-export and wire `index.ts`; add tests for flush, dedupe, unregister, and error reporting.

<sup>Written for commit f1d98a9d32bbce80c52fd0ff13e7ec2867476418. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

