### PR TITLE
Honor pinned package manager versions during setup

### DIFF
--- a/packages/cli/src/utils/install.ts
+++ b/packages/cli/src/utils/install.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { x } from "tinyexec";
 import { detectPackageManager, type PackageManager } from "./detect.js";
+import { shouldUseCorepack } from "./should-use-corepack.js";
 
 export interface InstallPackageOptions {
   cwd?: string;
@@ -38,10 +39,19 @@ export const installPackages = async (
   }
 
   const installVerb = detectedAgent === "npm" ? "install" : "add";
+  const shouldInvokeCorepack = await shouldUseCorepack(detectedAgent, options.cwd ?? process.cwd());
+  const packageManagerCommand = shouldInvokeCorepack ? "corepack" : detectedAgent;
+  const packageManagerArgs = shouldInvokeCorepack ? [detectedAgent] : [];
 
   await x(
-    detectedAgent,
-    [installVerb, ...(options.isDev !== false ? ["-D"] : []), ...args, ...packages],
+    packageManagerCommand,
+    [
+      ...packageManagerArgs,
+      installVerb,
+      ...(options.isDev !== false ? ["-D"] : []),
+      ...args,
+      ...packages,
+    ],
     {
       nodeOptions: {
         stdio: options.silent ? "ignore" : "inherit",

--- a/packages/cli/src/utils/should-use-corepack.ts
+++ b/packages/cli/src/utils/should-use-corepack.ts
@@ -1,0 +1,31 @@
+import { detect } from "package-manager-detector/detect";
+import { x } from "tinyexec";
+import type { PackageManager } from "./detect.js";
+
+export const shouldUseCorepack = async (
+  packageManager: PackageManager,
+  cwd: string,
+): Promise<boolean> => {
+  if (packageManager !== "pnpm" && packageManager !== "yarn") return false;
+
+  const detectedPackageManager = await detect({
+    cwd,
+    strategies: ["packageManager-field"],
+  });
+
+  if (
+    detectedPackageManager?.name !== packageManager ||
+    detectedPackageManager.version === undefined
+  ) {
+    return false;
+  }
+
+  try {
+    const corepackVersionResult = await x("corepack", ["--version"], {
+      nodeOptions: { cwd, stdio: "ignore" },
+    });
+    return corepackVersionResult.exitCode === 0;
+  } catch {
+    return false;
+  }
+};

--- a/packages/cli/test/install.test.ts
+++ b/packages/cli/test/install.test.ts
@@ -1,5 +1,74 @@
-import { describe, expect, it } from "vite-plus/test";
-import { getPackagesToInstall } from "../src/utils/install.js";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+vi.mock("tinyexec", () => ({
+  x: vi.fn(),
+}));
+
+vi.mock("../src/utils/should-use-corepack.js", () => ({
+  shouldUseCorepack: vi.fn(),
+}));
+
+import { x } from "tinyexec";
+import { getPackagesToInstall, installPackages } from "../src/utils/install.js";
+import { shouldUseCorepack } from "../src/utils/should-use-corepack.js";
+
+const mockExecute = vi.mocked(x);
+const mockShouldUseCorepack = vi.mocked(shouldUseCorepack);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockShouldUseCorepack.mockResolvedValue(false);
+});
+
+describe("installPackages", () => {
+  it("runs a pinned pnpm version through Corepack", async () => {
+    mockShouldUseCorepack.mockResolvedValue(true);
+    mockExecute.mockResolvedValue({
+      exitCode: 0,
+      stderr: "",
+      stdout: "",
+    });
+
+    await installPackages(["react-grab"], {
+      cwd: "/app",
+      packageManager: "pnpm",
+      silent: true,
+    });
+
+    expect(mockExecute).toHaveBeenCalledWith(
+      "corepack",
+      ["pnpm", "add", "-D", "--prod=false", "react-grab"],
+      {
+        nodeOptions: {
+          stdio: "ignore",
+          cwd: "/app",
+          env: { ...process.env, REACT_GRAB_INIT: "1" },
+        },
+        throwOnError: true,
+      },
+    );
+  });
+
+  it("falls back to the package manager executable", async () => {
+    mockExecute.mockResolvedValue({
+      exitCode: 0,
+      stderr: "",
+      stdout: "",
+    });
+
+    await installPackages(["react-grab"], {
+      cwd: "/app",
+      packageManager: "pnpm",
+      silent: true,
+    });
+
+    expect(mockExecute).toHaveBeenCalledWith(
+      "pnpm",
+      ["add", "-D", "--prod=false", "react-grab"],
+      expect.any(Object),
+    );
+  });
+});
 
 describe("getPackagesToInstall", () => {
   it("should return react-grab when includeReactGrab is true", () => {

--- a/packages/cli/test/should-use-corepack.test.ts
+++ b/packages/cli/test/should-use-corepack.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+vi.mock("package-manager-detector/detect", () => ({
+  detect: vi.fn(),
+}));
+
+vi.mock("tinyexec", () => ({
+  x: vi.fn(),
+}));
+
+import { detect } from "package-manager-detector/detect";
+import { x } from "tinyexec";
+import { shouldUseCorepack } from "../src/utils/should-use-corepack.js";
+
+const mockDetect = vi.mocked(detect);
+const mockExecute = vi.mocked(x);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("shouldUseCorepack", () => {
+  it("uses Corepack for a pinned pnpm version", async () => {
+    mockDetect.mockResolvedValue({
+      agent: "pnpm",
+      name: "pnpm",
+      version: "10.24.0",
+    });
+    mockExecute.mockResolvedValue({
+      exitCode: 0,
+      stderr: "",
+      stdout: "0.34.0",
+    });
+
+    await expect(shouldUseCorepack("pnpm", "/app")).resolves.toBe(true);
+    expect(mockDetect).toHaveBeenCalledWith({
+      cwd: "/app",
+      strategies: ["packageManager-field"],
+    });
+    expect(mockExecute).toHaveBeenCalledWith("corepack", ["--version"], {
+      nodeOptions: { cwd: "/app", stdio: "ignore" },
+    });
+  });
+
+  it("uses the package manager directly when no version is pinned", async () => {
+    mockDetect.mockResolvedValue({
+      agent: "pnpm",
+      name: "pnpm",
+    });
+
+    await expect(shouldUseCorepack("pnpm", "/app")).resolves.toBe(false);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("does not use Corepack for unsupported package managers", async () => {
+    await expect(shouldUseCorepack("bun", "/app")).resolves.toBe(false);
+    expect(mockDetect).not.toHaveBeenCalled();
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("falls back when Corepack is unavailable", async () => {
+    mockDetect.mockResolvedValue({
+      agent: "yarn@berry",
+      name: "yarn",
+      version: "4.9.1",
+    });
+    mockExecute.mockRejectedValue(new Error("spawn corepack ENOENT"));
+
+    await expect(shouldUseCorepack("yarn", "/app")).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- run pinned pnpm and Yarn versions through Corepack during package installation
- fall back to the package-manager executable when no version is pinned or Corepack is unavailable
- add regression coverage for command selection and fallback behavior

## Test plan
- [x] `pnpm build`
- [x] `pnpm test:cli`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm format:check`
- [x] reproduce with pnpm 8 first in `PATH` and pnpm 10.24.0 pinned in the project

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor pinned `pnpm`/`yarn` versions during CLI installs to prevent PATH shims from selecting incompatible versions. Previously we always invoked the detected agent; now we route installs through `corepack <agent>` when a version is pinned via `packageManager` and Corepack is available, falling back to the agent executable otherwise.

- **Review notes**
  - Command selection lives in new `shouldUseCorepack` (uses `package-manager-detector/detect`, supports only `pnpm` and `yarn`, and requires `corepack --version` to succeed).
  - `installPackages` builds `corepack <agent> ...` args when applicable; otherwise behavior is unchanged.
  - Added tests for Corepack path, fallback when not pinned, unsupported managers, and Corepack unavailable. No migration actions.

<sup>Written for commit 1e5ffd750d4843a1269efe402a95ec75c8936955. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

