### PR TITLE
Fix unfreeze renderer scheduling

### DIFF
--- a/packages/react-grab/e2e/freeze-updates.spec.ts
+++ b/packages/react-grab/e2e/freeze-updates.spec.ts
@@ -164,16 +164,26 @@ test.describe("Freeze Updates", () => {
         const staleScheduleUpdateCount = owningRendererScheduleUpdateCount;
         window.unfreezeReactGrab();
         await new Promise<void>((resolve) => queueMicrotask(resolve));
+
+        const scheduleUpdateCountBeforeRapidCycle = owningRendererScheduleUpdateCount;
+        window.freezeReactGrab();
+        window.unfreezeReactGrab();
+        window.freezeReactGrab();
+        window.unfreezeReactGrab();
+        await new Promise<void>((resolve) => queueMicrotask(resolve));
         return {
           foreignRendererScheduleUpdateCount,
           owningRendererScheduleUpdateCount,
+          rapidCycleScheduleUpdateCount:
+            owningRendererScheduleUpdateCount - scheduleUpdateCountBeforeRapidCycle,
           staleScheduleUpdateCount,
         };
       });
 
       expect(scheduleUpdateCounts).toEqual({
         foreignRendererScheduleUpdateCount: 0,
-        owningRendererScheduleUpdateCount: 1,
+        owningRendererScheduleUpdateCount: 2,
+        rapidCycleScheduleUpdateCount: 1,
         staleScheduleUpdateCount: 0,
       });
     });

