### PR TITLE
Restore Style previews when React Grab is disposed

### DIFF
--- a/packages/react-grab/e2e/edit-panel.spec.ts
+++ b/packages/react-grab/e2e/edit-panel.spec.ts
@@ -405,6 +405,21 @@ test.describe("Style Panel", () => {
       expect(await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR)).toBe(beforeTweak);
     });
 
+    test("disposal restores preview inline styles", async ({ reactGrab }) => {
+      await openEditPanel(reactGrab, BUTTON_SELECTOR);
+      const beforeTweak = await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR);
+      await reactGrab.page.keyboard.press("ArrowRight");
+      await reactGrab.page.waitForTimeout(IDLE_BUFFER_MS);
+      expect(await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR)).not.toBe(beforeTweak);
+
+      await reactGrab.page.evaluate(() => {
+        window.__REACT_GRAB__?.dispose();
+      });
+
+      await expect.poll(() => isEditPanelVisible(reactGrab.page)).toBe(false);
+      expect(await getInlineStyleAttribute(reactGrab.page, BUTTON_SELECTOR)).toBe(beforeTweak);
+    });
+
     test("held arrow repeat stops while discard prompt is visible", async ({ reactGrab }) => {
       await openEditPanel(reactGrab, BUTTON_SELECTOR);
       await reactGrab.page.keyboard.down("ArrowRight");

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -4312,6 +4312,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         disposed = true;
         hasInited = false;
         collectCleanupError(cancelPendingCopies, cleanupErrors);
+        collectCleanupError(editMode.resetWithDiscard, cleanupErrors);
         collectCleanupError(labelController.clearAll, cleanupErrors);
         if (disposeRenderer) collectCleanupError(disposeRenderer, cleanupErrors);
         disposeRenderer = undefined;


### PR DESCRIPTION
## Motivation

Style mode previews edits by writing temporary inline CSS onto the selected host element. Normal dismissal restores those styles, but disposing React Grab skipped that restoration and could permanently alter the host page.

## Example

1. Open Style mode for a button.
2. Preview a padding change.
3. Call `api.dispose()`.
4. The React Grab UI disappears, but the previewed padding remains without this fix.

## Changes

Run the existing `resetWithDiscard` cleanup during disposal before the Solid root is removed. Add an E2E regression that previews a style, disposes React Grab, and verifies the original inline style is restored.

## Validation

- `nr build`
- 158 unit tests
- focused disposal/style E2E regression
- `nr lint`
- `nr typecheck`
- `nr format`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Style mode preview cleanup when disposing `react-grab` so temporary inline styles are discarded and the host page stays unchanged.

- **Bug Fixes**
  - Run `editMode.resetWithDiscard` during `api.dispose()` to restore any previewed inline styles before unmounting.
  - Added an E2E test that previews a style, calls `api.dispose()`, and verifies the original inline style is restored.

<sup>Written for commit 3e475131fac61216b28d39d9f4bc357bcd5257ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small lifecycle fix reusing existing discard/restore logic; no new auth or data paths, covered by a focused E2E regression.
> 
> **Overview**
> **`api.dispose()`** now runs **`editMode.resetWithDiscard`** during teardown (alongside other cleanup), matching what happens when the overlay is disabled via **`setEnabled(false)`**. Style-mode preview tweaks that write temporary inline CSS on the host are discarded and original styles are restored before the Solid root is removed.
> 
> An E2E test in the Style panel **Dismissal** suite previews a tweak, calls **`window.__REACT_GRAB__?.dispose()`**, and asserts the panel is gone and the element’s inline **`style`** attribute matches the pre-preview value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e475131fac61216b28d39d9f4bc357bcd5257ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->