### PR TITLE
chore: bump bippy to 0.7.2

### DIFF
--- a/packages/react-grab/package.json
+++ b/packages/react-grab/package.json
@@ -109,7 +109,7 @@
   },
   "dependencies": {
     "@react-grab/cli": "workspace:*",
-    "bippy": "^0.6.1"
+    "bippy": "^0.7.2"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",

--- a/packages/react-grab/src/core/context.ts
+++ b/packages/react-grab/src/core/context.ts
@@ -3,6 +3,7 @@ import {
   isInstrumentationActive,
   getDisplayName,
   getLatestFiber,
+  isFiber,
   isCompositeFiber,
   traverseFiber,
   type Fiber,
@@ -259,10 +260,10 @@ export interface ResolvedSource extends SourceLocation {
 const pickNearestSourceFrame = (frames: StackFrame[]): StackFrame | null => frames[0] ?? null;
 
 const getSourceComponentName = (
-  fiber: Fiber | undefined,
+  fiber: Fiber["_debugOwner"],
   isNextProject: boolean,
 ): string | null => {
-  if (!fiber || !isCompositeFiber(fiber)) return null;
+  if (!isFiber(fiber) || !isCompositeFiber(fiber)) return null;
   return toSourceComponentName(getDisplayName(fiber.type), isNextProject);
 };
 

--- a/packages/react-grab/src/core/element-anchors.ts
+++ b/packages/react-grab/src/core/element-anchors.ts
@@ -1,10 +1,4 @@
-import {
-  getFiberFromHostInstance,
-  getLatestFiber,
-  getNearestHostFibers,
-  isHostFiber,
-  type Fiber,
-} from "bippy";
+import { getFiberFromHostInstance, getLatestFiber, isHostFiber, type Fiber } from "bippy";
 import { indexInParent } from "../utils/index-in-parent.js";
 import { isShadowRoot } from "../utils/is-shadow-root.js";
 import { isElementNode } from "../utils/is-element-node.js";
@@ -55,15 +49,37 @@ const resolveLiveAnchor = (anchor: ElementAnchor): Element | null => {
     return candidate && candidate.tagName === anchorTagName ? candidate : null;
   }
 
-  for (const hostFiber of getNearestHostFibers(latestParentFiber)) {
-    const node = hostFiber.stateNode;
-    // The tag match keeps recovery from latching onto an unrelated host when the
-    // original element type is gone. Same-tag siblings under a shared composite
-    // ancestor can't be told apart and resolve to the first match, which still
-    // leaves the selection on a valid node instead of dropping it.
-    if (isElementNode(node) && node.isConnected && node.tagName === anchorTagName) {
-      return node;
+  return findNearestHostElementWithTag(latestParentFiber, anchorTagName);
+};
+
+// Walks the nearest host fibers below `parentFiber` (stopping at each host
+// boundary, like bippy's removed getNearestHostFibers) for a connected element
+// with the anchor's tag. The tag match keeps recovery from latching onto an
+// unrelated host when the original element type is gone. Same-tag siblings
+// under a shared composite ancestor can't be told apart and resolve to the
+// first match, which still leaves the selection on a valid node instead of
+// dropping it.
+const findNearestHostElementWithTag = (
+  parentFiber: Fiber,
+  anchorTagName: string,
+): Element | null => {
+  let fiber: Fiber | null = parentFiber.child;
+  while (fiber) {
+    if (isHostFiber(fiber)) {
+      const node = fiber.stateNode;
+      if (isElementNode(node) && node.isConnected && node.tagName === anchorTagName) {
+        return node;
+      }
+    } else if (fiber.child) {
+      fiber = fiber.child;
+      continue;
     }
+    while (fiber !== parentFiber && !fiber.sibling) {
+      fiber = fiber.return;
+      if (!fiber) return null;
+    }
+    if (fiber === parentFiber) return null;
+    fiber = fiber.sibling;
   }
   return null;
 };

--- a/packages/react-grab/src/utils/freeze-updates.ts
+++ b/packages/react-grab/src/utils/freeze-updates.ts
@@ -19,10 +19,6 @@ import { RecoverableError } from "../errors.js";
 import { reportRecoverableError } from "./report-recoverable-error.js";
 import { IS_DEMO } from "./runtime-mode.js";
 
-interface FiberRootLike extends FiberRoot {
-  current: Fiber | null;
-}
-
 interface PendingUpdate {
   next: PendingUpdate | null;
   action: unknown;
@@ -91,9 +87,8 @@ const pendingStateUpdates: Array<() => void> = [];
 const pausedQueueStates = new WeakMap<HookQueue, PausedQueueState>();
 const pausedContextStates = new WeakMap<ContextDependency, PausedContextState>();
 const renderersWithPatchedDispatcher = new WeakSet<ReactRenderer>();
-const typedFiberRoots = _fiberRoots as Set<FiberRootLike>;
-const pausedFiberRoots = new Set<FiberRootLike>();
-const fiberRootRenderers = new WeakMap<FiberRootLike, ReactRenderer>();
+const pausedFiberRoots = new Set<FiberRoot>();
+const fiberRootRenderers = new WeakMap<FiberRoot, ReactRenderer>();
 
 instrument({
   name: "react-grab-freeze-updates",
@@ -112,17 +107,17 @@ const isDomRenderer = (renderer: ReactRenderer): boolean => {
   }
 };
 
-const getFiberRoot = (fiber: Fiber): FiberRootLike | null => {
+const getFiberRoot = (fiber: Fiber): FiberRoot | null => {
   let current: Fiber | null = fiber;
   while (current.return) {
     current = current.return;
   }
-  return (current.stateNode ?? null) as FiberRootLike | null;
+  return (current.stateNode ?? null) as FiberRoot | null;
 };
 
-const findHostInstance = (fiberRoot: FiberRootLike): object | null => {
+const findHostInstance = (fiberRoot: FiberRoot): object | null => {
   const root = fiberRoot.current;
-  let fiber = root;
+  let fiber: Fiber | null = root;
   while (fiber) {
     const stateNode = fiber.stateNode;
     if (
@@ -146,7 +141,7 @@ const findHostInstance = (fiberRoot: FiberRootLike): object | null => {
   return null;
 };
 
-const resolveFiberRootRenderer = (fiberRoot: FiberRootLike): ReactRenderer | null => {
+const resolveFiberRootRenderer = (fiberRoot: FiberRoot): ReactRenderer | null => {
   const renderer = fiberRootRenderers.get(fiberRoot);
   if (renderer) return isDomRenderer(renderer) ? renderer : null;
 
@@ -172,7 +167,7 @@ const resolveFiberRootRenderer = (fiberRoot: FiberRootLike): ReactRenderer | nul
   return null;
 };
 
-const isDomFiberRoot = (fiberRoot: FiberRootLike): boolean => {
+const isDomFiberRoot = (fiberRoot: FiberRoot): boolean => {
   const stateNode = fiberRoot.current?.stateNode;
   if (!stateNode || typeof stateNode !== "object") return false;
   const containerInfo = Reflect.get(stateNode, "containerInfo");
@@ -185,16 +180,16 @@ const isDomFiberRoot = (fiberRoot: FiberRootLike): boolean => {
 
 // Collects React fiber roots, preferring bippy's tracked set but falling back
 // to a DOM walk when the app mounted before bippy instrumented the renderers.
-const collectFiberRoots = (): Set<FiberRootLike> => {
-  if (typedFiberRoots.size > 0) {
-    const domFiberRoots = new Set<FiberRootLike>();
-    for (const fiberRoot of typedFiberRoots) {
+const collectFiberRoots = (): Set<FiberRoot> => {
+  if (_fiberRoots.size > 0) {
+    const domFiberRoots = new Set<FiberRoot>();
+    for (const fiberRoot of _fiberRoots) {
       if (isDomFiberRoot(fiberRoot)) domFiberRoots.add(fiberRoot);
     }
     return domFiberRoots;
   }
 
-  const collectedRoots = new Set<FiberRootLike>();
+  const collectedRoots = new Set<FiberRoot>();
 
   const traverseDOM = (element: Element): void => {
     const fiber = getFiberFromHostInstance(element);
@@ -601,7 +596,7 @@ const installDispatcherPatching = (renderer: ReactRenderer): void => {
 };
 
 const scheduleReactUpdate = (
-  fiberRoots: Set<FiberRootLike>,
+  fiberRoots: Set<FiberRoot>,
   scheduledFreezeSessionId: number,
 ): void => {
   queueMicrotask(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,8 +402,8 @@ importers:
         specifier: workspace:*
         version: link:../cli
       bippy:
-        specifier: ^0.6.1
-        version: 0.6.1(react@19.2.6)
+        specifier: ^0.7.2
+        version: 0.7.2(@types/react@19.2.14)(react@19.2.6)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -3695,6 +3695,11 @@ packages:
     peerDependencies:
       '@types/react': '*'
 
+  '@types/react-reconciler@0.33.0':
+    resolution: {integrity: sha512-HZOXsKT0tGI9LlUw2LuedXsVeB88wFa536vVL0M6vE8zN63nI+sSr1ByxmPToP5K5bukaVscyeCJcF9guVNJ1g==}
+    peerDependencies:
+      '@types/react': '*'
+
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
@@ -4357,8 +4362,8 @@ packages:
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
-  bippy@0.6.1:
-    resolution: {integrity: sha512-ky4m94Y/KfsddjGkKTsV4uFjZqkJjpOjQ2t5gKPdX6XH1MNxMNX5FrVefsxV4lpjemEmEdwe0e0YbzAMNs3oUQ==}
+  bippy@0.7.2:
+    resolution: {integrity: sha512-h8NFpBuVix0iuih7o5eclUP7W3DJyRUQz4OojD/S1DhyBGk6TeDrICvsAc0VMdl8KrMCEAyT4JbkX9ON3cHejg==}
     peerDependencies:
       react: 19.2.6
 
@@ -11505,6 +11510,10 @@ snapshots:
     dependencies:
       '@types/react': 19.2.14
 
+  '@types/react-reconciler@0.33.0(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
@@ -12011,9 +12020,12 @@ snapshots:
 
   bignumber.js@9.3.1: {}
 
-  bippy@0.6.1(react@19.2.6):
+  bippy@0.7.2(@types/react@19.2.14)(react@19.2.6):
     dependencies:
+      '@types/react-reconciler': 0.33.0(@types/react@19.2.14)
       react: 19.2.6
+    transitivePeerDependencies:
+      - '@types/react'
 
   bl@4.1.0:
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update `bippy` from `0.6.1` to `0.7.2`
- refresh the pnpm lockfile for the new transitive type dependency
- replace the removed `getNearestHostFibers` helper with equivalent local host-boundary traversal
- migrate owner and fiber-root handling to bippy 0.7 types

## Testing
- `nr build` — passed
- `nr typecheck` — 10/10 tasks passed
- `nr test` — 13/13 tasks passed; final Playwright performance run 73/73 passed
- lint with Node 22.22 — 0 warnings, 0 errors
- format with Node 22.22 — passed with no changes

The environment's default Node 22.14 cannot load the TypeScript Vite Plus config for lint/format, so those two checks were rerun under transient Node 22.22.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c756c5b-d333-4b58-b67d-bea5f9edfd53?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c756c5b-d333-4b58-b67d-bea5f9edfd53&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `bippy` from 0.6.1 to 0.7.2 to align with updated fiber APIs while keeping element anchor recovery intact. Previously used `getNearestHostFibers`; now uses a local host-boundary traversal. No runtime behavior change.

- Bumps `packages/react-grab` to `bippy@^0.7.2`; aligns to `FiberRoot` and `_fiberRoots`, adopts the `isFiber` guard for `_debugOwner`, and updates the lockfile with transitive `@types/react-reconciler` and peer `@types/react`.
- Replaces anchor recovery with `findNearestHostElementWithTag`, which walks nearest host boundaries and matches by tag.
- Migration: If TypeScript reports missing `@types/react`, add `@types/react` to workspace devDependencies.

<sup>Written for commit b5c7d042cc335c5a3fa1cb1b8041b6f543c003fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

