### PR TITLE
Preserve recoverable error diagnostics in production

### DIFF
--- a/packages/react-grab/e2e/ssr.spec.ts
+++ b/packages/react-grab/e2e/ssr.spec.ts
@@ -94,6 +94,18 @@ test.describe("SSR Compatibility", () => {
       ].join(" ");
       expect(runInNode(code)).toBe("OK");
     });
+
+    test("production bundles should report queued plugin setup failures", () => {
+      const code = [
+        "const m = require('./dist/index.cjs');",
+        "let didWarn = false;",
+        "console.warn = () => { didWarn = true; };",
+        "m.registerPlugin({ name: 'failing-plugin' });",
+        "m.setGlobalApi({ registerPlugin: () => { throw new Error('setup failed'); } });",
+        "console.log(didWarn ? 'REPORTED' : 'SILENT');",
+      ].join(" ");
+      expect(runInNode(code)).toBe("REPORTED");
+    });
   });
 
   test.describe("Noop API", () => {

--- a/packages/react-grab/src/utils/report-recoverable-error.ts
+++ b/packages/react-grab/src/utils/report-recoverable-error.ts
@@ -1,7 +1,5 @@
 import type { RecoverableError } from "../errors.js";
 
 export const reportRecoverableError = (error: RecoverableError): void => {
-  if (process.env.NODE_ENV !== "production") {
-    console.warn("[react-grab]", error);
-  }
+  console.warn("[react-grab]", error);
 };


### PR DESCRIPTION
## Motivation

Recoverable failures are caught so React Grab can keep running, but the production build replaced `process.env.NODE_ENV` and compiled `reportRecoverableError()` into a no-op. Specialized errors such as `PluginSetupError` were therefore created and immediately discarded for every published bundle.

## Example

A plugin registered before initialization throws from `registerPlugin()`. React Grab removes that failed queued plugin and continues, but production users receive no warning or error object explaining why the plugin disappeared.

## Changes

- Report specialized recoverable errors in production as well as development.
- Add an artifact-level regression test against the built CommonJS production bundle.
- Preserve the existing recovery behavior; failures still do not crash the host app.

## Validation

- `nr build`
- `nr test` — 1,067 passed, 24 skipped
- `pnpm --filter react-grab exec playwright test e2e/ssr.spec.ts` — 16 passed
- `nr lint`
- `nr typecheck`
- `nr format`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep recoverable error diagnostics in production for `react-grab`. Production builds now warn on recoverable failures (like queued plugin setup errors) while the app keeps running.

- **Bug Fixes**
  - Make recoverable errors always warn in production by removing the `NODE_ENV` guard.
  - Add a regression test against the built CJS bundle to verify queued plugin setup failures are reported without crashing.

<sup>Written for commit 86d88513dc11349c1b486e647df3b0eba049ecc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change (console warnings); no change to error handling or recovery control flow beyond removing the production no-op.
> 
> **Overview**
> Production builds were stripping recoverable-error diagnostics because `reportRecoverableError` only called `console.warn` when `NODE_ENV !== "production"`, so failures like queued plugin setup could be swallowed silently.
> 
> **`reportRecoverableError`** now always logs `[react-grab]` warnings for `RecoverableError` instances in every environment; recovery paths are unchanged and still avoid crashing the host app.
> 
> A new **SSR e2e** case runs against the built `dist/index.cjs` bundle and asserts that a queued plugin whose setup throws still triggers `console.warn` when the global API is attached.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86d88513dc11349c1b486e647df3b0eba049ecc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->