### PR TITLE
Use the shared time-unit constant in trace summaries

### DIFF
--- a/packages/react-grab/e2e/perf-render-trace-summary.ts
+++ b/packages/react-grab/e2e/perf-render-trace-summary.ts
@@ -1,4 +1,5 @@
 import {
+  PERF_MICROSECONDS_PER_MILLISECOND,
   PERF_MICROSECONDS_PER_SECOND,
   PERF_PAINT_DISPLAY_ITEM_LIMIT,
   PERF_PERCENT_SCALE,
@@ -197,8 +198,10 @@ const getVisualArea = (displayItem: Record<string, unknown>): number => {
 
 const finalizeStage = (stage: MutableTraceStageSummary): PerfTraceStageSummary => ({
   eventCount: stage.eventCount,
-  totalDurationMs: roundTo3(stage.totalDurationMicroseconds / 1000),
-  maximumDurationMs: roundTo3(stage.maximumDurationMicroseconds / 1000),
+  totalDurationMs: roundTo3(stage.totalDurationMicroseconds / PERF_MICROSECONDS_PER_MILLISECOND),
+  maximumDurationMs: roundTo3(
+    stage.maximumDurationMicroseconds / PERF_MICROSECONDS_PER_MILLISECOND,
+  ),
 });
 
 const addDuration = (stage: MutableTraceStageSummary, durationMicroseconds: number): void => {
@@ -452,7 +455,7 @@ export const summarizeRenderTrace = (traceFile: PerfTraceFile): PerfRenderPipeli
     return {
       selector: selectorTiming.selector,
       styleSheetId: selectorTiming.styleSheetId,
-      elapsedMs: roundTo3(selectorTiming.elapsedMicroseconds / 1000),
+      elapsedMs: roundTo3(selectorTiming.elapsedMicroseconds / PERF_MICROSECONDS_PER_MILLISECOND),
       matchAttempts: selectorTiming.matchAttempts,
       matchCount: selectorTiming.matchCount,
       fastRejectCount: selectorTiming.fastRejectCount,
@@ -465,7 +468,7 @@ export const summarizeRenderTrace = (traceFile: PerfTraceFile): PerfRenderPipeli
   };
 
   return {
-    windowDurationMs: roundTo3(windowDurationMicroseconds / 1000),
+    windowDurationMs: roundTo3(windowDurationMicroseconds / PERF_MICROSECONDS_PER_MILLISECOND),
     usedScenarioMarkers,
     traceEventCount: events.length,
     style: finalizeStage(stages.style),
@@ -484,7 +487,7 @@ export const summarizeRenderTrace = (traceFile: PerfTraceFile): PerfRenderPipeli
         selectorTimingSummaries.reduce(
           (total, selectorTiming) => total + selectorTiming.elapsedMicroseconds,
           0,
-        ) / 1000,
+        ) / PERF_MICROSECONDS_PER_MILLISECOND,
       ),
       matchAttempts: selectorMatchAttempts,
       matchCount: selectorMatchCount,
@@ -530,8 +533,12 @@ export const summarizeRenderTrace = (traceFile: PerfTraceFile): PerfRenderPipeli
         name: traceEvent.name,
         category: traceEvent.category,
         eventCount: traceEvent.eventCount,
-        totalDurationMs: roundTo3(traceEvent.totalDurationMicroseconds / 1000),
-        maximumDurationMs: roundTo3(traceEvent.maximumDurationMicroseconds / 1000),
+        totalDurationMs: roundTo3(
+          traceEvent.totalDurationMicroseconds / PERF_MICROSECONDS_PER_MILLISECOND,
+        ),
+        maximumDurationMs: roundTo3(
+          traceEvent.maximumDurationMicroseconds / PERF_MICROSECONDS_PER_MILLISECOND,
+        ),
       })),
   };
 };


### PR DESCRIPTION
## Motivation

The trace summarizer converted microseconds to milliseconds with seven raw `/ 1000` expressions even though the performance constants module already defines `PERF_MICROSECONDS_PER_MILLISECOND`.

That duplicates a unit convention and violates the repository's magic-number/DRY guidance.

## Example

Before:

```ts
roundTo3(stage.totalDurationMicroseconds / 1000)
```

After:

```ts
roundTo3(
  stage.totalDurationMicroseconds / PERF_MICROSECONDS_PER_MILLISECOND,
)
```

## Changes

- Reuse the existing unit constant for every microsecond-to-millisecond conversion in the trace summary.
- Keep output and runtime behavior unchanged.

## Validation

- `nr build`
- `nr test` — 1,065 passed, 24 skipped, 1 unrelated TanStack recovery test passed on retry
- `nr lint`
- `nr typecheck`
- `nr format`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced all microseconds-to-milliseconds divisions in the render trace summary with the shared `PERF_MICROSECONDS_PER_MILLISECOND` constant to remove magic numbers and enforce a single unit convention. Behavior and output are unchanged.

<sup>Written for commit 885cc3ec79daee81d208c044437e018e32d8f9a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2E perf summarization refactor with identical arithmetic; no auth, data, or runtime behavior changes.
> 
> **Overview**
> Replaces seven literal `/ 1000` microsecond-to-millisecond conversions in `perf-render-trace-summary.ts` with `PERF_MICROSECONDS_PER_MILLISECOND` from `perf-constants.js`, matching how other perf e2e code (e.g. `perf-hardware-gpu.ts`) handles units.
> 
> **Affected outputs:** stage totals/maxima, trace window duration, selector elapsed/total elapsed, and top-event duration fields—still passed through `roundTo3` with the same math.
> 
> No functional or reporting changes; this is naming/consistency only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 885cc3ec79daee81d208c044437e018e32d8f9a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->