### PR TITLE
Cancel host attachment after React Grab is disposed

### DIFF
--- a/packages/react-grab/e2e/api-methods.spec.ts
+++ b/packages/react-grab/e2e/api-methods.spec.ts
@@ -11,6 +11,7 @@ interface LifecycleWindow {
   initReactGrab?: () => ReactGrabAPI;
 }
 
+const HOST_ATTACHMENT_RECHECK_WAIT_MS = 1_100;
 const COPY_CANCELLATION_CASES: CopyCancellationCase[] = [
   { method: "deactivate", label: "deactivation" },
   { method: "dispose", label: "disposal" },
@@ -478,6 +479,52 @@ test.describe("API Methods", () => {
         subscriberCallCount: 1,
         didRejectDuplicateInitialization: true,
       });
+    });
+
+    test("should cancel a disposed host attachment before body is available", async ({
+      reactGrab,
+    }) => {
+      await reactGrab.page.evaluate(() => {
+        const targetWindow: LifecycleWindow = window;
+        const initReactGrab = targetWindow.initReactGrab;
+        if (!initReactGrab) throw new Error("React Grab initializer unavailable");
+        targetWindow.__REACT_GRAB__?.dispose();
+        document.body.remove();
+
+        const disposedApi = initReactGrab();
+        disposedApi.dispose();
+        const activeApi = initReactGrab();
+        targetWindow.__REACT_GRAB__ = activeApi;
+
+        const replacementBody = document.createElement("body");
+        document.documentElement.appendChild(replacementBody);
+        document.dispatchEvent(new Event("DOMContentLoaded"));
+      });
+
+      await reactGrab.page.waitForTimeout(HOST_ATTACHMENT_RECHECK_WAIT_MS);
+      const hostCount = await reactGrab.page.evaluate(
+        () => document.querySelectorAll("[data-react-grab]").length,
+      );
+      expect(hostCount).toBe(1);
+    });
+
+    test("should recheck a host reused by a replacement", async ({ reactGrab }) => {
+      await reactGrab.page.evaluate(() => {
+        const targetWindow: LifecycleWindow = window;
+        const initReactGrab = targetWindow.initReactGrab;
+        if (!initReactGrab) throw new Error("React Grab initializer unavailable");
+
+        targetWindow.__REACT_GRAB__?.dispose();
+        const replacementApi = initReactGrab();
+        targetWindow.__REACT_GRAB__ = replacementApi;
+        document.querySelector("[data-react-grab]")?.remove();
+      });
+
+      await reactGrab.page.waitForTimeout(HOST_ATTACHMENT_RECHECK_WAIT_MS);
+      const hostCount = await reactGrab.page.evaluate(
+        () => document.querySelectorAll("[data-react-grab]").length,
+      );
+      expect(hostCount).toBe(1);
     });
   });
 

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -3495,7 +3495,12 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     const overlayCssText = IS_DEMO
       ? `${resolvedCssText}\n* { pointer-events: none !important; }`
       : resolvedCssText;
-    const { root: rendererRoot, host: rendererHost } = mountRoot(overlayCssText);
+    const {
+      root: rendererRoot,
+      host: rendererHost,
+      cancelPendingAttachment,
+    } = mountRoot(overlayCssText);
+    onCleanup(cancelPendingAttachment);
 
     const themeWatcher = watchAppTheme(rendererHost);
     onCleanup(themeWatcher.cleanup);

