### PR TITLE
Optimize selection rendering

### DIFF
--- a/packages/react-grab/src/components/overlay-canvas.tsx
+++ b/packages/react-grab/src/components/overlay-canvas.tsx
@@ -36,13 +36,6 @@ const LAYER_STYLES = {
   grabbed: DEFAULT_LAYER_STYLE,
 } as const;
 
-type LayerName = "drag" | "selection" | "grabbed";
-
-interface OffscreenLayer {
-  canvas: OffscreenCanvas | null;
-  context: OffscreenCanvasRenderingContext2D | null;
-}
-
 interface AnimatedBounds {
   id: string;
   current: { x: number; y: number; width: number; height: number };
@@ -84,30 +77,11 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
   let fadeWakeTimeoutId: number | null = null;
   let previousFrameTimestamp: number | null = null;
 
-  const layers: Record<LayerName, OffscreenLayer> = {
-    drag: { canvas: null, context: null },
-    selection: { canvas: null, context: null },
-    grabbed: { canvas: null, context: null },
-  };
-
   let selectionAnimations: AnimatedBounds[] = [];
   let dragAnimation: AnimatedBounds | null = null;
   let grabbedAnimations: AnimatedBounds[] = [];
 
   const canvasColorSpace: PredefinedColorSpace = supportsDisplayP3() ? "display-p3" : "srgb";
-
-  const createOffscreenLayer = (
-    layerWidth: number,
-    layerHeight: number,
-    scaleFactor: number,
-  ): OffscreenLayer => {
-    const canvas = new OffscreenCanvas(layerWidth * scaleFactor, layerHeight * scaleFactor);
-    const context = canvas.getContext("2d", { colorSpace: canvasColorSpace });
-    if (context) {
-      context.scale(scaleFactor, scaleFactor);
-    }
-    return { canvas, context };
-  };
 
   const initializeCanvas = () => {
     if (!canvasRef) return;
@@ -130,10 +104,6 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
     mainContext = canvasRef.getContext("2d", { colorSpace: canvasColorSpace });
     if (mainContext) {
       mainContext.scale(devicePixelRatio, devicePixelRatio);
-    }
-
-    for (const layerName of Object.keys(layers) as LayerName[]) {
-      layers[layerName] = createOffscreenLayer(canvasWidth, canvasHeight, devicePixelRatio);
     }
   };
 
@@ -192,7 +162,7 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
     instance.boundsMultiple ?? [instance.bounds];
 
   const drawRoundedRectangle = (
-    context: OffscreenCanvasRenderingContext2D,
+    context: CanvasRenderingContext2D,
     rectX: number,
     rectY: number,
     rectWidth: number,
@@ -224,17 +194,11 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
   };
 
   const renderDragLayer = () => {
-    const layer = layers.drag;
-    if (!layer.context) return;
-
-    const context = layer.context;
-    context.clearRect(0, 0, canvasWidth, canvasHeight);
-
-    if (!props.dragVisible || !dragAnimation) return;
+    if (!mainContext || !props.dragVisible || !dragAnimation) return;
 
     const style = LAYER_STYLES.drag;
     drawRoundedRectangle(
-      context,
+      mainContext,
       dragAnimation.current.x,
       dragAnimation.current.y,
       dragAnimation.current.width,
@@ -246,19 +210,13 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
   };
 
   const renderSelectionLayer = () => {
-    const layer = layers.selection;
-    if (!layer.context) return;
-
-    const context = layer.context;
-    context.clearRect(0, 0, canvasWidth, canvasHeight);
-
-    if (!props.selectionVisible) return;
+    if (!mainContext || !props.selectionVisible) return;
 
     const style = LAYER_STYLES.selection;
 
     for (const animation of selectionAnimations) {
       drawRoundedRectangle(
-        context,
+        mainContext,
         animation.current.x,
         animation.current.y,
         animation.current.width,
@@ -271,21 +229,14 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
     }
   };
 
-  const renderBoundsLayer = (
-    layerName: keyof typeof LAYER_STYLES,
-    animations: AnimatedBounds[],
-  ) => {
-    const layer = layers[layerName];
-    if (!layer.context) return;
+  const renderBoundsLayer = (animations: AnimatedBounds[]) => {
+    if (!mainContext) return;
 
-    const context = layer.context;
-    context.clearRect(0, 0, canvasWidth, canvasHeight);
-
-    const style = LAYER_STYLES[layerName];
+    const style = LAYER_STYLES.grabbed;
 
     for (const animation of animations) {
       drawRoundedRectangle(
-        context,
+        mainContext,
         animation.current.x,
         animation.current.y,
         animation.current.width,
@@ -308,15 +259,7 @@ export const OverlayCanvas: Component<OverlayCanvasProps> = (props) => {
 
     renderDragLayer();
     renderSelectionLayer();
-    renderBoundsLayer("grabbed", grabbedAnimations);
-
-    const layerRenderOrder: LayerName[] = ["drag", "selection", "grabbed"];
-    for (const layerName of layerRenderOrder) {
-      const layer = layers[layerName];
-      if (layer.canvas) {
-        mainContext.drawImage(layer.canvas, 0, 0, canvasWidth, canvasHeight);
-      }
-    }
+    renderBoundsLayer(grabbedAnimations);
   };
 
   const interpolateBounds = (

--- a/packages/react-grab/src/components/toolbar/index.tsx
+++ b/packages/react-grab/src/components/toolbar/index.tsx
@@ -217,24 +217,36 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
           return;
         }
 
-        const handlePointerMove = ignoreRealInput((event: PointerEvent | MouseEvent) => {
+        let pointerFrameId: number | null = null;
+        let latestPointerX = 0;
+        let latestPointerY = 0;
+        const updateSelectIconRotation = () => {
+          pointerFrameId = null;
           if (!selectButtonRef) return;
           const rect = selectButtonRef.getBoundingClientRect();
           const centerX = rect.left + rect.width / 2;
           const centerY = rect.top + rect.height / 2;
-          const deltaX = event.clientX - centerX;
-          const deltaY = event.clientY - centerY;
+          const deltaX = latestPointerX - centerX;
+          const deltaY = latestPointerY - centerY;
           if (Math.hypot(deltaX, deltaY) < SELECT_ICON_POINT_MIN_DISTANCE_PX) return;
           const targetAngleDeg = (Math.atan2(deltaY, deltaX) * 180) / Math.PI;
           const desiredRotationDeg = targetAngleDeg - SELECT_ICON_NATURAL_POINT_ANGLE_DEG;
           setSelectIconRotationDeg((previousRotationDeg) =>
             accumulateRotationDeg(previousRotationDeg, desiredRotationDeg),
           );
+        };
+
+        const handlePointerMove = ignoreRealInput((event: PointerEvent | MouseEvent) => {
+          latestPointerX = event.clientX;
+          latestPointerY = event.clientY;
+          if (pointerFrameId !== null) return;
+          pointerFrameId = nativeRequestAnimationFrame(updateSelectIconRotation);
         });
 
         window.addEventListener("pointermove", handlePointerMove, { passive: true });
         onCleanup(() => {
           window.removeEventListener("pointermove", handlePointerMove);
+          if (pointerFrameId !== null) nativeCancelAnimationFrame(pointerFrameId);
         });
       },
     ),


### PR DESCRIPTION
## Summary

- render drag, selection, and grabbed bounds directly into the main overlay canvas
- remove three full-viewport offscreen canvas clears and composites per animation frame
- coalesce toolbar select-icon pointer tracking to one layout read and rotation update per animation frame

## Why

Performance traces showed the overlay repeatedly clearing and copying three viewport-sized canvases even when layers were empty. Those `drawImage` composites dominated React Grab-attributable sampled time. The select icon also called `getBoundingClientRect()` for every pointer event, forcing unnecessary work during pointer storms.

## Impact

Representative hover and scroll selection traces reduced renderer CPU by roughly 50–70%. The focused synthetic pointer storm reached 120 FPS with zero dropped frames after the changes. Canvas draw order and appearance remain unchanged.

## Validation

- `nr build`
- `nr test:perf --grep ' (hover-in-selection-mode|pointermove-storm-synthetic|scroll-during-selection|heavy-table-hover-in-selection-mode|heavy-virtual-scroll-during-selection) @perf$'` — 5 passed, all at 120 FPS with zero dropped frames
- `nr test` — 1,086 passed, 23 skipped
- `nr lint` — 0 warnings and 0 errors
- `nr typecheck` — 10 tasks passed
- `nr format`

`expect-cli` was attempted for an additional adversarial browser pass, but its agent stream stalled before producing any browser steps; this was a harness failure rather than a product test failure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize selection rendering by drawing drag, selection, and grabbed bounds directly to the main overlay canvas and batching select-icon rotation work to rAF. This removes three full-viewport offscreen composites per frame, cuts renderer CPU ~50–70%, and reaches 120 FPS in perf tests with no dropped frames.

- **Refactors**
  - Render on the main overlay canvas; remove offscreen layers and per-frame clears/composites while keeping draw order and appearance.
  - Coalesce select-icon pointer tracking: cache latest pointer, read `getBoundingClientRect()` once per frame, update via `requestAnimationFrame`, and cancel on cleanup.

<sup>Written for commit 12b445fcb1a6eaaae5cb6cfa12418b550f466361. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rendering-path refactor with unchanged draw order and appearance; perf-focused toolbar input coalescing with proper rAF cleanup.
> 
> **Overview**
> **Overlay rendering** no longer uses three full-viewport `OffscreenCanvas` layers per frame. Drag, selection, and grabbed bounds are cleared and drawn straight onto the main overlay context in the same order as before, dropping per-layer clears and `drawImage` compositing.
> 
> **Toolbar select icon** pointer tracking now stores the latest coordinates on each `pointermove` and runs **one** `getBoundingClientRect` + rotation update per animation frame via `requestAnimationFrame`, with pending frames cancelled on cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12b445fcb1a6eaaae5cb6cfa12418b550f466361. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->