### PR TITLE
Fix custom activation key crashes

### DIFF
--- a/packages/react-grab/e2e/malformed-events.spec.ts
+++ b/packages/react-grab/e2e/malformed-events.spec.ts
@@ -206,6 +206,36 @@ test.describe("Malformed Events", () => {
 
       expect(errors).toHaveLength(0);
     });
+
+    test("should not crash custom activation matchers on keydown or keyup", async ({
+      reactGrab,
+    }) => {
+      const errors = collectPageErrors(reactGrab.page);
+
+      await reactGrab.page.evaluate(() => {
+        window.__REACT_GRAB__?.setOptions({
+          activationKey: (event) => event.key.toLowerCase() === "c",
+        });
+      });
+
+      await dispatchMalformedEvent(
+        reactGrab.page,
+        "keydown",
+        "KeyboardEvent",
+        { ctrlKey: true },
+        { key: undefined },
+      );
+      await dispatchMalformedEvent(
+        reactGrab.page,
+        "keyup",
+        "KeyboardEvent",
+        { ctrlKey: true },
+        { key: undefined },
+      );
+      await reactGrab.page.waitForTimeout(50);
+
+      expect(errors).toHaveLength(0);
+    });
   });
 
   test.describe("Keyboard: while activated", () => {

--- a/packages/react-grab/src/core/index.tsx
+++ b/packages/react-grab/src/core/index.tsx
@@ -2964,9 +2964,7 @@ export const init = (rawOptions?: Options): ReactGrabAPI => {
               (requiredModifiers.altKey && !event.altKey);
 
         const isReleasingActivationKey = pluginRegistry.store.options.activationKey
-          ? typeof pluginRegistry.store.options.activationKey === "function"
-            ? pluginRegistry.store.options.activationKey(event)
-            : parseActivationKey(pluginRegistry.store.options.activationKey)(event)
+          ? parseActivationKey(pluginRegistry.store.options.activationKey)(event)
           : isCLikeKey(event.key, event.code);
 
         if (didJustCopy() || isCopyFeedbackCooldownActive) {

--- a/packages/react-grab/src/utils/parse-activation-key.ts
+++ b/packages/react-grab/src/utils/parse-activation-key.ts
@@ -50,7 +50,13 @@ export const parseActivationKey = (
   activationKey: ActivationKey,
 ): ((event: KeyboardEvent) => boolean) => {
   if (typeof activationKey === "function") {
-    return activationKey;
+    return (event: KeyboardEvent): boolean => {
+      try {
+        return activationKey(event);
+      } catch {
+        return false;
+      }
+    };
   }
 
   const parsed = parseString(activationKey);

--- a/packages/react-grab/tests/parse-activation-key.test.ts
+++ b/packages/react-grab/tests/parse-activation-key.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vite-plus/test";
+import { parseActivationKey } from "../src/utils/parse-activation-key.js";
+
+const createKeyboardEvent = (key = ""): KeyboardEvent =>
+  Object.create(null, {
+    key: {
+      value: key,
+    },
+  });
+
+describe("parseActivationKey", () => {
+  it("treats exceptions from custom matchers as non-matches", () => {
+    const matcher = parseActivationKey(() => {
+      throw new Error("Malformed keyboard event");
+    });
+
+    expect(matcher(createKeyboardEvent())).toBe(false);
+  });
+
+  it("preserves custom matcher results", () => {
+    const matcher = parseActivationKey((event) => event.key === "c");
+
+    expect(matcher(createKeyboardEvent("c"))).toBe(true);
+    expect(matcher(createKeyboardEvent("g"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- isolate exceptions thrown by function-valued `activationKey` matchers and treat them as non-matches
- route keyup matching through the same protected matcher path as keydown
- add unit and browser regression coverage for malformed keyboard events

## Root cause

Function-valued activation matchers were returned or invoked directly. If a malformed `KeyboardEvent` exposed an undefined `key`, consumer matchers following the public `KeyboardEvent` type could throw from React Grab's capture-phase listeners.

## Impact

Malformed or synthetic keyboard events can no longer crash React Grab through a custom activation matcher. Valid matcher results are unchanged.

## Validation

- `nr build`
- 166 unit tests
- 19 malformed-event Playwright tests on Vite Plus development
- `nr typecheck`
- `nr lint`
- `nr format:check`

Closes #562

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crashes in `react-grab` when custom `activationKey` matchers see malformed KeyboardEvents (closes #562). Both keydown and keyup now use a safe `parseActivationKey` wrapper that treats thrown errors as non-matches; valid matcher behavior is unchanged.

<sup>Written for commit bb45638221fe88812fcfc93596a222bc556ac1dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow defensive change to activation matching; successful matcher results are unchanged and failures only suppress activation instead of throwing.
> 
> **Overview**
> **Prevents React Grab from crashing** when a function-valued `activationKey` runs against malformed `KeyboardEvent` objects (e.g. `key` is `undefined`).
> 
> `parseActivationKey` now wraps custom matchers in **try/catch** and treats thrown errors as a non-match instead of bubbling out of capture-phase listeners. The **keyup** release path always goes through that wrapper (it no longer invokes the function matcher directly), so keydown and keyup behave the same.
> 
> Adds **unit tests** for the wrapper and a **Playwright** case that sets `activationKey: (e) => e.key.toLowerCase() === "c"` and dispatches keydown/keyup with `key: undefined`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb45638221fe88812fcfc93596a222bc556ac1dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->