### PR TITLE
Instrument exact Solid sources in E2E development builds

### DIFF
--- a/apps/e2e-app-next/next.config.ts
+++ b/apps/e2e-app-next/next.config.ts
@@ -1,9 +1,17 @@
 import type { NextConfig } from "next";
 
+const reactGrabDevelopmentAliases = {
+  "react-grab/primitives": "@react-grab/e2e-development/primitives",
+  "react-grab": "@react-grab/e2e-development",
+};
+
 const nextConfig: NextConfig = {
   distDir: process.env.NEXT_DIST_DIR ?? ".next",
   productionBrowserSourceMaps: false,
   reactStrictMode: true,
+  turbopack: {
+    resolveAlias: process.env.NODE_ENV === "development" ? reactGrabDevelopmentAliases : undefined,
+  },
   typescript: {
     tsconfigPath: process.env.NEXT_TSCONFIG_PATH ?? "tsconfig.json",
   },

--- a/apps/e2e-app-next/package.json
+++ b/apps/e2e-app-next/package.json
@@ -17,6 +17,7 @@
     "react-grab": "workspace:*"
   },
   "devDependencies": {
+    "@react-grab/e2e-development": "workspace:*",
     "@types/node": "^22.10.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/apps/e2e-app-tanstack-start/package.json
+++ b/apps/e2e-app-tanstack-start/package.json
@@ -16,6 +16,7 @@
     "react-grab": "workspace:*"
   },
   "devDependencies": {
+    "@react-grab/e2e-development": "workspace:*",
     "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/apps/e2e-app-tanstack-start/vite.config.ts
+++ b/apps/e2e-app-tanstack-start/vite.config.ts
@@ -1,14 +1,18 @@
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+import { REACT_GRAB_DEVELOPMENT_ALIASES } from "../e2e-react-grab-development-aliases.js";
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   build: {
     sourcemap: false,
   },
   plugins: [tanstackStart(), react()],
+  resolve: {
+    alias: command === "serve" ? REACT_GRAB_DEVELOPMENT_ALIASES : {},
+  },
   server: {
     port: 5178,
     strictPort: true,
   },
-});
+}));

--- a/apps/e2e-app-vite-upstream/package.json
+++ b/apps/e2e-app-vite-upstream/package.json
@@ -16,6 +16,7 @@
     "react-router-dom": "^7.9.6"
   },
   "devDependencies": {
+    "@react-grab/e2e-development": "workspace:*",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",

--- a/apps/e2e-app-vite-upstream/vite.config.ts
+++ b/apps/e2e-app-vite-upstream/vite.config.ts
@@ -1,9 +1,13 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+import { REACT_GRAB_DEVELOPMENT_ALIASES } from "../e2e-react-grab-development-aliases.js";
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   plugins: [react()],
   build: {
     sourcemap: false,
   },
-});
+  resolve: {
+    alias: command === "serve" ? REACT_GRAB_DEVELOPMENT_ALIASES : {},
+  },
+}));

--- a/apps/e2e-app-vite/package.json
+++ b/apps/e2e-app-vite/package.json
@@ -19,6 +19,7 @@
     "recharts": "^3.9.2"
   },
   "devDependencies": {
+    "@react-grab/e2e-development": "workspace:*",
     "@tailwindcss/vite": "^4.3.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/apps/e2e-app-vite/vite.config.ts
+++ b/apps/e2e-app-vite/vite.config.ts
@@ -1,6 +1,7 @@
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig, type Plugin } from "vite";
+import { REACT_GRAB_DEVELOPMENT_ALIASES } from "../e2e-react-grab-development-aliases.js";
 
 // Holds a request open for ?ms (default 30s) so the @perf source-fetch bench can
 // saturate the browser's per-origin connection pool and make react-grab's source
@@ -20,7 +21,7 @@ const slowEndpointPlugin = (): Plugin => ({
   },
 });
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   plugins: [react(), tailwindcss(), slowEndpointPlugin()],
   server: {
     port: 5175,
@@ -28,7 +29,8 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      ...(command === "serve" ? REACT_GRAB_DEVELOPMENT_ALIASES : {}),
       "@": "/src",
     },
   },
-});
+}));

--- a/apps/e2e-react-grab-development-aliases.ts
+++ b/apps/e2e-react-grab-development-aliases.ts
@@ -1,0 +1,4 @@
+export const REACT_GRAB_DEVELOPMENT_ALIASES = {
+  "react-grab/primitives": "@react-grab/e2e-development/primitives",
+  "react-grab": "@react-grab/e2e-development",
+};

