### PR TITLE
Fix strict CSP compatibility

### DIFF
--- a/packages/react-grab/e2e/csp.spec.ts
+++ b/packages/react-grab/e2e/csp.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "./fixtures.js";
+
+const STRICT_STYLE_POLICY = "style-src 'self' 'unsafe-inline'";
+const GOOGLE_FONTS_STYLESHEET_HOST = "fonts.googleapis.com";
+
+test("does not load an external font stylesheet under a strict style CSP", async ({
+  reactGrab,
+}) => {
+  const cspViolations: string[] = [];
+
+  reactGrab.page.on("console", (message) => {
+    if (
+      message.type() === "error" &&
+      message.text().includes("Content Security Policy") &&
+      message.text().includes(GOOGLE_FONTS_STYLESHEET_HOST)
+    ) {
+      cspViolations.push(message.text());
+    }
+  });
+
+  await reactGrab.page.route("**/*", async (route) => {
+    if (route.request().resourceType() !== "document") {
+      await route.continue();
+      return;
+    }
+
+    const response = await route.fetch();
+    await route.fulfill({
+      response,
+      headers: {
+        ...response.headers(),
+        "content-security-policy": STRICT_STYLE_POLICY,
+      },
+    });
+  });
+
+  await reactGrab.page.reload({ waitUntil: "domcontentloaded" });
+  await expect.poll(() => reactGrab.getOverlayHost().count()).toBe(1);
+
+  const overlayStyles = await reactGrab.getOverlayHost().evaluate((host) => {
+    return host.shadowRoot?.querySelector("style")?.textContent ?? "";
+  });
+
+  expect(overlayStyles).not.toContain(GOOGLE_FONTS_STYLESHEET_HOST);
+  expect(cspViolations).toEqual([]);
+});

--- a/packages/react-grab/src/utils/mount-root.ts
+++ b/packages/react-grab/src/utils/mount-root.ts
@@ -3,9 +3,6 @@ import { detectCspNonce } from "./detect-csp-nonce.js";
 import { hideFromThirdParties } from "./hide-from-third-parties.js";
 import { REACT_GRAB_ATTRIBUTE_NAME } from "./react-grab-attribute-name.js";
 
-const FONT_IMPORT =
-  '@import url("https://fonts.googleapis.com/css2?family=Geist:wght@500&display=swap");';
-
 // Mounting into <body> (not <html>) keeps React hydration happy: appending a
 // <div> directly to <html> throws "In HTML, <div> cannot be a child of <html>"
 // during hydration (see vercel/next.js#51242), which surfaces in Next.js's dev
@@ -93,7 +90,7 @@ export const mountRoot = (cssText?: string): MountRootResult => {
   const styleElement = document.createElement("style");
   const nonce = detectCspNonce();
   if (nonce) styleElement.nonce = nonce;
-  styleElement.textContent = `${FONT_IMPORT}\n${cssText ?? ""}`;
+  styleElement.textContent = cssText ?? "";
   shadowRoot.appendChild(styleElement);
 
   const root = document.createElement("div");


### PR DESCRIPTION
## Summary
- remove the overlay's remote Google Fonts import
- preserve the existing system font fallback and CSP nonce handling
- add browser coverage for strict `style-src` policies

Closes #611.

## Test plan
- [x] `nr build`
- [x] strict-CSP Playwright regression test
- [x] `nr lint`
- [x] `nr typecheck`
- [x] format check for changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the overlay’s Google Fonts import in `react-grab` to comply with strict CSPs. Previously the overlay fetched `fonts.googleapis.com` and could trigger `style-src 'self'` violations; now it uses only inline styles with the existing nonce and the system font fallback.

- Drops the external `@import` in `mount-root.ts`; nonce handling and mount behavior are unchanged.
- Adds `e2e/csp.spec.ts` to enforce a strict `style-src` and verify no external font stylesheet loads and the overlay still mounts.
- Visual impact: the overlay may render with system fonts if a custom font is not provided.
- Migration (if you relied on Google Fonts): self-host your font and include it in your app’s styles, or pass font rules via the `cssText` argument; do not rely on external `@import` to satisfy CSP.

<sup>Written for commit 67ff47a35e7a898704e2071914b58c9f835a646a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

