### PR TITLE
fix: prioritize interactive R3F objects during selection

### DIFF
--- a/apps/e2e-app-vite/src/three-fiber-fixture.tsx
+++ b/apps/e2e-app-vite/src/three-fiber-fixture.tsx
@@ -1,4 +1,5 @@
 import { Canvas } from "@react-three/fiber";
+import { useMemo } from "react";
 import {
   THREE_AMBIENT_LIGHT_INTENSITY,
   THREE_BOX_SIZE_UNITS,
@@ -18,11 +19,27 @@ interface ThreeGrabBoxProps {
 }
 
 const ThreeGrabBox = (props: ThreeGrabBoxProps): React.JSX.Element => (
-  <mesh name={props.name} position={props.position}>
+  <mesh name={props.name} position={props.position} onClick={() => undefined}>
     <boxGeometry args={[THREE_BOX_SIZE_UNITS, THREE_BOX_SIZE_UNITS, THREE_BOX_SIZE_UNITS]} />
     <meshStandardMaterial color={props.color} />
   </mesh>
 );
+
+const DecorativePoints = (): React.JSX.Element => {
+  const positions = useMemo(
+    () => new Float32Array([...THREE_LEFT_BOX_POSITION, ...THREE_RIGHT_BOX_POSITION]),
+    [],
+  );
+
+  return (
+    <points name="decorative-points" position={[0, 0, 1]}>
+      <bufferGeometry>
+        <bufferAttribute attach="attributes-position" args={[positions, 3]} />
+      </bufferGeometry>
+      <pointsMaterial color="#ffffff" size={0.08} />
+    </points>
+  );
+};
 
 export const ThreeFiberFixture = (): React.JSX.Element => (
   <section className="border rounded-lg p-4" data-testid="three-fiber-section">
@@ -38,6 +55,7 @@ export const ThreeFiberFixture = (): React.JSX.Element => (
           position={THREE_DIRECTIONAL_LIGHT_POSITION}
           intensity={THREE_DIRECTIONAL_LIGHT_INTENSITY}
         />
+        <DecorativePoints />
         <ThreeGrabBox color="#38bdf8" name="left-cube" position={THREE_LEFT_BOX_POSITION} />
         <ThreeGrabBox color="#f472b6" name="right-cube" position={THREE_RIGHT_BOX_POSITION} />
       </Canvas>

--- a/packages/react-grab/src/core/three-selection.ts
+++ b/packages/react-grab/src/core/three-selection.ts
@@ -46,6 +46,7 @@ interface ReactThreeFiberInstanceLike {
   type: string;
   props: Record<string, unknown>;
   object: ThreeObjectLike;
+  eventCount?: number;
 }
 
 interface ThreeObjectLike {
@@ -236,6 +237,18 @@ const findReactThreeFiberObject = (object: ThreeObjectLike): ThreeObjectLike | n
   return null;
 };
 
+const hasReactThreeFiberInteractionIntent = (object: ThreeObjectLike): boolean => {
+  let currentObject: ThreeObjectLike | null = object;
+  while (currentObject) {
+    const instance = getReactThreeFiberInstance(currentObject);
+    if (instance && typeof instance.eventCount === "number" && instance.eventCount > 0) {
+      return true;
+    }
+    currentObject = currentObject.parent;
+  }
+  return false;
+};
+
 const isThreeObjectInScene = (object: ThreeObjectLike, scene: ThreeSceneLike): boolean => {
   let currentObject: ThreeObjectLike | null = object;
   while (currentObject) {
@@ -331,6 +344,15 @@ export const resolveThreeElementAtPoint = (
     root.state.pointer.set(pointerX, pointerY);
     root.state.raycaster.setFromCamera(root.state.pointer, root.state.camera);
     const intersections = root.state.raycaster.intersectObjects(root.state.scene.children, true);
+    if (root.isReactThreeFiber) {
+      for (const intersection of intersections) {
+        if (!hasReactThreeFiberInteractionIntent(intersection.object)) continue;
+        const object = findReactThreeFiberObject(intersection.object);
+        if (!object || object.visible === false) continue;
+        const element = getOrCreateSelectionElement(root.state, object, intersection);
+        if (element) return element;
+      }
+    }
     for (const intersection of intersections) {
       const object = root.isReactThreeFiber
         ? findReactThreeFiberObject(intersection.object)


### PR DESCRIPTION
## What changed

- Rank React Three Fiber raycast intersections with registered pointer handlers ahead of passive scene objects.
- Walk ancestors when detecting interaction intent so handlers attached above the intersected object are respected.
- Preserve the existing nearest-hit fallback when no interactive R3F object is available.
- Extend the R3F fixture with passive decorative points positioned in front of interactive cubes.

## Why

React Grab previously accepted the nearest Three.js raycast intersection. Decorative `Points`, particles, or helper geometry could therefore steal selection from an interactive mesh behind them, even though the mesh was the more likely user target.

The new two-pass selection keeps raycast ordering within each priority tier: interactive R3F objects win first, while passive objects remain selectable when no intentional target is hit. Nothing is globally ignored by object type.

## Impact

R3F scenes with particle effects and decorative geometry should select actionable components more predictably. Interactive point clouds continue to work, and passive scene objects retain the previous fallback behavior.

## Validation

- `nr build`
- `E2E_ENVIRONMENT=vite-plus-development pnpm --filter react-grab exec playwright test e2e/three-fiber-selection.spec.ts --reporter=list` — 2 passed
- `nr lint`
- `nr typecheck`
- `nr format`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prioritize interactive `@react-three/fiber` objects during selection so clicks go to meshes with pointer handlers instead of front-most decorative geometry. Nearest-hit fallback remains when no interactive target is found.

- **Bug Fixes**
  - Add two-pass hit-testing: first choose intersections whose object or ancestors have `eventCount > 0`, preserving raycast order.
  - Traverse ancestors to respect handlers attached above the intersected node.
  - Add passive `Points` in front of cubes to the e2e fixture to validate the new behavior.

<sup>Written for commit 32b03619b2dc4bf3c068df1fd96179818ffc3de5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pointer-to-element resolution for React Three Fiber canvases; fallback preserves prior behavior for passive hits, but interactive vs decorative priority could surprise scenes that relied on nearest-hit only.
> 
> **Overview**
> **React Grab** no longer always picks the nearest Three.js raycast hit in R3F scenes. Selection now runs in two passes: intersections whose object or ancestors have R3F pointer handlers (`eventCount > 0`) are considered first, still in raycast order; if none qualify, behavior matches the previous nearest-hit pass.
> 
> The e2e **Three Fiber** fixture adds passive `Points` in front of the cubes and `onClick` on the grab boxes so selection can be verified when decorative geometry would have won before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32b03619b2dc4bf3c068df1fd96179818ffc3de5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->