### PR TITLE
fix(react-grab): centralize open file errors

### DIFF
--- a/packages/react-grab/e2e/open-file.spec.ts
+++ b/packages/react-grab/e2e/open-file.spec.ts
@@ -17,6 +17,7 @@ test.describe("Open File", () => {
           hooks: {
             onOpenFile: () => {
               (window as { __OPEN_FILE_CALLED__?: boolean }).__OPEN_FILE_CALLED__ = true;
+              return true;
             },
           },
         });
@@ -274,6 +275,7 @@ test.describe("Open File", () => {
 
       await reactGrab.activate();
       await reactGrab.hoverUntilSelected("li:first-child");
+      await reactGrab.waitForSelectionSource();
 
       await reactGrab.page.evaluate((attrName) => {
         const host = document.querySelector(`[${attrName}]`);
@@ -297,7 +299,7 @@ test.describe("Open File", () => {
         return (window as { __OPEN_FILE_CALLED__?: boolean }).__OPEN_FILE_CALLED__ ?? false;
       });
 
-      expect(typeof openFileCalled).toBe("boolean");
+      expect(openFileCalled).toBe(true);
     });
   });
 

--- a/packages/react-grab/src/components/renderer.tsx
+++ b/packages/react-grab/src/components/renderer.tsx
@@ -1,7 +1,6 @@
 import { For, Show, type Component } from "solid-js";
 import type { ReactGrabRendererProps } from "../types.js";
 import { DEFAULT_ACTION_ID } from "../constants.js";
-import { requestOpenFile } from "../utils/open-file.js";
 import { isElementConnected } from "../utils/is-element-connected.js";
 import { OverlayCanvas } from "./overlay-canvas.js";
 import { FrozenGlow } from "./frozen-glow.js";
