### PR TITLE
Optimize dynamic text rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ Before writing `createEffect`, classify the work and pick the right primitive:
 - MUST: Call `onCleanup` inside directives for cleanup.
 - SHOULD: Use `on:click` for `stopPropagation`, capture, passive, or custom events.
 - SHOULD: Use `style={{ color: color(), "--css-var": value() }}` for inline styles.
+- SHOULD: Use the native `textContent` prop for dynamic content that is guaranteed to be text-only.
 - SHOULD: Type refs as `let el: HTMLElement | undefined` with guard.
 - SHOULD: Use `use:directiveName={accessor}` for reusable DOM behaviors.
 - NEVER: Mix reactive `class={x()}` with `classList`.

--- a/packages/react-grab/src/components/context-menu.tsx
+++ b/packages/react-grab/src/components/context-menu.tsx
@@ -350,7 +350,7 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
                         props.onHide();
                       }}
                     >
-                      <Menu.Label class="text-[var(--rg-text-primary)]">{item.label}</Menu.Label>
+                      <Menu.Label class="text-[var(--rg-text-primary)]" textContent={item.label} />
                       <Show when={item.shortcut}>
                         {(shortcut) => (
                           <Menu.Shortcut shortcut={shortcut()} modifier={item.shortcutModifier} />

--- a/packages/react-grab/src/components/edit-panel/color-picker.tsx
+++ b/packages/react-grab/src/components/edit-panel/color-picker.tsx
@@ -87,9 +87,10 @@ export const ColorPicker: Component<ColorPickerProps> = (props) => {
     <div class="flex items-center gap-2 w-full px-2 h-[20px]">
       <Show when={props.label}>
         {(text) => (
-          <span class={`${EDIT_LABEL_CLASS} text-[var(--rg-text-primary)] truncate min-w-0`}>
-            {text()}
-          </span>
+          <span
+            class={`${EDIT_LABEL_CLASS} text-[var(--rg-text-primary)] truncate min-w-0`}
+            textContent={text()}
+          />
         )}
       </Show>
       <div class="flex items-center gap-1 ml-auto shrink-0">
@@ -105,9 +106,8 @@ export const ColorPicker: Component<ColorPickerProps> = (props) => {
                 event.stopPropagation();
                 setDraftText(displayValue());
               }}
-            >
-              {displayValue()}
-            </span>
+              textContent={displayValue()}
+            />
           }
         >
           <Input

--- a/packages/react-grab/src/components/edit-panel/cycle-control.tsx
+++ b/packages/react-grab/src/components/edit-panel/cycle-control.tsx
@@ -20,9 +20,10 @@ export const CycleControl: Component<CycleControlProps> = (props) => {
   return (
     <div class="flex items-center gap-2 w-full px-2 h-[20px]">
       <Show when={props.label}>
-        <span class={`${EDIT_LABEL_CLASS} text-[var(--rg-text-primary)] truncate min-w-0`}>
-          {props.label}
-        </span>
+        <span
+          class={`${EDIT_LABEL_CLASS} text-[var(--rg-text-primary)] truncate min-w-0`}
+          textContent={props.label}
+        />
       </Show>
       <div class="ml-auto shrink-0 flex items-center gap-1">
         <StepArrow
@@ -49,9 +50,8 @@ export const CycleControl: Component<CycleControlProps> = (props) => {
             event.stopPropagation();
             props.onStep(-1);
           }}
-        >
-          {currentLabel()}
-        </span>
+          textContent={currentLabel()}
+        />
         <StepArrow
           direction="right"
           active={props.activeKey === "right"}

--- a/packages/react-grab/src/components/edit-panel/property-list.tsx
+++ b/packages/react-grab/src/components/edit-panel/property-list.tsx
@@ -191,15 +191,19 @@ export const PropertyList: Component<PropertyListProps> = (props) => {
                 when={isActive()}
                 fallback={
                   <div class="flex items-center justify-between w-full h-[24px] px-2 gap-2">
-                    <span class="text-[13px] leading-4 font-sans font-medium text-[var(--rg-text-primary)] truncate min-w-0">
-                      {property().label}
-                    </span>
+                    <span
+                      class="text-[13px] leading-4 font-sans font-medium text-[var(--rg-text-primary)] truncate min-w-0"
+                      textContent={property().label}
+                    />
                     <Switch>
                       <Match when={narrowNumeric(property())}>
                         {(numeric) => (
                           <span class="font-sans text-[var(--rg-text-secondary)] tabular-nums shrink-0">
-                            <span class="text-[11px]">{formatDisplayValue(numeric().value)}</span>
-                            <span class="text-[9px] ml-px">{numeric().unit}</span>
+                            <span
+                              class="text-[11px]"
+                              textContent={formatDisplayValue(numeric().value)}
+                            />
+                            <span class="text-[9px] ml-px" textContent={numeric().unit} />
                           </span>
                         )}
                       </Match>
@@ -214,9 +218,10 @@ export const PropertyList: Component<PropertyListProps> = (props) => {
                       </Match>
                       <Match when={narrowEnum(property())}>
                         {(enumProp) => (
-                          <span class="text-[11px] font-sans text-[var(--rg-text-secondary)] shrink-0">
-                            {getEnumDisplayValue(enumProp())}
-                          </span>
+                          <span
+                            class="text-[11px] font-sans text-[var(--rg-text-secondary)] shrink-0"
+                            textContent={getEnumDisplayValue(enumProp())}
+                          />
                         )}
                       </Match>
                     </Switch>

--- a/packages/react-grab/src/components/edit-panel/value-stepper.tsx
+++ b/packages/react-grab/src/components/edit-panel/value-stepper.tsx
@@ -292,9 +292,10 @@ export const ValueStepper: Component<ValueStepperProps> = (props) => {
         <div class="relative z-10 flex items-center justify-between w-full px-2 pointer-events-none">
           <Show when={props.label}>
             {(text) => (
-              <span class={`${EDIT_LABEL_CLASS} text-[var(--rg-text-primary)] truncate min-w-0`}>
-                {text()}
-              </span>
+              <span
+                class={`${EDIT_LABEL_CLASS} text-[var(--rg-text-primary)] truncate min-w-0`}
+                textContent={text()}
+              />
             )}
           </Show>
           <Show
@@ -314,9 +315,8 @@ export const ValueStepper: Component<ValueStepperProps> = (props) => {
                       data-react-grab-tailwind-label
                       aria-hidden="true"
                       class="text-[10px] leading-4 text-[var(--rg-text-secondary)] tabular-nums"
-                    >
-                      {label()}
-                    </span>
+                      textContent={label()}
+                    />
                   )}
                 </Show>
                 <span
@@ -324,7 +324,10 @@ export const ValueStepper: Component<ValueStepperProps> = (props) => {
                   class={`${EDIT_VALUE_CLASS} text-[var(--rg-text-primary)]`}
                 >
                   <Slot>{formatDisplayValue(props.value)}</Slot>
-                  <span class="text-[9px] text-[var(--rg-text-secondary)] ml-px">{props.unit}</span>
+                  <span
+                    class="text-[9px] text-[var(--rg-text-secondary)] ml-px"
+                    textContent={props.unit}
+                  />
                 </span>
               </span>
             }

--- a/packages/react-grab/src/components/menu/menu-item-label.tsx
+++ b/packages/react-grab/src/components/menu/menu-item-label.tsx
@@ -1,13 +1,14 @@
-import type { Component, JSX } from "solid-js";
+import type { Component } from "solid-js";
 import { cn } from "../../utils/cn.js";
 
 interface MenuItemLabelProps {
   class?: string;
-  children: JSX.Element;
+  textContent: string;
 }
 
 export const MenuItemLabel: Component<MenuItemLabelProps> = (props) => (
-  <span class={cn("text-[13px] leading-4 font-sans font-medium", props.class)}>
-    {props.children}
-  </span>
+  <span
+    class={cn("text-[13px] leading-4 font-sans font-medium", props.class)}
+    textContent={props.textContent}
+  />
 );

--- a/packages/react-grab/src/components/selection-label/completion-view.tsx
+++ b/packages/react-grab/src/components/selection-label/completion-view.tsx
@@ -111,9 +111,10 @@ export const CompletionView: Component<CompletionViewProps> = (props) => {
     >
       <Show when={!didCopy() && props.onDismiss}>
         <div class="contain-layout shrink-0 flex items-center justify-between gap-2 pt-1.5 pb-1 px-2 w-full h-fit">
-          <span class="text-[var(--rg-text-primary)] text-[13px] leading-4 font-sans font-medium h-fit tabular-nums overflow-hidden text-ellipsis whitespace-nowrap min-w-0">
-            {displayStatusText()}
-          </span>
+          <span
+            class="text-[var(--rg-text-primary)] text-[13px] leading-4 font-sans font-medium h-fit tabular-nums overflow-hidden text-ellipsis whitespace-nowrap min-w-0"
+            textContent={displayStatusText()}
+          />
           <div class="contain-layout shrink-0 flex items-center gap-2 h-fit">
             <Show when={props.onShowContextMenu}>
               <MoreOptionsButton onClick={handleShowContextMenu} />
@@ -145,9 +146,10 @@ export const CompletionView: Component<CompletionViewProps> = (props) => {
             aria-hidden="true"
             class="text-[var(--rg-text-primary-85)] shrink-0"
           />
-          <span class="text-[var(--rg-text-primary)] text-[13px] leading-4 font-sans font-medium h-fit tabular-nums overflow-hidden text-ellipsis whitespace-nowrap min-w-0">
-            {displayStatusText()}
-          </span>
+          <span
+            class="text-[var(--rg-text-primary)] text-[13px] leading-4 font-sans font-medium h-fit tabular-nums overflow-hidden text-ellipsis whitespace-nowrap min-w-0"
+            textContent={displayStatusText()}
+          />
           <Show when={props.onShowContextMenu}>
             <MoreOptionsButton onClick={handleShowContextMenu} />
           </Show>

--- a/packages/react-grab/src/components/selection-label/discard-prompt.tsx
+++ b/packages/react-grab/src/components/selection-label/discard-prompt.tsx
@@ -47,9 +47,10 @@ export const DiscardPrompt: Component<DiscardPromptProps> = (props) => {
       onClick={claimFocus}
     >
       <div class="contain-layout shrink-0 flex items-center gap-1 pt-1.5 pb-1 px-2 w-full h-fit">
-        <span class="text-[var(--rg-text-primary)] text-[13px] leading-4 shrink-0 font-sans font-medium w-fit h-fit">
-          {props.label ?? "Discard?"}
-        </span>
+        <span
+          class="text-[var(--rg-text-primary)] text-[13px] leading-4 shrink-0 font-sans font-medium w-fit h-fit"
+          textContent={props.label ?? "Discard?"}
+        />
       </div>
       <BottomSection>
         <div class="contain-layout shrink-0 flex items-center justify-end gap-[5px] w-full h-fit">

--- a/packages/react-grab/src/components/selection-label/error-view.tsx
+++ b/packages/react-grab/src/components/selection-label/error-view.tsx
@@ -44,9 +44,8 @@ export const ErrorView: Component<ErrorViewProps> = (props) => {
         <span
           class="text-[var(--rg-error-text)] text-[13px] leading-4 font-sans font-medium overflow-hidden line-clamp-5"
           title={props.error}
-        >
-          {props.error}
-        </span>
+          textContent={props.error}
+        />
       </div>
       <Show when={hasActions()}>
         <BottomSection>

--- a/packages/react-grab/src/components/selection-label/index.tsx
+++ b/packages/react-grab/src/components/selection-label/index.tsx
@@ -438,9 +438,10 @@ export const SelectionLabel: Component<SelectionLabelProps> = (props) => {
             <div class="contain-layout shrink-0 flex flex-col justify-center items-start w-fit h-fit max-w-[280px]">
               <div class="contain-layout shrink-0 flex items-center gap-1 py-1.5 px-2 w-full h-fit">
                 <IconLoader size={13} class="text-[var(--rg-text-secondary)] shrink-0" />
-                <span class="shimmer-text text-[13px] leading-4 font-sans font-medium h-fit tabular-nums overflow-hidden text-ellipsis whitespace-nowrap">
-                  {props.statusText ?? "Grabbing…"}
-                </span>
+                <span
+                  class="shimmer-text text-[13px] leading-4 font-sans font-medium h-fit tabular-nums overflow-hidden text-ellipsis whitespace-nowrap"
+                  textContent={props.statusText ?? "Grabbing…"}
+                />
               </div>
             </div>
           </Show>

--- a/packages/react-grab/src/components/selection-label/tag-badge.tsx
+++ b/packages/react-grab/src/components/selection-label/tag-badge.tsx
@@ -22,11 +22,11 @@ export const TagBadge: Component<TagBadgeProps> = (props) => {
   const renderTagLabel = () => (
     <span class="text-[var(--rg-text-primary)] text-[13px] leading-4 h-fit font-medium overflow-hidden text-ellipsis whitespace-nowrap min-w-0">
       <Show when={props.componentName}>
-        <span>{props.componentName}</span>
-        <span class="text-[var(--rg-text-secondary)]">.{props.tagName}</span>
+        <span textContent={props.componentName} />
+        <span class="text-[var(--rg-text-secondary)]" textContent={`.${props.tagName}`} />
       </Show>
       <Show when={!props.componentName}>
-        <span class="text-[var(--rg-text-primary)]">{props.tagName}</span>
+        <span class="text-[var(--rg-text-primary)]" textContent={props.tagName} />
       </Show>
     </span>
   );

--- a/packages/react-grab/src/components/shortcut-hint.tsx
+++ b/packages/react-grab/src/components/shortcut-hint.tsx
@@ -23,10 +23,10 @@ export const ShortcutHint: Component<ShortcutHintProps> = (props) => {
         <IconReturn size={8} />
       </Show>
       <Show when={!isEnter()}>
-        <Show when={requiresModifier()} fallback={<span>{props.shortcut}</span>}>
-          <Show when={isMacPlatform} fallback={<span>Ctrl+{props.shortcut}</span>}>
+        <Show when={requiresModifier()} fallback={<span textContent={props.shortcut} />}>
+          <Show when={isMacPlatform} fallback={<span textContent={`Ctrl+${props.shortcut}`} />}>
             <IconCommand size={9} />
-            <span>{props.shortcut}</span>
+            <span textContent={props.shortcut} />
           </Show>
         </Show>
       </Show>

--- a/packages/react-grab/src/components/slot.tsx
+++ b/packages/react-grab/src/components/slot.tsx
@@ -84,18 +84,16 @@ const DigitColumn: Component<DigitColumnProps> = (props) => {
         class="rg-slot-cell"
         data-dir={String(props.direction)}
         style={cellStyle()}
-      >
-        {props.digit}
-      </span>
+        textContent={props.digit}
+      />
       <Show when={exitingDigit()} keyed>
         {(exitState) => (
           <span
             class="rg-slot-cell rg-slot-exit"
             data-dir={String(exitState.direction)}
             style={cellStyle()}
-          >
-            {exitState.digit}
-          </span>
+            textContent={exitState.digit}
+          />
         )}
       </Show>
     </span>
@@ -135,9 +133,7 @@ export const Slot: Component<SlotProps> = (props) => {
     >
       <Index each={renderSegments().prefixLiterals}>
         {(character) => (
-          <span class="inline-block whitespace-pre" aria-hidden="true">
-            {character()}
-          </span>
+          <span class="inline-block whitespace-pre" aria-hidden="true" textContent={character()} />
         )}
       </Index>
       <span class="inline-flex" style={{ "flex-direction": "row-reverse" }}>
@@ -146,9 +142,11 @@ export const Slot: Component<SlotProps> = (props) => {
             <Show
               when={segment().kind === "digit"}
               fallback={
-                <span class="inline-block whitespace-pre" aria-hidden="true">
-                  {segment().value}
-                </span>
+                <span
+                  class="inline-block whitespace-pre"
+                  aria-hidden="true"
+                  textContent={segment().value}
+                />
               }
             >
               <DigitColumn

--- a/packages/react-grab/src/components/toolbar/hierarchy-menu.tsx
+++ b/packages/react-grab/src/components/toolbar/hierarchy-menu.tsx
@@ -55,9 +55,8 @@ export const HierarchyMenu: Component<HierarchyMenuProps> = (props) => {
                         aria-hidden="true"
                         class="shrink-0 font-mono text-[11px] leading-4 text-[var(--rg-text-secondary)] opacity-60 mr-1"
                         style={{ "padding-left": `${(item.depth - 1) * HIERARCHY_INDENT_PX}px` }}
-                      >
-                        {item.isLast ? "└─" : "├─"}
-                      </span>
+                        textContent={item.isLast ? "└─" : "├─"}
+                      />
                     </Show>
                     <span
                       class="text-[13px] leading-4 h-fit font-medium overflow-hidden text-ellipsis whitespace-nowrap min-w-0 transition-colors"
@@ -67,10 +66,10 @@ export const HierarchyMenu: Component<HierarchyMenuProps> = (props) => {
                       }}
                     >
                       <Show when={item.componentName}>
-                        {item.componentName}
+                        <span textContent={item.componentName} />
                         <span class="text-[var(--rg-text-secondary)]">.</span>
                       </Show>
-                      {item.tagName}
+                      <span textContent={item.tagName} />
                     </span>
                   </span>
                 </Menu.Item>

--- a/packages/react-grab/src/components/toolbar/toolbar-action-button.tsx
+++ b/packages/react-grab/src/components/toolbar/toolbar-action-button.tsx
@@ -14,7 +14,7 @@ interface ToolbarActionButtonProps {
   onMouseEnter?: (event: MouseEvent) => void;
   onMouseLeave?: (event: MouseEvent) => void;
   icon: JSX.Element;
-  tooltip?: JSX.Element;
+  tooltip?: string;
   tooltipVisible?: boolean;
   tooltipPosition?: "top" | "bottom" | "left" | "right";
 }
@@ -38,9 +38,13 @@ export const ToolbarActionButton: Component<ToolbarActionButtonProps> = (props) 
       {props.icon}
     </button>
     <Show when={props.tooltip}>
-      <Tooltip visible={Boolean(props.tooltipVisible)} position={props.tooltipPosition ?? "top"}>
-        {props.tooltip}
-      </Tooltip>
+      {(tooltip) => (
+        <Tooltip
+          visible={Boolean(props.tooltipVisible)}
+          position={props.tooltipPosition ?? "top"}
+          textContent={tooltip()}
+        />
+      )}
     </Show>
   </div>
 );

--- a/packages/react-grab/src/components/toolbar/toolbar-menu.tsx
+++ b/packages/react-grab/src/components/toolbar/toolbar-menu.tsx
@@ -55,9 +55,8 @@ export const ToolbarMenu: Component<ToolbarMenuProps> = (props) => {
                           ? "text-[var(--rg-text-primary)]"
                           : "text-[var(--rg-text-secondary)]"
                       }
-                    >
-                      {action.label}
-                    </Menu.Label>
+                      textContent={action.label}
+                    />
                     <Show when={action.shortcut}>
                       {(shortcutKey) => (
                         <Menu.Shortcut

--- a/packages/react-grab/src/components/tooltip.tsx
+++ b/packages/react-grab/src/components/tooltip.tsx
@@ -1,5 +1,5 @@
 import { createSignal, createEffect, on, onCleanup, Show } from "solid-js";
-import type { Component, JSX } from "solid-js";
+import type { Component } from "solid-js";
 import { cn } from "../utils/cn.js";
 import { TOOLTIP_DELAY_MS, TOOLTIP_GRACE_PERIOD_MS, Z_INDEX_OVERLAY } from "../constants.js";
 
@@ -12,7 +12,7 @@ const wasTooltipRecentlyVisible = () => {
 interface TooltipProps {
   visible: boolean;
   position: "top" | "bottom" | "left" | "right";
-  children: JSX.Element;
+  textContent: string;
 }
 
 export const Tooltip: Component<TooltipProps> = (props) => {
@@ -81,9 +81,8 @@ export const Tooltip: Component<TooltipProps> = (props) => {
           shouldAnimate() && "animate-tooltip-fade-in",
         )}
         style={positionStyle()}
-      >
-        {props.children}
-      </div>
+        textContent={props.textContent}
+      />
     </Show>
   );
 };


### PR DESCRIPTION
## What changed

- use Solid's native `textContent` prop for dynamic, text-only UI content
- narrow text-only component APIs such as tooltips and menu labels from arbitrary JSX to strings
- document the `textContent` optimization in `AGENTS.md`

## Why

Solid's JSX compiler cannot assume arbitrary child expressions are text-only. Using the native `textContent` prop makes that intent explicit and enables the optimized text update path.

## Impact

Rendering behavior remains the same while dynamic text-only updates avoid the more general JSX insertion path.

## Validation

- `pnpm build`
- `pnpm test` (1085 passed, 23 skipped)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimizes dynamic text rendering by using Solid’s native `textContent` prop and narrowing text-only APIs to strings for faster updates. No visual changes; text updates now use a faster path.

- **Refactors**
  - Replaced JSX children with `textContent` for text-only nodes across `react-grab` (menu labels, tooltips, selection labels, steppers, slot digits).
  - Narrowed text-only props from `JSX.Element` to `string`: `Tooltip` now takes `textContent`, `ToolbarActionButton.tooltip` is a string, `MenuItemLabel` takes `textContent`.
  - Updated menus to use `Menu.Label` with `textContent`; documented guidance in `AGENTS.md`.

- **Migration**
  - `Tooltip`: use `<Tooltip textContent="..." />` instead of children.
  - `ToolbarActionButton`: pass `tooltip="..."` (string).
  - `MenuItemLabel`: use `<MenuItemLabel textContent="..." />`.
  - Convert any JSX passed to these text-only props into plain strings.

<sup>Written for commit 8f8c1839970d607d85c6018f602c5aa9fb652809. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI rendering and internal component prop shapes only; no security, data, or business-logic changes, with behavior intended to stay visually identical.
> 
> **Overview**
> Swaps many **text-only** dynamic spans and labels from JSX children to Solid’s native **`textContent`** prop so the compiler can use the faster text update path instead of generic child insertion.
> 
> **`Tooltip`**, **`MenuItemLabel`**, and **`ToolbarActionButton`** now take **strings** (`textContent` / `tooltip`) instead of **`JSX.Element`** children; call sites in menus, toolbars, and context menus were updated accordingly. The same pattern is applied across edit-panel controls, selection-label views, shortcut hints, slot digit animation, and hierarchy rows.
> 
> **`AGENTS.md`** adds a **SHOULD** guideline to prefer **`textContent`** when content is guaranteed to be plain text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f8c1839970d607d85c6018f602c5aa9fb652809. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->