### PR TITLE
stabilize pending copy selection test

### DIFF
--- a/packages/react-grab/e2e/selection.spec.ts
+++ b/packages/react-grab/e2e/selection.spec.ts
@@ -80,13 +80,11 @@ test.describe("Element Selection", () => {
           };
         }
       ).__REACT_GRAB__;
-      api?.unregisterPlugin("slow-copy-hook");
+      api?.unregisterPlugin("pending-copy-hook");
       api?.registerPlugin({
-        name: "slow-copy-hook",
+        name: "pending-copy-hook",
         hooks: {
-          onBeforeCopy: async () => {
-            await new Promise((resolve) => setTimeout(resolve, 600));
-          },
+          onBeforeCopy: () => new Promise<void>(() => {}),
         },
       });
     });


### PR DESCRIPTION
## summary

- keep the copy hook pending for the full interaction assertion
- remove the 600 ms timer race that completed before text selection on slower ci workers

## validation

- `nr build`
- `nr lint`
- `nr typecheck`
- `nr format`
- pending-copy text-selection regression repeated 30 times in vite plus development

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to e2e hook timing; no production behavior modified.
> 
> **Overview**
> **Stabilizes** the regression test that verifies the page stays interactive (native text selection works) while a copy is in progress.
> 
> The test plugin is renamed from `slow-copy-hook` to **`pending-copy-hook`**, and **`onBeforeCopy`** no longer uses a **600ms** `setTimeout`. It now returns a **promise that never settles**, so `isCopying` stays true for the whole interaction instead of racing ahead on slower CI workers before the drag-to-select assertion runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ed0a7b8bef217a917d993dcbb75c149c188247c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilize the pending-copy selection e2e test by holding the copy hook pending for the full interaction, removing the 600 ms race that caused CI flakes.

- **Bug Fixes**
  - Replaced the 600 ms delay with an unresolved Promise in `onBeforeCopy` to keep it pending.
  - Renamed plugin from `slow-copy-hook` to `pending-copy-hook`.

<sup>Written for commit 4ed0a7b8bef217a917d993dcbb75c149c188247c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

