### PR TITLE
Clear the disposed global React Grab API

### DIFF
--- a/packages/react-grab/e2e/api-methods.spec.ts
+++ b/packages/react-grab/e2e/api-methods.spec.ts
@@ -414,18 +414,11 @@ test.describe("API Methods", () => {
   });
 
   test.describe("dispose()", () => {
-    test("should set hasInited to false on dispose", async ({ reactGrab }) => {
-      await reactGrab.activate();
-      expect(await reactGrab.isOverlayVisible()).toBe(true);
-
+    test("should clear the disposed global API", async ({ reactGrab }) => {
       await reactGrab.dispose();
-      await reactGrab.page.waitForTimeout(200);
 
-      const canReinit = await reactGrab.page.evaluate(() => {
-        const initFn = (window as { initReactGrab?: () => void }).initReactGrab;
-        return typeof initFn === "function";
-      });
-      expect(canReinit).toBe(true);
+      const hasGlobalApi = await reactGrab.page.evaluate(() => window.__REACT_GRAB__ !== undefined);
+      expect(hasGlobalApi).toBe(false);
     });
 
     test("should remove overlay host element on dispose", async ({ reactGrab }) => {
@@ -442,10 +435,8 @@ test.describe("API Methods", () => {
     });
 
     test("should allow re-initialization after dispose", async ({ reactGrab }) => {
-      await reactGrab.activate();
-      await reactGrab.dispose();
-
-      await reactGrab.reinitialize();
+      const didInstallFreshApi = await reactGrab.reinitialize();
+      expect(didInstallFreshApi).toBe(true);
 
       await reactGrab.activate();
       expect(await reactGrab.isOverlayVisible()).toBe(true);

--- a/packages/react-grab/e2e/fixtures.ts
+++ b/packages/react-grab/e2e/fixtures.ts
@@ -56,6 +56,15 @@ interface LabelInstanceInfo {
   createdAt: number;
 }
 
+interface ReinitializableApi {
+  dispose: () => void;
+}
+
+interface ReinitializableWindow {
+  __REACT_GRAB__?: ReinitializableApi;
+  initReactGrab?: (options?: Record<string, unknown>) => ReinitializableApi;
+}
+
 interface ReactGrabState {
   isActive: boolean;
   isDragging: boolean;
@@ -178,7 +187,7 @@ export interface ReactGrabPageObject {
   copyElementViaApi: (selector: string) => Promise<boolean>;
   registerCommentAction: () => Promise<void>;
   updateOptions: (options: Record<string, unknown>) => Promise<void>;
-  reinitialize: (options?: Record<string, unknown>) => Promise<void>;
+  reinitialize: (options?: Record<string, unknown>) => Promise<boolean>;
 
   touchStart: (x: number, y: number) => Promise<void>;
   touchMove: (x: number, y: number) => Promise<void>;
@@ -1466,13 +1475,14 @@ const createReactGrabPageObject = (
   };
 
   const reinitialize = async (options?: Record<string, unknown>) => {
-    await page.evaluate((initialOptions) => {
-      const existingApi = (window as { __REACT_GRAB__?: { dispose: () => void } }).__REACT_GRAB__;
-      existingApi?.dispose();
-
-      const initFn = (window as { initReactGrab?: (o?: Record<string, unknown>) => void })
-        .initReactGrab;
-      initFn?.(initialOptions);
+    const didInstallFreshApi = await page.evaluate((initialOptions) => {
+      const targetWindow = window as ReinitializableWindow;
+      const previousApi = targetWindow.__REACT_GRAB__;
+      previousApi?.dispose();
+      const initializedApi = targetWindow.initReactGrab?.(initialOptions);
+      if (!initializedApi) return false;
+      targetWindow.__REACT_GRAB__ = initializedApi;
+      return initializedApi !== previousApi;
     }, options);
     await page.waitForFunction(
       () => {
@@ -1482,6 +1492,7 @@ const createReactGrabPageObject = (
       undefined,
       { timeout: 5000 },
     );
+    return didInstallFreshApi;
   };
 
   const dispatchPointerEvent = async (

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -162,6 +162,7 @@ import { notifyToolbarStateChangeSubscribers } from "../utils/notify-toolbar-sta
 import { forwardSameOriginFrameEvents } from "../utils/forward-same-origin-frame-events.js";
 import { isHtmlElement } from "../utils/is-html-element.js";
 import { isDocumentAncestorOfElement } from "../utils/is-document-ancestor-of-element.js";
+import { clearGlobalApi } from "../global-api.js";
 
 const builtInPlugins = [copyPlugin, editPlugin, commentPlugin, openPlugin];
 
@@ -4294,16 +4295,20 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       },
       dispose: () => {
         disposed = true;
-        cancelPendingCopies();
-        labelController.clearAll();
         hasInited = false;
-        disposeRenderer?.();
-        stopToolbarMenuTracking?.();
-        stopToolbarMenuTracking = null;
-        stopEditPanelTracking?.();
-        stopEditPanelTracking = null;
-        toolbarStateChangeCallbacks.clear();
-        dispose();
+        try {
+          cancelPendingCopies();
+          labelController.clearAll();
+          disposeRenderer?.();
+          stopToolbarMenuTracking?.();
+          stopToolbarMenuTracking = null;
+          stopEditPanelTracking?.();
+          stopEditPanelTracking = null;
+          toolbarStateChangeCallbacks.clear();
+          dispose();
+        } finally {
+          clearGlobalApi(api);
+        }
       },
       copyElement: copyElementAPI,
       getSource: async (element: Element): Promise<SourceInfo | null> => {

--- a/packages/react-grab/src/global-api.ts
+++ b/packages/react-grab/src/global-api.ts
@@ -34,6 +34,13 @@ export const setGlobalApi = (api: ReactGrabAPI | null): void => {
   }
 };
 
+export const clearGlobalApi = (api: ReactGrabAPI): void => {
+  if (globalApi === api) globalApi = null;
+  if (typeof window !== "undefined" && window.__REACT_GRAB__ === api) {
+    delete window.__REACT_GRAB__;
+  }
+};
+
 export const registerPlugin = (plugin: Plugin): void => {
   const api = getGlobalApi();
   if (api) {

--- a/packages/react-grab/tests/global-plugin-registry.test.ts
+++ b/packages/react-grab/tests/global-plugin-registry.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { createNoopApi } from "../src/core/noop-api.js";
 import { PluginSetupError } from "../src/errors.js";
-import { getGlobalApi, registerPlugin, setGlobalApi, unregisterPlugin } from "../src/global-api.js";
+import {
+  clearGlobalApi,
+  getGlobalApi,
+  registerPlugin,
+  setGlobalApi,
+  unregisterPlugin,
+} from "../src/global-api.js";
 import type { Plugin, ReactGrabAPI } from "../src/types.js";
 
 const PLUGIN_NAMES = ["first", "second", "failing"];
@@ -18,6 +24,19 @@ afterEach(() => {
 });
 
 describe("global plugin registration", () => {
+  it("only clears the API that owns the global reference", () => {
+    const disposingApi = createNoopApi();
+    const replacementApi = createNoopApi();
+
+    setGlobalApi(disposingApi);
+    setGlobalApi(replacementApi);
+    clearGlobalApi(disposingApi);
+
+    expect(getGlobalApi()).toBe(replacementApi);
+    clearGlobalApi(replacementApi);
+    expect(getGlobalApi()).toBeNull();
+  });
+
   it("flushes queued plugins when an API is attached", () => {
     const plugin: Plugin = { name: "first" };
     const apiRegisterPlugin = vi.fn();


### PR DESCRIPTION
## Motivation

`dispose()` tore down React Grab but left the disposed API in `window.__REACT_GRAB__` and the module-level registry. Global consumers could keep finding an instance that could no longer be used.

## Example

Before: call `window.__REACT_GRAB__.dispose()`, then a plugin or script reads `window.__REACT_GRAB__` and receives the dead instance.

After: disposing the owner clears both global references. A newer replacement instance is preserved if it was installed first.

## Changes

- Clear the disposed API from the module registry and `window` in a `finally` block.
- Clear references only when they still point to the disposing instance.
- Exercise real disposal, ownership safety, and fresh reinitialization.

## Validation

- `nr build`
- `nr test` — 1,066 passed, 24 skipped; one unrelated toolbar test passed on retry
- `nr lint`
- `nr typecheck`
- `nr format`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disposing React Grab now clears its global API from both the module registry and `window.__REACT_GRAB__`, preventing plugins or scripts from finding a dead instance. Re-initialization remains safe, and newer replacement instances are preserved.

- **Bug Fixes**
  - Clear disposed API in a `finally` block via `clearGlobalApi(api)` for both registry and `window`.
  - Only clear when the global reference matches the disposing instance, preserving newer installs.
  - Updated tests and e2e fixtures; `reinitialize` now returns a boolean to confirm a fresh install.

<sup>Written for commit ae5abb92a5e0dff2868e23e37d0e4a411a01de78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global singleton lifecycle used by plugins and `window.__REACT_GRAB__`; behavior change is intentional but could affect consumers that assumed the global persisted after dispose.
> 
> **Overview**
> **`dispose()`** now removes the disposed instance from the module-level registry and **`window.__REACT_GRAB__`**, so scripts and plugins no longer see a torn-down API after shutdown.
> 
> Teardown runs inside **`try`/`finally`** so **`clearGlobalApi(api)`** always runs; clearing is **identity-checked** so a newer replacement instance is not wiped if it was installed first.
> 
> E2E **`reinitialize`** returns whether a fresh API was installed; dispose tests assert the global is gone and re-init still works. Unit tests cover ownership-safe clearing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae5abb92a5e0dff2868e23e37d0e4a411a01de78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->