### PR TITLE
Fix dark mode ellipsis contrast

### DIFF
--- a/packages/react-grab/src/components/selection-label/tag-badge.tsx
+++ b/packages/react-grab/src/components/selection-label/tag-badge.tsx
@@ -20,9 +20,9 @@ export const TagBadge: Component<TagBadgeProps> = (props) => {
   // toggling isClickable can make the label vanish (see solidjs/solid#2216,
   // solidjs/solid#2357).
   const renderTagLabel = () => (
-    <span class="text-[13px] leading-4 h-fit font-medium overflow-hidden text-ellipsis whitespace-nowrap min-w-0">
+    <span class="text-[var(--rg-text-primary)] text-[13px] leading-4 h-fit font-medium overflow-hidden text-ellipsis whitespace-nowrap min-w-0">
       <Show when={props.componentName}>
-        <span class="text-[var(--rg-text-primary)]">{props.componentName}</span>
+        <span>{props.componentName}</span>
         <span class="text-[var(--rg-text-secondary)]">.{props.tagName}</span>
       </Show>
       <Show when={!props.componentName}>


### PR DESCRIPTION
## Summary

- apply the theme-aware primary text color to the element that paints truncated tag-label ellipses
- preserve secondary tag-name styling while removing the redundant nested primary-color class
- cover every `TagBadge` consumer, including selection labels, context menus, and edit-panel headers

## Root cause

`text-overflow: ellipsis` paints the marker using the truncating element's own `color`. The outer span had no React Grab theme color while its child text did, so the ellipsis could inherit a dark host-page color and disappear against the dark label surface.

## Validation

- `nr build`
- `nr lint`
- `nr typecheck`
- `nr format:check -- packages/react-grab/src/components/selection-label/tag-badge.tsx`
- `git diff --check`

`nr test` was also run. The unit and working browser suites passed, but the full matrix repeatedly failed during stock Vite and TanStack development fixture startup because Vite could not resolve the workspace `react-grab` import. The run was stopped after 26 identical fixture failures; this import-resolution issue is outside the changed file. Automated visual checks were attempted twice, but the browser-testing agent stalled before producing test steps.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dark-mode ellipsis visibility in tag labels by applying the theme primary text color to the truncating `TagBadge` span. Removes the redundant inner primary-color class and preserves secondary tag-name styling across all `TagBadge` usages.

<sup>Written for commit ac09801541094a79972608be2ea53c19f19ec523. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-component CSS class move with no logic, API, or data-path changes.
> 
> **Overview**
> Fixes **dark-mode tag labels** where truncated text could show an ellipsis that blended into the label background.
> 
> The theme primary color (`--rg-text-primary`) is now on the **outer truncating span** in `TagBadge`, so `text-overflow: ellipsis` uses the same color as the label text. The redundant primary color on the inner component-name span was removed; secondary styling for `.{tagName}` is unchanged.
> 
> Because `TagBadge` is shared, this applies everywhere it renders (selection labels, context menus, edit-panel headers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac09801541094a79972608be2ea53c19f19ec523. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->