### PR TITLE
Cancel stale toolbar snap work

### DIFF
--- a/packages/react-grab/src/utils/create-toolbar-drag.ts
+++ b/packages/react-grab/src/utils/create-toolbar-drag.ts
@@ -2,7 +2,7 @@ import { createSignal, onCleanup, type Accessor } from "solid-js";
 import type { Position } from "../types.js";
 import type { SnapEdge } from "../components/toolbar/state.js";
 import { TOOLBAR_DRAG_THRESHOLD_PX, TOOLBAR_SNAP_ANIMATION_DURATION_MS } from "../constants.js";
-import { nativeRequestAnimationFrame } from "./native-raf.js";
+import { nativeCancelAnimationFrame, nativeRequestAnimationFrame } from "./native-raf.js";
 import { ignoreRealInput } from "./runtime-mode.js";
 import {
   getRatioFromPosition,
@@ -43,12 +43,19 @@ export const createToolbarDrag = (config: ToolbarDragConfig): ToolbarDragResult 
   let lastPointerPosition = { x: 0, y: 0, time: 0 };
   let pointerStartPosition = { x: 0, y: 0 };
   let didDragOccur = false;
+  let snapAnimationFrame: number | undefined;
   let snapAnimationTimeout: ReturnType<typeof setTimeout> | undefined;
   let dragAbortController: AbortController | null = null;
 
   const teardownDragListeners = () => {
     dragAbortController?.abort();
     dragAbortController = null;
+  };
+
+  const cancelSnapAnimationFrame = () => {
+    if (snapAnimationFrame === undefined) return;
+    nativeCancelAnimationFrame(snapAnimationFrame);
+    snapAnimationFrame = undefined;
   };
 
   const handleWindowPointerMove = (event: PointerEvent) => {
@@ -115,13 +122,15 @@ export const createToolbarDrag = (config: ToolbarDragConfig): ToolbarDragResult 
     // orientation (horizontal to vertical), altering its dimensions. The first
     // frame waits for the DOM update and the second for layout to settle so
     // getBoundingClientRect returns the post-transition size.
-    nativeRequestAnimationFrame(() => {
+    cancelSnapAnimationFrame();
+    snapAnimationFrame = nativeRequestAnimationFrame(() => {
       const postRenderRect = containerRef?.getBoundingClientRect();
       const updatedDimensions = postRenderRect
         ? { width: postRenderRect.width, height: postRenderRect.height }
         : config.getExpandedDimensions();
 
-      nativeRequestAnimationFrame(() => {
+      snapAnimationFrame = nativeRequestAnimationFrame(() => {
+        snapAnimationFrame = undefined;
         const snappedPosition = getPositionFromEdgeAndRatio(
           snap.edge,
           ratio,
@@ -146,7 +155,7 @@ export const createToolbarDrag = (config: ToolbarDragConfig): ToolbarDragResult 
 
   const handlePointerDown = ignoreRealInput((event: PointerEvent) => {
     if (event.button !== 0) return;
-    if (config.isCollapsed()) return;
+    if (config.isCollapsed() || isSnapping()) return;
 
     const containerRef = config.getContainerRef();
     const rect = containerRef?.getBoundingClientRect();
@@ -186,6 +195,7 @@ export const createToolbarDrag = (config: ToolbarDragConfig): ToolbarDragResult 
 
   onCleanup(() => {
     teardownDragListeners();
+    cancelSnapAnimationFrame();
     clearTimeout(snapAnimationTimeout);
   });
 

--- a/packages/react-grab/tests/create-toolbar-drag.test.ts
+++ b/packages/react-grab/tests/create-toolbar-drag.test.ts
@@ -1,0 +1,99 @@
+import { createRoot } from "solid-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { createToolbarDrag } from "../src/utils/create-toolbar-drag.js";
+import {
+  nativeCancelAnimationFrame,
+  nativeRequestAnimationFrame,
+} from "../src/utils/native-raf.js";
+
+vi.mock("../src/utils/native-raf.js", () => ({
+  nativeCancelAnimationFrame: vi.fn(),
+  nativeRequestAnimationFrame: vi.fn(),
+}));
+
+describe("createToolbarDrag", () => {
+  const pendingAnimationFrames = new Map<number, FrameRequestCallback>();
+  const windowListeners = new Map<string, (event: PointerEvent) => void>();
+  let nextAnimationFrameId = 1;
+
+  beforeEach(() => {
+    nextAnimationFrameId = 1;
+    pendingAnimationFrames.clear();
+    windowListeners.clear();
+    vi.mocked(nativeRequestAnimationFrame).mockImplementation((callback) => {
+      const animationFrameId = nextAnimationFrameId++;
+      pendingAnimationFrames.set(animationFrameId, callback);
+      return animationFrameId;
+    });
+    vi.mocked(nativeCancelAnimationFrame).mockImplementation((animationFrameId) => {
+      pendingAnimationFrames.delete(animationFrameId);
+    });
+    vi.stubGlobal("window", {
+      addEventListener: (eventName: string, listener: (event: PointerEvent) => void): void => {
+        windowListeners.set(eventName, listener);
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("cancels disposed snap frames and ignores pointerdown while snapping", () => {
+    const containerRef: HTMLDivElement = Object.create({
+      getBoundingClientRect: () => ({
+        left: 10,
+        top: 10,
+        width: 100,
+        height: 40,
+      }),
+    });
+    const onSnapComplete = vi.fn();
+    const ownedDrag = createRoot((disposeOwner) => ({
+      disposeOwner,
+      drag: createToolbarDrag({
+        getContainerRef: () => containerRef,
+        isCollapsed: () => false,
+        getExpandedDimensions: () => ({ width: 100, height: 40 }),
+        onDragStart: () => {},
+        onPositionUpdate: () => {},
+        onSnapEdgeChange: () => {},
+        onSnapComplete,
+      }),
+    }));
+
+    const pointerDownEvent: PointerEvent = Object.create({
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+    });
+    const pointerMoveEvent: PointerEvent = Object.create({
+      clientX: 30,
+      clientY: 30,
+    });
+    const performDrag = () => {
+      ownedDrag.drag.handlePointerDown(pointerDownEvent);
+      windowListeners.get("pointermove")?.(pointerMoveEvent);
+      windowListeners.get("pointerup")?.(pointerMoveEvent);
+    };
+
+    performDrag();
+    expect(pendingAnimationFrames.has(1)).toBe(true);
+    expect(ownedDrag.drag.isSnapping()).toBe(true);
+
+    ownedDrag.drag.handlePointerDown(pointerDownEvent);
+    expect(ownedDrag.drag.isDragging()).toBe(false);
+
+    const firstFrame = pendingAnimationFrames.get(1);
+    pendingAnimationFrames.delete(1);
+    firstFrame?.(0);
+    expect(pendingAnimationFrames.has(2)).toBe(true);
+
+    ownedDrag.disposeOwner();
+
+    expect(nativeCancelAnimationFrame).toHaveBeenCalledWith(2);
+    expect(pendingAnimationFrames.size).toBe(0);
+    expect(onSnapComplete).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Motivation

Toolbar snapping waits two animation frames for the toolbar’s new orientation and size. Those queued callbacks are not currently owned by the toolbar lifecycle, so they can run after disposal. A second drag can also begin while the previous snap still owns pending layout work.

## Example

Drag the toolbar to an edge, then immediately dispose React Grab or press the toolbar again before its snap settles.

Before: an old snap callback can run against disposed state or reposition the toolbar during the new gesture.

After: disposal cancels the queued frame, and pointerdown is ignored until the active snap finishes.

## Changes

- Track and cancel the currently queued snap animation frame.
- Cancel pending snap work during Solid cleanup.
- Ignore new toolbar drags while a snap is in progress.
- Add a focused lifecycle test for both disposal and the snap guard.

## Validation

- `nr build`
- `nr --filter react-grab test:unit` — 164 passed
- `nr lint`
- `nr typecheck`
- `nr format`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancels stale toolbar snap frames so they don’t run after disposal, and blocks new drags until a snap finishes. Prevents unexpected repositioning and errors during rapid drag/cleanup sequences.

- **Bug Fixes**
  - Track the active snap `requestAnimationFrame` and cancel it on new snap or cleanup via `nativeCancelAnimationFrame`.
  - Ignore `pointerdown` while a snap is in progress.
  - Add unit test in `react-grab` to verify disposal cancellation and the snap guard.

<sup>Written for commit b3cd39daee02a1ec470c9517979384a64ee377f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI interaction fix in toolbar drag/snap with explicit cleanup and a focused unit test; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes toolbar snap lifecycle so **nested `requestAnimationFrame` callbacks** from edge snapping cannot run after the drag helper is disposed or overlap with a new gesture.
> 
> `createToolbarDrag` now **tracks the active snap frame ID**, cancels it before scheduling a new snap and on Solid **`onCleanup`**, and **ignores `pointerdown` while `isSnapping()`** so a second drag cannot start until the current snap finishes.
> 
> Adds a **unit test** that simulates drag-to-snap, verifies pointerdown is ignored during snap, and asserts disposal cancels the pending inner frame without calling `onSnapComplete`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3cd39daee02a1ec470c9517979384a64ee377f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->