### PR TITLE
Complete iframe teardown after cleanup errors

### DIFF
--- a/packages/react-grab/e2e/iframe.spec.ts
+++ b/packages/react-grab/e2e/iframe.spec.ts
@@ -420,6 +420,68 @@ test.describe("Iframe selection", () => {
     expect(didRestoreAttachShadow).toBe(true);
   });
 
+  test("continues frame cleanup after a shadow root hook fails", async ({ reactGrab }) => {
+    const cleanupResult = await reactGrab.page.evaluate(async () => {
+      const createIframe = async (): Promise<HTMLIFrameElement> => {
+        const iframeElement = document.createElement("iframe");
+        iframeElement.srcdoc = "<main>Frame cleanup target</main>";
+        const didLoad = new Promise<void>((resolve) => {
+          iframeElement.addEventListener("load", () => resolve(), { once: true });
+        });
+        document.body.append(iframeElement);
+        await didLoad;
+        return iframeElement;
+      };
+
+      const failingIframe = await createIframe();
+      const subsequentIframe = await createIframe();
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+      const findElementPrototype = (targetDocument: Document | null): object | null => {
+        let currentPrototype: object | null = targetDocument?.documentElement ?? null;
+        while (currentPrototype) {
+          currentPrototype = Object.getPrototypeOf(currentPrototype);
+          if (currentPrototype && Object.hasOwn(currentPrototype, "attachShadow")) {
+            return currentPrototype;
+          }
+        }
+        return null;
+      };
+
+      const failingElementPrototype = findElementPrototype(failingIframe.contentDocument);
+      const subsequentElementPrototype = findElementPrototype(subsequentIframe.contentDocument);
+      if (!failingElementPrototype || !subsequentElementPrototype) return null;
+
+      const failingPatchedAttachShadow = Reflect.get(failingElementPrototype, "attachShadow");
+      const subsequentPatchedAttachShadow = Reflect.get(subsequentElementPrototype, "attachShadow");
+      Object.defineProperty(failingElementPrototype, "attachShadow", {
+        configurable: true,
+        get: () => failingPatchedAttachShadow,
+        set: () => {
+          throw new Error("Expected frame cleanup failure");
+        },
+      });
+
+      let cleanupErrorMessage: string | null = null;
+      try {
+        window.__REACT_GRAB__?.dispose();
+      } catch (error) {
+        cleanupErrorMessage = error instanceof Error ? error.message : String(error);
+      }
+
+      return {
+        cleanupErrorMessage,
+        didRestoreSubsequentHook:
+          Reflect.get(subsequentElementPrototype, "attachShadow") !== subsequentPatchedAttachShadow,
+      };
+    });
+
+    expect(cleanupResult).toEqual({
+      cleanupErrorMessage: "Expected frame cleanup failure",
+      didRestoreSubsequentHook: true,
+    });
+  });
+
   test("does not descend into an iframe covered by an opaque ignored element", async ({
     reactGrab,
   }) => {

--- a/packages/react-grab/src/utils/observe-same-origin-frame-documents.ts
+++ b/packages/react-grab/src/utils/observe-same-origin-frame-documents.ts
@@ -3,6 +3,7 @@ import { getAccessibleIframeDocument } from "./get-accessible-iframe-document.js
 import { isElementNode } from "./is-element-node.js";
 import { isIframeElement } from "./is-iframe-element.js";
 import { isReactGrabElement } from "./is-react-grab-element.js";
+import { throwCollectedErrors } from "./throw-collected-errors.js";
 
 interface FrameDocumentCallback {
   (frameDocument: Document): (() => void) | void;
@@ -13,63 +14,78 @@ interface ObservedIframe {
   document: Document | null;
 }
 
+const collectCleanupError = (cleanup: () => void, cleanupErrors: unknown[]): void => {
+  try {
+    cleanup();
+  } catch (error) {
+    cleanupErrors.push(error);
+  }
+};
+
 export const observeSameOriginFrameDocuments = (callback: FrameDocumentCallback): (() => void) => {
   const documentCleanups = new Map<Document, (() => void) | void>();
   const shadowRootHookCleanups = new Map<Document, () => void>();
   const rootObservers = new Map<Document | ShadowRoot, MutationObserver>();
   const observedIframes = new Map<HTMLIFrameElement, ObservedIframe>();
 
-  const cleanupDocument = (targetDocument: Document): void => {
+  const cleanupDocument = (targetDocument: Document, cleanupErrors: unknown[]): void => {
     const rootObserver = rootObservers.get(targetDocument);
     if (rootObserver) {
-      rootObserver.disconnect();
       rootObservers.delete(targetDocument);
+      collectCleanupError(() => rootObserver.disconnect(), cleanupErrors);
     }
 
     for (const root of [...rootObservers.keys()]) {
-      if ("host" in root && root.ownerDocument === targetDocument) cleanupRoot(root);
+      if ("host" in root && root.ownerDocument === targetDocument) cleanupRoot(root, cleanupErrors);
     }
 
     for (const iframeElement of [...observedIframes.keys()]) {
-      if (iframeElement.ownerDocument === targetDocument) cleanupIframe(iframeElement);
+      if (iframeElement.ownerDocument === targetDocument)
+        cleanupIframe(iframeElement, cleanupErrors);
     }
 
-    shadowRootHookCleanups.get(targetDocument)?.();
+    const shadowRootHookCleanup = shadowRootHookCleanups.get(targetDocument);
     shadowRootHookCleanups.delete(targetDocument);
-    documentCleanups.get(targetDocument)?.();
+    if (shadowRootHookCleanup) collectCleanupError(shadowRootHookCleanup, cleanupErrors);
+
+    const documentCleanup = documentCleanups.get(targetDocument);
     documentCleanups.delete(targetDocument);
+    if (documentCleanup) collectCleanupError(documentCleanup, cleanupErrors);
   };
 
-  const cleanupRoot = (root: ShadowRoot): void => {
+  const cleanupRoot = (root: ShadowRoot, cleanupErrors: unknown[]): void => {
     const rootObserver = rootObservers.get(root);
     if (!rootObserver) return;
-    rootObserver.disconnect();
     rootObservers.delete(root);
+    collectCleanupError(() => rootObserver.disconnect(), cleanupErrors);
 
     for (const descendantElement of root.querySelectorAll("*")) {
-      cleanupElement(descendantElement);
+      cleanupElement(descendantElement, cleanupErrors);
     }
   };
 
-  const cleanupIframe = (iframeElement: HTMLIFrameElement): void => {
+  const cleanupIframe = (iframeElement: HTMLIFrameElement, cleanupErrors: unknown[]): void => {
     const observedIframe = observedIframes.get(iframeElement);
     if (!observedIframe) return;
     observedIframes.delete(iframeElement);
-    observedIframe.abortController.abort();
-    iframeElement.removeAttribute(SAME_ORIGIN_FRAME_ATTRIBUTE);
-    if (observedIframe.document) cleanupDocument(observedIframe.document);
+    collectCleanupError(() => observedIframe.abortController.abort(), cleanupErrors);
+    collectCleanupError(
+      () => iframeElement.removeAttribute(SAME_ORIGIN_FRAME_ATTRIBUTE),
+      cleanupErrors,
+    );
+    if (observedIframe.document) cleanupDocument(observedIframe.document, cleanupErrors);
   };
 
-  const cleanupElement = (element: Element): void => {
-    if (isIframeElement(element)) cleanupIframe(element);
-    if (element.shadowRoot) cleanupRoot(element.shadowRoot);
+  const cleanupElement = (element: Element, cleanupErrors: unknown[]): void => {
+    if (isIframeElement(element)) cleanupIframe(element, cleanupErrors);
+    if (element.shadowRoot) cleanupRoot(element.shadowRoot, cleanupErrors);
   };
 
-  const cleanupSubtree = (element: Element): void => {
+  const cleanupSubtree = (element: Element, cleanupErrors: unknown[]): void => {
     for (const descendantElement of element.querySelectorAll("*")) {
-      cleanupElement(descendantElement);
+      cleanupElement(descendantElement, cleanupErrors);
     }
-    cleanupElement(element);
+    cleanupElement(element, cleanupErrors);
   };
 
   const observeDocument = (targetDocument: Document): void => {
@@ -116,19 +132,22 @@ export const observeSameOriginFrameDocuments = (callback: FrameDocumentCallback)
     observedIframes.set(iframeElement, observedIframe);
 
     const connectCurrentDocument = (): void => {
+      const cleanupErrors: unknown[] = [];
       const frameDocument = getAccessibleIframeDocument(iframeElement);
       if (observedIframe.document && observedIframe.document !== frameDocument) {
-        cleanupDocument(observedIframe.document);
+        cleanupDocument(observedIframe.document, cleanupErrors);
       }
       observedIframe.document = frameDocument;
 
       if (!frameDocument) {
         iframeElement.removeAttribute(SAME_ORIGIN_FRAME_ATTRIBUTE);
+        throwCollectedErrors(cleanupErrors, "Cleaning up replaced frame document failed");
         return;
       }
 
       iframeElement.setAttribute(SAME_ORIGIN_FRAME_ATTRIBUTE, "");
       observeDocument(frameDocument);
+      throwCollectedErrors(cleanupErrors, "Cleaning up replaced frame document failed");
     };
 
     iframeElement.addEventListener("load", connectCurrentDocument, {
@@ -158,14 +177,16 @@ export const observeSameOriginFrameDocuments = (callback: FrameDocumentCallback)
     if (!rootWindow) return;
 
     const mutationObserver = new rootWindow.MutationObserver((records) => {
+      const cleanupErrors: unknown[] = [];
       for (const record of records) {
         for (const removedNode of record.removedNodes) {
-          if (isElementNode(removedNode)) cleanupSubtree(removedNode);
+          if (isElementNode(removedNode)) cleanupSubtree(removedNode, cleanupErrors);
         }
         for (const addedNode of record.addedNodes) {
           if (isElementNode(addedNode)) observeSubtree(addedNode);
         }
       }
+      throwCollectedErrors(cleanupErrors, "Cleaning up removed frame documents failed");
     });
     rootObservers.set(root, mutationObserver);
     mutationObserver.observe(root, { childList: true, subtree: true });
@@ -178,20 +199,22 @@ export const observeSameOriginFrameDocuments = (callback: FrameDocumentCallback)
   observeDocument(document);
 
   return () => {
+    const cleanupErrors: unknown[] = [];
     for (const iframeElement of [...observedIframes.keys()]) {
-      cleanupIframe(iframeElement);
+      cleanupIframe(iframeElement, cleanupErrors);
     }
-    for (const rootObserver of rootObservers.values()) {
-      rootObserver.disconnect();
+    for (const [root, rootObserver] of rootObservers) {
+      rootObservers.delete(root);
+      collectCleanupError(() => rootObserver.disconnect(), cleanupErrors);
     }
-    for (const shadowRootHookCleanup of shadowRootHookCleanups.values()) {
-      shadowRootHookCleanup();
+    for (const [targetDocument, shadowRootHookCleanup] of shadowRootHookCleanups) {
+      shadowRootHookCleanups.delete(targetDocument);
+      collectCleanupError(shadowRootHookCleanup, cleanupErrors);
     }
-    for (const documentCleanup of documentCleanups.values()) {
-      documentCleanup?.();
+    for (const [targetDocument, documentCleanup] of documentCleanups) {
+      documentCleanups.delete(targetDocument);
+      if (documentCleanup) collectCleanupError(documentCleanup, cleanupErrors);
     }
-    rootObservers.clear();
-    shadowRootHookCleanups.clear();
-    documentCleanups.clear();
+    throwCollectedErrors(cleanupErrors, "Cleaning up same-origin frame documents failed");
   };
 };


### PR DESCRIPTION
## Motivation

A cleanup callback from one same-origin iframe can throw. Previously, that stopped teardown immediately, so later iframe listeners, observers, and patched `attachShadow` methods could remain installed.

## Example

Before: frame A fails while restoring `attachShadow`, so frame B is never restored.

After: every cleanup runs, then React Grab reports the collected cleanup error.

## What changed

- Remove cleanup state before invoking fallible teardown callbacks.
- Continue cleaning every iframe, shadow root, observer, and document after an error.
- Re-throw collected errors through the existing `throwCollectedErrors` utility.
- Add a browser regression that forces one frame cleanup to fail and verifies the next frame is still restored.

## Impact

Disposal is deterministic even when third-party code interferes with iframe prototypes. Normal teardown behavior is unchanged.

## Checks

- `nr build`
- `nr test` — 1,065 passed, 24 skipped; one unrelated flaky test passed on retry
- `nr lint`
- `nr typecheck`
- `nr format`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure complete iframe and shadow-root teardown in `react-grab` even when a cleanup callback throws. We collect errors, finish cleanup across all frames, then rethrow a combined error.

- **Bug Fixes**
  - Continue cleaning every iframe, shadow root, observer, and document even if a callback fails.
  - Collect cleanup errors throughout and rethrow via `throwCollectedErrors` after cleanup completes.
  - Added an e2e regression that forces one frame’s hook restore to fail and verifies subsequent frames/hooks are restored.

<sup>Written for commit d47e92ab6a78f561428a4608a090add331863632. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches disposal paths for same-origin iframes, shadow-root patching, and mutation observers; behavior change is limited to error handling but affects teardown ordering and when errors propagate.
> 
> **Overview**
> **Disposal and frame-document cleanup no longer stop on the first thrown callback.** `observeSameOriginFrameDocuments` now wraps observer disconnects, iframe aborts, shadow `attachShadow` restores, and per-document cleanups in a small `collectCleanupError` helper, removes entries from internal maps before running those callbacks, and rethrows via `throwCollectedErrors` once the full pass finishes (including on iframe navigation and mutation-driven subtree removal).
> 
> An e2e test forces one iframe’s hook restore to throw during `dispose` and asserts the next iframe’s hook is still restored while the expected error surfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d47e92ab6a78f561428a4608a090add331863632. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->