### PR TITLE
Use a static import for the Solid JSX type

### DIFF
--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -1,3 +1,5 @@
+import type { JSX } from "solid-js";
+
 export interface Position {
   x: number;
   y: number;
@@ -664,7 +666,7 @@ export interface TagBadgeProps {
 }
 
 export interface BottomSectionProps {
-  children: import("solid-js").JSX.Element;
+  children: JSX.Element;
 }
 
 export interface DiscardPromptProps {


### PR DESCRIPTION
## Motivation

`BottomSectionProps` uses an inline `import("solid-js")` type even though the repository requires static imports unless a dynamic import is necessary. This is type-only, so no runtime loading or code-splitting concern applies.

## Example

Before:

```ts
children: import("solid-js").JSX.Element;
```

After:

```ts
import type { JSX } from "solid-js";

children: JSX.Element;
```

## Changes

- Add one static type-only `JSX` import.
- Reuse it for `BottomSectionProps.children`.
- Keep generated runtime behavior unchanged.

## Validation

- `nr build`
- `nr test` — 1,066 passed, 24 skipped
- `nr lint`
- `nr typecheck`
- `nr format`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `BottomSectionProps.children` from inline `import("solid-js").JSX.Element` to a static, type-only `JSX` import from `solid-js`. Aligns with our static import policy and has no runtime impact.

<sup>Written for commit 614b1551ebf0ecf9fd5b2c631494d52b4c5661ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only import style change in shared types; no logic, runtime, or public behavior impact.
> 
> **Overview**
> Replaces the inline `import("solid-js").JSX.Element` on **`BottomSectionProps.children`** with a file-level `import type { JSX } from "solid-js"` and `JSX.Element`, matching the repo’s static-import convention for type-only references.
> 
> **No runtime or API behavior changes**—only how the Solid JSX type is referenced in `types.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 614b1551ebf0ecf9fd5b2c631494d52b4c5661ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->