### PR TITLE
Isolate toolbar subscribers by React Grab instance

### DIFF
--- a/packages/react-grab/e2e/api-methods.spec.ts
+++ b/packages/react-grab/e2e/api-methods.spec.ts
@@ -364,14 +364,7 @@ test.describe("API Methods", () => {
   test.describe("Toolbar state", () => {
     test("isolates throwing state subscribers", async ({ reactGrab }) => {
       const result = await reactGrab.page.evaluate(() => {
-        const api = (
-          window as {
-            __REACT_GRAB__?: {
-              onToolbarStateChange: (callback: (state: { collapsed: boolean }) => void) => void;
-              setToolbarState: (state: { collapsed: boolean }) => void;
-            };
-          }
-        ).__REACT_GRAB__;
+        const api = (window as LifecycleWindow).__REACT_GRAB__;
         if (!api) throw new Error("React Grab API unavailable");
 
         let receivedCollapsed: boolean | undefined;
@@ -387,6 +380,41 @@ test.describe("API Methods", () => {
       });
 
       expect(result).toBe(true);
+    });
+
+    test("isolates subscribers from a disposed instance", async ({ reactGrab }) => {
+      const callbackCounts = await reactGrab.page.evaluate(() => {
+        const targetWindow = window as LifecycleWindow;
+        const previousApi = targetWindow.__REACT_GRAB__;
+        const initializeReactGrab = targetWindow.initReactGrab;
+        if (!previousApi || !initializeReactGrab) {
+          throw new Error("React Grab API unavailable");
+        }
+
+        let callbackCount = 0;
+        const sharedCallback = () => {
+          callbackCount += 1;
+        };
+        const unsubscribePrevious = previousApi.onToolbarStateChange(sharedCallback);
+
+        previousApi.dispose();
+        const replacementApi = initializeReactGrab();
+        targetWindow.__REACT_GRAB__ = replacementApi;
+        replacementApi.onToolbarStateChange(sharedCallback);
+
+        previousApi.setToolbarState({ collapsed: true });
+        const afterPreviousUpdate = callbackCount;
+
+        unsubscribePrevious();
+        replacementApi.setToolbarState({ collapsed: false });
+
+        return { afterPreviousUpdate, afterReplacementUpdate: callbackCount };
+      });
+
+      expect(callbackCounts).toEqual({
+        afterPreviousUpdate: 0,
+        afterReplacementUpdate: 1,
+      });
     });
   });
 

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -217,7 +217,6 @@ const CANCELLED_COPY_RESULT: CopyFlowResult = {
 };
 
 let hasInited = false;
-const toolbarStateChangeCallbacks = new Set<(state: ToolbarState) => void>();
 
 export const init = (rawOptions?: Options): ReactGrabAPI => {
   if (typeof window === "undefined") {
@@ -266,6 +265,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
     let copyAbortController = new AbortController();
     let pendingCopyMetadataIdentity: object | null = null;
     let disposeRenderer: (() => void) | undefined;
+    const toolbarStateChangeCallbacks = new Set<(state: ToolbarState) => void>();
 
     const pluginRegistry = createPluginRegistry(settableOptions);
 


### PR DESCRIPTION
## Motivation

Toolbar subscribers were stored in one module-level set shared by every React Grab instance. After disposal and re-initialization, a stale API could notify or unsubscribe callbacks owned by the replacement instance.

## Example

1. Instance A subscribes a callback and is disposed.
2. Instance B starts and subscribes the same callback.
3. Calling `A.setToolbarState(...)` incorrectly notifies B's callback, and A's old unsubscribe function can remove B's subscription.

## Changes

Move the subscriber set into `init()` so each instance owns only its callbacks. Add an API regression test covering stale updates and stale unsubscribe functions.

## Validation

- `nr build`
- 158 unit tests
- 34 API E2E tests
- `nr lint`
- `nr typecheck`
- `nr format`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolate toolbar state subscribers per `react-grab` instance to prevent stale APIs from notifying or unsubscribing callbacks after dispose/reinit. Fixes cross-instance leakage when using `onToolbarStateChange` and `setToolbarState`.

- **Bug Fixes**
  - Moved the subscriber set into `init()` so each instance owns only its callbacks.
  - Added E2E test ensuring a disposed instance cannot notify or unsubscribe the replacement instance’s callbacks.

<sup>Written for commit fef2889a9c2d501efb81675ed6d7cb1a7ab2d843. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped lifecycle fix for toolbar subscriber storage plus regression coverage; no auth or data-path changes.
> 
> **Overview**
> Fixes **cross-instance leakage** for `onToolbarStateChange` / `setToolbarState` after dispose and re-init.
> 
> **`toolbarStateChangeCallbacks`** is no longer a module-level `Set` shared by every `init()` call. It is created inside each instance’s `createRoot` closure, cleared on `dispose()`, so a stale API cannot notify or unsubscribe callbacks registered on a replacement instance.
> 
> Adds an **API E2E test** that disposes instance A, re-inits B with the same callback, and asserts `A.setToolbarState` does not fire the callback while B’s update does once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fef2889a9c2d501efb81675ed6d7cb1a7ab2d843. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->