--- a/apps/e2e-react-grab-development/package.json
+++ b/apps/e2e-react-grab-development/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@react-grab/e2e-development",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js",
+    "./primitives": "./dist/primitives.js"
+  }
+}

--- a/apps/openstory/package.json
+++ b/apps/openstory/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "openstory": "^0.0.16"
+    "openstory": "^0.1.0"
   },
   "devDependencies": {
     "@types/node": "^25.6.2",

--- a/apps/openstory/stories/toolbar.stories.tsx
+++ b/apps/openstory/stories/toolbar.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "openstory/solid";
 import { expect, waitFor } from "openstory/test";
 import { Toolbar } from "@react-grab-source/components/toolbar/index.js";
+import { getElementContext } from "@react-grab-source/primitives.js";
 import { Canvas } from "./target-box.js";
 import { noop } from "./noop.js";
 
@@ -49,6 +50,16 @@ const meta: Meta<ToolbarSceneProps> = {
     await waitFor(() => {
       expect(canvasElement.querySelector("[data-react-grab-toolbar]")).not.toBeNull();
     });
+    if (!import.meta.env.DEV) return;
+
+    const actionButton = canvasElement.querySelector("[data-react-grab-toolbar-action]");
+    expect(actionButton).toBeInstanceOf(HTMLButtonElement);
+    if (!(actionButton instanceof HTMLButtonElement)) return;
+
+    const elementContext = await getElementContext(actionButton);
+    expect(elementContext.filePath).toContain(
+      "packages/react-grab/src/components/toolbar/toolbar-action-button.tsx",
+    );
   },
   args: {
     isActive: false,

--- a/apps/openstory/vite.config.ts
+++ b/apps/openstory/vite.config.ts
@@ -2,13 +2,20 @@ import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
 import solid from "vite-plugin-solid";
 import { openstory } from "openstory/plugin";
+import { solidSourceLocationBabelPlugin } from "../../packages/react-grab/solid-source-location-babel-plugin.js";
 
 const REACT_FILE_PATTERN = /\.react\.tsx$/;
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   plugins: [
     solid({
       exclude: [REACT_FILE_PATTERN],
+      babel:
+        command === "serve"
+          ? {
+              plugins: [solidSourceLocationBabelPlugin],
+            }
+          : undefined,
     }),
     openstory({ framework: "solid" }),
   ],
@@ -25,9 +32,10 @@ export default defineConfig({
     // react-grab source reads this at module scope (utils/runtime-mode.ts);
     // without a define, the bare `process` access throws in the browser.
     "process.env.IS_DEMO": JSON.stringify(""),
+    "process.env.REACT_GRAB_SOURCE_LOCATIONS": JSON.stringify(command === "serve" ? "true" : ""),
   },
   esbuild: {
     jsx: "automatic",
     jsxImportSource: "react",
   },
-});
+}));

--- a/packages/react-grab/e2e/solid-source-location.spec.ts
+++ b/packages/react-grab/e2e/solid-source-location.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "./fixtures.js";
+import { ATTRIBUTE_NAME } from "./constants.js";
+import { isProductionProject } from "./framework/framework-helpers.js";
+import { SOLID_SOURCE_LOCATION_ATTRIBUTE } from "../src/utils/resolve-solid-source-location.js";
+
+const TOOLBAR_ACTION_SELECTOR = "[data-react-grab-toolbar-action]";
+const TOOLBAR_ACTION_SOURCE_PATH =
+  "packages/react-grab/src/components/toolbar/toolbar-action-button.tsx";
+const TOOLBAR_ACTION_SOURCE_LINE_NUMBER = 24;
+const TOOLBAR_ACTION_SOURCE_COLUMN_NUMBER = 5;
+
+test("exposes exact Solid sources only in development", async ({ reactGrab }, testInfo) => {
+  await reactGrab.activate();
+  await expect(reactGrab.getOverlayHost().locator(TOOLBAR_ACTION_SELECTOR).first()).toBeAttached();
+
+  const sourceResult = await reactGrab.page.evaluate(
+    async ({ overlayAttribute, sourceLocationAttribute, toolbarActionSelector }) => {
+      const overlayHost = document.querySelector(`[${overlayAttribute}]`);
+      const actionButton = overlayHost?.shadowRoot?.querySelector(toolbarActionSelector);
+      const source = actionButton ? await window.__REACT_GRAB__?.getSource(actionButton) : null;
+
+      return {
+        filePath: source?.filePath ?? null,
+        lineNumber: source?.lineNumber ?? null,
+        columnNumber: source?.columnNumber ?? null,
+        sourceLocation: actionButton?.getAttribute(sourceLocationAttribute) ?? null,
+      };
+    },
+    {
+      overlayAttribute: ATTRIBUTE_NAME,
+      sourceLocationAttribute: SOLID_SOURCE_LOCATION_ATTRIBUTE,
+      toolbarActionSelector: TOOLBAR_ACTION_SELECTOR,
+    },
+  );
+
+  if (isProductionProject(testInfo.project.name)) {
+    expect(sourceResult.sourceLocation).toBeNull();
+    expect(sourceResult.filePath ?? "").not.toContain(TOOLBAR_ACTION_SOURCE_PATH);
+    return;
+  }
+
+  expect(sourceResult.filePath).toContain(TOOLBAR_ACTION_SOURCE_PATH);
+  expect(sourceResult.lineNumber).toBe(TOOLBAR_ACTION_SOURCE_LINE_NUMBER);
+  expect(sourceResult.columnNumber).toBe(TOOLBAR_ACTION_SOURCE_COLUMN_NUMBER);
+  expect(sourceResult.sourceLocation).toContain(
+    `${TOOLBAR_ACTION_SOURCE_PATH}:${TOOLBAR_ACTION_SOURCE_LINE_NUMBER}:${TOOLBAR_ACTION_SOURCE_COLUMN_NUMBER}`,
+  );
+});

