### PR TITLE
Make React Grab disposal idempotent

### DIFF
--- a/packages/react-grab/e2e/api-methods.spec.ts
+++ b/packages/react-grab/e2e/api-methods.spec.ts
@@ -1,8 +1,14 @@
 import { test, expect } from "./fixtures.js";
+import type { ReactGrabAPI } from "../src/types.js";
 
 interface CopyCancellationCase {
   method: "deactivate" | "dispose";
   label: string;
+}
+
+interface LifecycleWindow {
+  __REACT_GRAB__?: ReactGrabAPI;
+  initReactGrab?: () => ReactGrabAPI;
 }
 
 const COPY_CANCELLATION_CASES: CopyCancellationCase[] = [
@@ -440,6 +446,38 @@ test.describe("API Methods", () => {
 
       await reactGrab.activate();
       expect(await reactGrab.isOverlayVisible()).toBe(true);
+    });
+
+    test("a stale API should not dispose a replacement", async ({ reactGrab }) => {
+      const result = await reactGrab.page.evaluate(() => {
+        const targetWindow: LifecycleWindow = window;
+        const staleApi = targetWindow.__REACT_GRAB__;
+        if (!staleApi || !targetWindow.initReactGrab) {
+          throw new Error("React Grab lifecycle API unavailable");
+        }
+
+        staleApi.dispose();
+        const replacementApi = targetWindow.initReactGrab();
+        targetWindow.__REACT_GRAB__ = replacementApi;
+
+        let subscriberCallCount = 0;
+        replacementApi.onToolbarStateChange(() => {
+          subscriberCallCount += 1;
+        });
+
+        staleApi.dispose();
+        replacementApi.setToolbarState({ collapsed: true });
+        const duplicateApi = targetWindow.initReactGrab();
+        const didRejectDuplicateInitialization = duplicateApi.getPlugins().length === 0;
+        if (!didRejectDuplicateInitialization) duplicateApi.dispose();
+
+        return { subscriberCallCount, didRejectDuplicateInitialization };
+      });
+
+      expect(result).toEqual({
+        subscriberCallCount: 1,
+        didRejectDuplicateInitialization: true,
+      });
     });
   });
 

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -4294,6 +4294,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         actions.setSelectionSource(null, null);
       },
       dispose: () => {
+        if (disposed) return;
         disposed = true;
         hasInited = false;
         try {


### PR DESCRIPTION
## Motivation

A disposed API handle remained callable. Calling its `dispose()` method a second time reset shared singleton state owned by a newer React Grab instance, allowing duplicate initialization and removing live toolbar subscribers.

## Example

Before: dispose instance A, initialize B, then call `A.dispose()` again. A later `init()` creates another live instance beside B.

After: a repeated disposal is a no-op, so B keeps ownership of the singleton and its subscriptions.

## Changes

- Return immediately when an API instance has already been disposed.
- Add an E2E regression covering a stale second disposal, subscriber preservation, and duplicate-init rejection.

## Validation

- `nr build`
- `nr test` — 1,067 passed, 24 skipped; one unrelated prompt/resize test passed on retry
- `nr lint`
- `nr typecheck`
- `nr format`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core lifecycle teardown and singleton init guards; behavior change is narrow (repeat dispose) but affects hot-reload/re-init paths where stale references are common.
> 
> **Overview**
> **`dispose()` on an already-disposed API instance is now a no-op**, so a stale handle cannot tear down singleton state owned by a newer instance (e.g. clearing `hasInited`, wiping toolbar subscribers, or allowing a second live init beside the replacement).
> 
> An **E2E regression** covers dispose → re-init → second `dispose()` on the old reference: toolbar subscribers still fire once and a duplicate `init()` is rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1530ca823c35f357e7f9437ddf747979bdca600. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->