### PR TITLE
Restore hovered copy labels

### DIFF
--- a/packages/react-grab/src/components/overlay-canvas.tsx
+++ b/packages/react-grab/src/components/overlay-canvas.tsx
@@ -181,6 +181,9 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
     target.height = bounds.height;
     animation.borderRadius = parseBorderRadiusValue(bounds.borderRadius);
     if (targetOpacity !== undefined) {
+      if (targetOpacity > animation.targetOpacity) {
+        animation.opacity = targetOpacity;
+      }
       animation.targetOpacity = targetOpacity;
     }
   };

--- a/packages/react-grab/src/core/label-controller.ts
+++ b/packages/react-grab/src/core/label-controller.ts
@@ -193,12 +193,16 @@ export const createLabelController = (
   };
 
   const handleHoverChange = (instanceId: string, isHovered: boolean) => {
-    if (isHovered) {
-      cancelFade(instanceId);
-      return;
-    }
     const instance = getLabelInstances().find((labelInstance) => labelInstance.id === instanceId);
     if (!instance) return;
+
+    if (isHovered) {
+      cancelFade(instanceId);
+      if (instance.status === "fading") {
+        store.updateLabelInstance(instanceId, "copied");
+      }
+      return;
+    }
     // Error labels are dismissed explicitly (Retry/Ok), so unhovering must not
     // start a fade; only the transient copied/fading labels fade on hover-out.
     if (instance.status === "copied" || instance.status === "fading") {

--- a/packages/react-grab/tests/label-controller.test.ts
+++ b/packages/react-grab/tests/label-controller.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { FADE_COMPLETE_BUFFER_MS, FEEDBACK_DURATION_MS } from "../src/constants.js";
+import { createLabelController } from "../src/core/label-controller.js";
+import type { SelectionLabelInstance } from "../src/types.js";
+
+const LABEL_BOUNDS = {
+  borderRadius: "0px",
+  height: 20,
+  width: 40,
+  x: 10,
+  y: 10,
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal("window", {
+    clearTimeout: globalThis.clearTimeout,
+    setTimeout: globalThis.setTimeout,
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("createLabelController", () => {
+  it("restores a fading copied label while it is hovered", () => {
+    const labelInstances: SelectionLabelInstance[] = [];
+    const controller = createLabelController(
+      {
+        clearLabelInstances: () => {
+          labelInstances.length = 0;
+        },
+        addLabelInstance: (instance) => {
+          labelInstances.push(instance);
+        },
+        updateLabelInstance: (instanceId, status, errorMessage) => {
+          const instance = labelInstances.find((labelInstance) => labelInstance.id === instanceId);
+          if (!instance) return;
+          instance.status = status;
+          instance.errorMessage = errorMessage;
+        },
+        removeLabelInstance: (instanceId) => {
+          const instanceIndex = labelInstances.findIndex(
+            (labelInstance) => labelInstance.id === instanceId,
+          );
+          if (instanceIndex >= 0) labelInstances.splice(instanceIndex, 1);
+        },
+      },
+      () => labelInstances,
+    );
+    const instanceId = controller.createInstance(LABEL_BOUNDS, "button", undefined, "copying");
+
+    controller.updateAfterCopy(instanceId, true);
+    vi.advanceTimersByTime(FEEDBACK_DURATION_MS);
+    expect(labelInstances[0]?.status).toBe("fading");
+
+    controller.handleHoverChange(instanceId, true);
+    expect(labelInstances[0]?.status).toBe("copied");
+
+    vi.advanceTimersByTime(FADE_COMPLETE_BUFFER_MS);
+    expect(labelInstances).toHaveLength(1);
+
+    controller.handleHoverChange(instanceId, false);
+    vi.advanceTimersByTime(FEEDBACK_DURATION_MS + FADE_COMPLETE_BUFFER_MS);
+    expect(labelInstances).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Motivation

A copied label begins fading after its feedback timeout. If the pointer reaches it during that fade, the controller cancels deletion but leaves both the label state and canvas opacity fading toward invisible. The label can therefore disappear while the user is trying to interact with it.

## Example

1. Copy an element.
2. Wait until its “Copied” label starts fading.
3. Hover the label.

Before: the label keeps disappearing even though its removal timer is paused.

After: the label becomes visible again, stays while hovered, then starts a fresh fade after the pointer leaves.

## Changes

- Restore a fading label to its copied state when hovered.
- Restore the matching canvas animation opacity when its target becomes visible again.
- Cover the timer and hover lifecycle with a focused unit test.

## Validation

- `nr build`
- `nr --filter react-grab test:unit` — 162 passed
- `nr lint`
- `nr typecheck`
- `nr format`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores fading “Copied” labels when hovered so they stay visible during interaction. Also syncs overlay canvas opacity when the label becomes visible again.

- **Bug Fixes**
  - On hover, cancel fade and restore status to copied; start a fresh fade after hover-out.
  - When target opacity increases, immediately raise canvas animation opacity to match visibility.
  - Added a focused unit test for fade timer and hover lifecycle.

<sup>Written for commit 947ce3fbd689a0bddcdcfeb95497208962b19e24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX fix in label hover/fade and overlay opacity sync, with a focused unit test and no auth or data-path changes.
> 
> **Overview**
> Fixes copy feedback labels that kept fading to invisible even after hover paused removal timers.
> 
> **Label controller:** When a label is hovered while `fading`, fade timers are cancelled and status is reset to `copied` so the label stays interactive; leaving hover still schedules a fresh fade for `copied`/`fading` only.
> 
> **Overlay canvas:** If `targetOpacity` rises (e.g. after status returns to `copied`), `animation.opacity` is set immediately to the new target instead of continuing a slow lerp from a near-zero value.
> 
> Adds a unit test covering fade → hover restore → hover-out removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 947ce3fbd689a0bddcdcfeb95497208962b19e24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->