--- a/packages/react-grab/package.json
+++ b/packages/react-grab/package.json
@@ -82,6 +82,8 @@
     "css:watch": "tailwindcss -i ./src/styles.css -o ./dist/styles.css -w",
     "prebuild": "mkdir -p dist && tailwindcss -i ./src/styles.css -o ./dist/styles.css -m && tsx scripts/css-rem-to-px.ts",
     "build": "NODE_ENV=production vp pack",
+    "build:e2e-development": "pnpm run prebuild && NODE_ENV=development REACT_GRAB_SOURCE_LOCATIONS=true vp pack --out-dir ../../apps/e2e-react-grab-development/dist",
+    "build:e2e-development:coverage": "pnpm run prebuild && NODE_ENV=production REACT_GRAB_SOURCE_LOCATIONS=true REACT_GRAB_NO_MINIFY=true REACT_GRAB_SOURCEMAP=true vp pack --out-dir ../../apps/e2e-react-grab-development/dist",
     "build:demo": "IS_DEMO=true pnpm build",
     "build:profiling": "pnpm run prebuild && NODE_ENV=profiling REACT_GRAB_NO_MINIFY=true REACT_GRAB_SOURCEMAP=true vp pack",
     "build:coverage": "pnpm run prebuild && NODE_ENV=production REACT_GRAB_NO_MINIFY=true REACT_GRAB_SOURCEMAP=true vp pack",

--- a/packages/react-grab/playwright.config.ts
+++ b/packages/react-grab/playwright.config.ts
@@ -30,6 +30,7 @@ const VITE_UPSTREAM_PRODUCTION_URL = "http://localhost:5182";
 const NEXT_DEVELOPMENT_SPEC_PATTERN = /next-(?!production-).*\.spec\.ts/;
 const VITE_PLUS_PRODUCTION_SPEC_PATTERN = /framework-production\.spec\.ts/;
 const FRAMEWORK_SPEC_PATTERN = /framework\/.*\.spec\.ts/;
+const SOLID_SOURCE_LOCATION_SPEC_PATTERN = /solid-source-location\.spec\.ts/;
 
 // The @perf bench (PERF_LABEL set by test-perf.yml) and coverage runs only
 // stimulate the Vite development app. Skip all other framework servers and
