### PR TITLE
fix toolbar recovery after body replacement

### DIFF
--- a/packages/react-grab/src/utils/mount-root.ts
+++ b/packages/react-grab/src/utils/mount-root.ts
@@ -47,7 +47,16 @@ const scheduleHostRecheck = (host: HTMLElement): (() => void) => {
   const recheckTimeoutId = window.setTimeout(() => {
     attachHostToBody(host);
   }, MOUNT_ROOT_RECHECK_DELAY_MS);
-  return () => window.clearTimeout(recheckTimeoutId);
+  const bodyObserver = new MutationObserver(() => {
+    if (host.parentNode !== document.body) {
+      attachHostToBody(host);
+    }
+  });
+  bodyObserver.observe(document.documentElement, { childList: true });
+  return () => {
+    window.clearTimeout(recheckTimeoutId);
+    bodyObserver.disconnect();
+  };
 };
 
 interface MountRootResult {


### PR DESCRIPTION
## summary

- reattach the live react grab host when an application replaces `<body>`
- keep the existing delayed stacking recheck
- disconnect the body observer during cleanup

## validation

- `nr build`
- `nr lint`
- `nr typecheck`
- `nr format`
- body replacement regression repeated 20 times in vite plus development

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to mount/reattach logic for the overlay host; no auth, data, or API changes. Observer is cleaned up on cancel.
> 
> **Overview**
> **Fixes React Grab toolbar disappearing when the app replaces `<body>`** (common in Vite/dev and some hydration flows).
> 
> `scheduleHostRecheck` still runs the existing delayed `attachHostToBody` pass, but now also watches `document.documentElement` with a `MutationObserver`. If the live host is no longer a direct child of `document.body`, it re-appends immediately via the existing zombie-host cleanup in `attachHostToBody`. Teardown disconnects the observer along with clearing the timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6f4069fe0698da018786c66392ccf0947b01354. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `react-grab` toolbar not recovering when an app replaces the `<body>`. We now watch for body changes, reattach the host, and clean up correctly.

- **Bug Fixes**
  - Use a `MutationObserver` on `document.documentElement` to detect `<body>` replacement and reattach the host to `document.body`.
  - Keep the delayed stacking recheck via the existing timeout.
  - Disconnect the observer and clear the timeout during cleanup.

<sup>Written for commit c6f4069fe0698da018786c66392ccf0947b01354. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

