### PR TITLE
Finish React Grab cleanup when one disposer fails

### DIFF
--- a/packages/react-grab/e2e/iframe.spec.ts
+++ b/packages/react-grab/e2e/iframe.spec.ts
@@ -422,6 +422,9 @@ test.describe("Iframe selection", () => {
 
   test("continues frame cleanup after a shadow root hook fails", async ({ reactGrab }) => {
     const cleanupResult = await reactGrab.page.evaluate(async () => {
+      document.body.style.touchAction = "pan-y";
+      window.__REACT_GRAB__?.activate();
+
       const createIframe = async (): Promise<HTMLIFrameElement> => {
         const iframeElement = document.createElement("iframe");
         iframeElement.srcdoc = "<main>Frame cleanup target</main>";
@@ -473,12 +476,14 @@ test.describe("Iframe selection", () => {
         cleanupErrorMessage,
         didRestoreSubsequentHook:
           Reflect.get(subsequentElementPrototype, "attachShadow") !== subsequentPatchedAttachShadow,
+        restoredTouchAction: document.body.style.touchAction,
       };
     });
 
     expect(cleanupResult).toEqual({
       cleanupErrorMessage: "Expected frame cleanup failure",
       didRestoreSubsequentHook: true,
+      restoredTouchAction: "pan-y",
     });
   });
 

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -163,6 +163,8 @@ import { forwardSameOriginFrameEvents } from "../utils/forward-same-origin-frame
 import { isHtmlElement } from "../utils/is-html-element.js";
 import { isDocumentAncestorOfElement } from "../utils/is-document-ancestor-of-element.js";
 import { clearGlobalApi } from "../global-api.js";
+import { collectCleanupError } from "../utils/collect-cleanup-error.js";
+import { throwCollectedErrors } from "../utils/throw-collected-errors.js";
 
 const builtInPlugins = [copyPlugin, editPlugin, commentPlugin, openPlugin];
 
@@ -3456,28 +3458,34 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     );
 
     onCleanup(() => {
-      stopForwardingSameOriginFrameEvents();
-      eventListenerManager.abort();
+      const cleanupErrors: unknown[] = [];
+      collectCleanupError(stopForwardingSameOriginFrameEvents, cleanupErrors);
+      collectCleanupError(() => eventListenerManager.abort(), cleanupErrors);
       if (dragPreviewDebounceTimerId !== null) {
         window.clearTimeout(dragPreviewDebounceTimerId);
       }
       if (keydownSpamTimerId) window.clearTimeout(keydownSpamTimerId);
-      clearCopyFeedbackCooldown();
-      stopToolbarMenuTracking?.();
+      collectCleanupError(clearCopyFeedbackCooldown, cleanupErrors);
+      if (stopToolbarMenuTracking) {
+        collectCleanupError(stopToolbarMenuTracking, cleanupErrors);
+      }
       stopToolbarMenuTracking = null;
-      stopEditPanelTracking?.();
+      if (stopEditPanelTracking) {
+        collectCleanupError(stopEditPanelTracking, cleanupErrors);
+      }
       stopEditPanelTracking = null;
       grabbedBoxTimeouts.forEach((timeoutId) => window.clearTimeout(timeoutId));
       grabbedBoxTimeouts.clear();
-      labelController.cancelAllFades();
+      collectCleanupError(labelController.cancelAllFades, cleanupErrors);
       retryCopyByInstanceId.clear();
-      autoScroller.stop();
-      unfreezeGlobalInteractions();
-      restoreHostBodyStyle("userSelect");
-      restoreHostBodyStyle("touchAction");
-      setCursorOverride(null);
-      keyboardClaimer.restore();
-      setScopeContainer(null);
+      collectCleanupError(autoScroller.stop, cleanupErrors);
+      collectCleanupError(unfreezeGlobalInteractions, cleanupErrors);
+      collectCleanupError(() => restoreHostBodyStyle("userSelect"), cleanupErrors);
+      collectCleanupError(() => restoreHostBodyStyle("touchAction"), cleanupErrors);
+      collectCleanupError(() => setCursorOverride(null), cleanupErrors);
+      collectCleanupError(keyboardClaimer.restore, cleanupErrors);
+      collectCleanupError(() => setScopeContainer(null), cleanupErrors);
+      throwCollectedErrors(cleanupErrors, "Disposing React Grab failed");
     });
 
     const resolvedCssText = typeof cssText === "string" ? cssText : "";
@@ -4295,21 +4303,25 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
       },
       dispose: () => {
         if (disposed) return;
+        const cleanupErrors: unknown[] = [];
         disposed = true;
         hasInited = false;
-        try {
-          cancelPendingCopies();
-          labelController.clearAll();
-          disposeRenderer?.();
-          stopToolbarMenuTracking?.();
-          stopToolbarMenuTracking = null;
-          stopEditPanelTracking?.();
-          stopEditPanelTracking = null;
-          toolbarStateChangeCallbacks.clear();
-          dispose();
-        } finally {
-          clearGlobalApi(api);
+        collectCleanupError(cancelPendingCopies, cleanupErrors);
+        collectCleanupError(labelController.clearAll, cleanupErrors);
+        if (disposeRenderer) collectCleanupError(disposeRenderer, cleanupErrors);
+        disposeRenderer = undefined;
+        if (stopToolbarMenuTracking) {
+          collectCleanupError(stopToolbarMenuTracking, cleanupErrors);
         }
+        stopToolbarMenuTracking = null;
+        if (stopEditPanelTracking) {
+          collectCleanupError(stopEditPanelTracking, cleanupErrors);
+        }
+        stopEditPanelTracking = null;
+        toolbarStateChangeCallbacks.clear();
+        collectCleanupError(dispose, cleanupErrors);
+        collectCleanupError(() => clearGlobalApi(api), cleanupErrors);
+        throwCollectedErrors(cleanupErrors, "Disposing React Grab failed");
       },
       copyElement: copyElementAPI,
       getSource: async (element: Element): Promise<SourceInfo | null> => {

--- a/packages/react-grab/src/utils/collect-cleanup-error.ts
+++ b/packages/react-grab/src/utils/collect-cleanup-error.ts
@@ -1,0 +1,7 @@
+export const collectCleanupError = (cleanup: () => void, cleanupErrors: unknown[]): void => {
+  try {
+    cleanup();
+  } catch (error) {
+    cleanupErrors.push(error);
+  }
+};

--- a/packages/react-grab/src/utils/observe-same-origin-frame-documents.ts
+++ b/packages/react-grab/src/utils/observe-same-origin-frame-documents.ts
@@ -3,6 +3,7 @@ import { getAccessibleIframeDocument } from "./get-accessible-iframe-document.js
 import { isElementNode } from "./is-element-node.js";
 import { isIframeElement } from "./is-iframe-element.js";
 import { isReactGrabElement } from "./is-react-grab-element.js";
+import { collectCleanupError } from "./collect-cleanup-error.js";
 import { throwCollectedErrors } from "./throw-collected-errors.js";
 
 interface FrameDocumentCallback {
@@ -13,14 +14,6 @@ interface ObservedIframe {
   abortController: AbortController;
   document: Document | null;
 }
-
-const collectCleanupError = (cleanup: () => void, cleanupErrors: unknown[]): void => {
-  try {
-    cleanup();
-  } catch (error) {
-    cleanupErrors.push(error);
-  }
-};
 
 export const observeSameOriginFrameDocuments = (callback: FrameDocumentCallback): (() => void) => {
   const documentCleanups = new Map<Document, (() => void) | void>();


### PR DESCRIPTION
## Motivation

Disposal stopped at the first thrown cleanup. A failure while restoring an iframe hook could leave later resources active: event listeners, timers, frozen interactions, body styles, cursor overrides, and the global API.

## Example

Before: an iframe shadow-hook restore throws, so React Grab never restores `document.body.style.touchAction`.

After: every cleanup is attempted, then the original error is rethrown (or multiple failures are aggregated).

## Changes

- Collect cleanup failures while continuing the root and public API disposal sequences.
- Reuse the same focused collector for iframe cleanup.
- Clear owned cleanup handles as they are consumed.
- Extend the iframe regression to prove a later body-style cleanup still runs.

## Validation

- `nr build`
- `nr test` — 1,067 passed, 24 skipped on the exhaustive-cleanup branch
- Combined latest-main validation: 158 unit tests and 31 iframe E2E tests
- `nr lint`
- `nr typecheck`
- `nr format`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `react-grab` completes disposal even if a cleanup throws. All cleanups now run, and any errors are aggregated and rethrown to avoid leaving listeners, timers, styles, or API state behind.

- **Bug Fixes**
  - Continue root and public API disposal after failures; collect errors with `collect-cleanup-error` and rethrow via `throwCollectedErrors`.
  - Apply the same error collection to iframe shadow-root and document cleanups.
  - Clear owned cleanup handles as they run to prevent double-dispose.
  - Extend iframe E2E to verify `document.body.style.touchAction` is restored after a prior frame cleanup failure.

<sup>Written for commit 62cc589ef2774edfe703c897efdba538f5d1a970. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core teardown and global API lifecycle; failures are surfaced after full cleanup rather than leaving partial state, but disposal behavior on error changes for callers.
> 
> **Overview**
> **Disposal no longer stops at the first thrown cleanup.** Root teardown (`onCleanup`) and the public `dispose()` API now run every cleanup step via `collectCleanupError`, then rethrow a single error or an `AggregateError` through `throwCollectedErrors`.
> 
> That covers listeners, timers, interaction unfreeze, restored `document.body` styles (`userSelect`, `touchAction`), cursor override, keyboard claimer, scope container, renderer disposal, and clearing the global API. The iframe observer reuses the same collector instead of a local duplicate.
> 
> The iframe E2E case now activates React Grab, forces a shadow-hook restore failure, and asserts a later step still restores `document.body.style.touchAction`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62cc589ef2774edfe703c897efdba538f5d1a970. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->