@@ -82,31 +83,35 @@ const vitePlusTouchProject: Project = {
 const vitePlusProductionProject: Project = {
   name: "vite-plus-production",
   use: { ...devices["Desktop Chrome"], baseURL: VITE_PLUS_PRODUCTION_URL },
-  testMatch: VITE_PLUS_PRODUCTION_SPEC_PATTERN,
+  testMatch: [VITE_PLUS_PRODUCTION_SPEC_PATTERN, SOLID_SOURCE_LOCATION_SPEC_PATTERN],
 };
 
 const viteUpstreamDevelopmentProject: Project = {
   name: "vite-upstream-development",
   use: { ...devices["Desktop Chrome"], baseURL: VITE_UPSTREAM_DEVELOPMENT_URL },
-  testMatch: FRAMEWORK_SPEC_PATTERN,
+  testMatch: [FRAMEWORK_SPEC_PATTERN, SOLID_SOURCE_LOCATION_SPEC_PATTERN],
 };
 
 const viteUpstreamProductionProject: Project = {
   name: "vite-upstream-production",
   use: { ...devices["Desktop Chrome"], baseURL: VITE_UPSTREAM_PRODUCTION_URL },
-  testMatch: FRAMEWORK_SPEC_PATTERN,
+  testMatch: [FRAMEWORK_SPEC_PATTERN, SOLID_SOURCE_LOCATION_SPEC_PATTERN],
 };
 
 const nextDevelopmentProject: Project = {
   name: "next-development",
   use: { ...devices["Desktop Chrome"], baseURL: NEXT_DEVELOPMENT_URL },
-  testMatch: [NEXT_DEVELOPMENT_SPEC_PATTERN, FRAMEWORK_SPEC_PATTERN],
+  testMatch: [
+    NEXT_DEVELOPMENT_SPEC_PATTERN,
+    FRAMEWORK_SPEC_PATTERN,
+    SOLID_SOURCE_LOCATION_SPEC_PATTERN,
+  ],
 };
 
 const nextProductionProject: Project = {
   name: "next-production",
   use: { ...devices["Desktop Chrome"], baseURL: NEXT_PRODUCTION_URL },
-  testMatch: FRAMEWORK_SPEC_PATTERN,
+  testMatch: [FRAMEWORK_SPEC_PATTERN, SOLID_SOURCE_LOCATION_SPEC_PATTERN],
 };
 
 const tanstackDevelopmentProject: Project = {
@@ -114,7 +119,7 @@ const tanstackDevelopmentProject: Project = {
   fullyParallel: false,
   workers: 1,
   use: { ...devices["Desktop Chrome"], baseURL: TANSTACK_DEVELOPMENT_URL },
-  testMatch: FRAMEWORK_SPEC_PATTERN,
+  testMatch: [FRAMEWORK_SPEC_PATTERN, SOLID_SOURCE_LOCATION_SPEC_PATTERN],
 };
 
 const tanstackProductionProject: Project = {
@@ -122,23 +127,26 @@ const tanstackProductionProject: Project = {
   fullyParallel: false,
   workers: 1,
   use: { ...devices["Desktop Chrome"], baseURL: TANSTACK_PRODUCTION_URL },
-  testMatch: FRAMEWORK_SPEC_PATTERN,
+  testMatch: [FRAMEWORK_SPEC_PATTERN, SOLID_SOURCE_LOCATION_SPEC_PATTERN],
 };
 
 // Under COVERAGE the dist must carry source maps (and stay unminified) so V8
 // byte ranges remap cleanly back onto src/*.ts(x).
-const reactGrabBuildCommand = isCoverageRun
+const reactGrabProductionBuildCommand = isCoverageRun
   ? "pnpm --filter react-grab build:coverage"
   : "pnpm --filter react-grab build";
+const reactGrabDevelopmentBuildCommand = isCoverageRun
+  ? "pnpm --filter react-grab build:e2e-development:coverage"
+  : "pnpm --filter react-grab build:e2e-development";
 
 const requestedEnvironment = shouldRunViteOnly
   ? "vite-plus-development"
   : process.env.E2E_ENVIRONMENT;
 const withRequestedEnvironmentBuild = (command: string): string =>
-  requestedEnvironment ? `${reactGrabBuildCommand} && ${command}` : command;
+  requestedEnvironment ? `${reactGrabProductionBuildCommand} && ${command}` : command;
 
 const vitePlusDevelopmentWebServer = {
-  command: `${reactGrabBuildCommand} && pnpm dev --port ${VITE_PLUS_DEVELOPMENT_PORT}`,
+  command: `${reactGrabDevelopmentBuildCommand} && pnpm dev --port ${VITE_PLUS_DEVELOPMENT_PORT}`,
   url: VITE_PLUS_DEVELOPMENT_URL,
   reuseExistingServer: !process.env.CI && !isCoverageRun,
   cwd: path.resolve(__dirname, "../../apps/e2e-app-vite"),
@@ -154,7 +162,7 @@ const vitePlusProductionWebServer = {
 };
 
 const viteUpstreamDevelopmentWebServer = {
-  command: withRequestedEnvironmentBuild("pnpm dev"),
+  command: requestedEnvironment ? `${reactGrabDevelopmentBuildCommand} && pnpm dev` : "pnpm dev",
   url: VITE_UPSTREAM_DEVELOPMENT_URL,
   reuseExistingServer: !process.env.CI && !isCoverageRun,
   cwd: path.resolve(__dirname, "../../apps/e2e-app-vite-upstream"),
@@ -170,7 +178,7 @@ const viteUpstreamProductionWebServer = {
 };
 
 const nextDevelopmentWebServer = {
-  command: withRequestedEnvironmentBuild("pnpm dev"),
+  command: requestedEnvironment ? `${reactGrabDevelopmentBuildCommand} && pnpm dev` : "pnpm dev",
   url: NEXT_DEVELOPMENT_URL,
   reuseExistingServer: !process.env.CI && !isCoverageRun,
   cwd: path.resolve(__dirname, "../../apps/e2e-app-next"),
@@ -188,7 +196,7 @@ const nextProductionWebServer = {
 };
 
 const tanstackDevelopmentWebServer = {
-  command: withRequestedEnvironmentBuild("pnpm dev"),
+  command: requestedEnvironment ? `${reactGrabDevelopmentBuildCommand} && pnpm dev` : "pnpm dev",
   url: TANSTACK_DEVELOPMENT_URL,
   reuseExistingServer: !process.env.CI && !isCoverageRun,
   cwd: path.resolve(__dirname, "../../apps/e2e-app-tanstack-start"),

--- a/packages/react-grab/solid-babel-plugin.ts
+++ b/packages/react-grab/solid-babel-plugin.ts
@@ -45,9 +45,15 @@ export const solidWebBrowserPlugin = () => {
   };
 };
 
-export const solidBabelPlugin = (filter: RegExp = /\.(tsx|jsx)$/) => ({
+export interface SolidBabelPluginOptions {
+  filter?: RegExp;
+  plugins?: babel.PluginItem[];
+}
+
+export const solidBabelPlugin = (options: SolidBabelPluginOptions = {}) => ({
   name: "solid-babel",
   transform(code: string, id: string) {
+    const filter = options.filter ?? /\.(tsx|jsx)$/;
     if (!filter.test(id)) return;
 
     const result = babel.transformSync(code, {
@@ -55,6 +61,7 @@ export const solidBabelPlugin = (filter: RegExp = /\.(tsx|jsx)$/) => ({
         ["@babel/preset-typescript", { onlyRemoveTypeImports: true }],
         "babel-preset-solid",
       ],
+      plugins: options.plugins,
       filename: id,
       sourceMaps: true,
       caller: { name: "solid-babel", supportsStaticESM: true },

--- a/packages/react-grab/solid-source-location-babel-plugin.ts
+++ b/packages/react-grab/solid-source-location-babel-plugin.ts
@@ -1,0 +1,45 @@
+import { types, type PluginObj } from "@babel/core";
+import { SOLID_SOURCE_LOCATION_ATTRIBUTE } from "./src/utils/resolve-solid-source-location.js";
+
+const SOURCE_COLUMN_OFFSET = 1;
+
+export const solidSourceLocationBabelPlugin: PluginObj = {
+  name: "solid-source-location",
+  visitor: {
+    Program: (path, state) => {
+      const filename = state.file.opts.filenameRelative ?? state.file.opts.filename;
+      if (!filename) return;
+
+      path.traverse({
+        JSXOpeningElement: (openingElementPath) => {
+          const openingElement = openingElementPath.node;
+          const elementName = openingElement.name;
+          const sourceStart = openingElement.loc?.start;
+          if (
+            !types.isJSXIdentifier(elementName) ||
+            elementName.name[0] !== elementName.name[0]?.toLowerCase() ||
+            !sourceStart
+          ) {
+            return;
+          }
+
+          const hasSourceLocation = openingElement.attributes.some(
+            (attribute) =>
+              types.isJSXAttribute(attribute) &&
+              types.isJSXIdentifier(attribute.name, { name: SOLID_SOURCE_LOCATION_ATTRIBUTE }),
+          );
+          if (hasSourceLocation) return;
+
+          openingElement.attributes.push(
+            types.jsxAttribute(
+              types.jsxIdentifier(SOLID_SOURCE_LOCATION_ATTRIBUTE),
+              types.stringLiteral(
+                `${filename}:${sourceStart.line}:${sourceStart.column + SOURCE_COLUMN_OFFSET}`,
+              ),
+            ),
+          );
+        },
+      });
+    },
+  },
+};

--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -22,6 +22,7 @@ import { isNextProjectRuntime } from "../utils/is-next-project-runtime.js";
 import { formatComponentNameLines } from "../utils/format-component-name-lines.js";
 import { enrichServerFrameLocations, symbolicateServerFrames } from "./next-server-frames.js";
 import { runQueuedSourceFetch } from "../utils/source-fetch-queue.js";
+import { resolveSolidSourceLocation } from "../utils/resolve-solid-source-location.js";
 import { getHTMLPreview, getInlineHTMLPreview } from "./html-preview.js";
 import { isShadowRoot } from "../utils/is-shadow-root.js";
 import {
@@ -263,6 +264,11 @@ export const selectResolvedSource = (
 };
 
 export const resolveSource = async (element: Element): Promise<ResolvedSource | null> => {
+  if (process.env.REACT_GRAB_SOURCE_LOCATIONS === "true") {
+    const solidSourceLocation = resolveSolidSourceLocation(element);
+    if (solidSourceLocation) return { ...solidSourceLocation, origin: "app" };
+  }
+
   const fiberSource = await getCachedFiberSource(element);
   if (fiberSource?.origin === "app" && isTrustedAppSourcePath(fiberSource.filePath)) {
     return fiberSource;

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -4333,6 +4333,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
         return {
           filePath: source.filePath,
           lineNumber: source.lineNumber,
+          columnNumber: source.columnNumber ?? null,
           componentName: source.componentName,
         };
       },

--- a/packages/react-grab/src/types.ts
+++ b/packages/react-grab/src/types.ts
@@ -443,6 +443,7 @@ export interface SettableOptions extends Options {
 export interface SourceInfo {
   filePath: string;
   lineNumber: number | null;
+  columnNumber: number | null;
   componentName: string | null;
 }
 

--- a/packages/react-grab/src/utils/resolve-solid-source-location.ts
+++ b/packages/react-grab/src/utils/resolve-solid-source-location.ts
@@ -1,0 +1,33 @@
+import type { SourceLocation } from "../types.js";
+
+export const SOLID_SOURCE_LOCATION_ATTRIBUTE = "data-react-grab-source-location";
+
+const SOURCE_LOCATION_DELIMITER = ":";
+
+export const resolveSolidSourceLocation = (element: Element): SourceLocation | null => {
+  const location = element
+    .closest(`[${SOLID_SOURCE_LOCATION_ATTRIBUTE}]`)
+    ?.getAttribute(SOLID_SOURCE_LOCATION_ATTRIBUTE);
+  if (!location) return null;
+
+  const columnDelimiterIndex = location.lastIndexOf(SOURCE_LOCATION_DELIMITER);
+  if (columnDelimiterIndex === -1) return null;
+
+  const lineDelimiterIndex = location.lastIndexOf(
+    SOURCE_LOCATION_DELIMITER,
+    columnDelimiterIndex - 1,
+  );
+  if (lineDelimiterIndex === -1) return null;
+
+  const filePath = location.slice(0, lineDelimiterIndex);
+  const lineNumber = Number(location.slice(lineDelimiterIndex + 1, columnDelimiterIndex));
+  const columnNumber = Number(location.slice(columnDelimiterIndex + 1));
+  if (!filePath || !Number.isInteger(lineNumber) || !Number.isInteger(columnNumber)) return null;
+
+  return {
+    filePath,
+    lineNumber,
+    columnNumber,
+    componentName: null,
+  };
+};

--- a/packages/react-grab/vite.config.ts
+++ b/packages/react-grab/vite.config.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import { defineConfig } from "vite-plus";
 import type { PackUserConfig } from "vite-plus/pack";
 import { cssTextPlugin, solidBabelPlugin, solidWebBrowserPlugin } from "./solid-babel-plugin.js";
+import { solidSourceLocationBabelPlugin } from "./solid-source-location-babel-plugin.js";
 
 const getCommitHash = (): string => {
   try {
@@ -35,13 +36,21 @@ const licenseBanner = `/**
 // process.env.IS_DEMO is a build-time constant. The library entries compile it
 // to "" (falsey) so every demo-only branch is dead-code-eliminated; the demo
 // entries compile it to "true" so the same source becomes a display-only build.
+const shouldInstrumentSolidSources = process.env.REACT_GRAB_SOURCE_LOCATIONS === "true";
 const createDefine = (isDemo: boolean) => ({
   "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV ?? "development"),
   "process.env.VERSION": JSON.stringify(version),
   "process.env.IS_DEMO": JSON.stringify(isDemo ? "true" : ""),
+  "process.env.REACT_GRAB_SOURCE_LOCATIONS": JSON.stringify(
+    shouldInstrumentSolidSources ? "true" : "",
+  ),
 });
 
 const alwaysBundle = [/^solid-js/, /^bippy/];
+const createSolidBabelPlugin = () =>
+  solidBabelPlugin({
+    plugins: shouldInstrumentSolidSources ? [solidSourceLocationBabelPlugin] : [],
+  });
 
 // Fresh plugin instances per pack; the two shapes (browser IIFE global, neutral
 // cjs/esm module) share everything except entry/format/output, so they're built
@@ -61,7 +70,7 @@ const makeIifePack = (entry: string, globalName: string, isDemo: boolean): PackU
   },
   define: createDefine(isDemo),
   deps: { alwaysBundle },
-  plugins: [solidWebBrowserPlugin(), cssTextPlugin(), solidBabelPlugin()],
+  plugins: [solidWebBrowserPlugin(), cssTextPlugin(), createSolidBabelPlugin()],
 });
 
 const makeModulePack = (entry: string[], isDemo: boolean): PackUserConfig => ({
@@ -75,7 +84,7 @@ const makeModulePack = (entry: string[], isDemo: boolean): PackUserConfig => ({
   banner: licenseBanner,
   define: createDefine(isDemo),
   deps: { alwaysBundle },
-  plugins: [solidWebBrowserPlugin(), cssTextPlugin(), solidBabelPlugin()],
+  plugins: [solidWebBrowserPlugin(), cssTextPlugin(), createSolidBabelPlugin()],
 });
 
 // The demo build is opt-in: `IS_DEMO=true` (via `pnpm build:demo`) emits the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,8 +198,8 @@ importers:
   apps/openstory:
     dependencies:
       openstory:
-        specifier: ^0.0.16
-        version: 0.0.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.37.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.4))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.12)(typescript@6.0.3)
+        specifier: ^0.1.0
+        version: 0.1.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.37.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.4))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.12)(typescript@6.0.3)
     devDependencies:
       '@types/node':
         specifier: ^25.6.2
@@ -1369,12 +1369,6 @@ packages:
   '@mswjs/interceptors@0.41.8':
     resolution: {integrity: sha512-pRLMNKTSGRoLq+KnEB/7OY5vijw1XmcheAAOiv6pj7W1FG32kAGqj1C/RK/cqxRGr1Fh+zBi8sDur8kj3EQv6A==}
     engines: {node: '>=18'}
-
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -3536,9 +3530,6 @@ packages:
     resolution: {integrity: sha512-XoR4bsg62/L/esRVcmoMESEiNZ36+YmyjYGLpoqk8nwMgXzzVjNOgX0lRSz5w/U/ajLGv3nhMsS0Q2QOdvp2AQ==}
     cpu: [arm64]
     os: [win32]
-
-  '@tybys/wasm-util@0.10.2':
-    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -6397,11 +6388,14 @@ packages:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
 
-  openstory@0.0.16:
-    resolution: {integrity: sha512-Fo44Rgo8fbx7mRssZNZN53cLQsouSH64NKW/OoMHG8fXQR4cy0WDJQqkpmGfLOMShv7BvEFR4NJDJLE2UB5K5g==}
+  openstory@0.1.0:
+    resolution: {integrity: sha512-HVuSd8drAaTp3D81GcVJQecF34U/p+lUm56vMDdsRdzbyYCOnw+nvdrS3SQaLv+wa2AmrLkJqpzXDLZnJu5YSQ==}
     engines: {node: '>=20', pnpm: '>=10'}
     hasBin: true
     peerDependencies:
+      '@effect/platform-browser': 4.0.0-beta.66
+      effect: 4.0.0-beta.66
+      foldkit: '>=0.104.0'
       react: 19.2.6
       react-dom: 19.2.6
       solid-js: ^1.5.0
@@ -6410,6 +6404,12 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
       vue: ^3.0.0
     peerDependenciesMeta:
+      '@effect/platform-browser':
+        optional: true
+      effect:
+        optional: true
+      foldkit:
+        optional: true
       react:
         optional: true
       react-dom:
@@ -9216,13 +9216,6 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@tybys/wasm-util': 0.10.2
-    optional: true
-
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -9634,7 +9627,7 @@ snapshots:
 
   '@oxc-parser/binding-wasm32-wasi@0.108.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -11245,11 +11238,6 @@ snapshots:
     optional: true
 
   '@turbo/windows-arm64@2.9.12':
-    optional: true
-
-  '@tybys/wasm-util@0.10.2':
-    dependencies:
-      tslib: 2.8.1
     optional: true
 
   '@tybys/wasm-util@0.10.3':
@@ -13990,7 +13978,7 @@ snapshots:
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
 
-  openstory@0.0.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.37.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.4))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.12)(typescript@6.0.3):
+  openstory@0.1.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.37.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.4))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.12)(typescript@6.0.3):
     dependencies:
       commander: 14.0.3
       fast-glob: 3.3.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
         specifier: workspace:*
         version: link:../../packages/react-grab
     devDependencies:
+      '@react-grab/e2e-development':
+        specifier: workspace:*
+        version: link:../e2e-react-grab-development
       '@types/node':
         specifier: ^22.10.0
         version: 22.20.0
@@ -82,6 +85,9 @@ importers:
         specifier: workspace:*
         version: link:../../packages/react-grab
     devDependencies:
+      '@react-grab/e2e-development':
+        specifier: workspace:*
+        version: link:../e2e-react-grab-development
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -128,6 +134,9 @@ importers:
         specifier: ^3.9.2
         version: 3.9.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react-is@16.13.1)(react@19.2.6)(redux@5.0.1)
     devDependencies:
+      '@react-grab/e2e-development':
+        specifier: workspace:*
+        version: link:../e2e-react-grab-development
       '@tailwindcss/vite':
         specifier: ^4.3.0
         version: 4.3.0(@voidzero-dev/vite-plus-core@0.1.22(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.37.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.4))
@@ -165,6 +174,9 @@ importers:
         specifier: ^7.9.6
         version: 7.18.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
+      '@react-grab/e2e-development':
+        specifier: workspace:*
+        version: link:../e2e-react-grab-development
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.17
@@ -180,6 +192,8 @@ importers:
       vite:
         specifier: 8.1.4
         version: 8.1.4(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.37.0)(tsx@4.21.0)(yaml@2.8.4)
+
+  apps/e2e-react-grab-development: {}
 
   apps/openstory:
     dependencies:


### PR DESCRIPTION
## Summary

- compile exact Solid JSX file, line, and column metadata into the private E2E development build
- resolve that metadata behind a build-time `process.env.REACT_GRAB_SOURCE_LOCATIONS` guard in React Grab core
- enable the same transform for Openstory dev while leaving Openstory production uninstrumented
- alias all four E2E development apps to the private build while their production variants use the normal package
- preserve the resolved column in the public `getSource()` result

## Why

Solid DOM nodes do not expose a React Fiber owner stack, but the Solid compiler already knows the exact intrinsic JSX location. For this controlled dogfooding setup, compiler metadata is simpler and more accurate than inspecting event handlers or fetching source modules at runtime.

The build now adds the source attribute only when `REACT_GRAB_SOURCE_LOCATIONS=true`. That same define enables a small source-resolution branch. Normal production builds define it as false, so the branch, parser, attribute name, and Solid source paths are removed by dead-code elimination.

## Impact

All four E2E development environments resolve React Grab toolbar elements to the exact Solid TSX source:

- Vite Plus
- stock Vite
- Next.js
- TanStack Start

Their production variants remain uninstrumented. Openstory gets the same behavior only while serving locally. There is no runtime module adapter, source injection, event-handler fallback, cache, or source-fetch path.

## Validation

- `nr build`
- `nr lint`
- `nr typecheck`
- `nr format`
- unit suite: 164 passed
- exact-source Playwright contract: 8 passed across four development and four production environments
- `nr --filter @react-grab/openstory build`
- verified the production package and Openstory bundles contain no source attribute, parser, env key, Solid filename, or debug instrumentation
- verified the private development bundle contains `toolbar-action-button.tsx:24:5`

The optional adversarial browser runner was attempted, but its agent stream produced no steps and timed out after 180 seconds. The deterministic Playwright browser coverage completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `resolveSource` and public `SourceInfo`, but behavior is gated behind a build-time flag stripped from normal production builds; risk is mainly regression in source resolution and E2E/CI wiring.
> 
> **Overview**
> Adds **build-time Solid JSX source instrumentation** so React Grab can resolve toolbar DOM nodes to exact file, line, and column without a React Fiber owner stack. A new Babel plugin stamps `data-react-grab-source-location` on lowercase intrinsic elements; when `REACT_GRAB_SOURCE_LOCATIONS=true`, `resolveSource` reads that attribute first and `getSource()` now returns **columnNumber**.
> 
> **E2E dev** uses a private `@react-grab/e2e-development` bundle (`build:e2e-development`) and dev-only aliases in all four framework apps (Vite Plus, stock Vite, Next turbopack, TanStack Start). **Production E2E** keeps the normal `react-grab` package with the flag off so instrumentation is dead-code eliminated.
> 
> Playwright gains `solid-source-location.spec.ts` across dev/prod matrix; Openstory dev enables the same Babel plugin and env define, with a toolbar story assertion in DEV only. Openstory bumps to `^0.1.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6878f373021aa470f6f7b9a8cab3191ff5b7f56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->