### PR TITLE
Expose documented subpaths from the grab package

### DIFF
--- a/packages/grab/README.md
+++ b/packages/grab/README.md
@@ -116,7 +116,7 @@ if (process.env.NODE_ENV === "development") {
 
 ## Build your own React Grab
 
-Build a custom interface with the selection engine from `react-grab/primitives`. Use its APIs for hit testing, source context, page freezing, clipboard access, and editor navigation.
+Build a custom interface with the selection engine from `grab/primitives`. Use its APIs for hit testing, source context, page freezing, clipboard access, and editor navigation.
 
 ### Customize hit testing
 

--- a/packages/grab/package.json
+++ b/packages/grab/package.json
@@ -59,6 +59,18 @@
         "default": "./dist/core/index.cjs"
       }
     },
+    "./primitives": {
+      "import": {
+        "types": "./dist/primitives.d.ts",
+        "default": "./dist/primitives.js"
+      },
+      "require": {
+        "types": "./dist/primitives.d.cts",
+        "default": "./dist/primitives.cjs"
+      }
+    },
+    "./styles.css": "./dist/styles.css",
+    "./dist/styles.css": "./dist/styles.css",
     "./dist/*": "./dist/*.js",
     "./dist/*.js": "./dist/*.js",
     "./dist/*.cjs": "./dist/*.cjs"

--- a/packages/grab/scripts/build.js
+++ b/packages/grab/scripts/build.js
@@ -65,6 +65,7 @@ const transformReadme = () => {
     .replace(/npm i react-grab/g, "npm i grab")
     .replace(/npx( -y)? react-grab@latest/g, "npx$1 grab@latest")
     .replace(/unpkg\.com\/react-grab/g, "unpkg.com/grab")
+    .replace(/`react-grab\/primitives`/g, "`grab/primitives`")
     .replace(/import\("react-grab"\)/g, 'import("grab")')
     .replace(/import\("react-grab\/core"\)/g, 'import("grab/core")')
     .replace(/from "react-grab\/core"/g, 'from "grab/core"')


### PR DESCRIPTION
## Motivation

The `grab` compatibility package README documents `grab/primitives`, and its build copies the primitive and stylesheet artifacts from `react-grab`. Its export map does not expose those files, so Node rejects the documented import with `ERR_PACKAGE_PATH_NOT_EXPORTED`.

## Example

Before:

```ts
import { getElementAtPoint } from "grab/primitives";
```

The file exists in `grab/dist`, but package resolution refuses it.

After this change, `grab/primitives`, `grab/styles.css`, and `grab/dist/styles.css` resolve like their `react-grab` counterparts.

## Changes

- Mirror the primitive and stylesheet subpath exports in `grab`.
- Rewrite the generated README's prose reference to `grab/primitives`.
- Keep source-only `react-grab/src/*` intentionally unexported because `grab` does not copy source files.

## Validation

- `nr build`
- `nr test` — 1,066 passed, 24 skipped
- `nr lint`
- `nr typecheck`
- `nr format`
- CommonJS and ESM resolution/import checks for all three subpaths
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `grab` subpath exports for primitives and styles so documented imports like `grab/primitives` and `grab/styles.css` resolve correctly. Aligns `grab` with `react-grab` and prevents ERR_PACKAGE_PATH_NOT_EXPORTED.

- **Bug Fixes**
  - Added export map for `./primitives` (ESM/CJS with types), `./styles.css`, and `./dist/styles.css` in `grab`.
  - Updated README transform to reference `grab/primitives`, including backticked mentions.
  - Left source-only `react-grab/src/*` unexported since `grab` doesn’t ship sources.

<sup>Written for commit 40f60a5afcb06b034a1b2d16c6961a35d6087cf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and README alignment only; no runtime logic changes, with artifacts already copied from react-grab at build time.
> 
> **Overview**
> Fixes **`ERR_PACKAGE_PATH_NOT_EXPORTED`** for documented `grab` imports by extending the **`grab`** package **`exports`** map to match **`react-grab`** for **`./primitives`** (ESM/CJS + types), **`./styles.css`**, and **`./dist/styles.css`**.
> 
> The generated **`grab`** README and build transform now consistently refer to **`grab/primitives`** (including backticked prose), so docs and examples align with resolvable entry points. **`react-grab/src/*`** stays unexported on **`grab`** because that package only ships **`dist`** artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40f60a5afcb06b034a1b2d16c6961a35d6087cf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->