### PR TITLE
Separate performance capture from trace summaries

### DIFF
--- a/packages/react-grab/e2e/perf-recorder.ts
+++ b/packages/react-grab/e2e/perf-recorder.ts
@@ -911,6 +911,264 @@ export interface RecordScenarioOptions {
   captureDomMutationAttribution?: boolean;
 }
 
+interface CaptureMeasuredSamplesOptions {
+  page: Page;
+  scenarioName: string;
+  scenarioBody: () => Promise<void>;
+  recordOptions: RecordScenarioOptions;
+  environment: PerfEnvironment;
+  sampleCount: number;
+}
+
+interface MeasuredSamples {
+  aggregates: PerfScenarioAggregate[];
+  processCpu: PerfProcessCpuSample[];
+  hardwareGpu: PerfHardwareGpuSample[];
+  validity: PerfRunValiditySummary[];
+  memory?: PerfMemoryMetrics;
+}
+
+interface CaptureScenarioReplaysOptions {
+  page: Page;
+  testInfo: TestInfo;
+  scenarioName: string;
+  scenarioBody: () => Promise<void>;
+  recordOptions: RecordScenarioOptions;
+  environment: PerfEnvironment;
+  aggregates: PerfScenarioAggregate[];
+}
+
+interface ScenarioReplays {
+  animationCounterfactual?: PerfAnimationCounterfactualReport;
+  renderTrace?: PerfRenderTraceReport;
+  domMutationAttribution?: PerfDomMutationAttributionReport;
+}
+
+const captureMeasuredSamples = async (
+  captureOptions: CaptureMeasuredSamplesOptions,
+): Promise<MeasuredSamples> => {
+  let memoryProbe: CDPSession | null = null;
+  let memoryBefore: PerfMemorySnapshot | null = null;
+  try {
+    memoryProbe = await startMemoryProbe(captureOptions.page);
+    memoryBefore = await readMemorySnapshot(memoryProbe, captureOptions.page);
+  } catch (probeError) {
+    console.warn(`[perf] ${captureOptions.scenarioName}: memory probe unavailable:`, probeError);
+  }
+
+  const aggregates: PerfScenarioAggregate[] = [];
+  const processCpuSamples: PerfProcessCpuSample[] = [];
+  const hardwareGpuSamples: PerfHardwareGpuSample[] = [];
+  const memoryDeltas: PerfMemorySnapshot[] = [];
+  const validitySamples: PerfRunValiditySummary[] = [];
+  let previousMemorySnapshot = memoryBefore;
+  let lastMemorySnapshot: PerfMemorySnapshot | null = null;
+  let memory: PerfMemoryMetrics | undefined;
+
+  try {
+    for (let sampleIndex = 0; sampleIndex < captureOptions.sampleCount; sampleIndex++) {
+      if (captureOptions.recordOptions.beforeEachSample) {
+        await captureOptions.recordOptions.beforeEachSample();
+      }
+      let validityProbe: PerfRunValidityProbe | undefined;
+      let hardwareGpuProbe: PerfHardwareGpuProbe | undefined;
+      let processCpuProbe: PerfProcessCpuProbe | undefined;
+      let rawSnapshot: PerfRawSnapshot | null = null;
+      let processCpu: PerfProcessCpuSample | undefined;
+      let hardwareGpu: PerfHardwareGpuSample | undefined;
+      let validity: PerfRunValiditySummary | undefined;
+      try {
+        validityProbe = await startPerfRunValidityProbe(captureOptions.page);
+        hardwareGpuProbe = await startHardwareGpuProbe(
+          captureOptions.page,
+          captureOptions.environment.gpu,
+        );
+        processCpuProbe = await startProcessCpuProbe(
+          captureOptions.page,
+          captureOptions.environment.host.logicalCpuCount,
+        );
+        await startRecording(captureOptions.page);
+        try {
+          await captureOptions.scenarioBody();
+        } finally {
+          rawSnapshot = await stopRecording(captureOptions.page);
+        }
+      } finally {
+        try {
+          if (processCpuProbe) processCpu = await processCpuProbe.stop();
+        } finally {
+          try {
+            if (hardwareGpuProbe) hardwareGpu = await hardwareGpuProbe.stop();
+          } finally {
+            if (validityProbe) validity = await validityProbe.stop();
+          }
+        }
+      }
+      if (!processCpu || !hardwareGpu || !validity) {
+        throw new Error(`Perf sample ${sampleIndex + 1} did not stop every probe`);
+      }
+      processCpuSamples.push(processCpu);
+      hardwareGpuSamples.push(hardwareGpu);
+      validitySamples.push(validity);
+      assertValidHeadedPerfRun(
+        validity,
+        `${captureOptions.scenarioName} sample ${sampleIndex + 1}`,
+      );
+      if (!rawSnapshot) {
+        throw new Error(`Perf sample ${sampleIndex + 1} produced no browser metrics`);
+      }
+      aggregates.push(
+        aggregateRawSnapshot(rawSnapshot, captureOptions.environment.page.refreshIntervalMs),
+      );
+
+      // Snapshot after every sample so memory growth can be aggregated
+      // per-sample (median) instead of one whole-scenario window. The
+      // sample-0 delta is recorded but excluded when other samples exist:
+      // one-time warmup allocations (JIT code objects, lazily-initialized
+      // module state, framework caches) land there and vary run to run,
+      // while steady-state per-iteration growth is the actual leak signal.
+      if (memoryProbe && previousMemorySnapshot) {
+        try {
+          const sampleEndSnapshot = await readMemorySnapshot(memoryProbe, captureOptions.page);
+          memoryDeltas.push(diffMemorySnapshots(previousMemorySnapshot, sampleEndSnapshot));
+          previousMemorySnapshot = sampleEndSnapshot;
+          lastMemorySnapshot = sampleEndSnapshot;
+        } catch (probeError) {
+          console.warn(`[perf] ${captureOptions.scenarioName}: memory read failed:`, probeError);
+        }
+      }
+    }
+    if (memoryBefore && lastMemorySnapshot && memoryDeltas.length > 0) {
+      const steadyStateDeltas = memoryDeltas.length > 1 ? memoryDeltas.slice(1) : memoryDeltas;
+      memory = {
+        before: memoryBefore,
+        after: lastMemorySnapshot,
+        delta: medianMemoryDelta(steadyStateDeltas),
+      };
+    }
+  } finally {
+    if (memoryProbe) await detachQuietly(memoryProbe);
+  }
+
+  return {
+    aggregates,
+    processCpu: processCpuSamples,
+    hardwareGpu: hardwareGpuSamples,
+    validity: validitySamples,
+    memory,
+  };
+};
+
+const captureScenarioReplays = async (
+  captureOptions: CaptureScenarioReplaysOptions,
+): Promise<ScenarioReplays> => {
+  const animationCounterfactual = captureOptions.recordOptions.captureAnimationCounterfactual
+    ? await captureAnimationCounterfactual(
+        captureOptions.page,
+        captureOptions.scenarioName,
+        captureOptions.environment.host.logicalCpuCount,
+        captureOptions.scenarioBody,
+        captureOptions.recordOptions.beforeEachSample,
+      )
+    : undefined;
+
+  // The CPU profile is captured on a dedicated extra pass so the sampler's
+  // overhead (and its sporadic renderer stall — see the comment above
+  // PERF_CPU_PROFILE_SAMPLING_INTERVAL_US) never pollutes the metric samples or
+  // fails the test.
+  if (process.env.PERF_TRACE === "1") {
+    if (captureOptions.recordOptions.beforeEachSample) {
+      await captureOptions.recordOptions.beforeEachSample();
+    }
+    await captureScenarioCpuProfile(
+      captureOptions.page,
+      captureOptions.testInfo,
+      captureOptions.scenarioName,
+      captureOptions.scenarioBody,
+    );
+  }
+
+  let renderTrace: PerfRenderTraceReport | undefined;
+  if (
+    process.env.PERF_RENDER_TRACE === "1" ||
+    captureOptions.recordOptions.captureRenderTrace === true
+  ) {
+    if (captureOptions.recordOptions.beforeEachSample) {
+      await captureOptions.recordOptions.beforeEachSample();
+    }
+    renderTrace = await captureRenderTrace(
+      captureOptions.page,
+      captureOptions.testInfo,
+      captureOptions.scenarioName,
+      PACKAGE_PERF_DIR,
+      captureOptions.scenarioBody,
+    );
+    if (renderTrace.validity) {
+      assertValidHeadedPerfRun(
+        renderTrace.validity,
+        `${captureOptions.scenarioName} render replay`,
+      );
+    }
+    if (animationCounterfactual) animationCounterfactual.activeRenderTrace = renderTrace;
+  }
+
+  if (animationCounterfactual) {
+    if (captureOptions.recordOptions.beforeEachSample) {
+      await captureOptions.recordOptions.beforeEachSample();
+    }
+    await pauseRunningAnimations(captureOptions.page);
+    try {
+      animationCounterfactual.pausedRenderTrace = await captureRenderTrace(
+        captureOptions.page,
+        captureOptions.testInfo,
+        `${captureOptions.scenarioName}-animations-paused`,
+        PACKAGE_PERF_DIR,
+        captureOptions.scenarioBody,
+      );
+      if (animationCounterfactual.pausedRenderTrace.validity) {
+        assertValidHeadedPerfRun(
+          animationCounterfactual.pausedRenderTrace.validity,
+          `${captureOptions.scenarioName} paused render replay`,
+        );
+      }
+    } finally {
+      await resumePausedAnimations(captureOptions.page);
+    }
+  }
+
+  let domMutationAttribution: PerfDomMutationAttributionReport | undefined;
+  if (
+    process.env.PERF_DOM_BREAKPOINTS === "1" ||
+    captureOptions.recordOptions.captureDomMutationAttribution === true
+  ) {
+    if (captureOptions.recordOptions.beforeEachSample) {
+      await captureOptions.recordOptions.beforeEachSample();
+    }
+    const attributionAggregate =
+      captureOptions.aggregates.length === 1
+        ? captureOptions.aggregates[0]
+        : medianAcrossSamples(captureOptions.aggregates);
+    domMutationAttribution = await captureDomMutationAttribution(
+      captureOptions.page,
+      captureOptions.testInfo,
+      captureOptions.scenarioName,
+      PACKAGE_PERF_DIR,
+      attributionAggregate.cssActivity.topMutationTargets.map(
+        (mutationTarget) => mutationTarget.target,
+      ),
+      captureOptions.scenarioBody,
+    );
+    if (domMutationAttribution.validity) {
+      assertValidHeadedPerfRun(
+        domMutationAttribution.validity,
+        `${captureOptions.scenarioName} DOM breakpoint replay`,
+      );
+    }
+  }
+
+  return { animationCounterfactual, renderTrace, domMutationAttribution };
+};
+
 export const recordScenario = async (
   page: Page,
   testInfo: TestInfo,
@@ -941,188 +1199,37 @@ export const recordScenario = async (
     if (options.beforeEachSample) await options.beforeEachSample();
     await scenarioBody();
   }
-  let memoryProbe: CDPSession | null = null;
-  let memoryBefore: PerfMemorySnapshot | null = null;
-  try {
-    memoryProbe = await startMemoryProbe(page);
-    memoryBefore = await readMemorySnapshot(memoryProbe, page);
-  } catch (probeError) {
-    console.warn(`[perf] ${scenarioName}: memory probe unavailable:`, probeError);
-  }
-  const perSampleAggregates: PerfScenarioAggregate[] = [];
-  const perSampleProcessCpu: PerfProcessCpuSample[] = [];
-  const perSampleHardwareGpu: PerfHardwareGpuSample[] = [];
-  const perSampleMemoryDeltas: PerfMemorySnapshot[] = [];
-  const perSampleValidity: PerfRunValiditySummary[] = [];
-  let previousMemorySnapshot = memoryBefore;
-  let lastMemorySnapshot: PerfMemorySnapshot | null = null;
-  let memory: PerfMemoryMetrics | undefined;
-  // try/finally so the probe's CDP session detaches even if a sample throws.
-  try {
-    for (let sampleIndex = 0; sampleIndex < sampleCount; sampleIndex++) {
-      if (options.beforeEachSample) await options.beforeEachSample();
-      let validityProbe: PerfRunValidityProbe | undefined;
-      let hardwareGpuProbe: PerfHardwareGpuProbe | undefined;
-      let processCpuProbe: PerfProcessCpuProbe | undefined;
-      let rawSnapshot: PerfRawSnapshot | null = null;
-      let processCpu: PerfProcessCpuSample | undefined;
-      let hardwareGpu: PerfHardwareGpuSample | undefined;
-      let validity: PerfRunValiditySummary | undefined;
-      try {
-        validityProbe = await startPerfRunValidityProbe(page);
-        hardwareGpuProbe = await startHardwareGpuProbe(page, environment.gpu);
-        processCpuProbe = await startProcessCpuProbe(page, environment.host.logicalCpuCount);
-        await startRecording(page);
-        try {
-          await scenarioBody();
-        } finally {
-          rawSnapshot = await stopRecording(page);
-        }
-      } finally {
-        try {
-          if (processCpuProbe) processCpu = await processCpuProbe.stop();
-        } finally {
-          try {
-            if (hardwareGpuProbe) hardwareGpu = await hardwareGpuProbe.stop();
-          } finally {
-            if (validityProbe) validity = await validityProbe.stop();
-          }
-        }
-      }
-      if (!processCpu || !hardwareGpu || !validity) {
-        throw new Error(`Perf sample ${sampleIndex + 1} did not stop every probe`);
-      }
-      perSampleProcessCpu.push(processCpu);
-      perSampleHardwareGpu.push(hardwareGpu);
-      perSampleValidity.push(validity);
-      assertValidHeadedPerfRun(validity, `${scenarioName} sample ${sampleIndex + 1}`);
-      if (!rawSnapshot)
-        throw new Error(`Perf sample ${sampleIndex + 1} produced no browser metrics`);
-      perSampleAggregates.push(
-        aggregateRawSnapshot(rawSnapshot, environment.page.refreshIntervalMs),
-      );
-      // Snapshot after every sample so memory growth can be aggregated
-      // per-sample (median) instead of one whole-scenario window. The
-      // sample-0 delta is recorded but excluded when other samples exist:
-      // one-time warmup allocations (JIT code objects, lazily-initialized
-      // module state, framework caches) land there and vary run to run,
-      // while steady-state per-iteration growth is the actual leak signal.
-      if (memoryProbe && previousMemorySnapshot) {
-        try {
-          const sampleEndSnapshot = await readMemorySnapshot(memoryProbe, page);
-          perSampleMemoryDeltas.push(
-            diffMemorySnapshots(previousMemorySnapshot, sampleEndSnapshot),
-          );
-          previousMemorySnapshot = sampleEndSnapshot;
-          lastMemorySnapshot = sampleEndSnapshot;
-        } catch (probeError) {
-          console.warn(`[perf] ${scenarioName}: memory read failed:`, probeError);
-        }
-      }
-    }
-    if (memoryBefore && lastMemorySnapshot && perSampleMemoryDeltas.length > 0) {
-      const steadyStateDeltas =
-        perSampleMemoryDeltas.length > 1 ? perSampleMemoryDeltas.slice(1) : perSampleMemoryDeltas;
-      memory = {
-        before: memoryBefore,
-        after: lastMemorySnapshot,
-        delta: medianMemoryDelta(steadyStateDeltas),
-      };
-    }
-  } finally {
-    if (memoryProbe) await detachQuietly(memoryProbe);
-  }
-  const animationCounterfactual = options.captureAnimationCounterfactual
-    ? await captureAnimationCounterfactual(
-        page,
-        scenarioName,
-        environment.host.logicalCpuCount,
-        scenarioBody,
-        options.beforeEachSample,
-      )
-    : undefined;
-  // The CPU profile is captured on a dedicated extra pass so the sampler's
-  // overhead (and its sporadic renderer stall — see the comment above
-  // CPU_PROFILE_SAMPLING_INTERVAL_US) never pollutes the metric samples or
-  // fails the test.
-  if (process.env.PERF_TRACE === "1") {
-    if (options.beforeEachSample) await options.beforeEachSample();
-    await captureScenarioCpuProfile(page, testInfo, scenarioName, scenarioBody);
-  }
-  let renderTrace: PerfRenderTraceReport | undefined;
-  if (process.env.PERF_RENDER_TRACE === "1" || options.captureRenderTrace === true) {
-    if (options.beforeEachSample) await options.beforeEachSample();
-    renderTrace = await captureRenderTrace(
-      page,
-      testInfo,
-      scenarioName,
-      PACKAGE_PERF_DIR,
-      scenarioBody,
-    );
-    if (renderTrace.validity) {
-      assertValidHeadedPerfRun(renderTrace.validity, `${scenarioName} render replay`);
-    }
-    if (animationCounterfactual) animationCounterfactual.activeRenderTrace = renderTrace;
-  }
-  if (animationCounterfactual) {
-    if (options.beforeEachSample) await options.beforeEachSample();
-    await pauseRunningAnimations(page);
-    try {
-      animationCounterfactual.pausedRenderTrace = await captureRenderTrace(
-        page,
-        testInfo,
-        `${scenarioName}-animations-paused`,
-        PACKAGE_PERF_DIR,
-        scenarioBody,
-      );
-      if (animationCounterfactual.pausedRenderTrace.validity) {
-        assertValidHeadedPerfRun(
-          animationCounterfactual.pausedRenderTrace.validity,
-          `${scenarioName} paused render replay`,
-        );
-      }
-    } finally {
-      await resumePausedAnimations(page);
-    }
-  }
-  let domMutationAttribution: PerfDomMutationAttributionReport | undefined;
-  if (process.env.PERF_DOM_BREAKPOINTS === "1" || options.captureDomMutationAttribution === true) {
-    if (options.beforeEachSample) await options.beforeEachSample();
-    const attributionAggregate =
-      perSampleAggregates.length === 1
-        ? perSampleAggregates[0]
-        : medianAcrossSamples(perSampleAggregates);
-    domMutationAttribution = await captureDomMutationAttribution(
-      page,
-      testInfo,
-      scenarioName,
-      PACKAGE_PERF_DIR,
-      attributionAggregate.cssActivity.topMutationTargets.map(
-        (mutationTarget) => mutationTarget.target,
-      ),
-      scenarioBody,
-    );
-    if (domMutationAttribution.validity) {
-      assertValidHeadedPerfRun(
-        domMutationAttribution.validity,
-        `${scenarioName} DOM breakpoint replay`,
-      );
-    }
-  }
+  const measuredSamples = await captureMeasuredSamples({
+    page,
+    scenarioName,
+    scenarioBody,
+    recordOptions: options,
+    environment,
+    sampleCount,
+  });
+  const scenarioReplays = await captureScenarioReplays({
+    page,
+    testInfo,
+    scenarioName,
+    scenarioBody,
+    recordOptions: options,
+    environment,
+    aggregates: measuredSamples.aggregates,
+  });
   const workloadAfter = await capturePerfWorkload(page);
   const workloadMetadata = await options.collectWorkloadMetadata?.();
-  const processCpu = aggregateProcessCpuSamples(perSampleProcessCpu);
-  const hardwareGpu = aggregateHardwareGpuSamples(perSampleHardwareGpu);
+  const processCpu = aggregateProcessCpuSamples(measuredSamples.processCpu);
+  const hardwareGpu = aggregateHardwareGpuSamples(measuredSamples.hardwareGpu);
   const medianAggregate =
-    perSampleAggregates.length === 1
-      ? perSampleAggregates[0]
-      : medianAcrossSamples(perSampleAggregates);
+    measuredSamples.aggregates.length === 1
+      ? measuredSamples.aggregates[0]
+      : medianAcrossSamples(measuredSamples.aggregates);
   const extra = options.collectExtraMetrics?.();
   await attachPerfReport(
     testInfo,
     scenarioName,
     medianAggregate,
-    perSampleAggregates,
+    measuredSamples.aggregates,
     {
       environment,
       workload: {
@@ -1132,24 +1239,24 @@ export const recordScenario = async (
       },
       processCpu,
       hardwareGpu,
-      renderTrace,
-      validity: aggregatePerfRunValidity(perSampleValidity),
-      animationCounterfactual,
-      domMutationAttribution,
+      renderTrace: scenarioReplays.renderTrace,
+      validity: aggregatePerfRunValidity(measuredSamples.validity),
+      animationCounterfactual: scenarioReplays.animationCounterfactual,
+      domMutationAttribution: scenarioReplays.domMutationAttribution,
       warmupSamples: warmupSampleCount,
     },
     baseline,
     extra,
-    memory,
+    measuredSamples.memory,
   );
   logAggregate(
     scenarioName,
     medianAggregate,
-    memory,
+    measuredSamples.memory,
     processCpu,
     hardwareGpu,
-    renderTrace,
-    animationCounterfactual,
+    scenarioReplays.renderTrace,
+    scenarioReplays.animationCounterfactual,
   );
   if (extra) {
     console.log(

--- a/packages/react-grab/e2e/perf-render-trace-summary.ts
+++ b/packages/react-grab/e2e/perf-render-trace-summary.ts
@@ -1,0 +1,537 @@
+import {
+  PERF_MICROSECONDS_PER_SECOND,
+  PERF_PAINT_DISPLAY_ITEM_LIMIT,
+  PERF_PERCENT_SCALE,
+  PERF_SELECTOR_STATS_LIMIT,
+  PERF_TRACE_EVENT_LIMIT,
+  PERF_TRACE_MARKER_END,
+  PERF_TRACE_MARKER_START,
+} from "./perf-constants.js";
+import { roundTo3 } from "./perf-statistics.js";
+
+export interface PerfTraceEvent {
+  cat?: string;
+  name: string;
+  ph?: string;
+  pid?: number;
+  tid?: number;
+  ts?: number;
+  dur?: number;
+  args?: Record<string, unknown>;
+}
+
+export interface PerfTraceFile {
+  traceEvents: PerfTraceEvent[];
+}
+
+export interface PerfTraceStageSummary {
+  eventCount: number;
+  totalDurationMs: number;
+  maximumDurationMs: number;
+}
+
+export interface PerfTraceTopEvent {
+  name: string;
+  category: string;
+  eventCount: number;
+  totalDurationMs: number;
+  maximumDurationMs: number;
+}
+
+export interface PerfTraceFrameSummary {
+  beginFrames: number;
+  submittedFrames: number;
+  drawAndSwapFrames: number;
+  presentedFrames: number;
+  droppedFrames: number;
+  skippedFrames: number;
+  productionRateFps: number;
+  productionDutyCyclePercent: number;
+}
+
+export interface PerfAnimationSchedulingSummary {
+  animationTickCount: number;
+  animationTicksPerSecond: number;
+  animateLayersCount: number;
+  needsTickAnimationsCount: number;
+  drawFrameCount: number;
+  drawsPerAnimationTick: number;
+  drawEfficiencyPercent: number;
+}
+
+export interface PerfSelectorTimingSummary {
+  selector: string;
+  styleSheetId: string;
+  elapsedMs: number;
+  matchAttempts: number;
+  matchCount: number;
+  fastRejectCount: number;
+  invalidationCount: number;
+  slowPathNonMatchPercent: number;
+}
+
+export interface PerfSelectorStatsSummary {
+  eventCount: number;
+  selectorCount: number;
+  totalElapsedMs: number;
+  matchAttempts: number;
+  matchCount: number;
+  fastRejectCount: number;
+  slowPathNonMatchPercent: number;
+  topSelectors: PerfSelectorTimingSummary[];
+}
+
+export interface PerfPaintDisplayItemSummary {
+  name: string;
+  count: number;
+  paintedVisualAreaPx: number;
+}
+
+export interface PerfAdvancedPaintSummary {
+  pictureSnapshotCount: number;
+  displayItemListSnapshotCount: number;
+  displayItemCount: number;
+  paintedVisualAreaPx: number;
+  topDisplayItems: PerfPaintDisplayItemSummary[];
+}
+
+export interface PerfRenderPipelineSummary {
+  windowDurationMs: number;
+  usedScenarioMarkers: boolean;
+  traceEventCount: number;
+  style: PerfTraceStageSummary;
+  layout: PerfTraceStageSummary;
+  paint: PerfTraceStageSummary;
+  raster: PerfTraceStageSummary;
+  compositor: PerfTraceStageSummary;
+  viz: PerfTraceStageSummary;
+  gpuProcess: PerfTraceStageSummary;
+  selectorEventCount: number;
+  invalidationEventCount: number;
+  selectorStats: PerfSelectorStatsSummary;
+  advancedPaint: PerfAdvancedPaintSummary;
+  frames: PerfTraceFrameSummary;
+  animationScheduling: PerfAnimationSchedulingSummary;
+  topEvents: PerfTraceTopEvent[];
+}
+
+interface MutableTraceStageSummary {
+  eventCount: number;
+  totalDurationMicroseconds: number;
+  maximumDurationMicroseconds: number;
+}
+
+interface MutableTraceTopEvent {
+  name: string;
+  category: string;
+  eventCount: number;
+  totalDurationMicroseconds: number;
+  maximumDurationMicroseconds: number;
+}
+
+interface MutableSelectorTimingSummary {
+  selector: string;
+  styleSheetId: string;
+  elapsedMicroseconds: number;
+  matchAttempts: number;
+  matchCount: number;
+  fastRejectCount: number;
+  invalidationCount: number;
+}
+
+interface MutablePaintDisplayItemSummary {
+  name: string;
+  count: number;
+  paintedVisualAreaPx: number;
+}
+
+const emptyStage = (): MutableTraceStageSummary => ({
+  eventCount: 0,
+  totalDurationMicroseconds: 0,
+  maximumDurationMicroseconds: 0,
+});
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const readNumber = (record: Record<string, unknown>, key: string): number => {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+};
+
+const readSelectorElapsedMicroseconds = (selectorTiming: Record<string, unknown>): number =>
+  readNumber(selectorTiming, "elapsed (us)") || readNumber(selectorTiming, "elapsed");
+
+const readString = (record: Record<string, unknown>, key: string): string => {
+  const value = record[key];
+  return typeof value === "string" ? value : "";
+};
+
+const getSelectorTimings = (traceEvent: PerfTraceEvent): Record<string, unknown>[] => {
+  if (traceEvent.name !== "SelectorStats" || !isRecord(traceEvent.args)) return [];
+  const selectorStats = traceEvent.args.selector_stats;
+  if (!isRecord(selectorStats) || !Array.isArray(selectorStats.selector_timings)) return [];
+  return selectorStats.selector_timings.filter(isRecord);
+};
+
+const getDisplayItems = (traceEvent: PerfTraceEvent): Record<string, unknown>[] => {
+  if (traceEvent.name !== "cc::DisplayItemList" || !isRecord(traceEvent.args)) return [];
+  const snapshot = traceEvent.args.snapshot;
+  if (!isRecord(snapshot) || !isRecord(snapshot.params) || !Array.isArray(snapshot.params.items)) {
+    return [];
+  }
+  return snapshot.params.items.filter(isRecord);
+};
+
+const hasTraceSnapshot = (traceEvent: PerfTraceEvent): boolean =>
+  isRecord(traceEvent.args) && isRecord(traceEvent.args.snapshot);
+
+const getVisualArea = (displayItem: Record<string, unknown>): number => {
+  const visualRect = displayItem.visual_rect;
+  if (!Array.isArray(visualRect)) return 0;
+  const width = visualRect[2];
+  const height = visualRect[3];
+  if (typeof width !== "number" || typeof height !== "number") return 0;
+  return Math.max(0, width) * Math.max(0, height);
+};
+
+const finalizeStage = (stage: MutableTraceStageSummary): PerfTraceStageSummary => ({
+  eventCount: stage.eventCount,
+  totalDurationMs: roundTo3(stage.totalDurationMicroseconds / 1000),
+  maximumDurationMs: roundTo3(stage.maximumDurationMicroseconds / 1000),
+});
+
+const addDuration = (stage: MutableTraceStageSummary, durationMicroseconds: number): void => {
+  stage.eventCount += 1;
+  stage.totalDurationMicroseconds += durationMicroseconds;
+  stage.maximumDurationMicroseconds = Math.max(
+    stage.maximumDurationMicroseconds,
+    durationMicroseconds,
+  );
+};
+
+const classifyTraceStage = (traceEvent: PerfTraceEvent): string | null => {
+  const eventName = traceEvent.name;
+  const category = traceEvent.cat ?? "";
+  if (/UpdateLayoutTree|RecalculateStyle|StyleRecalc|ParseAuthorStyleSheet/i.test(eventName)) {
+    return "style";
+  }
+  if (/^Layout$|LayoutTree|LocalFrameView::layout/i.test(eventName)) return "layout";
+  if (/Paint|PrePaint|PaintArtifact/i.test(eventName)) return "paint";
+  if (/Raster|TileTask|ImageDecodeTask/i.test(eventName)) return "raster";
+  if (/\bviz\b/i.test(category) || /DrawAndSwap|SurfaceAggregator|Display::Draw/i.test(eventName)) {
+    return "viz";
+  }
+  if (/\bgpu\b/i.test(category) || /Gpu|CommandBuffer|SkiaOutputSurface/i.test(eventName)) {
+    return "gpuProcess";
+  }
+  if (/BeginMainFrame/i.test(eventName)) return null;
+  if (
+    /Composite|Compositor|BeginFrame|Commit|Activate|DrawFrame|SubmitCompositorFrame/i.test(
+      eventName,
+    ) ||
+    /\bcc\b/i.test(category)
+  ) {
+    return "compositor";
+  }
+  return null;
+};
+
+export const summarizeRenderTrace = (traceFile: PerfTraceFile): PerfRenderPipelineSummary => {
+  const allEvents = traceFile.traceEvents ?? [];
+  const startMarker = allEvents.find((traceEvent) => traceEvent.name === PERF_TRACE_MARKER_START);
+  const endMarker = [...allEvents]
+    .reverse()
+    .find((traceEvent) => traceEvent.name === PERF_TRACE_MARKER_END);
+  const startTimestamp = startMarker?.ts;
+  const endTimestamp = endMarker?.ts;
+  const usedScenarioMarkers =
+    startTimestamp !== undefined && endTimestamp !== undefined && endTimestamp >= startTimestamp;
+  const events = usedScenarioMarkers
+    ? allEvents.filter(
+        (traceEvent) =>
+          traceEvent.ts !== undefined &&
+          traceEvent.ts >= startTimestamp &&
+          traceEvent.ts <= endTimestamp,
+      )
+    : allEvents;
+
+  const stages: Record<string, MutableTraceStageSummary> = {
+    style: emptyStage(),
+    layout: emptyStage(),
+    paint: emptyStage(),
+    raster: emptyStage(),
+    compositor: emptyStage(),
+    viz: emptyStage(),
+    gpuProcess: emptyStage(),
+  };
+  const topEventsByKey = new Map<string, MutableTraceTopEvent>();
+  const selectorTimingsByKey = new Map<string, MutableSelectorTimingSummary>();
+  const paintDisplayItemsByName = new Map<string, MutablePaintDisplayItemSummary>();
+  let selectorEventCount = 0;
+  let invalidationEventCount = 0;
+  let selectorStatsEventCount = 0;
+  let pictureSnapshotCount = 0;
+  let displayItemListSnapshotCount = 0;
+  let displayItemCount = 0;
+  let paintedVisualAreaPx = 0;
+  const frames: PerfTraceFrameSummary = {
+    beginFrames: 0,
+    submittedFrames: 0,
+    drawAndSwapFrames: 0,
+    presentedFrames: 0,
+    droppedFrames: 0,
+    skippedFrames: 0,
+    productionRateFps: 0,
+    productionDutyCyclePercent: 0,
+  };
+  const animationScheduling: PerfAnimationSchedulingSummary = {
+    animationTickCount: 0,
+    animationTicksPerSecond: 0,
+    animateLayersCount: 0,
+    needsTickAnimationsCount: 0,
+    drawFrameCount: 0,
+    drawsPerAnimationTick: 0,
+    drawEfficiencyPercent: 0,
+  };
+
+  for (const traceEvent of events) {
+    const durationMicroseconds = traceEvent.ph === "X" ? (traceEvent.dur ?? 0) : 0;
+    const stageName = classifyTraceStage(traceEvent);
+    if (stageName) addDuration(stages[stageName], durationMicroseconds);
+    if (/Selector/i.test(traceEvent.name)) selectorEventCount += 1;
+    if (/Invalidat/i.test(traceEvent.name)) invalidationEventCount += 1;
+    const selectorTimings = getSelectorTimings(traceEvent);
+    if (selectorTimings.length > 0) selectorStatsEventCount += 1;
+    for (const selectorTiming of selectorTimings) {
+      const selector = readString(selectorTiming, "selector") || "(unknown selector)";
+      const styleSheetId = readString(selectorTiming, "style_sheet_id");
+      const selectorKey = `${selector}\u0000${styleSheetId}`;
+      const existingSelectorTiming = selectorTimingsByKey.get(selectorKey);
+      if (existingSelectorTiming) {
+        existingSelectorTiming.elapsedMicroseconds +=
+          readSelectorElapsedMicroseconds(selectorTiming);
+        existingSelectorTiming.matchAttempts += readNumber(selectorTiming, "match_attempts");
+        existingSelectorTiming.matchCount += readNumber(selectorTiming, "match_count");
+        existingSelectorTiming.fastRejectCount += readNumber(selectorTiming, "fast_reject_count");
+        existingSelectorTiming.invalidationCount += readNumber(
+          selectorTiming,
+          "invalidation_count",
+        );
+      } else {
+        selectorTimingsByKey.set(selectorKey, {
+          selector,
+          styleSheetId,
+          elapsedMicroseconds: readSelectorElapsedMicroseconds(selectorTiming),
+          matchAttempts: readNumber(selectorTiming, "match_attempts"),
+          matchCount: readNumber(selectorTiming, "match_count"),
+          fastRejectCount: readNumber(selectorTiming, "fast_reject_count"),
+          invalidationCount: readNumber(selectorTiming, "invalidation_count"),
+        });
+      }
+    }
+    if (traceEvent.name === "cc::Picture" && hasTraceSnapshot(traceEvent)) {
+      pictureSnapshotCount += 1;
+    }
+    const displayItems = getDisplayItems(traceEvent);
+    if (traceEvent.name === "cc::DisplayItemList" && hasTraceSnapshot(traceEvent)) {
+      displayItemListSnapshotCount += 1;
+    }
+    for (const displayItem of displayItems) {
+      const name = readString(displayItem, "name") || "(unknown display item)";
+      const visualAreaPx = getVisualArea(displayItem);
+      const existingDisplayItem = paintDisplayItemsByName.get(name);
+      if (existingDisplayItem) {
+        existingDisplayItem.count += 1;
+        existingDisplayItem.paintedVisualAreaPx += visualAreaPx;
+      } else {
+        paintDisplayItemsByName.set(name, {
+          name,
+          count: 1,
+          paintedVisualAreaPx: visualAreaPx,
+        });
+      }
+      displayItemCount += 1;
+      paintedVisualAreaPx += visualAreaPx;
+    }
+    if (traceEvent.name === "Scheduler::BeginFrame") frames.beginFrames += 1;
+    if (traceEvent.name === "SubmitCompositorFrame") frames.submittedFrames += 1;
+    if (traceEvent.name === "Display::DrawAndSwap") frames.drawAndSwapFrames += 1;
+    if (traceEvent.name === "FramePresented") frames.presentedFrames += 1;
+    if (
+      traceEvent.name === "DroppedFrame" ||
+      traceEvent.name === "Scheduler::MissedBeginFrameDropped"
+    ) {
+      frames.droppedFrames += 1;
+    }
+    if (traceEvent.name === "LayerTreeHostImpl::DidNotProduceFrame") frames.skippedFrames += 1;
+    if (traceEvent.name === "AnimationHost::TickAnimations") {
+      animationScheduling.animationTickCount += 1;
+    }
+    if (traceEvent.name === "LayerTreeHostImpl::AnimateLayers") {
+      animationScheduling.animateLayersCount += 1;
+    }
+    if (traceEvent.name === "NeedsTickAnimations") {
+      animationScheduling.needsTickAnimationsCount += 1;
+    }
+    if (traceEvent.name === "DrawFrame") animationScheduling.drawFrameCount += 1;
+    if (durationMicroseconds <= 0) continue;
+    const eventKey = `${traceEvent.name}\u0000${traceEvent.cat ?? ""}`;
+    const existingTopEvent = topEventsByKey.get(eventKey);
+    if (existingTopEvent) {
+      existingTopEvent.eventCount += 1;
+      existingTopEvent.totalDurationMicroseconds += durationMicroseconds;
+      existingTopEvent.maximumDurationMicroseconds = Math.max(
+        existingTopEvent.maximumDurationMicroseconds,
+        durationMicroseconds,
+      );
+    } else {
+      topEventsByKey.set(eventKey, {
+        name: traceEvent.name,
+        category: traceEvent.cat ?? "",
+        eventCount: 1,
+        totalDurationMicroseconds: durationMicroseconds,
+        maximumDurationMicroseconds: durationMicroseconds,
+      });
+    }
+  }
+
+  const traceStart = events.reduce(
+    (minimum, traceEvent) => Math.min(minimum, traceEvent.ts ?? minimum),
+    Number.POSITIVE_INFINITY,
+  );
+  const traceEnd = events.reduce(
+    (maximum, traceEvent) => Math.max(maximum, (traceEvent.ts ?? maximum) + (traceEvent.dur ?? 0)),
+    Number.NEGATIVE_INFINITY,
+  );
+  const windowDurationMicroseconds = usedScenarioMarkers
+    ? endTimestamp - startTimestamp
+    : Number.isFinite(traceStart) && Number.isFinite(traceEnd)
+      ? traceEnd - traceStart
+      : 0;
+  const productionOpportunityCount = frames.drawAndSwapFrames + frames.skippedFrames;
+  frames.productionRateFps = roundTo3(
+    (frames.drawAndSwapFrames * PERF_MICROSECONDS_PER_SECOND) /
+      Math.max(windowDurationMicroseconds, 1),
+  );
+  frames.productionDutyCyclePercent = roundTo3(
+    (frames.drawAndSwapFrames / Math.max(productionOpportunityCount, 1)) * PERF_PERCENT_SCALE,
+  );
+  animationScheduling.animationTicksPerSecond = roundTo3(
+    (animationScheduling.animationTickCount * PERF_MICROSECONDS_PER_SECOND) /
+      Math.max(windowDurationMicroseconds, 1),
+  );
+  animationScheduling.drawsPerAnimationTick = roundTo3(
+    animationScheduling.drawFrameCount / Math.max(animationScheduling.animationTickCount, 1),
+  );
+  animationScheduling.drawEfficiencyPercent = roundTo3(
+    animationScheduling.drawsPerAnimationTick * PERF_PERCENT_SCALE,
+  );
+  const selectorTimingSummaries = [...selectorTimingsByKey.values()];
+  const selectorMatchAttempts = selectorTimingSummaries.reduce(
+    (total, selectorTiming) => total + selectorTiming.matchAttempts,
+    0,
+  );
+  const selectorMatchCount = selectorTimingSummaries.reduce(
+    (total, selectorTiming) => total + selectorTiming.matchCount,
+    0,
+  );
+  const selectorFastRejectCount = selectorTimingSummaries.reduce(
+    (total, selectorTiming) => total + selectorTiming.fastRejectCount,
+    0,
+  );
+  const selectorNonMatchCount = Math.max(selectorMatchAttempts - selectorMatchCount, 0);
+  const selectorSlowPathNonMatchCount = Math.max(
+    selectorNonMatchCount - selectorFastRejectCount,
+    0,
+  );
+  const toSelectorTimingSummary = (
+    selectorTiming: MutableSelectorTimingSummary,
+  ): PerfSelectorTimingSummary => {
+    const nonMatchCount = Math.max(selectorTiming.matchAttempts - selectorTiming.matchCount, 0);
+    return {
+      selector: selectorTiming.selector,
+      styleSheetId: selectorTiming.styleSheetId,
+      elapsedMs: roundTo3(selectorTiming.elapsedMicroseconds / 1000),
+      matchAttempts: selectorTiming.matchAttempts,
+      matchCount: selectorTiming.matchCount,
+      fastRejectCount: selectorTiming.fastRejectCount,
+      invalidationCount: selectorTiming.invalidationCount,
+      slowPathNonMatchPercent: roundTo3(
+        (Math.max(nonMatchCount - selectorTiming.fastRejectCount, 0) / Math.max(nonMatchCount, 1)) *
+          PERF_PERCENT_SCALE,
+      ),
+    };
+  };
+
+  return {
+    windowDurationMs: roundTo3(windowDurationMicroseconds / 1000),
+    usedScenarioMarkers,
+    traceEventCount: events.length,
+    style: finalizeStage(stages.style),
+    layout: finalizeStage(stages.layout),
+    paint: finalizeStage(stages.paint),
+    raster: finalizeStage(stages.raster),
+    compositor: finalizeStage(stages.compositor),
+    viz: finalizeStage(stages.viz),
+    gpuProcess: finalizeStage(stages.gpuProcess),
+    selectorEventCount,
+    invalidationEventCount,
+    selectorStats: {
+      eventCount: selectorStatsEventCount,
+      selectorCount: selectorTimingSummaries.length,
+      totalElapsedMs: roundTo3(
+        selectorTimingSummaries.reduce(
+          (total, selectorTiming) => total + selectorTiming.elapsedMicroseconds,
+          0,
+        ) / 1000,
+      ),
+      matchAttempts: selectorMatchAttempts,
+      matchCount: selectorMatchCount,
+      fastRejectCount: selectorFastRejectCount,
+      slowPathNonMatchPercent: roundTo3(
+        (selectorSlowPathNonMatchCount / Math.max(selectorNonMatchCount, 1)) * PERF_PERCENT_SCALE,
+      ),
+      topSelectors: selectorTimingSummaries
+        .sort(
+          (leftSelector, rightSelector) =>
+            rightSelector.elapsedMicroseconds - leftSelector.elapsedMicroseconds,
+        )
+        .slice(0, PERF_SELECTOR_STATS_LIMIT)
+        .map(toSelectorTimingSummary),
+    },
+    advancedPaint: {
+      pictureSnapshotCount,
+      displayItemListSnapshotCount,
+      displayItemCount,
+      paintedVisualAreaPx: roundTo3(paintedVisualAreaPx),
+      topDisplayItems: [...paintDisplayItemsByName.values()]
+        .sort(
+          (leftItem, rightItem) =>
+            rightItem.paintedVisualAreaPx - leftItem.paintedVisualAreaPx ||
+            rightItem.count - leftItem.count,
+        )
+        .slice(0, PERF_PAINT_DISPLAY_ITEM_LIMIT)
+        .map((displayItem) => ({
+          name: displayItem.name,
+          count: displayItem.count,
+          paintedVisualAreaPx: roundTo3(displayItem.paintedVisualAreaPx),
+        })),
+    },
+    frames,
+    animationScheduling,
+    topEvents: [...topEventsByKey.values()]
+      .sort(
+        (leftEvent, rightEvent) =>
+          rightEvent.totalDurationMicroseconds - leftEvent.totalDurationMicroseconds,
+      )
+      .slice(0, PERF_TRACE_EVENT_LIMIT)
+      .map((traceEvent) => ({
+        name: traceEvent.name,
+        category: traceEvent.category,
+        eventCount: traceEvent.eventCount,
+        totalDurationMs: roundTo3(traceEvent.totalDurationMicroseconds / 1000),
+        maximumDurationMs: roundTo3(traceEvent.maximumDurationMicroseconds / 1000),
+      })),
+  };
+};

--- a/packages/react-grab/e2e/perf-render-trace.ts
+++ b/packages/react-grab/e2e/perf-render-trace.ts
@@ -11,11 +11,8 @@ import {
   PERF_ANIMATION_INVENTORY_LIMIT,
   PERF_ANIMATION_LIFECYCLE_SAMPLE_INTERVAL_MS,
   PERF_CSS_RULE_TEXT_LIMIT,
-  PERF_MICROSECONDS_PER_SECOND,
-  PERF_PAINT_DISPLAY_ITEM_LIMIT,
   PERF_PERCENT_SCALE,
   PERF_RENDER_TRACE_CATEGORIES,
-  PERF_SELECTOR_STATS_LIMIT,
   PERF_TRACE_DEADLINE_MS,
   PERF_TRACE_BUFFER_SIZE_KB,
   PERF_TRACE_EVENT_LIMIT,
@@ -23,60 +20,31 @@ import {
   PERF_TRACE_MARKER_START,
 } from "./perf-constants.js";
 import {
+  summarizeRenderTrace,
+  type PerfRenderPipelineSummary,
+  type PerfTraceFile,
+} from "./perf-render-trace-summary.js";
+import { roundTo3 } from "./perf-statistics.js";
+import {
   startPerfRunValidityProbe,
   type PerfRunValidityProbe,
   type PerfRunValiditySummary,
 } from "./perf-validity.js";
 
-export interface PerfTraceEvent {
-  cat?: string;
-  name: string;
-  ph?: string;
-  pid?: number;
-  tid?: number;
-  ts?: number;
-  dur?: number;
-  args?: Record<string, unknown>;
-}
-
-export interface PerfTraceFile {
-  traceEvents: PerfTraceEvent[];
-}
-
-export interface PerfTraceStageSummary {
-  eventCount: number;
-  totalDurationMs: number;
-  maximumDurationMs: number;
-}
-
-export interface PerfTraceTopEvent {
-  name: string;
-  category: string;
-  eventCount: number;
-  totalDurationMs: number;
-  maximumDurationMs: number;
-}
-
-export interface PerfTraceFrameSummary {
-  beginFrames: number;
-  submittedFrames: number;
-  drawAndSwapFrames: number;
-  presentedFrames: number;
-  droppedFrames: number;
-  skippedFrames: number;
-  productionRateFps: number;
-  productionDutyCyclePercent: number;
-}
-
-export interface PerfAnimationSchedulingSummary {
-  animationTickCount: number;
-  animationTicksPerSecond: number;
-  animateLayersCount: number;
-  needsTickAnimationsCount: number;
-  drawFrameCount: number;
-  drawsPerAnimationTick: number;
-  drawEfficiencyPercent: number;
-}
+export {
+  summarizeRenderTrace,
+  type PerfAdvancedPaintSummary,
+  type PerfAnimationSchedulingSummary,
+  type PerfPaintDisplayItemSummary,
+  type PerfRenderPipelineSummary,
+  type PerfSelectorStatsSummary,
+  type PerfSelectorTimingSummary,
+  type PerfTraceEvent,
+  type PerfTraceFile,
+  type PerfTraceFrameSummary,
+  type PerfTraceStageSummary,
+  type PerfTraceTopEvent,
+} from "./perf-render-trace-summary.js";
 
 export interface PerfAnimationLifecycleRecord {
   id: string;
@@ -104,62 +72,6 @@ export interface PerfAnimationLifecycleSummary {
   activeTimelineDutyCyclePercent: number;
   preventedTimelineIdle: boolean;
   records: PerfAnimationLifecycleRecord[];
-}
-
-export interface PerfSelectorTimingSummary {
-  selector: string;
-  styleSheetId: string;
-  elapsedMs: number;
-  matchAttempts: number;
-  matchCount: number;
-  fastRejectCount: number;
-  invalidationCount: number;
-  slowPathNonMatchPercent: number;
-}
-
-export interface PerfSelectorStatsSummary {
-  eventCount: number;
-  selectorCount: number;
-  totalElapsedMs: number;
-  matchAttempts: number;
-  matchCount: number;
-  fastRejectCount: number;
-  slowPathNonMatchPercent: number;
-  topSelectors: PerfSelectorTimingSummary[];
-}
-
-export interface PerfPaintDisplayItemSummary {
-  name: string;
-  count: number;
-  paintedVisualAreaPx: number;
-}
-
-export interface PerfAdvancedPaintSummary {
-  pictureSnapshotCount: number;
-  displayItemListSnapshotCount: number;
-  displayItemCount: number;
-  paintedVisualAreaPx: number;
-  topDisplayItems: PerfPaintDisplayItemSummary[];
-}
-
-export interface PerfRenderPipelineSummary {
-  windowDurationMs: number;
-  usedScenarioMarkers: boolean;
-  traceEventCount: number;
-  style: PerfTraceStageSummary;
-  layout: PerfTraceStageSummary;
-  paint: PerfTraceStageSummary;
-  raster: PerfTraceStageSummary;
-  compositor: PerfTraceStageSummary;
-  viz: PerfTraceStageSummary;
-  gpuProcess: PerfTraceStageSummary;
-  selectorEventCount: number;
-  invalidationEventCount: number;
-  selectorStats: PerfSelectorStatsSummary;
-  advancedPaint: PerfAdvancedPaintSummary;
-  frames: PerfTraceFrameSummary;
-  animationScheduling: PerfAnimationSchedulingSummary;
-  topEvents: PerfTraceTopEvent[];
 }
 
 export interface PerfCssRuleUsageEntry {
@@ -297,92 +209,10 @@ interface AnimationLifecycleTracker {
   stop(): PerfAnimationLifecycleSummary;
 }
 
-interface MutableTraceStageSummary {
-  eventCount: number;
-  totalDurationMicroseconds: number;
-  maximumDurationMicroseconds: number;
-}
-
-interface MutableTraceTopEvent {
-  name: string;
-  category: string;
-  eventCount: number;
-  totalDurationMicroseconds: number;
-  maximumDurationMicroseconds: number;
-}
-
-interface MutableSelectorTimingSummary {
-  selector: string;
-  styleSheetId: string;
-  elapsedMicroseconds: number;
-  matchAttempts: number;
-  matchCount: number;
-  fastRejectCount: number;
-  invalidationCount: number;
-}
-
-interface MutablePaintDisplayItemSummary {
-  name: string;
-  count: number;
-  paintedVisualAreaPx: number;
-}
-
 interface PerfViewportSize {
   width: number;
   height: number;
 }
-
-const emptyStage = (): MutableTraceStageSummary => ({
-  eventCount: 0,
-  totalDurationMicroseconds: 0,
-  maximumDurationMicroseconds: 0,
-});
-
-const roundTo3 = (value: number): number => Number(value.toFixed(3));
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
-const readNumber = (record: Record<string, unknown>, key: string): number => {
-  const value = record[key];
-  return typeof value === "number" && Number.isFinite(value) ? value : 0;
-};
-
-const readSelectorElapsedMicroseconds = (selectorTiming: Record<string, unknown>): number =>
-  readNumber(selectorTiming, "elapsed (us)") || readNumber(selectorTiming, "elapsed");
-
-const readString = (record: Record<string, unknown>, key: string): string => {
-  const value = record[key];
-  return typeof value === "string" ? value : "";
-};
-
-const getSelectorTimings = (traceEvent: PerfTraceEvent): Record<string, unknown>[] => {
-  if (traceEvent.name !== "SelectorStats" || !isRecord(traceEvent.args)) return [];
-  const selectorStats = traceEvent.args.selector_stats;
-  if (!isRecord(selectorStats) || !Array.isArray(selectorStats.selector_timings)) return [];
-  return selectorStats.selector_timings.filter(isRecord);
-};
-
-const getDisplayItems = (traceEvent: PerfTraceEvent): Record<string, unknown>[] => {
-  if (traceEvent.name !== "cc::DisplayItemList" || !isRecord(traceEvent.args)) return [];
-  const snapshot = traceEvent.args.snapshot;
-  if (!isRecord(snapshot) || !isRecord(snapshot.params) || !Array.isArray(snapshot.params.items)) {
-    return [];
-  }
-  return snapshot.params.items.filter(isRecord);
-};
-
-const hasTraceSnapshot = (traceEvent: PerfTraceEvent): boolean =>
-  isRecord(traceEvent.args) && isRecord(traceEvent.args.snapshot);
-
-const getVisualArea = (displayItem: Record<string, unknown>): number => {
-  const visualRect = displayItem.visual_rect;
-  if (!Array.isArray(visualRect)) return 0;
-  const width = visualRect[2];
-  const height = visualRect[3];
-  if (typeof width !== "number" || typeof height !== "number") return 0;
-  return Math.max(0, width) * Math.max(0, height);
-};
 
 const getExpectedAnimationEndTime = (animation: PerfProtocolAnimation): number | undefined => {
   const iterations = animation.source?.iterations;
@@ -588,347 +418,6 @@ const createAnimationLifecycleTracker = (): AnimationLifecycleTracker => {
           })),
       };
     },
-  };
-};
-
-const finalizeStage = (stage: MutableTraceStageSummary): PerfTraceStageSummary => ({
-  eventCount: stage.eventCount,
-  totalDurationMs: roundTo3(stage.totalDurationMicroseconds / 1000),
-  maximumDurationMs: roundTo3(stage.maximumDurationMicroseconds / 1000),
-});
-
-const addDuration = (stage: MutableTraceStageSummary, durationMicroseconds: number): void => {
-  stage.eventCount += 1;
-  stage.totalDurationMicroseconds += durationMicroseconds;
-  stage.maximumDurationMicroseconds = Math.max(
-    stage.maximumDurationMicroseconds,
-    durationMicroseconds,
-  );
-};
-
-const classifyTraceStage = (traceEvent: PerfTraceEvent): string | null => {
-  const eventName = traceEvent.name;
-  const category = traceEvent.cat ?? "";
-  if (/UpdateLayoutTree|RecalculateStyle|StyleRecalc|ParseAuthorStyleSheet/i.test(eventName)) {
-    return "style";
-  }
-  if (/^Layout$|LayoutTree|LocalFrameView::layout/i.test(eventName)) return "layout";
-  if (/Paint|PrePaint|PaintArtifact/i.test(eventName)) return "paint";
-  if (/Raster|TileTask|ImageDecodeTask/i.test(eventName)) return "raster";
-  if (/\bviz\b/i.test(category) || /DrawAndSwap|SurfaceAggregator|Display::Draw/i.test(eventName)) {
-    return "viz";
-  }
-  if (/\bgpu\b/i.test(category) || /Gpu|CommandBuffer|SkiaOutputSurface/i.test(eventName)) {
-    return "gpuProcess";
-  }
-  if (/BeginMainFrame/i.test(eventName)) return null;
-  if (
-    /Composite|Compositor|BeginFrame|Commit|Activate|DrawFrame|SubmitCompositorFrame/i.test(
-      eventName,
-    ) ||
-    /\bcc\b/i.test(category)
-  ) {
-    return "compositor";
-  }
-  return null;
-};
-
-export const summarizeRenderTrace = (traceFile: PerfTraceFile): PerfRenderPipelineSummary => {
-  const allEvents = traceFile.traceEvents ?? [];
-  const startMarker = allEvents.find((traceEvent) => traceEvent.name === PERF_TRACE_MARKER_START);
-  const endMarker = [...allEvents]
-    .reverse()
-    .find((traceEvent) => traceEvent.name === PERF_TRACE_MARKER_END);
-  const startTimestamp = startMarker?.ts;
-  const endTimestamp = endMarker?.ts;
-  const usedScenarioMarkers =
-    startTimestamp !== undefined && endTimestamp !== undefined && endTimestamp >= startTimestamp;
-  const events = usedScenarioMarkers
-    ? allEvents.filter(
-        (traceEvent) =>
-          traceEvent.ts !== undefined &&
-          traceEvent.ts >= startTimestamp &&
-          traceEvent.ts <= endTimestamp,
-      )
-    : allEvents;
-
-  const stages: Record<string, MutableTraceStageSummary> = {
-    style: emptyStage(),
-    layout: emptyStage(),
-    paint: emptyStage(),
-    raster: emptyStage(),
-    compositor: emptyStage(),
-    viz: emptyStage(),
-    gpuProcess: emptyStage(),
-  };
-  const topEventsByKey = new Map<string, MutableTraceTopEvent>();
-  const selectorTimingsByKey = new Map<string, MutableSelectorTimingSummary>();
-  const paintDisplayItemsByName = new Map<string, MutablePaintDisplayItemSummary>();
-  let selectorEventCount = 0;
-  let invalidationEventCount = 0;
-  let selectorStatsEventCount = 0;
-  let pictureSnapshotCount = 0;
-  let displayItemListSnapshotCount = 0;
-  let displayItemCount = 0;
-  let paintedVisualAreaPx = 0;
-  const frames: PerfTraceFrameSummary = {
-    beginFrames: 0,
-    submittedFrames: 0,
-    drawAndSwapFrames: 0,
-    presentedFrames: 0,
-    droppedFrames: 0,
-    skippedFrames: 0,
-    productionRateFps: 0,
-    productionDutyCyclePercent: 0,
-  };
-  const animationScheduling: PerfAnimationSchedulingSummary = {
-    animationTickCount: 0,
-    animationTicksPerSecond: 0,
-    animateLayersCount: 0,
-    needsTickAnimationsCount: 0,
-    drawFrameCount: 0,
-    drawsPerAnimationTick: 0,
-    drawEfficiencyPercent: 0,
-  };
-
-  for (const traceEvent of events) {
-    const durationMicroseconds = traceEvent.ph === "X" ? (traceEvent.dur ?? 0) : 0;
-    const stageName = classifyTraceStage(traceEvent);
-    if (stageName) addDuration(stages[stageName], durationMicroseconds);
-    if (/Selector/i.test(traceEvent.name)) selectorEventCount += 1;
-    if (/Invalidat/i.test(traceEvent.name)) invalidationEventCount += 1;
-    const selectorTimings = getSelectorTimings(traceEvent);
-    if (selectorTimings.length > 0) selectorStatsEventCount += 1;
-    for (const selectorTiming of selectorTimings) {
-      const selector = readString(selectorTiming, "selector") || "(unknown selector)";
-      const styleSheetId = readString(selectorTiming, "style_sheet_id");
-      const selectorKey = `${selector}\u0000${styleSheetId}`;
-      const existingSelectorTiming = selectorTimingsByKey.get(selectorKey);
-      if (existingSelectorTiming) {
-        existingSelectorTiming.elapsedMicroseconds +=
-          readSelectorElapsedMicroseconds(selectorTiming);
-        existingSelectorTiming.matchAttempts += readNumber(selectorTiming, "match_attempts");
-        existingSelectorTiming.matchCount += readNumber(selectorTiming, "match_count");
-        existingSelectorTiming.fastRejectCount += readNumber(selectorTiming, "fast_reject_count");
-        existingSelectorTiming.invalidationCount += readNumber(
-          selectorTiming,
-          "invalidation_count",
-        );
-      } else {
-        selectorTimingsByKey.set(selectorKey, {
-          selector,
-          styleSheetId,
-          elapsedMicroseconds: readSelectorElapsedMicroseconds(selectorTiming),
-          matchAttempts: readNumber(selectorTiming, "match_attempts"),
-          matchCount: readNumber(selectorTiming, "match_count"),
-          fastRejectCount: readNumber(selectorTiming, "fast_reject_count"),
-          invalidationCount: readNumber(selectorTiming, "invalidation_count"),
-        });
-      }
-    }
-    if (traceEvent.name === "cc::Picture" && hasTraceSnapshot(traceEvent)) {
-      pictureSnapshotCount += 1;
-    }
-    const displayItems = getDisplayItems(traceEvent);
-    if (traceEvent.name === "cc::DisplayItemList" && hasTraceSnapshot(traceEvent)) {
-      displayItemListSnapshotCount += 1;
-    }
-    for (const displayItem of displayItems) {
-      const name = readString(displayItem, "name") || "(unknown display item)";
-      const visualAreaPx = getVisualArea(displayItem);
-      const existingDisplayItem = paintDisplayItemsByName.get(name);
-      if (existingDisplayItem) {
-        existingDisplayItem.count += 1;
-        existingDisplayItem.paintedVisualAreaPx += visualAreaPx;
-      } else {
-        paintDisplayItemsByName.set(name, {
-          name,
-          count: 1,
-          paintedVisualAreaPx: visualAreaPx,
-        });
-      }
-      displayItemCount += 1;
-      paintedVisualAreaPx += visualAreaPx;
-    }
-    if (traceEvent.name === "Scheduler::BeginFrame") frames.beginFrames += 1;
-    if (traceEvent.name === "SubmitCompositorFrame") frames.submittedFrames += 1;
-    if (traceEvent.name === "Display::DrawAndSwap") frames.drawAndSwapFrames += 1;
-    if (traceEvent.name === "FramePresented") frames.presentedFrames += 1;
-    if (
-      traceEvent.name === "DroppedFrame" ||
-      traceEvent.name === "Scheduler::MissedBeginFrameDropped"
-    ) {
-      frames.droppedFrames += 1;
-    }
-    if (traceEvent.name === "LayerTreeHostImpl::DidNotProduceFrame") frames.skippedFrames += 1;
-    if (traceEvent.name === "AnimationHost::TickAnimations") {
-      animationScheduling.animationTickCount += 1;
-    }
-    if (traceEvent.name === "LayerTreeHostImpl::AnimateLayers") {
-      animationScheduling.animateLayersCount += 1;
-    }
-    if (traceEvent.name === "NeedsTickAnimations") {
-      animationScheduling.needsTickAnimationsCount += 1;
-    }
-    if (traceEvent.name === "DrawFrame") animationScheduling.drawFrameCount += 1;
-    if (durationMicroseconds <= 0) continue;
-    const eventKey = `${traceEvent.name}\u0000${traceEvent.cat ?? ""}`;
-    const existingTopEvent = topEventsByKey.get(eventKey);
-    if (existingTopEvent) {
-      existingTopEvent.eventCount += 1;
-      existingTopEvent.totalDurationMicroseconds += durationMicroseconds;
-      existingTopEvent.maximumDurationMicroseconds = Math.max(
-        existingTopEvent.maximumDurationMicroseconds,
-        durationMicroseconds,
-      );
-    } else {
-      topEventsByKey.set(eventKey, {
-        name: traceEvent.name,
-        category: traceEvent.cat ?? "",
-        eventCount: 1,
-        totalDurationMicroseconds: durationMicroseconds,
-        maximumDurationMicroseconds: durationMicroseconds,
-      });
-    }
-  }
-
-  const traceStart = events.reduce(
-    (minimum, traceEvent) => Math.min(minimum, traceEvent.ts ?? minimum),
-    Number.POSITIVE_INFINITY,
-  );
-  const traceEnd = events.reduce(
-    (maximum, traceEvent) => Math.max(maximum, (traceEvent.ts ?? maximum) + (traceEvent.dur ?? 0)),
-    Number.NEGATIVE_INFINITY,
-  );
-  const windowDurationMicroseconds = usedScenarioMarkers
-    ? endTimestamp - startTimestamp
-    : Number.isFinite(traceStart) && Number.isFinite(traceEnd)
-      ? traceEnd - traceStart
-      : 0;
-  const productionOpportunityCount = frames.drawAndSwapFrames + frames.skippedFrames;
-  frames.productionRateFps = roundTo3(
-    (frames.drawAndSwapFrames * PERF_MICROSECONDS_PER_SECOND) /
-      Math.max(windowDurationMicroseconds, 1),
-  );
-  frames.productionDutyCyclePercent = roundTo3(
-    (frames.drawAndSwapFrames / Math.max(productionOpportunityCount, 1)) * PERF_PERCENT_SCALE,
-  );
-  animationScheduling.animationTicksPerSecond = roundTo3(
-    (animationScheduling.animationTickCount * PERF_MICROSECONDS_PER_SECOND) /
-      Math.max(windowDurationMicroseconds, 1),
-  );
-  animationScheduling.drawsPerAnimationTick = roundTo3(
-    animationScheduling.drawFrameCount / Math.max(animationScheduling.animationTickCount, 1),
-  );
-  animationScheduling.drawEfficiencyPercent = roundTo3(
-    animationScheduling.drawsPerAnimationTick * PERF_PERCENT_SCALE,
-  );
-  const selectorTimingSummaries = [...selectorTimingsByKey.values()];
-  const selectorMatchAttempts = selectorTimingSummaries.reduce(
-    (total, selectorTiming) => total + selectorTiming.matchAttempts,
-    0,
-  );
-  const selectorMatchCount = selectorTimingSummaries.reduce(
-    (total, selectorTiming) => total + selectorTiming.matchCount,
-    0,
-  );
-  const selectorFastRejectCount = selectorTimingSummaries.reduce(
-    (total, selectorTiming) => total + selectorTiming.fastRejectCount,
-    0,
-  );
-  const selectorNonMatchCount = Math.max(selectorMatchAttempts - selectorMatchCount, 0);
-  const selectorSlowPathNonMatchCount = Math.max(
-    selectorNonMatchCount - selectorFastRejectCount,
-    0,
-  );
-  const toSelectorTimingSummary = (
-    selectorTiming: MutableSelectorTimingSummary,
-  ): PerfSelectorTimingSummary => {
-    const nonMatchCount = Math.max(selectorTiming.matchAttempts - selectorTiming.matchCount, 0);
-    return {
-      selector: selectorTiming.selector,
-      styleSheetId: selectorTiming.styleSheetId,
-      elapsedMs: roundTo3(selectorTiming.elapsedMicroseconds / 1000),
-      matchAttempts: selectorTiming.matchAttempts,
-      matchCount: selectorTiming.matchCount,
-      fastRejectCount: selectorTiming.fastRejectCount,
-      invalidationCount: selectorTiming.invalidationCount,
-      slowPathNonMatchPercent: roundTo3(
-        (Math.max(nonMatchCount - selectorTiming.fastRejectCount, 0) / Math.max(nonMatchCount, 1)) *
-          PERF_PERCENT_SCALE,
-      ),
-    };
-  };
-
-  return {
-    windowDurationMs: roundTo3(windowDurationMicroseconds / 1000),
-    usedScenarioMarkers,
-    traceEventCount: events.length,
-    style: finalizeStage(stages.style),
-    layout: finalizeStage(stages.layout),
-    paint: finalizeStage(stages.paint),
-    raster: finalizeStage(stages.raster),
-    compositor: finalizeStage(stages.compositor),
-    viz: finalizeStage(stages.viz),
-    gpuProcess: finalizeStage(stages.gpuProcess),
-    selectorEventCount,
-    invalidationEventCount,
-    selectorStats: {
-      eventCount: selectorStatsEventCount,
-      selectorCount: selectorTimingSummaries.length,
-      totalElapsedMs: roundTo3(
-        selectorTimingSummaries.reduce(
-          (total, selectorTiming) => total + selectorTiming.elapsedMicroseconds,
-          0,
-        ) / 1000,
-      ),
-      matchAttempts: selectorMatchAttempts,
-      matchCount: selectorMatchCount,
-      fastRejectCount: selectorFastRejectCount,
-      slowPathNonMatchPercent: roundTo3(
-        (selectorSlowPathNonMatchCount / Math.max(selectorNonMatchCount, 1)) * PERF_PERCENT_SCALE,
-      ),
-      topSelectors: selectorTimingSummaries
-        .sort(
-          (leftSelector, rightSelector) =>
-            rightSelector.elapsedMicroseconds - leftSelector.elapsedMicroseconds,
-        )
-        .slice(0, PERF_SELECTOR_STATS_LIMIT)
-        .map(toSelectorTimingSummary),
-    },
-    advancedPaint: {
-      pictureSnapshotCount,
-      displayItemListSnapshotCount,
-      displayItemCount,
-      paintedVisualAreaPx: roundTo3(paintedVisualAreaPx),
-      topDisplayItems: [...paintDisplayItemsByName.values()]
-        .sort(
-          (leftItem, rightItem) =>
-            rightItem.paintedVisualAreaPx - leftItem.paintedVisualAreaPx ||
-            rightItem.count - leftItem.count,
-        )
-        .slice(0, PERF_PAINT_DISPLAY_ITEM_LIMIT)
-        .map((displayItem) => ({
-          name: displayItem.name,
-          count: displayItem.count,
-          paintedVisualAreaPx: roundTo3(displayItem.paintedVisualAreaPx),
-        })),
-    },
-    frames,
-    animationScheduling,
-    topEvents: [...topEventsByKey.values()]
-      .sort(
-        (leftEvent, rightEvent) =>
-          rightEvent.totalDurationMicroseconds - leftEvent.totalDurationMicroseconds,
-      )
-      .slice(0, PERF_TRACE_EVENT_LIMIT)
-      .map((traceEvent) => ({
-        name: traceEvent.name,
-        category: traceEvent.category,
-        eventCount: traceEvent.eventCount,
-        totalDurationMs: roundTo3(traceEvent.totalDurationMicroseconds / 1000),
-        maximumDurationMs: roundTo3(traceEvent.maximumDurationMicroseconds / 1000),
-      })),
   };
 };
 


### PR DESCRIPTION
## Motivation

Two performance entry points mixed unrelated responsibilities:

- `recordScenario` managed measurement probes, optional diagnostic replays, aggregation, and reporting in one long function.
- `perf-render-trace.ts` mixed pure trace summarization with CDP capture and artifact I/O.

That made small changes require editing large, nested flows.

## Example

Adding a probe previously meant modifying the same nested block that owns memory cleanup, CPU/GPU teardown, render tracing, and report assembly.

## What changed

- Extract measured-sample capture from the top-level scenario coordinator.
- Extract optional CPU/render/DOM diagnostic replays into a focused helper.
- Move pure trace parsing and summarization into `perf-render-trace-summary.ts`.
- Preserve the existing public exports and runtime behavior.

## Impact

The top-level scenario function now reads as a sequence of phases, and trace capture no longer owns the pure summarizer. This PR intentionally introduces no new framework or public API.

## Checks

- `nr build`
- `nr test` — 1,065 passed, 24 skipped; one unrelated flaky test passed on retry
- `nr lint`
- `nr typecheck`
- `nr format`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2e perf harness refactor only; logic is largely moved, not rewritten, with no product API changes.
> 
> **Overview**
> Refactors **e2e perf instrumentation** so coordinators stay thin and pure trace parsing lives in one place, without changing scenario behavior or public exports.
> 
> **`recordScenario`** in `perf-recorder.ts` is split into **`captureMeasuredSamples`** (probes, memory, per-sample aggregation) and **`captureScenarioReplays`** (optional CPU profile, render trace, animation counterfactual, DOM breakpoint attribution). The top-level function now runs warmup → measured samples → replays → report assembly in sequence.
> 
> **Render trace summarization** moves out of `perf-render-trace.ts` into new **`perf-render-trace-summary.ts`** (`summarizeRenderTrace` and pipeline/trace types). Capture/CDP/I/O stays in `perf-render-trace.ts`, which imports the summarizer and **re-exports** the same symbols for existing callers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4632035bae4e07c0b505bf5d91f4509f80b5c89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->