### PR TITLE
Isolate public element bounds from the internal cache

### DIFF
--- a/packages/react-grab/src/primitives.ts
+++ b/packages/react-grab/src/primitives.ts
@@ -57,7 +57,9 @@ export const isElementGrabbable = (element: Element): boolean => isValidGrabbabl
  * Returns viewport bounds in the top-level window, including elements inside
  * transformed same-origin iframes.
  */
-export const getElementBounds = (element: Element): ElementBounds => createElementBounds(element);
+export const getElementBounds = (element: Element): ElementBounds => ({
+  ...createElementBounds(element),
+});
 
 /**
  * Returns a stable selector, crossing open shadow roots and same-origin iframes

--- a/packages/react-grab/tests/primitives-hit-testing.test.ts
+++ b/packages/react-grab/tests/primitives-hit-testing.test.ts
@@ -137,7 +137,7 @@ describe("element inspection primitives", () => {
     expect(isValidGrabbableElement).toHaveBeenCalledWith(element);
   });
 
-  it("returns top-window element bounds", () => {
+  it("returns isolated top-window element bounds", () => {
     const element = createElement();
     const bounds = {
       x: 10,
@@ -148,7 +148,16 @@ describe("element inspection primitives", () => {
     };
     vi.mocked(createElementBounds).mockReturnValue(bounds);
 
-    expect(getElementBounds(element)).toBe(bounds);
+    const firstPublicBounds = getElementBounds(element);
+    expect(firstPublicBounds).toEqual(bounds);
+    expect(firstPublicBounds).not.toBe(bounds);
+
+    firstPublicBounds.x = 100;
+
+    const secondPublicBounds = getElementBounds(element);
+    expect(secondPublicBounds).toEqual(bounds);
+    expect(secondPublicBounds).not.toBe(bounds);
+    expect(secondPublicBounds).not.toBe(firstPublicBounds);
   });
 
   it("creates a selector for the nearest useful selector target", () => {


### PR DESCRIPTION
## Motivation

`getElementBounds()` is public, but it currently returns the same mutable object used by React Grab's short-lived internal bounds cache. A caller can accidentally change React Grab's own geometry until that cache expires.

## Example

Before:

```ts
const bounds = getElementBounds(button);
bounds.x = 0;
```

A second bounds lookup can now observe the caller's `x` value instead of the element's real cached position.

## Changes

- Return a shallow snapshot at the public API boundary.
- Keep internal hot paths on the existing cached object.
- Verify structural equality, distinct identity, and mutation isolation.

## Validation

- `nr build`
- `nr test` — 1,065 passed, 24 skipped, 1 unrelated flaky test passed on retry
- `nr lint`
- `nr typecheck`
- `nr format`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return a new object from `getElementBounds` so external code can't mutate the internal bounds cache. Each call returns an isolated snapshot of the element’s top-window bounds.

- **Bug Fixes**
  - Public `getElementBounds` now returns a shallow copy via `{ ...createElementBounds(...) }`; internal hot paths still use the cached object.
  - Tests assert structural equality with cached values, distinct identity per call, and mutation isolation.

<sup>Written for commit 4e4ad967cb0cf5a5ae67c6ca43941c866f0fa01e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small public-API encapsulation fix at the primitives boundary; internal caching behavior is unchanged.
> 
> **Overview**
> **`getElementBounds`** no longer returns the same object instance that **`createElementBounds`** keeps in its short-lived internal cache. Each public call now returns a **shallow copy** (`{ ...createElementBounds(element) }`), so consumers cannot mutate cached geometry that React Grab still uses on hot paths.
> 
> Tests were updated to expect **equal values but distinct objects**, and to confirm that mutating one returned bounds object does not affect later lookups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e4ad967cb0cf5a5ae67c6ca43941c866f0fa01e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->