### PR TITLE
fix(react-grab): make freeze transactional

### DIFF
--- a/packages/react-grab/src/errors.ts
+++ b/packages/react-grab/src/errors.ts
@@ -12,6 +12,13 @@ export class RecoverableError extends ReactGrabError {
   }
 }
 
+export class FreezeError extends ReactGrabError {
+  constructor(cause: unknown) {
+    super("Failed to freeze page", { cause });
+    this.name = "FreezeError";
+  }
+}
+
 export class PluginHookError extends RecoverableError {
   readonly pluginName: string;
   readonly hookName: string;

--- a/packages/react-grab/src/index.ts
+++ b/packages/react-grab/src/index.ts
@@ -7,6 +7,7 @@ export {
 } from "./core/index.js";
 export { commentPlugin } from "./core/plugins/comment.js";
 export { openPlugin } from "./core/plugins/open.js";
+export { FreezeError } from "./errors.js";
 export { generateSnippet } from "./utils/generate-snippet.js";
 export type {
   Options,

--- a/packages/react-grab/src/primitives.ts
+++ b/packages/react-grab/src/primitives.ts
@@ -3,7 +3,9 @@ import {
   freezeGlobalInteractions,
   unfreezeGlobalInteractions,
 } from "./utils/freeze-global-interactions.js";
-import { freezeUpdates } from "./utils/freeze-updates.js";
+import { FreezeError, RecoverableError } from "./errors.js";
+import { freezeUpdatesOrThrow } from "./utils/freeze-updates.js";
+import { reportRecoverableError } from "./utils/report-recoverable-error.js";
 import {
   suspendPointerEventsFreeze,
   resumePointerEventsFreeze,
@@ -102,8 +104,40 @@ export const getElementsAtPosition = (clientX: number, clientY: number): Element
   }
 };
 
-const freezeCleanupFns = new Set<() => void>();
+const freezeCleanupFunctions = new Set<() => void>();
 let _isFreezeActive = false;
+let isFreezeInProgress = false;
+let isUnfreezeInProgress = false;
+let isUnfreezeRequested = false;
+
+const unfreezeTargetAnimations = (): void => {
+  freezeAnimations([]);
+};
+
+const runFreezeCleanups = (): unknown[] => {
+  if (isUnfreezeInProgress) return [];
+  isUnfreezeInProgress = true;
+  const cleanupFunctions = Array.from(freezeCleanupFunctions).reverse();
+  const failedCleanupFunctions: Array<() => void> = [];
+  const cleanupErrors: unknown[] = [];
+  freezeCleanupFunctions.clear();
+  try {
+    for (const cleanupFunction of cleanupFunctions) {
+      try {
+        cleanupFunction();
+      } catch (error) {
+        failedCleanupFunctions.unshift(cleanupFunction);
+        cleanupErrors.push(error);
+      }
+    }
+  } finally {
+    for (const failedCleanupFunction of failedCleanupFunctions) {
+      freezeCleanupFunctions.add(failedCleanupFunction);
+    }
+    isUnfreezeInProgress = false;
+  }
+  return cleanupErrors;
+};
 
 /**
  * Freezes the page by halting React updates, pausing CSS/JS animations,
@@ -114,13 +148,33 @@ let _isFreezeActive = false;
  * freeze([document.querySelector('.modal')!]); // freezes only the modal subtree
  */
 export const freeze = (elements?: Element[]): void => {
-  _isFreezeActive = true;
-  freezeCleanupFns.add(freezeUpdates());
-  // Batched layout reads must run before freezeAnimations injects its
-  // stylesheet and sets frozen attributes, or those writes force a second
-  // full-document style recalc under the reads.
-  freezeGlobalInteractions();
-  freezeCleanupFns.add(freezeAnimations(elements ?? [document.body]));
+  if (_isFreezeActive || isFreezeInProgress) return;
+  isFreezeInProgress = true;
+  try {
+    freezeCleanupFunctions.add(freezeUpdatesOrThrow());
+    freezeCleanupFunctions.add(unfreezeGlobalInteractions);
+    // Batched layout reads must run before freezeAnimations injects its
+    // stylesheet and sets frozen attributes, or those writes force a second
+    // full-document style recalc under the reads.
+    freezeGlobalInteractions();
+    freezeCleanupFunctions.add(unfreezeTargetAnimations);
+    freezeAnimations(elements ?? [document.body]);
+    _isFreezeActive = true;
+  } catch (error) {
+    const rollbackErrors = runFreezeCleanups();
+    _isFreezeActive = freezeCleanupFunctions.size > 0;
+    throw new FreezeError(
+      rollbackErrors.length === 0
+        ? error
+        : new AggregateError([error, ...rollbackErrors], "Rolling back page freeze failed"),
+    );
+  } finally {
+    isFreezeInProgress = false;
+    if (isUnfreezeRequested) {
+      isUnfreezeRequested = false;
+      unfreeze();
+    }
+  }
 };
 
 /**
@@ -133,13 +187,16 @@ export const freeze = (elements?: Element[]): void => {
  * unfreeze(); // page resumes normal behavior
  */
 export const unfreeze = (): void => {
-  _isFreezeActive = false;
-  for (const cleanup of Array.from(freezeCleanupFns)) {
-    cleanup();
+  if (isFreezeInProgress) {
+    isUnfreezeRequested = true;
+    return;
   }
-  freezeCleanupFns.clear();
-  freezeAnimations([]);
-  unfreezeGlobalInteractions();
+  if (isUnfreezeInProgress) return;
+  const cleanupErrors = runFreezeCleanups();
+  _isFreezeActive = freezeCleanupFunctions.size > 0;
+  for (const error of cleanupErrors) {
+    reportRecoverableError(new RecoverableError("Unfreezing page failed", error));
+  }
 };
 
 /**
@@ -167,4 +224,5 @@ export const openFile = async (filePath: string, lineNumber?: number): Promise<v
   await requestOpenFile(filePath, lineNumber);
 };
 
+export { FreezeError };
 export { disposeBaselineStyles };

--- a/packages/react-grab/src/utils/freeze-animations.ts
+++ b/packages/react-grab/src/utils/freeze-animations.ts
@@ -2,6 +2,7 @@ import { FROZEN_ELEMENT_ATTRIBUTE, WAAPI_GLOBAL_FREEZE_MAX_ANIMATIONS } from "..
 import { createStyleElement } from "./create-style-element.js";
 import { freezeGsap, unfreezeGsap } from "./freeze-gsap.js";
 import { IS_DEMO } from "./runtime-mode.js";
+import { throwCollectedErrors } from "./throw-collected-errors.js";
 
 const FROZEN_STYLES = `
 [${FROZEN_ELEMENT_ATTRIBUTE}],
@@ -36,6 +37,11 @@ let globalUsedCssFreeze = false;
 // a depth counter per element and only unpause when all layers are removed.
 const svgFreezeDepthMap = new Map<SVGSVGElement, number>();
 let frozenWaapiAnimations: Animation[] = [];
+
+const hasGlobalAnimationFreeze = (): boolean =>
+  globalAnimationStyleElement !== null ||
+  globalFrozenSvgElements.length > 0 ||
+  globalFrozenWaapiAnimations.length > 0;
 
 const ensureStylesInjected = (): void => {
   if (styleElement) return;
@@ -75,29 +81,46 @@ const callSvgAnimationMethod = (
   animationMethod.call(svgElement);
 };
 
-const pauseSvgAnimations = (svgElements: SVGSVGElement[]): void => {
+const pauseSvgAnimations = (
+  svgElements: SVGSVGElement[],
+  frozenSvgElementStorage: SVGSVGElement[],
+): void => {
   for (const svgElement of svgElements) {
     const currentFreezeDepth = svgFreezeDepthMap.get(svgElement) ?? 0;
     if (currentFreezeDepth === 0) {
+      svgFreezeDepthMap.set(svgElement, 1);
+      frozenSvgElementStorage.push(svgElement);
       callSvgAnimationMethod(svgElement, "pauseAnimations");
+      continue;
     }
     svgFreezeDepthMap.set(svgElement, currentFreezeDepth + 1);
+    frozenSvgElementStorage.push(svgElement);
   }
 };
 
-const resumeSvgAnimations = (svgElements: SVGSVGElement[]): void => {
+const resumeSvgAnimations = (
+  svgElements: SVGSVGElement[],
+  cleanupErrors: unknown[],
+): SVGSVGElement[] => {
+  const svgElementsStillFrozen: SVGSVGElement[] = [];
   for (const svgElement of svgElements) {
     const currentFreezeDepth = svgFreezeDepthMap.get(svgElement);
     if (!currentFreezeDepth) continue;
 
     if (currentFreezeDepth === 1) {
-      svgFreezeDepthMap.delete(svgElement);
-      callSvgAnimationMethod(svgElement, "unpauseAnimations");
+      try {
+        callSvgAnimationMethod(svgElement, "unpauseAnimations");
+        svgFreezeDepthMap.delete(svgElement);
+      } catch (error) {
+        svgElementsStillFrozen.push(svgElement);
+        cleanupErrors.push(error);
+      }
       continue;
     }
 
     svgFreezeDepthMap.set(svgElement, currentFreezeDepth - 1);
   }
+  return svgElementsStillFrozen;
 };
 
 const collectWaapiAnimations = (elements: Element[]): Animation[] => {
@@ -122,6 +145,20 @@ const finishAnimations = (animations: Iterable<Animation>): void => {
   }
 };
 
+const restorePausedAnimations = (animations: Iterable<Animation>): void => {
+  for (const animation of animations) {
+    try {
+      animation.finish();
+    } catch {
+      try {
+        animation.play();
+      } catch {
+        // animation was cancelled or its target detached during the freeze
+      }
+    }
+  }
+};
+
 // Animations whose target lives in a shadow root are react-grab's own toolbar/
 // label animations — the global freeze must leave them running.
 // @see https://github.com/aidenybai/react-grab/issues/163
@@ -138,19 +175,31 @@ export const freezeAllAnimations = (elements: Element[]): void => {
 
   unfreezeAllAnimations();
   const elementSnapshot = [...elements];
-  lastInputElements = elementSnapshot;
   ensureStylesInjected();
   frozenElements = elementSnapshot;
-  frozenSvgElements = collectFrozenSvgElements(frozenElements);
-  pauseSvgAnimations(frozenSvgElements);
+  frozenSvgElements = [];
+  try {
+    const svgElementsToFreeze = collectFrozenSvgElements(frozenElements);
+    pauseSvgAnimations(svgElementsToFreeze, frozenSvgElements);
 
-  for (const element of frozenElements) {
-    element.setAttribute(FROZEN_ELEMENT_ATTRIBUTE, "");
-  }
+    for (const element of frozenElements) {
+      element.setAttribute(FROZEN_ELEMENT_ATTRIBUTE, "");
+    }
 
-  frozenWaapiAnimations = collectWaapiAnimations(frozenElements);
-  for (const animation of frozenWaapiAnimations) {
-    animation.pause();
+    const animationsToFreeze = collectWaapiAnimations(frozenElements);
+    frozenWaapiAnimations = [];
+    for (const animation of animationsToFreeze) {
+      animation.pause();
+      frozenWaapiAnimations.push(animation);
+    }
+    lastInputElements = elementSnapshot;
+  } catch (error) {
+    try {
+      unfreezeAllAnimations();
+    } catch (rollbackError) {
+      throw new AggregateError([error, rollbackError], "Rolling back animation freeze failed");
+    }
+    throw error;
   }
 };
 
@@ -162,17 +211,26 @@ const unfreezeAllAnimations = (): void => {
   )
     return;
 
-  for (const element of frozenElements) {
-    element.removeAttribute(FROZEN_ELEMENT_ATTRIBUTE);
-  }
-  resumeSvgAnimations(frozenSvgElements);
+  const elementsToUnfreeze = frozenElements;
+  const svgElementsToUnfreeze = frozenSvgElements;
+  const animationsToFinish = frozenWaapiAnimations;
 
-  finishAnimations(frozenWaapiAnimations);
-
-  frozenElements = [];
-  frozenSvgElements = [];
-  frozenWaapiAnimations = [];
+  const cleanupErrors: unknown[] = [];
+  const elementsStillFrozen: Element[] = [];
   lastInputElements = [];
+  for (const element of elementsToUnfreeze) {
+    try {
+      element.removeAttribute(FROZEN_ELEMENT_ATTRIBUTE);
+    } catch (error) {
+      elementsStillFrozen.push(element);
+      cleanupErrors.push(error);
+    }
+  }
+  frozenElements = elementsStillFrozen;
+  frozenSvgElements = resumeSvgAnimations(svgElementsToUnfreeze, cleanupErrors);
+  restorePausedAnimations(animationsToFinish);
+  frozenWaapiAnimations = [];
+  throwCollectedErrors(cleanupErrors, "Unfreezing element animations failed");
 };
 
 export const freezeAnimations = (elements: Element[]): (() => void) => {
@@ -194,7 +252,7 @@ export const collectGlobalAnimationsToFreeze = (): Animation[] => {
   // Demo mode is display-only and must never freeze (or force a style flush
   // on) the host page.
   if (IS_DEMO) return [];
-  if (globalAnimationStyleElement) return [];
+  if (hasGlobalAnimationFreeze()) return [];
   const runningAnimations: Animation[] = [];
   for (const animation of document.getAnimations()) {
     if (isShadowAnimation(animation)) continue;
@@ -207,7 +265,7 @@ export const collectGlobalAnimationsToFreeze = (): Animation[] => {
 // layout reads, so it never forces a recalc on its own.
 export const applyGlobalAnimationFreeze = (runningAnimations: Animation[]): void => {
   if (IS_DEMO) return;
-  if (globalAnimationStyleElement) return;
+  if (hasGlobalAnimationFreeze()) return;
 
   // Marker element; also carries the `*` freeze rule on the CSS path below. Its
   // presence signals the global freeze is active (asserted by the e2e suite).
@@ -222,61 +280,75 @@ export const applyGlobalAnimationFreeze = (runningAnimations: Animation[]): void
   } else {
     // Few animations (the common case): pause them directly. This touches only
     // the animating elements instead of forcing a full-document style recalc.
-    for (const animation of runningAnimations) animation.pause();
-    globalFrozenWaapiAnimations = runningAnimations;
+    globalFrozenWaapiAnimations = [];
+    for (const animation of runningAnimations) {
+      animation.pause();
+      globalFrozenWaapiAnimations.push(animation);
+    }
     globalUsedCssFreeze = false;
   }
 
-  globalFrozenSvgElements = collectFrozenSvgElements(
+  const svgElementsToFreeze = collectFrozenSvgElements(
     Array.from(document.querySelectorAll(SVG_ROOT_SELECTOR)),
   );
-  pauseSvgAnimations(globalFrozenSvgElements);
+  globalFrozenSvgElements = [];
+  pauseSvgAnimations(svgElementsToFreeze, globalFrozenSvgElements);
   freezeGsap();
 };
 
 export const unfreezeGlobalAnimations = (): void => {
-  if (!globalAnimationStyleElement) return;
+  if (!hasGlobalAnimationFreeze()) return;
 
-  if (globalUsedCssFreeze) {
-    // CSS path. All paused animations must be finished before the freeze
-    // stylesheet is removed, because simply removing animation-play-state:paused
-    // would resume them from their mid-point and create visual jumps. finish()
-    // advances them to their end state; the interim transition:none rule
-    // prevents any visual flash during cleanup. Shadow-root animations are
-    // skipped so react-grab's own toolbar/label animations aren't finished.
-    globalAnimationStyleElement.textContent = `
+  const styleElementToRemove = globalAnimationStyleElement;
+  const didUseCssFreeze = globalUsedCssFreeze;
+  const waapiAnimationsToRestore = globalFrozenWaapiAnimations;
+  const svgElementsToUnfreeze = globalFrozenSvgElements;
+  const cleanupErrors: unknown[] = [];
+
+  if (styleElementToRemove) {
+    try {
+      if (didUseCssFreeze) {
+        // CSS path. All paused animations must be finished before the freeze
+        // stylesheet is removed, because simply removing animation-play-state:paused
+        // would resume them from their mid-point and create visual jumps. finish()
+        // advances them to their end state; the interim transition:none rule
+        // prevents any visual flash during cleanup. Shadow-root animations are
+        // skipped so react-grab's own toolbar/label animations aren't finished.
+        styleElementToRemove.textContent = `
 *, *::before, *::after {
   transition: none !important;
 }
 `;
-    const animationsToFinish: Animation[] = [];
-    for (const animation of document.getAnimations()) {
-      if (isShadowAnimation(animation)) continue;
-      animationsToFinish.push(animation);
-    }
-    finishAnimations(animationsToFinish);
-    globalUsedCssFreeze = false;
-  } else {
-    // WAAPI path: restore the specific animations we paused. Finite animations
-    // advance to their end (finish()) so they don't jump backward through their
-    // timeline; infinite ones (finish() throws) resume looping (play()).
-    for (const animation of globalFrozenWaapiAnimations) {
-      try {
-        animation.finish();
-      } catch {
-        try {
-          animation.play();
-        } catch {
-          // animation was cancelled or its target detached during the freeze
+        const animationsToFinish: Animation[] = [];
+        for (const animation of document.getAnimations()) {
+          if (isShadowAnimation(animation)) continue;
+          animationsToFinish.push(animation);
         }
+        finishAnimations(animationsToFinish);
+      } else {
+        // WAAPI path: restore the specific animations we paused. Finite animations
+        // advance to their end (finish()) so they don't jump backward through their
+        // timeline; infinite ones (finish() throws) resume looping (play()).
+        restorePausedAnimations(waapiAnimationsToRestore);
       }
+    } catch (error) {
+      cleanupErrors.push(error);
     }
+    globalUsedCssFreeze = false;
     globalFrozenWaapiAnimations = [];
-  }
 
-  globalAnimationStyleElement.remove();
-  globalAnimationStyleElement = null;
-  resumeSvgAnimations(globalFrozenSvgElements);
-  globalFrozenSvgElements = [];
-  unfreezeGsap();
+    try {
+      styleElementToRemove.remove();
+      globalAnimationStyleElement = null;
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+  }
+  globalFrozenSvgElements = resumeSvgAnimations(svgElementsToUnfreeze, cleanupErrors);
+  try {
+    unfreezeGsap();
+  } catch (error) {
+    cleanupErrors.push(error);
+  }
+  throwCollectedErrors(cleanupErrors, "Unfreezing global animations failed");
 };

--- a/packages/react-grab/src/utils/freeze-global-interactions.ts
+++ b/packages/react-grab/src/utils/freeze-global-interactions.ts
@@ -8,6 +8,22 @@ import {
   collectPseudoStates,
   unfreezePseudoStates,
 } from "./freeze-pseudo-states.js";
+import { throwCollectedErrors } from "./throw-collected-errors.js";
+
+const unfreezeInteractionLayers = (): unknown[] => {
+  const cleanupErrors: unknown[] = [];
+  try {
+    unfreezePseudoStates();
+  } catch (error) {
+    cleanupErrors.push(error);
+  }
+  try {
+    unfreezeGlobalAnimations();
+  } catch (error) {
+    cleanupErrors.push(error);
+  }
+  return cleanupErrors;
+};
 
 // Batches every layout read (elementFromPoint, getComputedStyle,
 // document.getAnimations) ahead of every freeze write. Interleaving them makes
@@ -16,11 +32,17 @@ import {
 export const freezeGlobalInteractions = (cursorX?: number, cursorY?: number): void => {
   const pseudoSnapshot = collectPseudoStates(cursorX, cursorY);
   const animationsToFreeze = collectGlobalAnimationsToFreeze();
-  applyPseudoStates(pseudoSnapshot);
-  applyGlobalAnimationFreeze(animationsToFreeze);
+  try {
+    applyPseudoStates(pseudoSnapshot);
+    applyGlobalAnimationFreeze(animationsToFreeze);
+  } catch (error) {
+    const rollbackErrors = unfreezeInteractionLayers();
+    if (rollbackErrors.length === 0) throw error;
+    throw new AggregateError([error, ...rollbackErrors], "Freezing global interactions failed");
+  }
 };
 
 export const unfreezeGlobalInteractions = (): void => {
-  unfreezePseudoStates();
-  unfreezeGlobalAnimations();
+  const cleanupErrors = unfreezeInteractionLayers();
+  throwCollectedErrors(cleanupErrors, "Unfreezing global interactions failed");
 };

--- a/packages/react-grab/src/utils/freeze-pseudo-states.ts
+++ b/packages/react-grab/src/utils/freeze-pseudo-states.ts
@@ -5,6 +5,7 @@ import {
   isPointerEventsFreezeInstalled,
   uninstallPointerEventsFreeze,
 } from "./pointer-events-freeze.js";
+import { throwCollectedErrors } from "./throw-collected-errors.js";
 
 // These capture-phase blockers prevent hover and focus side effects while the
 // pointer-events freeze is briefly suspended for hit-testing. Even though the
@@ -144,17 +145,24 @@ const applyFrozenStates = (
 
 const restoreFrozenStates = (
   storageMap: Map<HTMLElement, Map<string, InlineStyleProperty>>,
-): void => {
+): unknown[] => {
+  const cleanupErrors: unknown[] = [];
   for (const [element, originalPropertyValues] of storageMap) {
     for (const [property, originalProperty] of originalPropertyValues) {
-      if (originalProperty.value) {
-        element.style.setProperty(property, originalProperty.value, originalProperty.priority);
-      } else {
-        element.style.removeProperty(property);
+      try {
+        if (originalProperty.value) {
+          element.style.setProperty(property, originalProperty.value, originalProperty.priority);
+        } else {
+          element.style.removeProperty(property);
+        }
+        originalPropertyValues.delete(property);
+      } catch (error) {
+        cleanupErrors.push(error);
       }
     }
+    if (originalPropertyValues.size === 0) storageMap.delete(element);
   }
-  storageMap.clear();
+  return cleanupErrors;
 };
 
 interface PseudoFreezeSnapshot {
@@ -231,8 +239,15 @@ export const unfreezePseudoStates = (): void => {
     document.removeEventListener(eventType, preventFocusChange, true);
   }
 
-  restoreFrozenStates(frozenHoverElements);
-  restoreFrozenStates(frozenFocusElements);
+  const cleanupErrors = [
+    ...restoreFrozenStates(frozenHoverElements),
+    ...restoreFrozenStates(frozenFocusElements),
+  ];
 
-  uninstallPointerEventsFreeze();
+  try {
+    uninstallPointerEventsFreeze();
+  } catch (error) {
+    cleanupErrors.push(error);
+  }
+  throwCollectedErrors(cleanupErrors, "Unfreezing pseudo states failed");
 };

--- a/packages/react-grab/src/utils/freeze-updates.ts
+++ b/packages/react-grab/src/utils/freeze-updates.ts
@@ -598,7 +598,7 @@ const resumeUpdates = (): void => {
   }
 };
 
-export const freezeUpdates = (): (() => void) => {
+export const freezeUpdatesOrThrow = (): (() => void) => {
   // Demo mode is display-only and must never pause the host app's React renders,
   // even via the toolbar's own (ungated) freeze path.
   if (IS_DEMO) return () => {};
@@ -618,9 +618,8 @@ export const freezeUpdates = (): (() => void) => {
       }
     } catch (error) {
       freezeOwnerCount -= 1;
-      reportRecoverableError(new RecoverableError("Pausing React updates failed", error));
       if (isUpdatesPaused) resumeUpdates();
-      return () => {};
+      throw error;
     }
   }
 
@@ -632,4 +631,13 @@ export const freezeUpdates = (): (() => void) => {
     freezeOwnerCount -= 1;
     if (freezeOwnerCount === 0) resumeUpdates();
   };
+};
+
+export const freezeUpdates = (): (() => void) => {
+  try {
+    return freezeUpdatesOrThrow();
+  } catch (error) {
+    reportRecoverableError(new RecoverableError("Pausing React updates failed", error));
+    return () => {};
+  }
 };

--- a/packages/react-grab/src/utils/throw-collected-errors.ts
+++ b/packages/react-grab/src/utils/throw-collected-errors.ts
@@ -1,0 +1,5 @@
+export const throwCollectedErrors = (errors: unknown[], message: string): void => {
+  if (errors.length === 0) return;
+  if (errors.length === 1) throw errors[0];
+  throw new AggregateError(errors, message);
+};

--- a/packages/react-grab/tests/primitives-freeze.test.ts
+++ b/packages/react-grab/tests/primitives-freeze.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { FreezeError } from "../src/errors.js";
+import { freeze, isFreezeActive, unfreeze } from "../src/primitives.js";
+import { freezeAnimations } from "../src/utils/freeze-animations.js";
+import {
+  freezeGlobalInteractions,
+  unfreezeGlobalInteractions,
+} from "../src/utils/freeze-global-interactions.js";
+import { freezeUpdatesOrThrow } from "../src/utils/freeze-updates.js";
+
+vi.mock("../src/utils/freeze-animations.js", () => ({
+  freezeAnimations: vi.fn(),
+}));
+
+vi.mock("../src/utils/freeze-global-interactions.js", () => ({
+  freezeGlobalInteractions: vi.fn(),
+  unfreezeGlobalInteractions: vi.fn(),
+}));
+
+vi.mock("../src/utils/freeze-updates.js", () => ({
+  freezeUpdatesOrThrow: vi.fn(),
+}));
+
+const createElement = (): Element => Object.create(null);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(freezeUpdatesOrThrow).mockReturnValue(() => {});
+  vi.mocked(freezeAnimations).mockReturnValue(() => {});
+});
+
+afterEach(() => {
+  unfreeze();
+  vi.restoreAllMocks();
+});
+
+describe("freeze", () => {
+  it("commits after setup and cleans up in reverse order", () => {
+    const calls: string[] = [];
+    vi.mocked(freezeUpdatesOrThrow).mockImplementation(() => {
+      calls.push("freeze updates");
+      return () => calls.push("unfreeze updates");
+    });
+    vi.mocked(freezeGlobalInteractions).mockImplementation(() => {
+      calls.push("freeze interactions");
+    });
+    vi.mocked(unfreezeGlobalInteractions).mockImplementation(() => {
+      calls.push("unfreeze interactions");
+    });
+    vi.mocked(freezeAnimations).mockImplementation((elements) => {
+      calls.push(elements.length === 0 ? "unfreeze animations" : "freeze animations");
+      return () => {};
+    });
+
+    freeze([createElement()]);
+    expect(isFreezeActive()).toBe(true);
+    unfreeze();
+
+    expect(calls).toEqual([
+      "freeze updates",
+      "freeze interactions",
+      "freeze animations",
+      "unfreeze animations",
+      "unfreeze interactions",
+      "unfreeze updates",
+    ]);
+    expect(isFreezeActive()).toBe(false);
+  });
+
+  it("rolls back acquired layers when setup fails", () => {
+    const calls: string[] = [];
+    vi.mocked(freezeUpdatesOrThrow).mockReturnValue(() => calls.push("unfreeze updates"));
+    vi.mocked(freezeGlobalInteractions).mockImplementation(() => {
+      throw new Error("interactions failed");
+    });
+    vi.mocked(unfreezeGlobalInteractions).mockImplementation(() => {
+      calls.push("unfreeze interactions");
+    });
+
+    expect(() => freeze([createElement()])).toThrow(FreezeError);
+
+    expect(calls).toEqual(["unfreeze interactions", "unfreeze updates"]);
+    expect(isFreezeActive()).toBe(false);
+  });
+
+  it("keeps an active freeze as one idempotent session", () => {
+    const element = createElement();
+
+    freeze([element]);
+    freeze([element]);
+
+    expect(freezeUpdatesOrThrow).toHaveBeenCalledOnce();
+    expect(freezeGlobalInteractions).toHaveBeenCalledOnce();
+    expect(freezeAnimations).toHaveBeenCalledOnce();
+    expect(isFreezeActive()).toBe(true);
+  });
+
+  it("honors unfreeze requested during setup", () => {
+    const calls: string[] = [];
+    vi.mocked(freezeUpdatesOrThrow).mockReturnValue(() => calls.push("unfreeze updates"));
+    vi.mocked(unfreezeGlobalInteractions).mockImplementation(() => {
+      calls.push("unfreeze interactions");
+    });
+    vi.mocked(freezeAnimations).mockImplementation((elements) => {
+      if (elements.length > 0) {
+        unfreeze();
+        return () => {};
+      }
+      calls.push("unfreeze animations");
+      return () => {};
+    });
+
+    freeze([createElement()]);
+
+    expect(calls).toEqual(["unfreeze animations", "unfreeze interactions", "unfreeze updates"]);
+    expect(isFreezeActive()).toBe(false);
+  });
+
+  it("does not reenter a cleanup", () => {
+    let animationCleanupAttempts = 0;
+    vi.mocked(freezeAnimations).mockImplementation((elements) => {
+      if (elements.length > 0) return () => {};
+      animationCleanupAttempts += 1;
+      unfreeze();
+      return () => {};
+    });
+
+    freeze([createElement()]);
+    unfreeze();
+
+    expect(animationCleanupAttempts).toBe(1);
+    expect(isFreezeActive()).toBe(false);
+  });
+
+  it("attempts every cleanup and retries failures", () => {
+    const calls: string[] = [];
+    let animationCleanupAttempts = 0;
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.mocked(freezeUpdatesOrThrow).mockReturnValue(() => calls.push("unfreeze updates"));
+    vi.mocked(unfreezeGlobalInteractions).mockImplementation(() => {
+      calls.push("unfreeze interactions");
+    });
+    vi.mocked(freezeAnimations).mockImplementation((elements) => {
+      if (elements.length > 0) return () => {};
+      calls.push("unfreeze animations");
+      animationCleanupAttempts += 1;
+      if (animationCleanupAttempts === 1) throw new Error("animation cleanup failed");
+      return () => {};
+    });
+
+    freeze([createElement()]);
+    unfreeze();
+
+    expect(calls).toEqual(["unfreeze animations", "unfreeze interactions", "unfreeze updates"]);
+    expect(warning).toHaveBeenCalledOnce();
+    expect(isFreezeActive()).toBe(true);
+
+    unfreeze();
+
+    expect(calls).toEqual([
+      "unfreeze animations",
+      "unfreeze interactions",
+      "unfreeze updates",
+      "unfreeze animations",
+    ]);
+    expect(isFreezeActive()).toBe(false);
+  });
+});


### PR DESCRIPTION
Depends on #551.

## Motivation

A freeze spans React updates, pointer/pseudo state, CSS/WAAPI/SVG animations, and GSAP. If setup or cleanup fails, React Grab must not leave the host page half-frozen or let a retry undo newer page state.

## Example

If one SVG fails to unpause, the successful SVGs must be forgotten immediately. A later `unfreeze()` should retry only that failed SVG—not decrement already-released ownership or finish animations created after the first cleanup.

## Changes

- Commit `freeze()` only after every layer succeeds; otherwise roll back in reverse and throw `FreezeError`.
- Defer `unfreeze()` requested during setup and prevent cleanup re-entry.
- Run every cleanup, retaining only failed work for a safe retry.
- Track partial element/global animation setup so rollback restores exactly what was acquired.
- Resume infinite WAAPI animations when `finish()` is invalid.
- Restore pseudo-state styles while transition suppression is still active.
- Keep the implementation to existing arrays/maps plus one small collected-error helper.

## Validation

- `nr build`
- `nr --filter react-grab test:unit` — 112 passed
- focused freeze Playwright suite — 21 passed
- `nr test` — 1,017 passed, 24 skipped, 3 load flakes; all 3 passed alone
- `nr lint`
- `nr typecheck`
- `nr format:check`
