### PR TITLE
Stop auto-scroll at page boundaries

### DIFF
--- a/packages/react-grab/src/core/auto-scroll.ts
+++ b/packages/react-grab/src/core/auto-scroll.ts
@@ -48,18 +48,24 @@ export const createAutoScroller = (
     if (direction.left) scrollDeltaX -= AUTO_SCROLL_SPEED_PX;
     if (direction.right) scrollDeltaX += AUTO_SCROLL_SPEED_PX;
 
+    let didScroll = false;
     if (scrollDeltaX !== 0 || scrollDeltaY !== 0) {
       const previousScrollX = window.scrollX;
       const previousScrollY = window.scrollY;
-      window.scrollBy(scrollDeltaX, scrollDeltaY);
+      window.scrollBy({
+        behavior: "instant",
+        left: scrollDeltaX,
+        top: scrollDeltaY,
+      });
       const didScrollByX = window.scrollX - previousScrollX;
       const didScrollByY = window.scrollY - previousScrollY;
-      if (didScrollByX !== 0 || didScrollByY !== 0) {
+      didScroll = didScrollByX !== 0 || didScrollByY !== 0;
+      if (didScroll) {
         onScrollStep?.({ x: didScrollByX, y: didScrollByY });
       }
     }
 
-    if (direction.top || direction.bottom || direction.left || direction.right) {
+    if (didScroll) {
       animationId = nativeRequestAnimationFrame(scroll);
     } else {
       animationId = null;

--- a/packages/react-grab/tests/auto-scroll.test.ts
+++ b/packages/react-grab/tests/auto-scroll.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { AUTO_SCROLL_EDGE_THRESHOLD_PX, AUTO_SCROLL_SPEED_PX } from "../src/constants.js";
+import { createAutoScroller } from "../src/core/auto-scroll.js";
+import {
+  nativeCancelAnimationFrame,
+  nativeRequestAnimationFrame,
+} from "../src/utils/native-raf.js";
+
+vi.mock("../src/utils/native-raf.js", () => ({
+  nativeCancelAnimationFrame: vi.fn(),
+  nativeRequestAnimationFrame: vi.fn(() => Number.MIN_SAFE_INTEGER),
+}));
+
+interface MutableScrollPosition {
+  x: number;
+  y: number;
+}
+
+const stubWindow = (scrollPosition: MutableScrollPosition) => {
+  const scrollBy = vi.fn((options: ScrollToOptions) => {
+    scrollPosition.x = Math.max(0, scrollPosition.x + (options.left ?? 0));
+    scrollPosition.y = Math.max(0, scrollPosition.y + (options.top ?? 0));
+  });
+  vi.stubGlobal("window", {
+    innerHeight: Infinity,
+    innerWidth: Infinity,
+    get scrollX() {
+      return scrollPosition.x;
+    },
+    get scrollY() {
+      return scrollPosition.y;
+    },
+    scrollBy,
+  });
+  return scrollBy;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("createAutoScroller", () => {
+  it("stops scheduling frames at the scroll boundary", () => {
+    const scrollBy = stubWindow({ x: 0, y: 0 });
+    const autoScroller = createAutoScroller(
+      () => ({ x: AUTO_SCROLL_EDGE_THRESHOLD_PX, y: 0 }),
+      () => true,
+    );
+
+    autoScroller.start();
+
+    expect(scrollBy).toHaveBeenCalledWith({
+      behavior: "instant",
+      left: 0,
+      top: -AUTO_SCROLL_SPEED_PX,
+    });
+    expect(nativeRequestAnimationFrame).not.toHaveBeenCalled();
+    expect(autoScroller.isActive()).toBe(false);
+  });
+
+  it("keeps scheduling while the page scrolls", () => {
+    stubWindow({ x: 0, y: AUTO_SCROLL_SPEED_PX * 2 });
+    const onScrollStep = vi.fn();
+    const autoScroller = createAutoScroller(
+      () => ({ x: AUTO_SCROLL_EDGE_THRESHOLD_PX, y: 0 }),
+      () => true,
+      onScrollStep,
+    );
+
+    autoScroller.start();
+
+    expect(onScrollStep).toHaveBeenCalledWith({ x: 0, y: -AUTO_SCROLL_SPEED_PX });
+    expect(nativeRequestAnimationFrame).toHaveBeenCalledOnce();
+    expect(autoScroller.isActive()).toBe(true);
+
+    autoScroller.stop();
+    expect(nativeCancelAnimationFrame).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Motivation

Auto-scroll kept requesting animation frames while the pointer stayed near an edge even after the page reached its scroll boundary. Each frame attempted the same no-op scroll indefinitely.

## Example

While dragging upward at the top of the page, `window.scrollBy(0, -8)` leaves `scrollY` at `0`, but React Grab previously scheduled another frame forever.

## Changes

- Continue the auto-scroll loop only when the page actually moved.
- Keep the existing pointer-move restart behavior.
- Add tests for both boundary stopping and continued scrolling.

## Validation

- `nr build`
- `nr --filter react-grab test:unit` — 161 passed
- `nr lint`
- `nr typecheck`
- `nr format`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop auto-scroll in `react-grab` at page edges to avoid endless `requestAnimationFrame` loops and no-op scrolls. The loop now re-schedules only when a frame actually changes `scrollX`/`scrollY`, calls `onScrollStep` only on real movement, and uses `window.scrollBy({ behavior: "instant" })` for deterministic steps; pointer-move restarts still work, and unit tests cover boundary stopping, continued scrolling, and cancel on stop.

<sup>Written for commit 99c8a45301302ca9083a78f32e5006ab7be3f9bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavior change in drag auto-scroll with clear boundary handling and new unit tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **edge auto-scroll** in React Grab so it no longer spins an endless `requestAnimationFrame` loop when the pointer stays in the edge zone but the page cannot move further (e.g. `scrollY` already at `0` while dragging upward).
> 
> The scroller now tracks whether the last `scrollBy` actually changed `scrollX`/`scrollY` and **only schedules the next frame when a real scroll happened**, instead of continuing whenever the cursor is still near an edge.
> 
> Adds unit tests for stopping at boundaries and for keeping the loop active while scrolling still works.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fe2df90739cf78e7db47924dc3cafde7e78672f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->