@@ -82,11 +81,7 @@ export const ReactGrabRenderer: Component<ReactGrabRendererProps> = (props) => {
           selectionLabelShakeCount={props.selectionLabelShakeCount}
           onConfirmDismiss={props.onConfirmDismiss}
           discardPrompt={props.discardPrompt}
-          onOpen={() => {
-            if (props.selectionFilePath) {
-              requestOpenFile(props.selectionFilePath, props.selectionLineNumber);
-            }
-          }}
+          onOpen={props.onOpenSelectionFile}
           isContextMenuOpen={props.contextMenuPosition !== null}
         />
       </Show>

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -102,7 +102,7 @@ import { isCLikeKey } from "../utils/is-c-like-key.js";
 import { isTargetKeyCombination } from "../utils/is-target-key-combination.js";
 import { parseActivationKey } from "../utils/parse-activation-key.js";
 import { isEventFromOverlay } from "../utils/is-event-from-overlay.js";
-import { requestOpenFile } from "../utils/open-file.js";
+import { executeOpenFileAction } from "./open-file-action.js";
 import { combineBounds } from "../utils/combine-bounds.js";
 import type {
   Position,
@@ -2619,25 +2619,22 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       return true;
     };
 
+    const openSelectionFile = (): void => {
+      const filePath = store.selectionFilePath;
+      const lineNumber = store.selectionLineNumber;
+      if (!filePath) return;
+
+      executeOpenFileAction(filePath, lineNumber ?? undefined, pluginRegistry.hooks);
+    };
+
     const tryHandleOpenFileShortcut = (event: KeyboardEvent): boolean => {
       if (event.key?.toLowerCase() !== "o") return false;
       if (!isActivated() || !(event.metaKey || event.ctrlKey)) return false;
-
-      const filePath = store.selectionFilePath;
-      const lineNumber = store.selectionLineNumber;
-      if (!filePath) return false;
+      if (!store.selectionFilePath) return false;
 
       event.preventDefault();
       event.stopPropagation();
-
-      const wasHandled = pluginRegistry.hooks.onOpenFile(filePath, lineNumber ?? undefined);
-      if (!wasHandled) {
-        requestOpenFile(
-          filePath,
-          lineNumber ?? undefined,
-          pluginRegistry.hooks.transformOpenFileUrl,
-        );
-      }
+      openSelectionFile();
       return true;
     };
 
@@ -4119,6 +4116,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
                 onToggleExpand={handleToggleExpand}
                 selectionLabelShakeCount={selectionLabelShakeCount()}
                 onConfirmDismiss={handleConfirmDismiss}
+                onOpenSelectionFile={openSelectionFile}
                 discardPrompt={
                   keyboardSelection.isPendingDismiss()
                     ? {

--- a/packages/react-grab/src/core/open-file-action.ts
+++ b/packages/react-grab/src/core/open-file-action.ts
@@ -1,0 +1,24 @@
+import { OpenFileError } from "../errors.js";
+import type { OpenFileActionHooks } from "../types.js";
+import { requestOpenFile } from "../utils/open-file.js";
+import { reportRecoverableError } from "../utils/report-recoverable-error.js";
+
+export const executeOpenFileAction = (
+  filePath: string,
+  lineNumber: number | undefined,
+  hooks: OpenFileActionHooks,
+): void => {
+  try {
+    if (hooks.onOpenFile(filePath, lineNumber)) return;
+
+    void requestOpenFile(filePath, lineNumber, hooks.transformOpenFileUrl).catch((error) => {
+      reportRecoverableError(
+        error instanceof OpenFileError ? error : new OpenFileError(filePath, lineNumber, error),
+      );
+    });
+  } catch (error) {
+    reportRecoverableError(
+      error instanceof OpenFileError ? error : new OpenFileError(filePath, lineNumber, error),
+    );
+  }
+};

--- a/packages/react-grab/src/core/plugins/open.ts
+++ b/packages/react-grab/src/core/plugins/open.ts
@@ -1,5 +1,5 @@
 import type { Plugin } from "../../types.js";
-import { requestOpenFile } from "../../utils/open-file.js";
+import { executeOpenFileAction } from "../open-file-action.js";
 
 export const openPlugin: Plugin = {
   name: "open",
@@ -12,11 +12,7 @@ export const openPlugin: Plugin = {
       onAction: (context) => {
         if (!context.filePath) return;
 
-        const wasHandled = context.hooks.onOpenFile(context.filePath, context.lineNumber);
-
-        if (!wasHandled) {
-          requestOpenFile(context.filePath, context.lineNumber, context.hooks.transformOpenFileUrl);
-        }
+        executeOpenFileAction(context.filePath, context.lineNumber, context.hooks);
 
         context.hideContextMenu();
         context.cleanup();

--- a/packages/react-grab/src/errors.ts
+++ b/packages/react-grab/src/errors.ts
@@ -19,6 +19,18 @@ export class FreezeError extends ReactGrabError {
   }
 }
 
+export class OpenFileError extends RecoverableError {
+  readonly filePath: string;
+  readonly lineNumber: number | undefined;
+
+  constructor(filePath: string, lineNumber: number | undefined, cause: unknown) {
+    super(`Failed to open source file "${filePath}"`, cause);
+    this.name = "OpenFileError";
+    this.filePath = filePath;
+    this.lineNumber = lineNumber;
+  }
+}
+
 export class PluginHookError extends RecoverableError {
   readonly pluginName: string;
   readonly hookName: string;

--- a/packages/react-grab/src/index.ts
+++ b/packages/react-grab/src/index.ts
@@ -8,6 +8,7 @@ export {
 export { commentPlugin } from "./core/plugins/comment.js";
 export { openPlugin } from "./core/plugins/open.js";
 export { FreezeError } from "./errors.js";
+export { OpenFileError } from "./errors.js";
 export { generateSnippet } from "./utils/generate-snippet.js";
 export { PluginSetupError, ReactGrabError } from "./errors.js";
 export type {
@@ -33,6 +34,7 @@ export type {
   ContextMenuActionContext,
   ActionContext,
   ActionContextHooks,
+  OpenFileActionHooks,
   Plugin,
   PluginConfig,
   PluginHooks,

--- a/packages/react-grab/src/primitives.ts
+++ b/packages/react-grab/src/primitives.ts
@@ -26,6 +26,8 @@ import { extractElementCss, disposeBaselineStyles } from "./utils/extract-elemen
 import { findSelectorTarget } from "./utils/find-selector-target.js";
 import { requestOpenFile } from "./utils/open-file.js";
 
+export { OpenFileError } from "./errors.js";
+
 export interface ReactGrabElementContext {
   element: Element;
   snippet: string;

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -135,10 +135,13 @@ export type ActivationMode = "toggle" | "hold";
 
 export type OverlayDismissSource = "keyboard" | "pointer";
 
-export interface ActionContextHooks {
-  transformHtmlContent: (html: string, elements: Element[]) => Promise<string>;
+export interface OpenFileActionHooks {
   onOpenFile: (filePath: string, lineNumber?: number) => boolean | void;
   transformOpenFileUrl: (url: string, filePath: string, lineNumber?: number) => string;
+}
+
+export interface ActionContextHooks extends OpenFileActionHooks {
+  transformHtmlContent: (html: string, elements: Element[]) => Promise<string>;
 }
 
 export interface ActionContext {
@@ -571,6 +574,7 @@ export interface ReactGrabRendererProps {
   onToggleExpand?: () => void;
   selectionLabelShakeCount?: number;
   onConfirmDismiss?: () => void;
+  onOpenSelectionFile?: () => void;
   discardPrompt?: SelectionDiscardPrompt;
   toolbarVisible?: boolean;
   isActive?: boolean;

--- a/packages/react-grab/src/utils/open-file.ts
+++ b/packages/react-grab/src/utils/open-file.ts
@@ -1,6 +1,7 @@
 import { isNextProjectRuntime } from "./is-next-project-runtime.js";
 import { getNextBasePath } from "./get-next-base-path.js";
 import { normalizeFilePath } from "./normalize-file-path.js";
+import { OpenFileError } from "../errors.js";
 
 const OPEN_FILE_BASE_URL =
   process.env.NODE_ENV === "production" ? "https://react-grab.com" : "http://localhost:3000";
@@ -29,15 +30,20 @@ export const requestOpenFile = async (
   lineNumber: number | undefined,
   transformUrl?: (url: string, filePath: string, lineNumber?: number) => string,
 ): Promise<void> => {
-  const normalizedFilePath = normalizeFilePath(filePath);
+  try {
+    const normalizedFilePath = normalizeFilePath(filePath);
 
-  const wasOpenedByDevServer = await tryDevServerOpen(normalizedFilePath, lineNumber).catch(
-    () => false,
-  );
-  if (wasOpenedByDevServer) return;
+    const wasOpenedByDevServer = await tryDevServerOpen(normalizedFilePath, lineNumber).catch(
+      () => false,
+    );
+    if (wasOpenedByDevServer) return;
 
-  const lineParam = lineNumber ? `&line=${lineNumber}` : "";
-  const rawUrl = `${OPEN_FILE_BASE_URL}/open-file?url=${encodeURIComponent(normalizedFilePath)}${lineParam}`;
-  const url = transformUrl ? transformUrl(rawUrl, normalizedFilePath, lineNumber) : rawUrl;
-  window.open(url, "_blank", "noopener,noreferrer");
+    const lineParam = lineNumber ? `&line=${lineNumber}` : "";
+    const rawUrl = `${OPEN_FILE_BASE_URL}/open-file?url=${encodeURIComponent(normalizedFilePath)}${lineParam}`;
+    const url = transformUrl ? transformUrl(rawUrl, normalizedFilePath, lineNumber) : rawUrl;
+    window.open(url, "_blank", "noopener,noreferrer");
+  } catch (error) {
+    if (error instanceof OpenFileError) throw error;
+    throw new OpenFileError(filePath, lineNumber, error);
+  }
 };

--- a/packages/react-grab/tests/open-file-action.test.ts
+++ b/packages/react-grab/tests/open-file-action.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { executeOpenFileAction } from "../src/core/open-file-action.js";
+import { OpenFileError } from "../src/errors.js";
+import type { OpenFileActionHooks } from "../src/types.js";
+import { requestOpenFile } from "../src/utils/open-file.js";
+
+vi.mock("../src/utils/open-file.js", () => ({
+  requestOpenFile: vi.fn(),
+}));
+
+const createHooks = (): OpenFileActionHooks => ({
+  onOpenFile: vi.fn(),
+  transformOpenFileUrl: vi.fn((url) => url),
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("executeOpenFileAction", () => {
+  it("does not fall back when a plugin handles the file", () => {
+    const hooks = createHooks();
+    vi.mocked(hooks.onOpenFile).mockReturnValue(true);
+
+    executeOpenFileAction("/src/button.tsx", 12, hooks);
+
+    expect(requestOpenFile).not.toHaveBeenCalled();
+  });
+
+  it("opens unhandled files with the plugin URL transform", () => {
+    const hooks = createHooks();
+
+    executeOpenFileAction("/src/button.tsx", 12, hooks);
+
+    expect(requestOpenFile).toHaveBeenCalledWith("/src/button.tsx", 12, hooks.transformOpenFileUrl);
+  });
+
+  it("reports rejected UI opens once with source context", async () => {
+    const cause = new Error("blocked");
+    const hooks = createHooks();
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.mocked(requestOpenFile).mockRejectedValue(cause);
+
+    executeOpenFileAction("/src/button.tsx", 12, hooks);
+    await Promise.resolve();
+
+    expect(warning).toHaveBeenCalledOnce();
+    expect(warning).toHaveBeenCalledWith("[react-grab]", expect.any(OpenFileError));
+    expect(warning.mock.calls[0]?.[1]).toMatchObject({
+      filePath: "/src/button.tsx",
+      lineNumber: 12,
+      cause,
+    });
+  });
+});

--- a/packages/react-grab/tests/open-file.test.ts
+++ b/packages/react-grab/tests/open-file.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { OpenFileError } from "../src/errors.js";
+import { requestOpenFile } from "../src/utils/open-file.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("requestOpenFile", () => {
+  it("throws a typed error when the fallback opener fails", async () => {
+    const cause = new Error("blocked");
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("no dev server")));
+    vi.stubGlobal("window", {
+      open: vi.fn(() => {
+        throw cause;
+      }),
+    });
+
+    const pendingOpen = requestOpenFile("/src/button.tsx", 12);
+
+    await expect(pendingOpen).rejects.toMatchObject({
+      name: "OpenFileError",
+      filePath: "/src/button.tsx",
+      lineNumber: 12,
+      cause,
+    });
+    await expect(pendingOpen).rejects.toBeInstanceOf(OpenFileError);
+  });
+});


### PR DESCRIPTION
Depends on #551.

## Motivation

Open-file behavior was implemented three different ways. The tag badge bypassed editor plugins, while keyboard, context-menu, and badge clicks all ignored rejected promises.

## Example

An editor plugin intercepts Cmd+O successfully, but clicking the selected element tag used the default URL instead. Now every UI path honors the same hooks. If opening fails, UI actions report one structured `OpenFileError`; `await openFile()` throws it to the API caller.

## Changes

- Add `OpenFileError` with file path, line number, and cause.
- Centralize plugin interception, URL transformation, and UI error containment.
- Route Cmd+O, context-menu Open, and tag-badge clicks through one action.
- Keep the public primitive awaitable and throwable.
- Strengthen the tag-badge browser test so it proves the plugin ran.

## Validation

- `nr build`
- `nr test:unit` (110 tests)
- focused Playwright open-file suite (11 tests)
- `nr lint`
- `nr typecheck`
- `nr format:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of dev-tool open-in-editor flows with consistent error handling; no auth, payments, or persistent data changes.
> 
> **Overview**
> **Open-file** behavior is unified so **Cmd/Ctrl+O**, the context-menu **Open** action, and **selection tag-badge** clicks all go through the same path that honors `onOpenFile` and `transformOpenFileUrl` instead of the badge calling `requestOpenFile` directly.
> 
> A new **`executeOpenFileAction`** helper runs the plugin hook first, then falls back to **`requestOpenFile`**; UI failures are reported once via **`reportRecoverableError`** as **`OpenFileError`** (path, line, cause). **`requestOpenFile`** now throws **`OpenFileError`** on failure so **`openFile()`** in primitives stays awaitable. Types add **`OpenFileActionHooks`**; e2e asserts the tag-badge path actually invokes the plugin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cb9f3d5e7dded18c009e1e41218fb8db2a47661. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized open-file handling and error reporting in `react-grab` so Cmd/Ctrl+O, context menu, and the selection tag all use one action that honors plugin hooks. Failures now surface as a single typed `OpenFileError` and are reported once.

- **Bug Fixes**
  - Added `OpenFileError` (path, line, cause); `requestOpenFile` wraps failures and throws it; UI reports via `reportRecoverableError`.
  - Introduced `executeOpenFileAction` that tries `onOpenFile` first, then falls back to `requestOpenFile` with `transformOpenFileUrl`; handles sync and async errors.
  - Routed keyboard, context menu, and tag-badge opens through the centralized action via `onOpenSelectionFile`; updated `open` plugin accordingly.
  - Exported `OpenFileError` and `OpenFileActionHooks`; added tests for plugin interception and typed error propagation.

<sup>Written for commit 5cb9f3d5e7dded18c009e1e41218fb8db2a47661. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

