### PR TITLE
Reject empty transformed copies

### DIFF
--- a/packages/react-grab/src/core/copy.ts
+++ b/packages/react-grab/src/core/copy.ts
@@ -138,11 +138,13 @@ export const runCopyFlow = async (
       finalContent = prependedPrompt
         ? `${prependedPrompt}\n${transformedContent}`
         : transformedContent;
-      didStartClipboardWrite = true;
-      didCopy = copyContent(finalContent, {
-        componentName: options.componentName,
-        entries: getMetadataEntries(payload, finalContent, prependedPrompt),
-      });
+      if (finalContent.trim()) {
+        didStartClipboardWrite = true;
+        didCopy = copyContent(finalContent, {
+          componentName: options.componentName,
+          entries: getMetadataEntries(payload, finalContent, prependedPrompt),
+        });
+      }
     }
   } catch (error) {
     if (!didStartClipboardWrite && options.signal?.aborted) return CANCELLED_COPY_FLOW_RESULT;

--- a/packages/react-grab/tests/copy-flow.test.ts
+++ b/packages/react-grab/tests/copy-flow.test.ts
@@ -86,4 +86,17 @@ describe("runCopyFlow", () => {
     expect(hooks.onCopyError).not.toHaveBeenCalled();
     expect(hooks.onAfterCopy).not.toHaveBeenCalled();
   });
+
+  it("does not copy content removed by a transform", async () => {
+    const hooks = createHooks();
+    hooks.transformCopyContent.mockResolvedValue("   ");
+    const elements = [Object.create(null)];
+
+    const result = await runCopyFlow({ getContent: () => "content" }, hooks, elements);
+
+    expect(result).toEqual({ status: "failed" });
+    expect(hooks.onCopyError).not.toHaveBeenCalled();
+    expect(hooks.onCopySuccess).not.toHaveBeenCalled();
+    expect(hooks.onAfterCopy).toHaveBeenCalledWith(elements, false);
+  });
 });


### PR DESCRIPTION
## Motivation

A copy transform can remove all generated content. The copy flow currently treats that empty result like valid clipboard text, reports success, and can replace the user’s clipboard with whitespace.

## Example

A plugin uses `transformCopyContent` to filter generated output and returns `"   "`.

Before: React Grab writes whitespace and reports a successful copy.

After: React Grab skips the clipboard write and reports the copy as failed, while still running the normal `onAfterCopy(elements, false)` cleanup hook.

## Changes

- Start the clipboard write only when the final transformed content contains a non-whitespace character.
- Add a focused copy-flow test for an empty transform result.

## Validation

- `nr build`
- `nr --filter react-grab test:unit` — 163 passed
- `nr lint`
- `nr typecheck`
- `nr format`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject whitespace-only transformed copy results in `react-grab` to avoid replacing the clipboard with blanks. The copy flow now fails in this case and still runs cleanup.

- **Bug Fixes**
  - Start clipboard write only if the final transformed content contains a non-whitespace character.
  - On empty transform, skip write, report failure, and call `onAfterCopy(elements, false)`. Added a focused unit test to cover this path.

<sup>Written for commit 8a9ae40fd8c43c8e1bf7c34fa9f25b779f5daa75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard in the copy path with no auth or data-model changes; behavior is covered by a focused unit test.
> 
> **Overview**
> **Copy flow** no longer treats whitespace-only output from `transformCopyContent` as a successful copy. The clipboard write runs only when **`finalContent` has non-whitespace text** (after optional prepended prompt), so plugins that filter everything out cannot overwrite the clipboard with blanks.
> 
> When the transform clears the payload, the flow returns **`failed`**, skips **`onCopySuccess`**, and still invokes **`onAfterCopy(elements, false)`** for cleanup. A unit test covers a transform that returns `"   "`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a9ae40fd8c43c8e1bf7c34fa9f25b779f5daa75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->