### PR TITLE
Generate regular performance shards from one matrix

### DIFF
--- a/.github/workflows/test-perf.yml
+++ b/.github/workflows/test-perf.yml
@@ -11,100 +11,46 @@ permissions:
 
 jobs:
   perf-shard:
-    name: perf-shard (${{ matrix.artifact-suffix }})
+    name: perf-shard (${{ matrix.artifact_suffix || format('regular-{0}-of-15', matrix.shard) }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
         include:
           # Pair each shard's base and HEAD samples on one runner while spreading
           # independent scenarios across runners to preserve process isolation.
-          - test_shard: "1/15"
-            test_grep: "@perf"
-            test_grep_invert: "animation-scheduling-controls|activate-deactivate-dense-animations"
-            artifact-suffix: regular-1-of-15
-          - test_shard: "2/15"
-            test_grep: "@perf"
-            test_grep_invert: "animation-scheduling-controls|activate-deactivate-dense-animations"
-            artifact-suffix: regular-2-of-15
-          - test_shard: "3/15"
-            test_grep: "@perf"
-            test_grep_invert: "animation-scheduling-controls|activate-deactivate-dense-animations"
-            artifact-suffix: regular-3-of-15
-          - test_shard: "4/15"
-            test_grep: "@perf"
-            test_grep_invert: "animation-scheduling-controls|activate-deactivate-dense-animations"
-            artifact-suffix: regular-4-of-15
-          - test_shard: "5/15"
-            test_grep: "@perf"
-            test_grep_invert: "animation-scheduling-controls|activate-deactivate-dense-animations"
-            artifact-suffix: regular-5-of-15
-          - test_shard: "6/15"
-            test_grep: "@perf"
-            test_grep_invert: "animation-scheduling-controls|activate-deactivate-dense-animations"
-            artifact-suffix: regular-6-of-15
-          - test_shard: "7/15"
-            test_grep: "@perf"
-            test_grep_invert: "animation-scheduling-controls|activate-deactivate-dense-animations"
-            artifact-suffix: regular-7-of-15
-          - test_shard: "8/15"
-            test_grep: "@perf"
-            test_grep_invert: "animation-scheduling-controls|activate-deactivate-dense-animations"
-            artifact-suffix: regular-8-of-15
-          - test_shard: "9/15"
-            test_grep: "@perf"
-            test_grep_invert: "animation-scheduling-controls|activate-deactivate-dense-animations"
-            artifact-suffix: regular-9-of-15
-          - test_shard: "10/15"
-            test_grep: "@perf"
-            test_grep_invert: "animation-scheduling-controls|activate-deactivate-dense-animations"
-            artifact-suffix: regular-10-of-15
-          - test_shard: "11/15"
-            test_grep: "@perf"
-            test_grep_invert: "animation-scheduling-controls|activate-deactivate-dense-animations"
-            artifact-suffix: regular-11-of-15
-          - test_shard: "12/15"
-            test_grep: "@perf"
-            test_grep_invert: "animation-scheduling-controls|activate-deactivate-dense-animations"
-            artifact-suffix: regular-12-of-15
-          - test_shard: "13/15"
-            test_grep: "@perf"
-            test_grep_invert: "animation-scheduling-controls|activate-deactivate-dense-animations"
-            artifact-suffix: regular-13-of-15
-          - test_shard: "14/15"
-            test_grep: "@perf"
-            test_grep_invert: "animation-scheduling-controls|activate-deactivate-dense-animations"
-            artifact-suffix: regular-14-of-15
-          - test_shard: "15/15"
-            test_grep: "@perf"
-            test_grep_invert: "animation-scheduling-controls|activate-deactivate-dense-animations"
-            artifact-suffix: regular-15-of-15
-          - test_shard: "1/1"
+          - shard: dense-animation-control
+            test_shard: "1/1"
             test_grep: "activate-deactivate-dense-animations @perf"
             test_grep_invert: "(?!)"
-            artifact-suffix: dense-animation-control
-          - test_shard: "1/1"
+            artifact_suffix: dense-animation-control
+          - shard: animation-controls-legacy-production-count
+            test_shard: "1/1"
             test_grep: "animation-scheduling-controls @perf"
             test_grep_invert: "(?!)"
             animation_control_mode: legacy-production-count
             animation_include_paused_trace: "1"
-            artifact-suffix: animation-controls-legacy-production-count
-          - test_shard: "1/1"
+            artifact_suffix: animation-controls-legacy-production-count
+          - shard: animation-controls-legacy-one-indicator
+            test_shard: "1/1"
             test_grep: "animation-scheduling-controls @perf"
             test_grep_invert: "(?!)"
             animation_control_mode: legacy-one-indicator
-            artifact-suffix: animation-controls-legacy-one-indicator
-          - test_shard: "1/1"
+            artifact_suffix: animation-controls-legacy-one-indicator
+          - shard: animation-controls-infinite-stepped
+            test_shard: "1/1"
             test_grep: "animation-scheduling-controls @perf"
             test_grep_invert: "(?!)"
             animation_control_mode: infinite-stepped
-            artifact-suffix: animation-controls-infinite-stepped
-          - test_shard: "1/1"
+            artifact_suffix: animation-controls-infinite-stepped
+          - shard: animation-controls-finite-static-holds
+            test_shard: "1/1"
             test_grep: "animation-scheduling-controls @perf"
             test_grep_invert: "(?!)"
             animation_control_mode: finite-static-holds
-            artifact-suffix: animation-controls-finite-static-holds
+            artifact_suffix: animation-controls-finite-static-holds
 
     steps:
       - name: Checkout
@@ -150,9 +96,9 @@ jobs:
         env:
           PERF_LABEL: baseline
           PERF_SHARDABLE: "1"
-          PERF_TEST_GREP: ${{ matrix.test_grep }}
-          PERF_TEST_GREP_INVERT: ${{ matrix.test_grep_invert }}
-          PERF_TEST_SHARD: ${{ matrix.test_shard }}
+          PERF_TEST_GREP: ${{ matrix.test_grep || '@perf' }}
+          PERF_TEST_GREP_INVERT: ${{ matrix.test_grep_invert || 'animation-scheduling-controls|activate-deactivate-dense-animations' }}
+          PERF_TEST_SHARD: ${{ matrix.test_shard || format('{0}/15', matrix.shard) }}
           PERF_ANIMATION_CONTROL_MODE: ${{ matrix.animation_control_mode }}
           PERF_ANIMATION_INCLUDE_PAUSED_TRACE: ${{ matrix.animation_include_paused_trace }}
         # One worker prevents concurrent scenarios from contaminating the
@@ -168,9 +114,9 @@ jobs:
         env:
           PERF_LABEL: current
           PERF_SHARDABLE: "1"
-          PERF_TEST_GREP: ${{ matrix.test_grep }}
-          PERF_TEST_GREP_INVERT: ${{ matrix.test_grep_invert }}
-          PERF_TEST_SHARD: ${{ matrix.test_shard }}
+          PERF_TEST_GREP: ${{ matrix.test_grep || '@perf' }}
+          PERF_TEST_GREP_INVERT: ${{ matrix.test_grep_invert || 'animation-scheduling-controls|activate-deactivate-dense-animations' }}
+          PERF_TEST_SHARD: ${{ matrix.test_shard || format('{0}/15', matrix.shard) }}
           PERF_ANIMATION_CONTROL_MODE: ${{ matrix.animation_control_mode }}
           PERF_ANIMATION_INCLUDE_PAUSED_TRACE: ${{ matrix.animation_include_paused_trace }}
         run: pnpm --filter react-grab exec playwright test --grep "$PERF_TEST_GREP" --grep-invert "$PERF_TEST_GREP_INVERT" --workers=1 --shard="$PERF_TEST_SHARD" --reporter=list
@@ -179,7 +125,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: perf-reports-${{ matrix.artifact-suffix }}
+          name: perf-reports-${{ matrix.artifact_suffix || format('regular-{0}-of-15', matrix.shard) }}
           path: packages/react-grab/perf/
           if-no-files-found: warn
           retention-days: 1


### PR DESCRIPTION
## Motivation

The performance workflow copied the same grep configuration 15 times. Only the shard number and artifact name changed, so updating the regular lane required synchronized edits across all 15 entries.

## Example

Changing the regular exclusion pattern previously meant editing 15 identical `test_grep_invert` values.

## What changed

- Represent regular shards as one numeric matrix.
- Derive each `N/15` shard value and artifact name.
- Keep the five special animation-control jobs explicit.
- Preserve the same 20 total job combinations and environment values.

## Impact

The workflow behavior is unchanged, but shard count and regular filters now have one source of truth.

## Checks

- `actionlint .github/workflows/test-perf.yml`
- `nr build`
- `nr test` — 1,065 passed, 24 skipped; one unrelated flaky test passed on retry
- `nr lint`
- `nr typecheck`
- `nr format`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generate regular performance shards from a single numeric matrix and derive `N/15` shard values and artifact names automatically. This removes 15 duplicated entries and keeps the five animation-control jobs explicit with no behavior change.

- **Refactors**
  - Replace 15 regular entries with `shard: [1..15]` and defaults for `PERF_TEST_GREP`, `PERF_TEST_GREP_INVERT`, and `PERF_TEST_SHARD` (e.g., `${{ format('{0}/15', matrix.shard) }}`).
  - Compute artifact names via fallback `regular-{shard}-of-15`; use `artifact_suffix` for special jobs.
  - Keep the five animation-control jobs explicit; total jobs stay at 20 and env values are unchanged.

<sup>Written for commit 8a5ba38dee0222b4025e0f7d253a539fed70194c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow refactor with no application or runtime changes; main risk is a matrix/expression mistake changing which tests run per shard.
> 
> **Overview**
> Refactors **`test-perf.yml`** so the 15 regular Playwright perf shards come from a single `shard: [1..15]` matrix instead of 15 copy-pasted `include` rows.
> 
> **Regular lanes** now get `PERF_TEST_GREP`, `PERF_TEST_GREP_INVERT`, and `PERF_TEST_SHARD` via expression defaults (`@perf`, the animation exclusions, and `format('{0}/15', matrix.shard)`). Job display names and artifact names use the same fallback pattern (`regular-{N}-of-15`).
> 
> The **five special animation-control jobs** stay explicit in `matrix.include`, with `artifact-suffix` renamed to **`artifact_suffix`** for consistency. Total shard count and env values are intended to match the previous workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a5ba38dee0222b4025e0f7d253a539fed70194c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->