### PR TITLE
Fix iframe hydration marker race

### DIFF
--- a/packages/react-grab/e2e/iframe.spec.ts
+++ b/packages/react-grab/e2e/iframe.spec.ts
@@ -13,6 +13,27 @@ import {
 import { movePointerToLocatorCenter } from "./move-pointer-to-locator-center.js";
 
 test.describe("Iframe selection", () => {
+  test("does not mark a pending cross-origin iframe as same-origin", async ({ reactGrab }) => {
+    const pendingFrameState = await reactGrab.page.evaluate(async () => {
+      const iframeElement = document.createElement("iframe");
+      iframeElement.src = "data:text/html,<main>Cross-origin frame</main>";
+      document.body.append(iframeElement);
+      await Promise.resolve();
+
+      return {
+        documentUrl: iframeElement.contentDocument?.URL,
+        hasSameOriginMarker: iframeElement.hasAttribute(
+          "data-react-grab-same-origin-frame",
+        ),
+      };
+    });
+
+    expect(pendingFrameState).toEqual({
+      documentUrl: "about:blank",
+      hasSameOriginMarker: false,
+    });
+  });
+
   test("does not forward iframe resizes for a top-document selection", async ({ reactGrab }) => {
     await reactGrab.page.evaluate((zIndex) => {
       const targetElement = document.createElement("button");

--- a/packages/react-grab/src/utils/is-iframe-initial-navigation-pending.ts
+++ b/packages/react-grab/src/utils/is-iframe-initial-navigation-pending.ts
@@ -1,0 +1,10 @@
+export const isIframeInitialNavigationPending = (
+  iframeElement: HTMLIFrameElement,
+  frameDocument: Document | null,
+): boolean => {
+  if (!frameDocument || frameDocument.URL !== "about:blank") return false;
+  if (iframeElement.hasAttribute("srcdoc")) return true;
+
+  const source = iframeElement.getAttribute("src")?.trim();
+  return Boolean(source && source.toLowerCase() !== "about:blank");
+};

--- a/packages/react-grab/src/utils/observe-same-origin-frame-documents.ts
+++ b/packages/react-grab/src/utils/observe-same-origin-frame-documents.ts
@@ -5,6 +5,7 @@ import { isIframeElement } from "./is-iframe-element.js";
 import { isReactGrabElement } from "./is-react-grab-element.js";
 import { collectCleanupError } from "./collect-cleanup-error.js";
 import { throwCollectedErrors } from "./throw-collected-errors.js";
+import { isIframeInitialNavigationPending } from "./is-iframe-initial-navigation-pending.js";
 
 interface FrameDocumentCallback {
   (frameDocument: Document): (() => void) | void;
@@ -127,6 +128,7 @@ export const observeSameOriginFrameDocuments = (callback: FrameDocumentCallback)
     const connectCurrentDocument = (): void => {
       const cleanupErrors: unknown[] = [];
       const frameDocument = getAccessibleIframeDocument(iframeElement);
+      if (isIframeInitialNavigationPending(iframeElement, frameDocument)) return;
       if (observedIframe.document && observedIframe.document !== frameDocument) {
         cleanupDocument(observedIframe.document, cleanupErrors);
       }


### PR DESCRIPTION
## Summary
- avoid marking an iframe's transient `about:blank` document as same-origin while its configured navigation is pending
- add regression coverage for the hydration-visible marker race

## Test plan
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `E2E_ENVIRONMENT=vite-plus-development pnpm --filter react-grab exec playwright test e2e/iframe.spec.ts --workers=1`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoids marking an iframe’s transient about:blank document as same-origin while its initial navigation is pending, removing a hydration-visible marker race in `react-grab`. Previously the same-origin marker could be added before navigation; now it appears only after the real document loads. This may delay same-origin observation for pending frames but does not change APIs.

- Add `isIframeInitialNavigationPending` to detect about:blank with pending `src`/`srcdoc`.
- Gate `observeSameOriginFrameDocuments` with this check to skip connecting until navigation completes.
- Add regression test to ensure a pending cross-origin iframe lacks the `data-react-grab-same-origin-frame` marker.

<sup>Written for commit 65ded7d78addc9254f51c7c11a066c0fdce3a270. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