--- a/packages/react-grab/src/utils/mount-root.ts
+++ b/packages/react-grab/src/utils/mount-root.ts
@@ -32,10 +32,10 @@ const attachHostToBody = (host: HTMLElement): void => {
 // During parsing (readyState === "loading") <body> may not exist yet, and
 // attaching to <html> as a fallback is what triggers the hydration error
 // above. Create the host detached and attach once <body> is parsed.
-const scheduleHostAttachment = (host: HTMLElement): void => {
+const scheduleHostAttachment = (host: HTMLElement): (() => void) => {
   if (document.body) {
     attachHostToBody(host);
-    return;
+    return () => {};
   }
 
   const onReady = () => {
@@ -43,11 +43,20 @@ const scheduleHostAttachment = (host: HTMLElement): void => {
     attachHostToBody(host);
   };
   document.addEventListener("DOMContentLoaded", onReady, { once: true });
+  return () => document.removeEventListener("DOMContentLoaded", onReady);
+};
+
+const scheduleHostRecheck = (host: HTMLElement): (() => void) => {
+  const recheckTimeoutId = window.setTimeout(() => {
+    attachHostToBody(host);
+  }, MOUNT_ROOT_RECHECK_DELAY_MS);
+  return () => window.clearTimeout(recheckTimeoutId);
 };
 
 interface MountRootResult {
   root: HTMLDivElement;
   host: HTMLElement;
+  cancelPendingAttachment: () => void;
 }
 
 export const mountRoot = (cssText?: string): MountRootResult => {
@@ -55,7 +64,11 @@ export const mountRoot = (cssText?: string): MountRootResult => {
   for (const mountedHost of mountedHosts) {
     const mountedRoot = mountedHost.shadowRoot?.querySelector(`[${REACT_GRAB_ATTRIBUTE_NAME}]`);
     if (mountedRoot instanceof HTMLDivElement) {
-      return { root: mountedRoot, host: mountedHost };
+      return {
+        root: mountedRoot,
+        host: mountedHost,
+        cancelPendingAttachment: scheduleHostRecheck(mountedHost),
+      };
     }
     mountedHost.remove();
   }
@@ -83,15 +96,20 @@ export const mountRoot = (cssText?: string): MountRootResult => {
 
   shadowRoot.appendChild(root);
 
-  scheduleHostAttachment(host);
+  const cancelReadyAttachment = scheduleHostAttachment(host);
   // Re-appending after a delay handles two cases: framework hydration
   // (React/Next.js) may blow away the DOM and remove our host, and another
   // tool (e.g. react-scan) may have appended at the same z-index where last
   // DOM child wins the stacking tiebreaker. Moving an already-attached node
   // via appendChild is atomic with no flash or reflow.
-  setTimeout(() => {
-    attachHostToBody(host);
-  }, MOUNT_ROOT_RECHECK_DELAY_MS);
+  const cancelHostRecheck = scheduleHostRecheck(host);
 
-  return { root, host };
+  return {
+    root,
+    host,
+    cancelPendingAttachment: () => {
+      cancelReadyAttachment();
+      cancelHostRecheck();
+    },
+  };
 };


### PR DESCRIPTION
## Motivation

When React Grab initializes before `<body>` exists, it schedules a `DOMContentLoaded` attachment and a delayed recheck. Disposal did not cancel either callback, so a dead instance could attach its overlay host later.

## Example

Before: initialize A before `<body>`, dispose A, initialize B, then finish parsing. Both A and B can attach hosts.

After: disposing A cancels its pending listener and timer. If B reuses A's existing host, B receives its own recheck, so hydration recovery is preserved.

## Changes

- Return a focused pending-attachment cleanup from `mountRoot()`.
- Register that cleanup with the owning Solid root.
- Schedule the hydration recheck for both new and reused hosts.
- Cover pre-body disposal and reused-host hydration removal in E2E regressions.

## Validation

- `nr build`
- 158 unit tests
- 33 API E2E tests
- `nr lint`
- `nr typecheck`
- `nr format`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped overlay mount lifecycle cleanup with targeted E2E tests; no auth or data-path changes, though incorrect cancellation could affect early-script / hydration timing edge cases.
> 
> **Overview**
> Fixes a lifecycle bug where **disposing** React Grab did not cancel deferred overlay host work, so a disposed instance could still attach its `[data-react-grab]` host after `DOMContentLoaded` or the existing **~1s recheck** timer—leading to **duplicate hosts** when init happens before `<body>` exists or after dispose/re-init.
> 
> **`mountRoot()`** now returns **`cancelPendingAttachment`**, which tears down the `DOMContentLoaded` listener and clears the recheck timeout (refactored into `scheduleHostRecheck`). The Solid root registers that cleanup via **`onCleanup`** alongside other dispose logic.
> 
> E2E coverage asserts a single host after dispose → re-init before body is ready (with synthetic `DOMContentLoaded`) and after removing a host while a replacement instance is active (recheck path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dbc2cce678eff974638be9b4791fc0f9fc2b556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->