### PR TITLE
Use Chrome for Playwright in CI

### DIFF
--- a/packages/react-grab/playwright.config.ts
+++ b/packages/react-grab/playwright.config.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "url";
 import { PERF_DEEP_TEST_TIMEOUT_MS, PERF_DEFAULT_TEST_TIMEOUT_MS } from "./e2e/perf-constants.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const isCI = Boolean(process.env.CI);
 
 // COVERAGE wires a sourcemapped/unminified build, the per-test V8 capture
 // fixture, and globalSetup/globalTeardown that clear the raw dir and write the
@@ -289,8 +290,8 @@ const environmentConfig = requestedEnvironment
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
-  forbidOnly: Boolean(process.env.CI),
-  retries: process.env.CI ? 2 : 1,
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 1,
   workers: PLAYWRIGHT_WORKER_COUNT,
   // Deep profiler, render-trace, and DOM-breakpoint replays add extra passes.
   // The V8 sampler can sporadically wedge the headless renderer for minutes
@@ -298,6 +299,8 @@ export default defineConfig({
   timeout: isDeepPerfRun ? PERF_DEEP_TEST_TIMEOUT_MS : PERF_DEFAULT_TEST_TIMEOUT_MS,
   reporter: "html",
   use: {
+    // Use Chrome preinstalled on GitHub Actions runners.
+    channel: isCI ? "chrome" : undefined,
     trace: process.env.PERF_RENDER_TRACE === "1" ? "off" : "on-first-retry",
     permissions: ["clipboard-read", "clipboard-write"],
   },


### PR DESCRIPTION
## Summary

- use the shared CI flag for Playwright CI behavior
- run CI browser tests with the Chrome installation already available on GitHub Actions runners
- keep local browser tests on Playwright's default bundled Chromium

## Why

CI should use the Chrome binary preinstalled on GitHub Actions runners instead of requiring Playwright's bundled Chromium for test execution.

## Validation

- `nr build`
- `nr typecheck`
- CI-mode Playwright config listing
- CI-mode Playwright activation test in the `chrome` channel


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `playwright` browser tests in CI using the Chrome binary preinstalled on GitHub Actions runners. Local runs stay on the default bundled Chromium, and CI settings now use the `CI` flag for `forbidOnly` and retries.

<sup>Written for commit fafd54b1e2c7d988c58469f0dfd219be17e3dc69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file E2E config change with no production or auth logic; main effect is which browser binary CI uses.
> 
> **Overview**
> CI Playwright runs now launch the **Chrome** channel (the binary already on GitHub Actions runners) instead of relying on Playwright’s bundled Chromium; local runs leave `channel` unset so behavior stays on default Chromium.
> 
> The config also introduces a shared **`isCI`** flag and wires **`forbidOnly`** and **`retries`** through it, matching the previous `process.env.CI` behavior with a single check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fafd54b1e2c7d988c58469f0dfd219be17e3dc69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->