### PR TITLE
Clean up failed clipboard fallback setup

### DIFF
--- a/packages/react-grab/src/utils/copy-content.ts
+++ b/packages/react-grab/src/utils/copy-content.ts
@@ -61,17 +61,17 @@ export const copyContent = (content: string, options?: CopyContentOptions): bool
   // Clipboard API. The hidden textarea provides the selection context that
   // execCommand requires, and the copy handler installed above intercepts the
   // browser's default behavior to set our custom clipboard data.
+  const textarea = document.createElement("textarea");
   document.addEventListener("copy", copyHandler);
 
-  const textarea = document.createElement("textarea");
-  textarea.value = content;
-  textarea.style.position = "fixed";
-  textarea.style.left = "-9999px";
-  textarea.ariaHidden = "true";
-  document.body.appendChild(textarea);
-  textarea.select();
-
   try {
+    textarea.value = content;
+    textarea.style.position = "fixed";
+    textarea.style.left = "-9999px";
+    textarea.ariaHidden = "true";
+    document.body.appendChild(textarea);
+    textarea.select();
+
     if (typeof document.execCommand !== "function") {
       return false;
     }

--- a/packages/react-grab/tests/copy-content.test.ts
+++ b/packages/react-grab/tests/copy-content.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { copyContent } from "../src/utils/copy-content.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("copyContent", () => {
+  it("removes the copy listener when textarea setup fails", () => {
+    const copyListeners = new Set<EventListenerOrEventListenerObject>();
+    const setupError = new Error("append failed");
+    const textarea = {
+      value: "",
+      style: { position: "", left: "" },
+      ariaHidden: "",
+      select: vi.fn(),
+      remove: vi.fn(),
+    };
+    vi.stubGlobal("document", {
+      addEventListener: (_eventName: string, listener: EventListenerOrEventListenerObject) => {
+        copyListeners.add(listener);
+      },
+      removeEventListener: (_eventName: string, listener: EventListenerOrEventListenerObject) => {
+        copyListeners.delete(listener);
+      },
+      createElement: () => textarea,
+      body: {
+        appendChild: () => {
+          throw setupError;
+        },
+      },
+    });
+
+    expect(() => copyContent("content")).toThrow(setupError);
+    expect(copyListeners.size).toBe(0);
+    expect(textarea.remove).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Motivation

The legacy clipboard fallback installs a document-level `copy` listener before it creates and selects its hidden textarea. If textarea setup throws, cleanup was skipped and the listener remained attached.

## Example

If `document.body.appendChild(textarea)` throws, the stale listener intercepts later copy events even though this copy attempt failed.

## Changes

- Include textarea setup in the existing `try/finally` cleanup boundary.
- Add a regression test that forces setup to fail and verifies both the listener and textarea are removed.

## Validation

- `nr build`
- `nr --filter react-grab test:unit` — 159 passed
- `nr lint`
- `nr typecheck`
- `nr format`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes clipboard fallback cleanup in `react-grab` so failed textarea setup no longer leaves a stale document `copy` listener. Prevents future copy events from being intercepted after a failed attempt.

- **Bug Fixes**
  - Moved textarea setup into the existing try/finally so the `copy` listener and textarea are always removed on failure.
  - Added a regression test that forces `appendChild` to throw and verifies both the listener and textarea are cleaned up.

<sup>Written for commit a9ad7ee6886a0a46bb83aef9e3b2ef6db364e887. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to clipboard fallback error handling in one utility, with a regression test and no API or auth/data impact.
> 
> **Overview**
> Fixes a leak in the `execCommand("copy")` fallback in **`copyContent`**: the document-level **`copy`** listener was registered before hidden textarea setup, so if setup threw (e.g. **`appendChild`**), **`finally`** never ran and later copies could be hijacked.
> 
> **Textarea** creation, styling, **`appendChild`**, and **`select`** now run inside the existing **`try`/`finally`**, so the listener is always removed and the textarea is always torn down on failure. A unit test stubs a failing **`appendChild`** and asserts the listener set is empty and **`textarea.remove`** runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9ad7ee6886a0a46bb83aef9e3b2ef6db364e887. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->