### PR TITLE
Keep the perf baseline from blocking dependency PRs

### DIFF
--- a/.github/workflows/test-perf.yml
+++ b/.github/workflows/test-perf.yml
@@ -82,16 +82,44 @@ jobs:
         run: |
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           git fetch origin "$BASE_SHA" --depth=1
-          if git cat-file -e "$BASE_SHA:packages/react-grab/src" 2>/dev/null; then
-            git checkout "$BASE_SHA" -- packages/react-grab/src
-            echo "swapped=true" >> "$GITHUB_OUTPUT"
-            echo "Swapped react-grab/src to base revision $BASE_SHA"
-          else
+          if ! git cat-file -e "$BASE_SHA:packages/react-grab/src" 2>/dev/null; then
             echo "Base ref lacks packages/react-grab/src; skipping baseline run."
             echo "swapped=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          git checkout "$BASE_SHA" -- packages/react-grab/src
+          echo "Swapped react-grab/src to base revision $BASE_SHA"
 
+          # Base src builds against whatever this job installed, so a dependency
+          # change leaves it importing exports the new version dropped and the
+          # fixture's dev server never starts. Swapping the manifests too keeps
+          # the baseline a measurement of the base ref instead of a mix that
+          # cannot build, and it is the comparison a dependency bump wants.
+          if git diff --quiet "$BASE_SHA" HEAD -- '*package.json' pnpm-lock.yaml; then
+            echo "swapped=true" >> "$GITHUB_OUTPUT"
+            echo "deps_swapped=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Manifests the PR adds have no base revision to restore, and leaving
+          # them would make the base lockfile fail its frozen check.
+          git diff --name-only --diff-filter=A "$BASE_SHA" HEAD -- '*package.json' | xargs -r rm -f
+          git checkout "$BASE_SHA" -- '*package.json' pnpm-lock.yaml
+          if pnpm install; then
+            echo "swapped=true" >> "$GITHUB_OUTPUT"
+            echo "deps_swapped=true" >> "$GITHUB_OUTPUT"
+            echo "Swapped dependencies to base revision $BASE_SHA"
+            exit 0
+          fi
+          echo "Base dependencies failed to install; skipping baseline run."
+          git checkout HEAD -- packages/react-grab/src '*package.json' pnpm-lock.yaml
+          pnpm install
+          echo "swapped=false" >> "$GITHUB_OUTPUT"
+
+      # The baseline is a measurement, not a gate: the base ref is already tested
+      # by its own CI, so a baseline that cannot build or run must not block this
+      # PR. diff-perf-runs.mjs reports the missing comparison instead.
       - name: Run paired shard against base ref src
+        continue-on-error: true
         if: github.event_name == 'pull_request' && steps.swap-base.outputs.swapped == 'true'
         env:
           PERF_LABEL: baseline
@@ -108,7 +136,12 @@ jobs:
 
       - name: Restore react-grab src to HEAD
         if: github.event_name == 'pull_request' && steps.swap-base.outputs.swapped == 'true'
-        run: git checkout HEAD -- packages/react-grab/src
+        run: |
+          git checkout HEAD -- packages/react-grab/src
+          if [ "${{ steps.swap-base.outputs.deps_swapped }}" = "true" ]; then
+            git checkout HEAD -- '*package.json' pnpm-lock.yaml
+            pnpm install
+          fi
 
       - name: Run paired shard against HEAD src
         env:


### PR DESCRIPTION
## Problem

Every perf shard fails on any PR that changes a dependency, and the aggregate `test-perf` gate fails with it — currently [#626](https://github.com/aidenybai/react-grab/pull/626) (bippy 0.7.2) and [#621](https://github.com/aidenybai/react-grab/pull/621) (bippy 0.7.1), whose own code compiles fine.

`test-perf.yml` builds its paired baseline by checking out `packages/react-grab/src` at the base SHA while leaving the PR's installed `node_modules` in place. Main's `element-anchors.ts` imports `getNearestHostFibers`, which bippy 0.7.2 removed, so the baseline fixture never starts:

```
[MISSING_EXPORT] Error: "getNearestHostFibers" is not exported by "bippy@0.7.2/dist/index.js"
   ╭─[ src/core/element-anchors.ts:4:3 ]
Error: Process from config.webServer was not able to start. Exit code: 1
```

All 15 shards die there, and `Verify perf shards` turns that into a red gate on a healthy PR.

## Fix

**Swap the base dependency tree along with base src, but only when the PR touches a manifest.** Normal PRs are unaffected and pay nothing. Dependency PRs get a baseline that builds — and get the comparison they actually want, since base src measured against the PR's dependencies was never the base ref in the first place. Manifests the PR adds are removed before the base lockfile is restored so its frozen check passes, and a base install that still fails falls back to skipping the baseline rather than failing the job.

**The baseline run is no longer fatal.** It is a measurement, not a gate: the base ref is covered by its own CI, so a baseline that cannot build or run should not block the PR. `diff-perf-runs.mjs` already handles this — it prints `Perf diff skipped: no baseline data` and exits 0. The HEAD run remains a hard gate.

## Verification

Replayed the swap sequence locally against #626's head (`dc7a0da1`) with base `bc0c7d0d`:

| state | `build:e2e-development` |
| --- | --- |
| base src + PR deps (today) | fails with the CI's `MISSING_EXPORT` |
| base src + base deps (this PR) | builds |
| restored HEAD src + HEAD deps | builds, `git status` clean |

The workflow YAML parses and both `run` scripts pass `bash -n`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops perf baseline from blocking dependency PRs by swapping base manifests with base `src` when manifests change and making the baseline run non-fatal. Before: base `src` ran against PR deps and failed at startup; now: dependency PRs get a buildable baseline or a skipped comparison, while the HEAD run remains the gate.

- Swaps `packages/react-grab/src` to base. If `*package.json` or `pnpm-lock.yaml` changed, removes newly added manifests, restores base manifests and lockfile, then runs `pnpm install`. Marks whether deps were swapped.
- If base `src` is missing or base install fails, skips the baseline and proceeds; `diff-perf-runs.mjs` reports “Perf diff skipped: no baseline data”.
- Baseline shard uses `continue-on-error: true`. If deps were swapped, restores HEAD manifests and runs `pnpm install` before the HEAD shard.
- Normal PRs are unchanged; only dependency PRs do the extra install to get a correct comparison.

<sup>Written for commit 3fb210e5189f995847a59960cae0e229460dd8ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aidenybai/react-grab/pull/628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