--- a/packages/react-grab/e2e/freeze-updates.spec.ts
+++ b/packages/react-grab/e2e/freeze-updates.spec.ts
@@ -90,6 +90,50 @@ test.describe("Freeze Updates", () => {
   });
 
   test.describe("Multiple Freeze/Unfreeze Cycles", () => {
+    test("schedules updates only with the renderer that owns each root", async ({ reactGrab }) => {
+      await reactGrab.page.evaluate(() => {
+        document.documentElement.dataset.foreignScheduleUpdateCount = "0";
+        const devtoolsHook = Reflect.get(window, "__REACT_DEVTOOLS_GLOBAL_HOOK__");
+        if (!devtoolsHook || typeof devtoolsHook !== "object") {
+          throw new Error("React DevTools hook is unavailable");
+        }
+        const injectRenderer = Reflect.get(devtoolsHook, "inject");
+        if (typeof injectRenderer !== "function") {
+          throw new Error("React DevTools renderer injection is unavailable");
+        }
+        const domRenderer = Array.from(devtoolsHook.renderers.values()).find((renderer) =>
+          renderer.rendererPackageName.startsWith("react-dom"),
+        );
+        if (!domRenderer) throw new Error("React DOM renderer is unavailable");
+        injectRenderer.call(devtoolsHook, {
+          bundleType: domRenderer.bundleType,
+          currentDispatcherRef: null,
+          reconcilerVersion: domRenderer.reconcilerVersion,
+          rendererPackageName: "react-dom-foreign",
+          scheduleUpdate: () => {
+            const currentCount = Number(
+              document.documentElement.dataset.foreignScheduleUpdateCount,
+            );
+            document.documentElement.dataset.foreignScheduleUpdateCount = String(currentCount + 1);
+          },
+          version: domRenderer.version,
+        });
+      });
+
+      await reactGrab.page.evaluate(() => {
+        window.freezeReactGrab();
+        window.unfreezeReactGrab();
+      });
+
+      await expect
+        .poll(() =>
+          reactGrab.page.evaluate(() =>
+            Number(document.documentElement.dataset.foreignScheduleUpdateCount),
+          ),
+        )
+        .toBe(0);
+    });
+
     test("should handle multiple prompt mode cycles correctly", async ({ reactGrab }) => {
       await reactGrab.registerCommentAction();
 

--- a/packages/react-grab/e2e/freeze-updates.spec.ts
+++ b/packages/react-grab/e2e/freeze-updates.spec.ts
@@ -90,9 +90,8 @@ test.describe("Freeze Updates", () => {
   });
 
   test.describe("Multiple Freeze/Unfreeze Cycles", () => {
-    test("schedules updates only with the renderer that owns each root", async ({ reactGrab }) => {
+    test("ignores malformed renderer registrations", async ({ reactGrab }) => {
       await reactGrab.page.evaluate(() => {
-        document.documentElement.dataset.foreignScheduleUpdateCount = "0";
         const devtoolsHook = Reflect.get(window, "__REACT_DEVTOOLS_GLOBAL_HOOK__");
         if (!devtoolsHook || typeof devtoolsHook !== "object") {
           throw new Error("React DevTools hook is unavailable");
@@ -101,37 +100,78 @@ test.describe("Freeze Updates", () => {
         if (typeof injectRenderer !== "function") {
           throw new Error("React DevTools renderer injection is unavailable");
         }
-        const domRenderer = Array.from(devtoolsHook.renderers.values()).find((renderer) =>
-          renderer.rendererPackageName.startsWith("react-dom"),
-        );
-        if (!domRenderer) throw new Error("React DOM renderer is unavailable");
-        injectRenderer.call(devtoolsHook, {
-          bundleType: domRenderer.bundleType,
-          currentDispatcherRef: null,
-          reconcilerVersion: domRenderer.reconcilerVersion,
-          rendererPackageName: "react-dom-foreign",
-          scheduleUpdate: () => {
-            const currentCount = Number(
-              document.documentElement.dataset.foreignScheduleUpdateCount,
-            );
-            document.documentElement.dataset.foreignScheduleUpdateCount = String(currentCount + 1);
+        const incompleteRenderer = Object.create(null);
+        Reflect.set(incompleteRenderer, "scheduleRefresh", () => {});
+        Reflect.apply(injectRenderer, devtoolsHook, [incompleteRenderer]);
+        const inaccessibleRenderer = Object.create(null);
+        Object.defineProperty(inaccessibleRenderer, "rendererPackageName", {
+          get: () => {
+            throw new Error("Renderer metadata is inaccessible");
           },
-          version: domRenderer.version,
         });
-      });
+        Reflect.apply(injectRenderer, devtoolsHook, [inaccessibleRenderer]);
 
-      await reactGrab.page.evaluate(() => {
         window.freezeReactGrab();
         window.unfreezeReactGrab();
       });
+    });
 
-      await expect
-        .poll(() =>
-          reactGrab.page.evaluate(() =>
-            Number(document.documentElement.dataset.foreignScheduleUpdateCount),
-          ),
-        )
-        .toBe(0);
+    test("schedules only the owning renderer and skips stale updates", async ({ reactGrab }) => {
+      const scheduleUpdateCounts = await reactGrab.page.evaluate(async () => {
+        const devtoolsHook = Reflect.get(window, "__REACT_DEVTOOLS_GLOBAL_HOOK__");
+        if (!devtoolsHook || typeof devtoolsHook !== "object") {
+          throw new Error("React DevTools hook is unavailable");
+        }
+        const injectRenderer = Reflect.get(devtoolsHook, "inject");
+        const commitFiberRoot = Reflect.get(devtoolsHook, "onCommitFiberRoot");
+        if (typeof injectRenderer !== "function" || typeof commitFiberRoot !== "function") {
+          throw new Error("React DevTools instrumentation is unavailable");
+        }
+        let owningRendererScheduleUpdateCount = 0;
+        let foreignRendererScheduleUpdateCount = 0;
+        const owningRenderer = Object.create(null);
+        Reflect.set(owningRenderer, "currentDispatcherRef", null);
+        Reflect.set(owningRenderer, "rendererPackageName", "react-dom-owning");
+        Reflect.set(owningRenderer, "scheduleUpdate", () => {
+          owningRendererScheduleUpdateCount += 1;
+        });
+        const foreignRenderer = Object.create(null);
+        Reflect.set(foreignRenderer, "currentDispatcherRef", null);
+        Reflect.set(foreignRenderer, "rendererPackageName", "react-dom-foreign");
+        Reflect.set(foreignRenderer, "scheduleUpdate", () => {
+          foreignRendererScheduleUpdateCount += 1;
+        });
+        const owningRendererId = Reflect.apply(injectRenderer, devtoolsHook, [owningRenderer]);
+        Reflect.apply(injectRenderer, devtoolsHook, [foreignRenderer]);
+        const syntheticFiberRoot = Object.create(null);
+        const syntheticRootFiber = Object.create(null);
+        Reflect.set(syntheticRootFiber, "child", null);
+        Reflect.set(syntheticRootFiber, "return", null);
+        Reflect.set(syntheticRootFiber, "sibling", null);
+        Reflect.set(syntheticRootFiber, "stateNode", syntheticFiberRoot);
+        Reflect.set(syntheticFiberRoot, "containerInfo", document.body);
+        Reflect.set(syntheticFiberRoot, "current", syntheticRootFiber);
+        Reflect.apply(commitFiberRoot, devtoolsHook, [owningRendererId, syntheticFiberRoot]);
+
+        window.freezeReactGrab();
+        window.unfreezeReactGrab();
+        window.freezeReactGrab();
+        await new Promise<void>((resolve) => queueMicrotask(resolve));
+        const staleScheduleUpdateCount = owningRendererScheduleUpdateCount;
+        window.unfreezeReactGrab();
+        await new Promise<void>((resolve) => queueMicrotask(resolve));
+        return {
+          foreignRendererScheduleUpdateCount,
+          owningRendererScheduleUpdateCount,
+          staleScheduleUpdateCount,
+        };
+      });
+
+      expect(scheduleUpdateCounts).toEqual({
+        foreignRendererScheduleUpdateCount: 0,
+        owningRendererScheduleUpdateCount: 1,
+        staleScheduleUpdateCount: 0,
+      });
     });
 
     test("should handle multiple prompt mode cycles correctly", async ({ reactGrab }) => {

--- a/packages/react-grab/e2e/freeze-updates.spec.ts
+++ b/packages/react-grab/e2e/freeze-updates.spec.ts
@@ -100,8 +100,7 @@ test.describe("Freeze Updates", () => {
         if (typeof injectRenderer !== "function") {
           throw new Error("React DevTools renderer injection is unavailable");
         }
-        const incompleteRenderer = Object.create(null);
-        Reflect.set(incompleteRenderer, "scheduleRefresh", () => {});
+        const incompleteRenderer = { scheduleRefresh: () => {} };
         Reflect.apply(injectRenderer, devtoolsHook, [incompleteRenderer]);
         const inaccessibleRenderer = Object.create(null);
         Object.defineProperty(inaccessibleRenderer, "rendererPackageName", {
@@ -129,28 +128,33 @@ test.describe("Freeze Updates", () => {
         }
         let owningRendererScheduleUpdateCount = 0;
         let foreignRendererScheduleUpdateCount = 0;
-        const owningRenderer = Object.create(null);
-        Reflect.set(owningRenderer, "currentDispatcherRef", null);
-        Reflect.set(owningRenderer, "rendererPackageName", "react-dom-owning");
-        Reflect.set(owningRenderer, "scheduleUpdate", () => {
-          owningRendererScheduleUpdateCount += 1;
-        });
-        const foreignRenderer = Object.create(null);
-        Reflect.set(foreignRenderer, "currentDispatcherRef", null);
-        Reflect.set(foreignRenderer, "rendererPackageName", "react-dom-foreign");
-        Reflect.set(foreignRenderer, "scheduleUpdate", () => {
-          foreignRendererScheduleUpdateCount += 1;
-        });
+        const owningRenderer = {
+          currentDispatcherRef: null,
+          rendererPackageName: "react-dom-owning",
+          scheduleUpdate: () => {
+            owningRendererScheduleUpdateCount += 1;
+          },
+        };
+        const foreignRenderer = {
+          currentDispatcherRef: null,
+          rendererPackageName: "react-dom-foreign",
+          scheduleUpdate: () => {
+            foreignRendererScheduleUpdateCount += 1;
+          },
+        };
         const owningRendererId = Reflect.apply(injectRenderer, devtoolsHook, [owningRenderer]);
         Reflect.apply(injectRenderer, devtoolsHook, [foreignRenderer]);
         const syntheticFiberRoot = Object.create(null);
-        const syntheticRootFiber = Object.create(null);
-        Reflect.set(syntheticRootFiber, "child", null);
-        Reflect.set(syntheticRootFiber, "return", null);
-        Reflect.set(syntheticRootFiber, "sibling", null);
-        Reflect.set(syntheticRootFiber, "stateNode", syntheticFiberRoot);
-        Reflect.set(syntheticFiberRoot, "containerInfo", document.body);
-        Reflect.set(syntheticFiberRoot, "current", syntheticRootFiber);
+        const syntheticRootFiber = {
+          child: null,
+          return: null,
+          sibling: null,
+          stateNode: syntheticFiberRoot,
+        };
+        Object.assign(syntheticFiberRoot, {
+          containerInfo: document.body,
+          current: syntheticRootFiber,
+        });
         Reflect.apply(commitFiberRoot, devtoolsHook, [owningRendererId, syntheticFiberRoot]);
 
         window.freezeReactGrab();

--- a/packages/react-grab/src/utils/freeze-updates.ts
+++ b/packages/react-grab/src/utils/freeze-updates.ts
@@ -62,6 +62,7 @@ interface PausedContextState {
 
 let isUpdatesPaused = false;
 let freezeOwnerCount = 0;
+let freezeSessionId = 0;
 
 const getOrCache = <K extends object, V>(cache: WeakMap<K, V>, key: K, create: () => V): V => {
   const cached = cache.get(key);
@@ -599,9 +600,12 @@ const installDispatcherPatching = (renderer: ReactRenderer): void => {
   });
 };
 
-const scheduleReactUpdate = (fiberRoots: Set<FiberRootLike>): void => {
+const scheduleReactUpdate = (
+  fiberRoots: Set<FiberRootLike>,
+  scheduledFreezeSessionId: number,
+): void => {
   queueMicrotask(() => {
-    if (isUpdatesPaused) return;
+    if (isUpdatesPaused || freezeSessionId !== scheduledFreezeSessionId) return;
     try {
       for (const fiberRoot of fiberRoots) {
         const renderer = resolveFiberRootRenderer(fiberRoot);
@@ -647,6 +651,7 @@ const clearPendingUpdates = (): void => {
 };
 
 const resumeUpdates = (): void => {
+  const resumedFreezeSessionId = freezeSessionId;
   const fiberRootsToResume = new Set(pausedFiberRoots);
   try {
     for (const fiberRoot of collectFiberRoots()) {
@@ -679,8 +684,8 @@ const resumeUpdates = (): void => {
   invokeCallbacks(storeCallbacksToInvoke);
   invokeCallbacks(transitionCallbacksToInvoke);
   invokeCallbacks(stateUpdatesToInvoke);
-  if (!isUpdatesPaused) {
-    scheduleReactUpdate(fiberRootsToResume);
+  if (!isUpdatesPaused && freezeSessionId === resumedFreezeSessionId) {
+    scheduleReactUpdate(fiberRootsToResume, resumedFreezeSessionId);
   }
 };
 
@@ -695,6 +700,7 @@ export const freezeUpdatesOrThrow = (): (() => void) => {
   if (isFirstFreezeOwner) {
     try {
       initializeFreezeSupport();
+      freezeSessionId += 1;
       isUpdatesPaused = true;
 
       const fiberRoots = collectFiberRoots();

--- a/packages/react-grab/src/utils/freeze-updates.ts
+++ b/packages/react-grab/src/utils/freeze-updates.ts
@@ -92,21 +92,20 @@ const pausedContextStates = new WeakMap<ContextDependency, PausedContextState>()
 const renderersWithPatchedDispatcher = new WeakSet<ReactRenderer>();
 const typedFiberRoots = _fiberRoots as Set<FiberRootLike>;
 const pausedFiberRoots = new Set<FiberRootLike>();
-const fiberRootRendererIds = new WeakMap<FiberRootLike, number>();
+const fiberRootRenderers = new WeakMap<FiberRootLike, ReactRenderer>();
 
 instrument({
   name: "react-grab-freeze-updates",
   onCommitFiberRoot: (rendererId, fiberRoot) => {
-    fiberRootRendererIds.set(fiberRoot, rendererId);
+    const renderer = getRDTHook().renderers.get(rendererId);
+    if (renderer) fiberRootRenderers.set(fiberRoot, renderer);
   },
 });
 
 const isDomRenderer = (renderer: ReactRenderer): boolean => {
   try {
-    return (
-      typeof renderer.rendererPackageName === "string" &&
-      renderer.rendererPackageName.startsWith("react-dom")
-    );
+    const packageName = renderer.rendererPackageName;
+    return typeof packageName === "string" && packageName.startsWith("react-dom");
   } catch {
     return false;
   }
@@ -146,26 +145,27 @@ const findHostInstance = (fiberRoot: FiberRootLike): object | null => {
   return null;
 };
 
-const resolveFiberRootRenderer = (
-  fiberRoot: FiberRootLike,
-  renderers: Map<number, ReactRenderer>,
-): ReactRenderer | null => {
-  const rendererId = fiberRootRendererIds.get(fiberRoot);
-  if (rendererId !== undefined) {
-    const renderer = renderers.get(rendererId);
-    return renderer && isDomRenderer(renderer) ? renderer : null;
-  }
+const resolveFiberRootRenderer = (fiberRoot: FiberRootLike): ReactRenderer | null => {
+  const renderer = fiberRootRenderers.get(fiberRoot);
+  if (renderer) return isDomRenderer(renderer) ? renderer : null;
 
-  const domRenderers = Array.from(renderers.values()).filter(isDomRenderer);
-  if (domRenderers.length === 1) return domRenderers[0] ?? null;
+  const domRenderers = Array.from(getRDTHook().renderers.values()).filter(isDomRenderer);
+  if (domRenderers.length === 1) {
+    const domRenderer = domRenderers[0];
+    if (domRenderer) fiberRootRenderers.set(fiberRoot, domRenderer);
+    return domRenderer ?? null;
+  }
 
   const hostInstance = findHostInstance(fiberRoot);
   if (!hostInstance) return null;
 
-  for (const renderer of domRenderers) {
+  for (const domRenderer of domRenderers) {
     try {
-      const hostFiber = renderer.findFiberByHostInstance?.(hostInstance);
-      if (hostFiber && getFiberRoot(hostFiber) === fiberRoot) return renderer;
+      const hostFiber = domRenderer.findFiberByHostInstance?.(hostInstance);
+      if (hostFiber && getFiberRoot(hostFiber) === fiberRoot) {
+        fiberRootRenderers.set(fiberRoot, domRenderer);
+        return domRenderer;
+      }
     } catch {}
   }
   return null;
@@ -603,9 +603,8 @@ const scheduleReactUpdate = (fiberRoots: Set<FiberRootLike>): void => {
   queueMicrotask(() => {
     if (isUpdatesPaused) return;
     try {
-      const renderers = getRDTHook().renderers;
       for (const fiberRoot of fiberRoots) {
-        const renderer = resolveFiberRootRenderer(fiberRoot, renderers);
+        const renderer = resolveFiberRootRenderer(fiberRoot);
         if (fiberRoot.current && renderer?.scheduleUpdate) {
           try {
             renderer.scheduleUpdate(fiberRoot.current);

--- a/packages/react-grab/src/utils/freeze-updates.ts
+++ b/packages/react-grab/src/utils/freeze-updates.ts
@@ -9,6 +9,7 @@ import {
   _fiberRoots,
   getFiberFromHostInstance,
   getRDTHook,
+  instrument,
   isCompositeFiber,
   type Fiber,
   type ReactRenderer,
@@ -91,6 +92,14 @@ const pausedContextStates = new WeakMap<ContextDependency, PausedContextState>()
 const renderersWithPatchedDispatcher = new WeakSet<ReactRenderer>();
 const typedFiberRoots = _fiberRoots as Set<FiberRootLike>;
 const pausedFiberRoots = new Set<FiberRootLike>();
+const fiberRootRendererIds = new WeakMap<FiberRootLike, number>();
+
+instrument({
+  name: "react-grab-freeze-updates",
+  onCommitFiberRoot: (rendererId, fiberRoot) => {
+    fiberRootRendererIds.set(fiberRoot, rendererId);
+  },
+});
 
 const isDomRenderer = (renderer: ReactRenderer): boolean =>
   renderer.rendererPackageName.startsWith("react-dom");
@@ -101,6 +110,57 @@ const getFiberRoot = (fiber: Fiber): FiberRootLike | null => {
     current = current.return;
   }
   return (current.stateNode ?? null) as FiberRootLike | null;
+};
+
+const findHostInstance = (fiberRoot: FiberRootLike): object | null => {
+  const root = fiberRoot.current;
+  let fiber = root;
+  while (fiber) {
+    const stateNode = fiber.stateNode;
+    if (
+      stateNode &&
+      typeof stateNode === "object" &&
+      typeof Reflect.get(stateNode, "nodeType") === "number"
+    ) {
+      return stateNode;
+    }
+    if (fiber.child) {
+      fiber = fiber.child;
+      continue;
+    }
+    while (fiber !== root && !fiber.sibling) {
+      fiber = fiber.return;
+      if (!fiber) return null;
+    }
+    if (fiber === root) return null;
+    fiber = fiber.sibling;
+  }
+  return null;
+};
+
+const resolveFiberRootRenderer = (
+  fiberRoot: FiberRootLike,
+  renderers: Map<number, ReactRenderer>,
+): ReactRenderer | null => {
+  const rendererId = fiberRootRendererIds.get(fiberRoot);
+  if (rendererId !== undefined) {
+    const renderer = renderers.get(rendererId);
+    return renderer && isDomRenderer(renderer) ? renderer : null;
+  }
+
+  const domRenderers = Array.from(renderers.values()).filter(isDomRenderer);
+  if (domRenderers.length === 1) return domRenderers[0] ?? null;
+
+  const hostInstance = findHostInstance(fiberRoot);
+  if (!hostInstance) return null;
+
+  for (const renderer of domRenderers) {
+    try {
+      const hostFiber = renderer.findFiberByHostInstance?.(hostInstance);
+      if (hostFiber && getFiberRoot(hostFiber) === fiberRoot) return renderer;
+    } catch {}
+  }
+  return null;
 };
 
 const isDomFiberRoot = (fiberRoot: FiberRootLike): boolean => {
@@ -534,18 +594,16 @@ const installDispatcherPatching = (renderer: ReactRenderer): void => {
 const scheduleReactUpdate = (fiberRoots: Set<FiberRootLike>): void => {
   queueMicrotask(() => {
     try {
-      for (const renderer of getRDTHook().renderers.values()) {
-        if (!isDomRenderer(renderer)) continue;
-        if (typeof renderer.scheduleUpdate !== "function") continue;
-        for (const fiberRoot of fiberRoots) {
-          if (fiberRoot.current) {
-            try {
-              renderer.scheduleUpdate(fiberRoot.current);
-            } catch (error) {
-              reportRecoverableError(
-                new RecoverableError("scheduleUpdate failed during unfreeze", error),
-              );
-            }
+      const renderers = getRDTHook().renderers;
+      for (const fiberRoot of fiberRoots) {
+        const renderer = resolveFiberRootRenderer(fiberRoot, renderers);
+        if (fiberRoot.current && renderer?.scheduleUpdate) {
+          try {
+            renderer.scheduleUpdate(fiberRoot.current);
+          } catch (error) {
+            reportRecoverableError(
+              new RecoverableError("scheduleUpdate failed during unfreeze", error),
+            );
           }
         }
       }

--- a/packages/react-grab/src/utils/freeze-updates.ts
+++ b/packages/react-grab/src/utils/freeze-updates.ts
@@ -101,8 +101,16 @@ instrument({
   },
 });
 
-const isDomRenderer = (renderer: ReactRenderer): boolean =>
-  renderer.rendererPackageName.startsWith("react-dom");
+const isDomRenderer = (renderer: ReactRenderer): boolean => {
+  try {
+    return (
+      typeof renderer.rendererPackageName === "string" &&
+      renderer.rendererPackageName.startsWith("react-dom")
+    );
+  } catch {
+    return false;
+  }
+};
 
 const getFiberRoot = (fiber: Fiber): FiberRootLike | null => {
   let current: Fiber | null = fiber;
@@ -593,6 +601,7 @@ const installDispatcherPatching = (renderer: ReactRenderer): void => {
 
 const scheduleReactUpdate = (fiberRoots: Set<FiberRootLike>): void => {
   queueMicrotask(() => {
+    if (isUpdatesPaused) return;
     try {
       const renderers = getRDTHook().renderers;
       for (const fiberRoot of fiberRoots) {


### PR DESCRIPTION
## Summary

- track the owning renderer for each committed fiber root
- resolve roots that predate instrumentation through host instances
- schedule unfreeze updates only through the owning React DOM renderer
- ignore malformed or inaccessible renderer metadata
- suppress stale scheduled refreshes when another freeze has already started
- add deterministic multi-renderer and refreeze regression coverage

## Root cause

The unfreeze path called every React DOM renderer's private `scheduleUpdate` method for every collected fiber root. On pages with multiple renderers, including non-DOM renderers such as React Three Fiber, a renderer could receive a root it did not own and throw repeated `scheduleUpdate failed during unfreeze` recoverable errors.

The audit also found two adjacent failure modes: incomplete DevTools renderer registrations could abort freezing while reading `rendererPackageName`, and the queued unfreeze refresh could run after an immediate refreeze.

## Impact

Unfreezing no longer emits repeated recoverable errors on multi-renderer pages. Malformed renderer registrations are skipped, stale refreshes do not escape into a new freeze session, and buffered React updates continue to resume through the correct renderer.

## Validation

- `nr build`
- `nr lint`
- `nr typecheck`
- format check
- 243 unit tests
- 15 freeze-update E2E tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches React-internals freeze/unfreeze and DevTools hook integration; behavior is well covered by new E2E tests but remains fragile by design.
> 
> **Overview**
> Fixes **unfreeze** so post-thaw `scheduleUpdate` runs only on the React DOM renderer that owns each fiber root, instead of calling every DOM renderer for every root (which broke multi-renderer pages and spammed recoverable errors).
> 
> **`freeze-updates.ts`** records root→renderer on commit via bippy `instrument`, with fallbacks (`findHostInstance`, `findFiberByHostInstance`) for roots that mounted before instrumentation. **`isDomRenderer`** is wrapped in try/catch so bad DevTools registrations don’t abort freeze. A **`freezeSessionId`** gates the microtask refresh so a quick refreeze doesn’t apply a stale scheduled update.
> 
> **E2E** adds coverage for malformed renderer injection and for owning-vs-foreign `scheduleUpdate` counts across refreeze cycles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2910b1404e479e1464bce45108bca8e11614e8b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->